### PR TITLE
fix: move thumbnail to entries section to reduce header spacing

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -186,15 +186,11 @@ async function buildJournalViewPayload(
   const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
   const footer = `-# ${total} public ${entryLabel(total)}${pageInfo}`;
 
-  const introSection = new SectionBuilder().addTextDisplayComponents(
+  container.addTextDisplayComponents(
     new TextDisplayBuilder().setContent(
       `${ownerLabel}'s Game Journal\n## ${gameTitle}`,
     ),
   );
-  if (coverUrl) {
-    introSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
-  }
-  container.addSectionComponents(introSection);
   container.addSeparatorComponents(
     new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
   );
@@ -211,9 +207,13 @@ async function buildJournalViewPayload(
   }
   entryLines.push(footer);
 
-  container.addTextDisplayComponents(
+  const entriesSection = new SectionBuilder().addTextDisplayComponents(
     new TextDisplayBuilder().setContent(entryLines.join("\n\n")),
   );
+  if (coverUrl) {
+    entriesSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
+  }
+  container.addSectionComponents(entriesSection);
 
   const pageRow = new ActionRowBuilder<ButtonBuilder>();
   if (safePage > 1) {


### PR DESCRIPTION
## Summary
The `SectionBuilder` wrapper on the header was imposing a minimum height to accommodate the thumbnail accessory, leaving too much vertical padding around the two-line game title. This PR moves the thumbnail to the entries block instead.

**Before:** `SectionBuilder` (header + thumbnail) → separator → `TextDisplayBuilder` (entries)

**After:** `TextDisplayBuilder` (header) → separator → `SectionBuilder` (entries + thumbnail)

The header now renders at natural text height with no extra padding, and the thumbnail sits beside the entries content where there's enough text to fill the space.

🤖 Generated with [Claude Code](https://claude.com/claude-code)