### PR TITLE
feat: add /game-journal command

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -124,6 +124,20 @@ export interface IGameJournalPreference {
   defaultIsPublic: boolean;
 }
 
+export interface IGameJournalListEntry {
+  gameId: number;
+  title: string;
+  totalEntries: number;
+  publicEntries: number;
+}
+
+export interface IJournalUserSummary {
+  userId: string;
+  username: string | null;
+  globalName: string | null;
+  gameCount: number;
+}
+
 export interface IAvatarHistoryRecord {
   eventId: number;
   userId: string;
@@ -2482,5 +2496,77 @@ export default class Member {
     }
 
     return totalUpdated;
+  }
+
+  static async getGameJournalList(userId: string): Promise<IGameJournalListEntry[]> {
+    const connection = await getOraclePool().getConnection();
+    try {
+      const res = await connection.execute<{
+        GAME_ID: number;
+        TITLE: string;
+        TOTAL_ENTRIES: number;
+        PUBLIC_ENTRIES: number;
+      }>(
+        `SELECT g.GAME_ID,
+                g.TITLE,
+                COUNT(e.ENTRY_ID) AS TOTAL_ENTRIES,
+                SUM(CASE WHEN e.IS_PUBLIC = 1 THEN 1 ELSE 0 END) AS PUBLIC_ENTRIES
+           FROM USER_GAME_JOURNAL_PREFS jp
+           JOIN GAMEDB_GAMES g ON g.GAME_ID = jp.GAMEDB_GAME_ID
+           LEFT JOIN USER_GAME_JOURNAL_ENTRIES e
+             ON e.USER_ID = jp.USER_ID
+            AND e.GAMEDB_GAME_ID = jp.GAMEDB_GAME_ID
+          WHERE jp.USER_ID = :userId
+            AND jp.IS_ENABLED = 1
+          GROUP BY g.GAME_ID, g.TITLE
+          ORDER BY g.TITLE`,
+        { userId },
+        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      );
+      return (res.rows ?? []).map((row) => ({
+        gameId: Number(row.GAME_ID),
+        title: row.TITLE,
+        totalEntries: Number(row.TOTAL_ENTRIES ?? 0),
+        publicEntries: Number(row.PUBLIC_ENTRIES ?? 0),
+      }));
+    } finally {
+      await connection.close();
+    }
+  }
+
+  static async getAllJournalUsers(): Promise<IJournalUserSummary[]> {
+    const connection = await getOraclePool().getConnection();
+    try {
+      const res = await connection.execute<{
+        USER_ID: string;
+        USERNAME: string | null;
+        GLOBAL_NAME: string | null;
+        GAME_COUNT: number;
+      }>(
+        `SELECT u.USER_ID,
+                u.USERNAME,
+                u.GLOBAL_NAME,
+                COUNT(DISTINCT jp.GAMEDB_GAME_ID) AS GAME_COUNT
+           FROM USER_GAME_JOURNAL_PREFS jp
+           JOIN RPG_CLUB_USERS u ON u.USER_ID = jp.USER_ID
+          WHERE jp.IS_ENABLED = 1
+            AND NVL(u.IS_BOT, 0) = 0
+            AND u.SERVER_LEFT_AT IS NULL
+          GROUP BY u.USER_ID, u.USERNAME, u.GLOBAL_NAME
+          ORDER BY COUNT(DISTINCT jp.GAMEDB_GAME_ID) DESC,
+                   u.GLOBAL_NAME NULLS LAST,
+                   u.USERNAME NULLS LAST`,
+        {},
+        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      );
+      return (res.rows ?? []).map((row) => ({
+        userId: row.USER_ID,
+        username: row.USERNAME ?? null,
+        globalName: row.GLOBAL_NAME ?? null,
+        gameCount: Number(row.GAME_COUNT ?? 0),
+      }));
+    } finally {
+      await connection.close();
+    }
   }
 }

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -1,0 +1,125 @@
+import {
+  ApplicationCommandOptionType,
+  CommandInteraction,
+  EmbedBuilder,
+  MessageFlags,
+  User,
+} from "discord.js";
+import { Discord, Slash, SlashOption } from "discordx";
+import Member, {
+  type IGameJournalListEntry,
+  type IJournalUserSummary,
+} from "../classes/Member.js";
+import { safeDeferReply, safeReply } from "../functions/InteractionUtils.js";
+
+function displayName(user: User): string {
+  return user.displayName ?? user.username;
+}
+
+function formatGameLine(entry: IGameJournalListEntry, isSelf: boolean): string {
+  const count = isSelf ? entry.totalEntries : entry.publicEntries;
+  const label = count === 1 ? "entry" : "entries";
+  return `**${entry.title}** — ${count} ${label}`;
+}
+
+function formatUserLine(summary: IJournalUserSummary): string {
+  const label = summary.gameCount === 1 ? "game" : "games";
+  return `<@${summary.userId}> — ${summary.gameCount} ${label}`;
+}
+
+function buildUserJournalEmbed(
+  target: User,
+  entries: IGameJournalListEntry[],
+  isSelf: boolean,
+): EmbedBuilder {
+  const name = displayName(target);
+  const embed = new EmbedBuilder()
+    .setTitle(`${name}'s Game Journals`)
+    .setThumbnail(target.displayAvatarURL());
+
+  if (!entries.length) {
+    embed.setDescription("No game journals found.");
+    return embed;
+  }
+
+  const lines = entries.map((e) => formatGameLine(e, isSelf));
+  const gameLabel = entries.length === 1 ? "game" : "games";
+  embed.setDescription(lines.join("\n"));
+  embed.setFooter({ text: `${entries.length} ${gameLabel}` });
+  return embed;
+}
+
+function buildAllJournalsEmbed(summaries: IJournalUserSummary[]): EmbedBuilder {
+  const embed = new EmbedBuilder().setTitle("Game Journal Users");
+
+  if (!summaries.length) {
+    embed.setDescription("No members are currently using Game Journals.");
+    return embed;
+  }
+
+  const lines = summaries.map(formatUserLine);
+  const memberLabel = summaries.length === 1 ? "member" : "members";
+  embed.setDescription(lines.join("\n"));
+  embed.setFooter({ text: `${summaries.length} ${memberLabel}` });
+  return embed;
+}
+
+@Discord()
+export class GameJournalCommand {
+  @Slash({ description: "View Game Journal lists for yourself, a member, or everyone", name: "game-journal" })
+  async gameJournal(
+    @SlashOption({
+      description: "Show all members who use Game Journals",
+      name: "all",
+      required: false,
+      type: ApplicationCommandOptionType.Boolean,
+    })
+    all: boolean | undefined,
+    @SlashOption({
+      description: "Member whose journal list to view; defaults to you",
+      name: "member",
+      required: false,
+      type: ApplicationCommandOptionType.User,
+    })
+    member: User | undefined,
+    @SlashOption({
+      description: "Return the result as an ephemeral (private) message",
+      name: "private",
+      required: false,
+      type: ApplicationCommandOptionType.Boolean,
+    })
+    isPrivate: boolean | undefined,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    const ephemeral = isPrivate === true;
+    await safeDeferReply(interaction, { flags: ephemeral ? MessageFlags.Ephemeral : undefined });
+
+    if (member !== undefined) {
+      const isSelf = member.id === interaction.user.id;
+      const entries = await Member.getGameJournalList(member.id);
+      const embed = buildUserJournalEmbed(member, entries, isSelf);
+      await safeReply(interaction, {
+        embeds: [embed],
+        flags: ephemeral ? MessageFlags.Ephemeral : undefined,
+      });
+      return;
+    }
+
+    if (all === true) {
+      const summaries = await Member.getAllJournalUsers();
+      const embed = buildAllJournalsEmbed(summaries);
+      await safeReply(interaction, {
+        embeds: [embed],
+        flags: ephemeral ? MessageFlags.Ephemeral : undefined,
+      });
+      return;
+    }
+
+    const entries = await Member.getGameJournalList(interaction.user.id);
+    const embed = buildUserJournalEmbed(interaction.user, entries, true);
+    await safeReply(interaction, {
+      embeds: [embed],
+      flags: ephemeral ? MessageFlags.Ephemeral : undefined,
+    });
+  }
+}


### PR DESCRIPTION
Closes #234

## Summary
- Adds `getGameJournalList` and `getAllJournalUsers` static methods to `Member.ts` (plus `IGameJournalListEntry` and `IJournalUserSummary` interfaces)
- Implements `/game-journal` slash command with `all`, `member`, and `private` options
- Self view shows all journal-enabled games with total entry count; other-member view shows public entry count; `all` mode lists every active member using Game Journals sorted by game count

## Acceptance criteria coverage
1. `/game-journal` with no args returns invoking user's journal list
2. `/game-journal all:true` returns all members using Game Journals
3. `/game-journal member:<user>` returns that member's journal list
4. `private:true` returns ephemeral response for any mode
5. `member` takes priority over `all` if both are provided
6. Clear "No game journals found." / "No members are currently using Game Journals." messages when empty

## Test plan
- [ ] Run `/game-journal` — should show your own journal list (or empty state)
- [ ] Run `/game-journal member:@someone` — should show that member's public journal entries
- [ ] Run `/game-journal all:true` — should list all members with journal counts
- [ ] Run `/game-journal private:true` — result should be ephemeral
- [ ] Run `/game-journal all:true member:@someone` — member param should win

🤖 Generated with [Claude Code](https://claude.com/claude-code)