### PR TITLE
feat: emoji + mention header and unified section in journal view

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -22,11 +22,9 @@ import {
 import {
   ContainerBuilder,
   SectionBuilder,
-  SeparatorBuilder,
   TextDisplayBuilder,
   ThumbnailBuilder,
 } from "@discordjs/builders";
-import { SeparatorSpacingSize } from "discord-api-types/v10";
 import Member, {
   type IGameJournalListEntry,
   type IJournalUserSummary,
@@ -157,10 +155,9 @@ async function buildJournalViewPayload(
   components: Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>>;
   files: AttachmentBuilder[];
   flags: number;
+  allowedMentions: { users: string[] };
 }> {
   const game = await Game.getGameById(gameId);
-  const ownerProfile = await Member.getByUserId(targetUserId);
-  const ownerLabel = ownerProfile?.globalName ?? ownerProfile?.username ?? targetUserId;
 
   const total = await Member.countGameJournalEntries(targetUserId, gameId, "__public__");
   const totalPages = Math.max(1, Math.ceil(total / JOURNAL_PAGE_SIZE));
@@ -174,7 +171,6 @@ async function buildJournalViewPayload(
   });
 
   const files: AttachmentBuilder[] = [];
-  const container = new ContainerBuilder();
 
   let coverUrl: string | null = null;
   if (game?.imageData) {
@@ -187,14 +183,8 @@ async function buildJournalViewPayload(
   const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
   const footer = `-# ${total} public ${entryLabel(total)}${pageInfo}`;
 
-  container.addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(
-      `${ownerLabel}'s Game Journal\n## ${gameTitle}`,
-    ),
-  );
-  container.addSeparatorComponents(
-    new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(true),
-  );
+  const emojiPrefix = getUserEmojiString(targetUserId);
+  const ownerTag = emojiPrefix ? `${emojiPrefix} <@${targetUserId}>` : `<@${targetUserId}>`;
 
   const entryLines: string[] = [];
   if (!entries.length) {
@@ -208,13 +198,18 @@ async function buildJournalViewPayload(
   }
   entryLines.push(footer);
 
-  const entriesSection = new SectionBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(entryLines.join("\n\n")),
-  );
+  const section = new SectionBuilder()
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(`${ownerTag}'s Game Journal\n## ${gameTitle}`),
+    )
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(entryLines.join("\n\n")),
+    );
   if (coverUrl) {
-    entriesSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
+    section.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
   }
-  container.addSectionComponents(entriesSection);
+
+  const container = new ContainerBuilder().addSectionComponents(section);
 
   const pageRow = new ActionRowBuilder<ButtonBuilder>();
   if (safePage > 1) {
@@ -243,7 +238,7 @@ async function buildJournalViewPayload(
     components.push(pageRow);
   }
 
-  return { components, files, flags: COMPONENTS_V2_FLAG };
+  return { components, files, flags: COMPONENTS_V2_FLAG, allowedMentions: { users: [] } };
 }
 
 function buildAllEmbed(
@@ -411,6 +406,7 @@ export class GameJournalCommand {
       components: payload.components,
       files: payload.files,
       flags: payload.flags,
+      allowedMentions: payload.allowedMentions,
     });
   }
 
@@ -531,6 +527,7 @@ export class GameJournalCommand {
       components: payload.components,
       files: payload.files,
       flags: payload.flags,
+      allowedMentions: payload.allowedMentions,
     });
   }
 }

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -40,6 +40,7 @@ import {
 } from "../functions/InteractionUtils.js";
 import { formatTableDate } from "../commands/profile.command.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
+import { getUserEmojiString } from "../services/UserEmojiService.js";
 
 const LIST_PAGE_SIZE = 15;
 const ALL_PAGE_SIZE = 20;
@@ -253,9 +254,11 @@ function buildAllEmbed(
   const start = page * ALL_PAGE_SIZE;
   const pageSummaries = summaries.slice(start, start + ALL_PAGE_SIZE);
   const memberLabel = summaries.length === 1 ? "member" : "members";
-  const lines = pageSummaries.map(
-    (s) => `<@${s.userId}> — ${s.gameCount} ${gameLabel(s.gameCount)}`,
-  );
+  const lines = pageSummaries.map((s) => {
+    const emoji = getUserEmojiString(s.userId);
+    const prefix = emoji ? `${emoji} ` : "";
+    return `${prefix}<@${s.userId}> — ${s.gameCount} ${gameLabel(s.gameCount)}`;
+  });
   return new EmbedBuilder()
     .setTitle("Game Journal Users")
     .setDescription(lines.join("\n"))


### PR DESCRIPTION
## Summary
- Journal view header now shows `{emoji} <@userId>'s Game Journal` with the user's custom avatar emoji (falls back to plain mention if no emoji cached)
- Mention uses `allowedMentions: { users: [] }` so it renders visually without pinging the target user
- Header text and entries are now in a single `SectionBuilder` so the game cover thumbnail spans the full content area
- Removed now-unused `SeparatorBuilder` and `SeparatorSpacingSize` imports
- Dropped the redundant `Member.getByUserId` call in `buildJournalViewPayload` (no longer needed)

## Test plan
- [ ] Open a journal view and confirm the emoji + mention appear in the header
- [ ] Confirm the target user is NOT pinged
- [ ] Confirm the game cover thumbnail appears alongside both the header and entries
- [ ] Test with a user who has no cached emoji (should fall back to plain mention)
- [ ] Paginate through a multi-page journal and verify all pages render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)