### PR TITLE
fix: journal view header/entries separator and single content block

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -22,9 +22,11 @@ import {
 import {
   ContainerBuilder,
   SectionBuilder,
+  SeparatorBuilder,
   TextDisplayBuilder,
   ThumbnailBuilder,
 } from "@discordjs/builders";
+import { SeparatorSpacingSize } from "discord-api-types/v10";
 import Member, {
   type IGameJournalListEntry,
   type IJournalUserSummary,
@@ -184,31 +186,34 @@ async function buildJournalViewPayload(
   const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
   const footer = `-# ${total} public ${entryLabel(total)}${pageInfo}`;
 
-  const bodyLines: string[] = [];
-  if (!entries.length) {
-    bodyLines.push("No public journal entries for this game.");
-  } else {
-    for (const entry of entries) {
-      const titleLine = entry.title ? `### ${entry.title}` : "### Untitled Entry";
-      const date = formatTableDate(entry.createdAt);
-      bodyLines.push(`${titleLine}\n-# ${date}\n${trimContent(entry.body)}`);
-    }
-  }
-
-  const fullContent = [
-    `${ownerLabel}'s Game Journal`,
-    `## ${gameTitle}`,
-    bodyLines.join("\n\n"),
-    footer,
-  ].join("\n");
-
   const introSection = new SectionBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(fullContent),
+    new TextDisplayBuilder().setContent(
+      `${ownerLabel}'s Game Journal\n## ${gameTitle}`,
+    ),
   );
   if (coverUrl) {
     introSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
   }
   container.addSectionComponents(introSection);
+  container.addSeparatorComponents(
+    new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
+  );
+
+  const entryLines: string[] = [];
+  if (!entries.length) {
+    entryLines.push("No public journal entries for this game.");
+  } else {
+    for (const entry of entries) {
+      const titleLine = entry.title ? `### ${entry.title}` : "### Untitled Entry";
+      const date = formatTableDate(entry.createdAt);
+      entryLines.push(`${titleLine}\n-# ${date}\n${trimContent(entry.body)}`);
+    }
+  }
+  entryLines.push(footer);
+
+  container.addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(entryLines.join("\n\n")),
+  );
 
   const pageRow = new ActionRowBuilder<ButtonBuilder>();
   if (safePage > 1) {

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -182,35 +182,33 @@ async function buildJournalViewPayload(
 
   const gameTitle = game?.title ?? `Game #${gameId}`;
   const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
+  const footer = `-# ${total} public ${entryLabel(total)}${pageInfo}`;
+
+  const bodyLines: string[] = [];
+  if (!entries.length) {
+    bodyLines.push("No public journal entries for this game.");
+  } else {
+    for (const entry of entries) {
+      const titleLine = entry.title ? `### ${entry.title}` : "### Untitled Entry";
+      const date = formatTableDate(entry.createdAt);
+      bodyLines.push(`${titleLine}\n-# ${date}\n${trimContent(entry.body)}`);
+    }
+  }
+
+  const fullContent = [
+    `${ownerLabel}'s Game Journal`,
+    `## ${gameTitle}`,
+    bodyLines.join("\n\n"),
+    footer,
+  ].join("\n");
+
   const introSection = new SectionBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(
-      [
-        `${ownerLabel}'s Game Journal`,
-        `**${gameTitle}**`,
-        `-# ${total} public ${entryLabel(total)}${pageInfo}`,
-      ].join("\n"),
-    ),
+    new TextDisplayBuilder().setContent(fullContent),
   );
   if (coverUrl) {
     introSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
   }
   container.addSectionComponents(introSection);
-
-  if (!entries.length) {
-    container.addTextDisplayComponents(
-      new TextDisplayBuilder().setContent("No public journal entries for this game."),
-    );
-  } else {
-    for (const entry of entries) {
-      const titleLine = entry.title ? `### ${entry.title}` : "### Untitled Entry";
-      const body = trimContent(entry.body);
-      container.addTextDisplayComponents(
-        new TextDisplayBuilder().setContent(
-          `${titleLine}\n-# ${formatTableDate(entry.createdAt)}\n${body}`,
-        ),
-      );
-    }
-  }
 
   const pageRow = new ActionRowBuilder<ButtonBuilder>();
   if (safePage > 1) {


### PR DESCRIPTION
## Summary
- Header (`username's Game Journal` + `## Game Title`) lives in a `SectionBuilder` (retains the cover thumbnail accessory)
- A `SeparatorBuilder` with `setDivider(true)` and `Small` spacing provides a visual rule between the header and entries
- All entries and the `-# footer` are joined into **one `TextDisplayBuilder`** so there is no spacing between individual entries
- Page `x of y` still only appended to the footer when `totalPages > 1`

## Layout
```
merph518's Game Journal
## Pragmata                    [cover thumbnail]
──────────────────────────────
### Finished Sector 2
-# 05/14/2026
entry body...

### Finally, Less Roadblocks
-# 05/11/2026
entry body...

-# 3 public entries
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)