### PR TITLE
feat: UserEmojiService — per-user application emoji from Regulars avatars

### DIFF
--- a/src/RPGClub_GameDB.ts
+++ b/src/RPGClub_GameDB.ts
@@ -30,6 +30,7 @@ import { startThreadLinkPromptService } from "./services/ThreadLinkPromptService
 import { refreshGiveawayHubMessage } from "./services/GiveawayHubService.js";
 import { startGameReleaseAnnouncementService } from "./services/GameReleaseAnnouncementService.js";
 import { startIgdbScanService } from "./services/IGDB/IgdbScanService.js";
+import { startUserEmojiService } from "./services/UserEmojiService.js";
 import { tryHandleManagedRawModalInteraction } from "./services/raw-modal/RawModalInteractionRouter.js";
 installConsoleLogging();
 
@@ -193,6 +194,7 @@ bot.once("clientReady", async () => {
   await joinAllTargetForumThreads(bot);
   startRssFeedService(bot);
   await refreshGiveawayHubMessage(bot);
+  await startUserEmojiService(bot);
   console.log("Startup sequence completed.");
 });
 

--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -4,6 +4,11 @@ import { Discord, On } from "discordx";
 import Member, { type IMemberRecord } from "../classes/Member.js";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { logAvatarChange, updateAvatarRecordFromUrl } from "../utilities/AvatarLogUtils.js";
+import {
+  ensureUserEmojiForMember,
+  syncUserEmojiFromAvatarChange,
+} from "../services/UserEmojiService.js";
+import { REGULARS_ROLE_ID } from "../config/roles.js";
 
 @Discord()
 export class GuildMemberUpdate {
@@ -71,7 +76,17 @@ export class GuildMemberUpdate {
         if (updated) {
           await logAvatarChange(_client, user, "Server avatar changed");
         }
+        const emojiUrl = newMember.displayAvatarURL({
+          extension: "png",
+          size: 128,
+          forceStatic: true,
+        });
+        await syncUserEmojiFromAvatarChange(_client, user.id, emojiUrl);
       }
+    }
+
+    if (!user.bot && addedRoles.has(REGULARS_ROLE_ID)) {
+      await ensureUserEmojiForMember(_client, newMember);
     }
 
     if (!user.bot && nicknameChanged) {

--- a/src/events/UserUpdate.command.ts
+++ b/src/events/UserUpdate.command.ts
@@ -3,6 +3,7 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { logAvatarChange, updateAvatarRecordFromUrl } from "../utilities/AvatarLogUtils.js";
+import { syncUserEmojiFromAvatarChange } from "../services/UserEmojiService.js";
 
 @Discord()
 export class UserUpdate {
@@ -32,6 +33,12 @@ export class UserUpdate {
         if (updated) {
           await logAvatarChange(client, newUser, "Avatar changed");
         }
+        const emojiUrl = newUser.displayAvatarURL({
+          extension: "png",
+          size: 128,
+          forceStatic: true,
+        });
+        await syncUserEmojiFromAvatarChange(client, newUser.id, emojiUrl);
       }
     }
 

--- a/src/services/UserEmojiService.ts
+++ b/src/services/UserEmojiService.ts
@@ -1,0 +1,128 @@
+import type { Client, GuildMember } from "discord.js";
+import { REGULARS_ROLE_ID } from "../config/roles.js";
+
+const EMOJI_NAME_PREFIX = "u_";
+const CREATION_THROTTLE_MS = 600;
+
+type EmojiCacheEntry = { emojiId: string };
+
+// userId -> { emojiId }
+const emojiCache = new Map<string, EmojiCacheEntry>();
+let initialized = false;
+
+function toEmojiName(userId: string): string {
+  return `${EMOJI_NAME_PREFIX}${userId}`;
+}
+
+function toUserId(emojiName: string): string {
+  return emojiName.slice(EMOJI_NAME_PREFIX.length);
+}
+
+export function getUserEmojiString(userId: string): string | null {
+  const entry = emojiCache.get(userId);
+  if (!entry) return null;
+  return `<:${toEmojiName(userId)}:${entry.emojiId}>`;
+}
+
+export async function startUserEmojiService(client: Client): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+  syncAllRegularsEmoji(client).catch((err) => {
+    console.error("[UserEmojiService] Initial sync failed:", err);
+  });
+}
+
+async function syncAllRegularsEmoji(client: Client): Promise<void> {
+  const app = client.application;
+  if (!app) {
+    console.error("[UserEmojiService] client.application not available.");
+    return;
+  }
+
+  const existing = await app.emojis.fetch();
+  for (const [, emoji] of existing) {
+    if (!emoji.name?.startsWith(EMOJI_NAME_PREFIX) || !emoji.id) continue;
+    emojiCache.set(toUserId(emoji.name), { emojiId: emoji.id });
+  }
+
+  const guild = client.guilds.cache.first();
+  if (!guild) {
+    console.error("[UserEmojiService] No guild found.");
+    return;
+  }
+
+  const members = await guild.members.fetch();
+  const regulars = members.filter((m) => m.roles.cache.has(REGULARS_ROLE_ID) && !m.user.bot);
+
+  let created = 0;
+  for (const [userId, member] of regulars) {
+    if (emojiCache.has(userId)) continue;
+    const success = await createEmojiForMember(app, member);
+    if (success) {
+      created++;
+      await new Promise((resolve) => setTimeout(resolve, CREATION_THROTTLE_MS));
+    }
+  }
+
+  console.log(
+    `[UserEmojiService] Sync complete. Created ${created} emoji. Cache: ${emojiCache.size}`,
+  );
+}
+
+async function createEmojiForMember(
+  app: NonNullable<Client["application"]>,
+  member: GuildMember,
+): Promise<boolean> {
+  const avatarUrl = member.displayAvatarURL({ extension: "png", size: 128, forceStatic: true });
+  try {
+    const emoji = await app.emojis.create({ attachment: avatarUrl, name: toEmojiName(member.id) });
+    if (emoji.id) {
+      emojiCache.set(member.id, { emojiId: emoji.id });
+      return true;
+    }
+  } catch (err) {
+    console.error(`[UserEmojiService] Failed to create emoji for ${member.id}:`, err);
+  }
+  return false;
+}
+
+export async function syncUserEmojiFromAvatarChange(
+  client: Client,
+  userId: string,
+  newAvatarUrl: string,
+): Promise<void> {
+  const app = client.application;
+  if (!app) return;
+
+  const existing = emojiCache.get(userId);
+  if (existing) {
+    try {
+      await app.emojis.delete(existing.emojiId);
+    } catch (err) {
+      console.error(`[UserEmojiService] Failed to delete old emoji for ${userId}:`, err);
+    }
+    emojiCache.delete(userId);
+  }
+
+  try {
+    const emoji = await app.emojis.create({
+      attachment: newAvatarUrl,
+      name: toEmojiName(userId),
+    });
+    if (emoji.id) {
+      emojiCache.set(userId, { emojiId: emoji.id });
+    }
+  } catch (err) {
+    console.error(`[UserEmojiService] Failed to recreate emoji for ${userId}:`, err);
+  }
+}
+
+export async function ensureUserEmojiForMember(
+  client: Client,
+  member: GuildMember,
+): Promise<void> {
+  if (emojiCache.has(member.id)) return;
+  const app = client.application;
+  if (!app) return;
+  await createEmojiForMember(app, member);
+}


