### PR TITLE
fix: cancel in Now Playing edit sub-menus returns to edit menu

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -4195,25 +4195,7 @@ export class NowPlayingCommand {
       });
       return;
     }
-    const list = await Member.getNowPlaying(ownerId);
-    const payload = await this.buildNowPlayingListPayload(
-      interaction.user,
-      list,
-      interaction.guildId,
-      "Your Now Playing List",
-    );
-    const components = this.withNowPlayingActions(
-      true,
-      ownerId,
-      payload.components,
-      false,
-      this.hasDisplayableNowPlayingNotes(list),
-    );
-    await interaction.update({
-      components,
-      files: payload.files,
-      flags: buildComponentsV2Flags(true),
-    });
+    await this.returnToNowPlayingEditMenu(interaction, ownerId);
   }
 
   async showSingle(


### PR DESCRIPTION
Fixes #240

## Summary
- `handleNowPlayingListCancel` now calls `returnToNowPlayingEditMenu` instead of re-rendering the full Now Playing list
- Covers all cancel buttons in the edit PM flows (edit platform, sort, add completion wizard) since they all share the `nowplaying-list-cancel:{ownerId}` button ID

## Test plan
- [ ] In the Edit PM flow, open the Sort sub-menu and hit Cancel -- should return to the main edit menu
- [ ] In the Edit PM flow, open the Edit Platform sub-menu and hit Cancel -- should return to the main edit menu
- [ ] In the Edit PM flow, open the Add Completion wizard and hit Cancel -- should return to the main edit menu
- [ ] Confirm no /now-playing list render occurs on any cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)