### PR TITLE
fix: expand user emoji eligibility to member/regular/moderator/admin

### DIFF
--- a/src/RPGClub_GameDB.ts
+++ b/src/RPGClub_GameDB.ts
@@ -30,6 +30,7 @@ import { startThreadLinkPromptService } from "./services/ThreadLinkPromptService
 import { refreshGiveawayHubMessage } from "./services/GiveawayHubService.js";
 import { startGameReleaseAnnouncementService } from "./services/GameReleaseAnnouncementService.js";
 import { startIgdbScanService } from "./services/IGDB/IgdbScanService.js";
+import { startUserEmojiService } from "./services/UserEmojiService.js";
 import { tryHandleManagedRawModalInteraction } from "./services/raw-modal/RawModalInteractionRouter.js";
 installConsoleLogging();
 
@@ -193,6 +194,7 @@ bot.once("clientReady", async () => {
   await joinAllTargetForumThreads(bot);
   startRssFeedService(bot);
   await refreshGiveawayHubMessage(bot);
+  await startUserEmojiService(bot);
   console.log("Startup sequence completed.");
 });
 

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -1,1 +1,7 @@
 export const REGULARS_ROLE_ID = "267883288817958912";
+export const ADMIN_ROLE_ID =
+  process.env.ADMIN_ROLE_ID?.replace(/[<@&>]/g, "").trim() ?? null;
+export const MODERATOR_ROLE_ID =
+  process.env.MODERATOR_ROLE_ID?.replace(/[<@&>]/g, "").trim() ?? null;
+export const MEMBER_ROLE_ID =
+  process.env.MEMBER_ROLE_ID?.replace(/[<@&>]/g, "").trim() ?? null;

--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -4,6 +4,11 @@ import { Discord, On } from "discordx";
 import Member, { type IMemberRecord } from "../classes/Member.js";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { logAvatarChange, updateAvatarRecordFromUrl } from "../utilities/AvatarLogUtils.js";