### PR DESCRIPTION
## Summary
Adds `src/services/UserEmojiService.ts` which owns the full lifecycle of one application emoji per Regulars-role member, named `u_{userId}`, created from their current display avatar.

## Lifecycle
| Event | Behaviour |
|---|---|
| Bot startup | Loads existing app emojis into memory cache, then creates any missing ones for current Regulars (600 ms throttle) |
| Global avatar change (`UserUpdate`) | Deletes old emoji, creates new one from updated avatar |
| Guild avatar change (`GuildMemberUpdate`) | Deletes old emoji, creates new one from updated guild avatar |
| Regulars role granted (`GuildMemberUpdate`) | Creates emoji if not already cached |

## Usage
```ts
import { getUserEmojiString } from "../services/UserEmojiService.js";
const icon = getUserEmojiString(userId); // "<:u_123456789:987654321>" or null
```

## Notes
- Emoji names use `u_` prefix (`u_{userId}`) so they are easily identifiable and avoid any pure-numeric naming edge cases
- Initial population runs in the background (does not block startup)
- No emoji is deleted when a member loses the Regulars role — keeping the cache within the 2000-slot budget is a future concern if membership grows very large

## Test plan
- [ ] Deploy and confirm startup log shows `[UserEmojiService] Sync complete`
- [ ] Confirm application emojis appear in the Discord developer portal under the bot application
- [ ] Change your avatar — confirm the emoji is replaced within seconds
- [ ] Grant Regulars to a test account that doesn't have an emoji — confirm it's created

🤖 Generated with [Claude Code](https://claude.com/claude-code)