### PR TITLE
fix: restructure journal header lines

### DIFF
--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -116,10 +116,10 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
 
   // Container 1: owner header + game title + status + thumbnail
   const threadId = threadIds[0] ?? null;
-  const gameTitleLine =
+  const gameTitlePart =
     guildId && threadId
-      ? `## [${gameTitle}](https://discord.com/channels/${guildId}/${threadId})`
-      : `## ${gameTitle}`;
+      ? `[${gameTitle}](https://discord.com/channels/${guildId}/${threadId})`
+      : gameTitle;
 
   let statusLine = "";
   if (nowPlayingMeta?.addedAt) {
@@ -132,10 +132,12 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
     statusLine = `${latest.completionType} on ${completedDate}`;
   }
 
-  const gameInfoContent = statusLine ? `${gameTitleLine}\n${statusLine}` : gameTitleLine;
-  const headerSection = new SectionBuilder()
-    .addTextDisplayComponents(new TextDisplayBuilder().setContent(`## ${ownerTag}'s Game Journal`))
-    .addTextDisplayComponents(new TextDisplayBuilder().setContent(gameInfoContent));
+  const headerLines = [ownerTag, `## ${gameTitlePart} Game Journal`];
+  if (statusLine) headerLines.push(statusLine);
+
+  const headerSection = new SectionBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(headerLines.join("\n")),
+  );
   if (coverUrl) {
     headerSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
   }


### PR DESCRIPTION
## Summary

- Line 1: plain text — emoji + username (no heading)
- Line 2: `## [Game Title](thread) Game Journal` heading
- Line 3: status line (Now Playing / Completed) when present, unchanged

## Test plan

- [ ] Open a journal — confirm three-line header with plain username on top, heading on second line, status below
- [ ] Confirm game title links to thread when one exists, plain text otherwise

🤖 Generated with [Claude Code](https://claude.com/claude-code)