### PR TITLE
fix: restyle game journal view header

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -180,11 +180,16 @@ async function buildJournalViewPayload(
     coverUrl = `attachment://${filename}`;
   }
 
+  const gameTitle = game?.title ?? `Game #${gameId}`;
+  const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
   const introSection = new SectionBuilder().addTextDisplayComponents(
     new TextDisplayBuilder().setContent(
-      `## ${ownerLabel}'s Game Journal: ${game?.title ?? `Game #${gameId}`}`,
+      [
+        `${ownerLabel}'s Game Journal`,
+        `**${gameTitle}**`,
+        `-# ${total} public ${entryLabel(total)}${pageInfo}`,
+      ].join("\n"),
     ),
-    new TextDisplayBuilder().setContent(`${total} public ${entryLabel(total)}`),
   );
   if (coverUrl) {
     introSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));


### PR DESCRIPTION
## Summary
- Removes the `##` heading (which adds unwanted vertical space) from the journal view intro
- Username line renders as normal-size text
- Game title renders as **bold** inline text with no heading spacing below it
- Entry count + page info renders as `-#` subtext; page `x of y` is only included when `totalPages > 1`

## Before / After
**Before:** `## username's Game Journal: Game Title` + separate line for entry count

**After:**
```
username's Game Journal
**Game Title**
-# 12 public entries, page 1 of 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)