+import {
+  ensureUserEmojiForMember,
+  syncUserEmojiFromAvatarChange,
+} from "../services/UserEmojiService.js";
+import { REGULARS_ROLE_ID } from "../config/roles.js";
 
 @Discord()
 export class GuildMemberUpdate {
@@ -71,7 +76,17 @@ export class GuildMemberUpdate {
         if (updated) {
           await logAvatarChange(_client, user, "Server avatar changed");
         }
+        const emojiUrl = newMember.displayAvatarURL({
+          extension: "png",
+          size: 128,
+          forceStatic: true,
+        });
+        await syncUserEmojiFromAvatarChange(_client, user.id, emojiUrl);
       }
+    }
+
+    if (!user.bot && addedRoles.has(REGULARS_ROLE_ID)) {
+      await ensureUserEmojiForMember(_client, newMember);
     }
 
     if (!user.bot && nicknameChanged) {

--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -8,7 +8,18 @@ import {
   ensureUserEmojiForMember,
   syncUserEmojiFromAvatarChange,
 } from "../services/UserEmojiService.js";
-import { REGULARS_ROLE_ID } from "../config/roles.js";
+import {
+  ADMIN_ROLE_ID,
+  MEMBER_ROLE_ID,
+  MODERATOR_ROLE_ID,
+  REGULARS_ROLE_ID,
+} from "../config/roles.js";
+
+const QUALIFYING_ROLE_IDS_SET = new Set(
+  [REGULARS_ROLE_ID, ADMIN_ROLE_ID, MODERATOR_ROLE_ID, MEMBER_ROLE_ID].filter(
+    (id): id is string => id !== null,
+  ),
+);
 
 @Discord()
 export class GuildMemberUpdate {
@@ -85,7 +96,8 @@ export class GuildMemberUpdate {
       }
     }
 
-    if (!user.bot && addedRoles.has(REGULARS_ROLE_ID)) {
+    const gainedQualifyingRole = addedRoles.some((r) => QUALIFYING_ROLE_IDS_SET.has(r.id));
+    if (!user.bot && gainedQualifyingRole) {
       await ensureUserEmojiForMember(_client, newMember);
     }
 

--- a/src/events/UserUpdate.command.ts
+++ b/src/events/UserUpdate.command.ts
@@ -3,6 +3,7 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { logAvatarChange, updateAvatarRecordFromUrl } from "../utilities/AvatarLogUtils.js";
+import { syncUserEmojiFromAvatarChange } from "../services/UserEmojiService.js";
 
 @Discord()
 export class UserUpdate {
@@ -32,6 +33,12 @@ export class UserUpdate {
         if (updated) {
           await logAvatarChange(client, newUser, "Avatar changed");
         }
+        const emojiUrl = newUser.displayAvatarURL({
+          extension: "png",
+          size: 128,
+          forceStatic: true,
+        });
+        await syncUserEmojiFromAvatarChange(client, newUser.id, emojiUrl);
       }
     }
 

--- a/src/services/UserEmojiService.ts
+++ b/src/services/UserEmojiService.ts
@@ -1,8 +1,24 @@
 import type { Client, GuildMember } from "discord.js";
-import { REGULARS_ROLE_ID } from "../config/roles.js";
+import {
+  ADMIN_ROLE_ID,
+  MEMBER_ROLE_ID,
+  MODERATOR_ROLE_ID,
+  REGULARS_ROLE_ID,
+} from "../config/roles.js";
 
 const EMOJI_NAME_PREFIX = "u_";
 const CREATION_THROTTLE_MS = 600;
+
+const QUALIFYING_ROLE_IDS = [
+  REGULARS_ROLE_ID,
+  ADMIN_ROLE_ID,
+  MODERATOR_ROLE_ID,
+  MEMBER_ROLE_ID,
+].filter((id): id is string => id !== null);
+
+function hasQualifyingRole(member: GuildMember): boolean {
+  return QUALIFYING_ROLE_IDS.some((id) => member.roles.cache.has(id));
+}
 
 type EmojiCacheEntry = { emojiId: string };
 
@@ -52,7 +68,7 @@ async function syncAllRegularsEmoji(client: Client): Promise<void> {
   }
 
   const members = await guild.members.fetch();
-  const regulars = members.filter((m) => m.roles.cache.has(REGULARS_ROLE_ID) && !m.user.bot);
+  const regulars = members.filter((m) => !m.user.bot && hasQualifyingRole(m));
 
   let created = 0;
   for (const [userId, member] of regulars) {

--- a/src/services/UserEmojiService.ts
+++ b/src/services/UserEmojiService.ts
@@ -1,0 +1,128 @@
+import type { Client, GuildMember } from "discord.js";
+import { REGULARS_ROLE_ID } from "../config/roles.js";
+
+const EMOJI_NAME_PREFIX = "u_";
+const CREATION_THROTTLE_MS = 600;
+
+type EmojiCacheEntry = { emojiId: string };
+
+// userId -> { emojiId }
+const emojiCache = new Map<string, EmojiCacheEntry>();
+let initialized = false;
+
+function toEmojiName(userId: string): string {
+  return `${EMOJI_NAME_PREFIX}${userId}`;
+}
+
+function toUserId(emojiName: string): string {
+  return emojiName.slice(EMOJI_NAME_PREFIX.length);
+}
+
+export function getUserEmojiString(userId: string): string | null {
+  const entry = emojiCache.get(userId);
+  if (!entry) return null;
+  return `<:${toEmojiName(userId)}:${entry.emojiId}>`;
+}
+
+export async function startUserEmojiService(client: Client): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+  syncAllRegularsEmoji(client).catch((err) => {
+    console.error("[UserEmojiService] Initial sync failed:", err);
+  });
+}
+
+async function syncAllRegularsEmoji(client: Client): Promise<void> {
+  const app = client.application;
+  if (!app) {
+    console.error("[UserEmojiService] client.application not available.");
+    return;
+  }
+
+  const existing = await app.emojis.fetch();
+  for (const [, emoji] of existing) {
+    if (!emoji.name?.startsWith(EMOJI_NAME_PREFIX) || !emoji.id) continue;
+    emojiCache.set(toUserId(emoji.name), { emojiId: emoji.id });
+  }
+
+  const guild = client.guilds.cache.first();
+  if (!guild) {
+    console.error("[UserEmojiService] No guild found.");
+    return;
+  }
+
+  const members = await guild.members.fetch();
+  const regulars = members.filter((m) => m.roles.cache.has(REGULARS_ROLE_ID) && !m.user.bot);
+
+  let created = 0;
+  for (const [userId, member] of regulars) {
+    if (emojiCache.has(userId)) continue;
+    const success = await createEmojiForMember(app, member);
+    if (success) {
+      created++;
+      await new Promise((resolve) => setTimeout(resolve, CREATION_THROTTLE_MS));
+    }
+  }
+
+  console.log(
+    `[UserEmojiService] Sync complete. Created ${created} emoji. Cache: ${emojiCache.size}`,
+  );
+}
+
+async function createEmojiForMember(
+  app: NonNullable<Client["application"]>,
+  member: GuildMember,
+): Promise<boolean> {
+  const avatarUrl = member.displayAvatarURL({ extension: "png", size: 128, forceStatic: true });
+  try {
+    const emoji = await app.emojis.create({ attachment: avatarUrl, name: toEmojiName(member.id) });
+    if (emoji.id) {
+      emojiCache.set(member.id, { emojiId: emoji.id });
+      return true;
+    }
+  } catch (err) {
+    console.error(`[UserEmojiService] Failed to create emoji for ${member.id}:`, err);
+  }
+  return false;
+}
+
+export async function syncUserEmojiFromAvatarChange(
+  client: Client,
+  userId: string,
+  newAvatarUrl: string,
+): Promise<void> {
+  const app = client.application;
+  if (!app) return;
+
+  const existing = emojiCache.get(userId);
+  if (existing) {
+    try {
+      await app.emojis.delete(existing.emojiId);
+    } catch (err) {
+      console.error(`[UserEmojiService] Failed to delete old emoji for ${userId}:`, err);
+    }
+    emojiCache.delete(userId);
+  }
+
+  try {
+    const emoji = await app.emojis.create({
+      attachment: newAvatarUrl,
+      name: toEmojiName(userId),
+    });
+    if (emoji.id) {
+      emojiCache.set(userId, { emojiId: emoji.id });
+    }
+  } catch (err) {
+    console.error(`[UserEmojiService] Failed to recreate emoji for ${userId}:`, err);
+  }
+}
+
+export async function ensureUserEmojiForMember(
+  client: Client,
+  member: GuildMember,
+): Promise<void> {
+  if (emojiCache.has(member.id)) return;
+  const app = client.application;
+  if (!app) return;
+  await createEmojiForMember(app, member);
+}


### PR DESCRIPTION
## Summary
Removes the Regulars-only restriction from `UserEmojiService`. Any non-bot guild member holding at least one of **member, regular, moderator, or admin** roles now gets an application emoji created and kept up to date.

## Changes
- **`src/config/roles.ts`** — adds `ADMIN_ROLE_ID`, `MODERATOR_ROLE_ID`, and `MEMBER_ROLE_ID` exported from env vars (same pattern already used in `RoleScanService`)
- **`src/services/UserEmojiService.ts`** — builds `QUALIFYING_ROLE_IDS` from all four role constants; `hasQualifyingRole()` replaces the single-role check
- **`src/events/GuildMemberUpdate.command.ts`** — role-add trigger now fires when any qualifying role is gained, not just Regulars

🤖 Generated with [Claude Code](https://claude.com/claude-code)