### PR TITLE
feat: extract shared user header container component

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -32,6 +32,7 @@ import {
 import { getUserEmojiString } from "../services/UserEmojiService.js";
 import { buildJournalView } from "../functions/journalView.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
+import { buildUserHeaderContainer } from "../functions/uiComponents.js";
 
 const LIST_PAGE_SIZE = 15;
 const ALL_PAGE_SIZE = 20;
@@ -64,19 +65,17 @@ function buildListComponents(
   totalPages: number,
 ): ContainerBuilder[] {
   const ownerName = target.displayName ?? target.username;
-  const emojiPrefix = getUserEmojiString(target.id);
-  const ownerTag = emojiPrefix ? `${emojiPrefix} ${ownerName}` : ownerName;
-
-  const headerContainer = new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(`${ownerTag}\n## Game Journals`),
-  );
+  const userHeader = buildUserHeaderContainer(target.id, ownerName);
 
   const start = page * LIST_PAGE_SIZE;
   const pageEntries = entries.slice(start, start + LIST_PAGE_SIZE);
-  const lines = pageEntries.map((e) => {
-    const count = isSelf ? e.totalEntries : e.publicEntries;
-    return `**${e.title}** — ${count} ${entryLabel(count)}`;
-  });
+  const lines = [`## Game Journals`];
+  lines.push(
+    ...pageEntries.map((e) => {
+      const count = isSelf ? e.totalEntries : e.publicEntries;
+      return `**${e.title}** — ${count} ${entryLabel(count)}`;
+    }),
+  );
   const pageInfo = totalPages > 1 ? ` • Page ${page + 1}/${totalPages}` : "";
   lines.push(`-# ${entries.length} ${gameLabel(entries.length)}${pageInfo}`);
 
@@ -84,7 +83,7 @@ function buildListComponents(
     new TextDisplayBuilder().setContent(lines.join("\n")),
   );
 
-  return [headerContainer, listContainer];
+  return [userHeader, listContainer];
 }
 
 function buildListSelectRow(

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -13,9 +13,9 @@ import {
 import Member, { type ICompletionRecord } from "../classes/Member.js";
 import Game from "../classes/Game.js";
 import { getThreadsByGameId } from "../classes/Thread.js";
-import { getUserEmojiString } from "../services/UserEmojiService.js";
 import { formatTableDate, formatPlaytimeHours } from "../commands/profile.command.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
+import { buildUserHeaderContainer } from "./uiComponents.js";
 
 const JOURNAL_PAGE_SIZE = 3;
 const ENTRY_SEPARATOR = "​";
@@ -110,11 +110,10 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
   }
 
   const gameTitle = game?.title ?? `Game #${gameId}`;
-  const emojiPrefix = getUserEmojiString(ownerId);
   const ownerName = memberRecord?.globalName ?? memberRecord?.username ?? ownerId;
-  const ownerTag = emojiPrefix ? `${emojiPrefix} ${ownerName}` : ownerName;
+  const userHeaderContainer = buildUserHeaderContainer(ownerId, ownerName);
 
-  // Container 1: owner header + game title + status + thumbnail
+  // Container 2: game title + status + thumbnail
   const threadId = threadIds[0] ?? null;
   const gameTitlePart =
     guildId && threadId
@@ -132,16 +131,16 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
     statusLine = `${latest.completionType} on ${completedDate}`;
   }
 
-  const headerLines = [ownerTag, `## ${gameTitlePart} Game Journal`];
-  if (statusLine) headerLines.push(statusLine);
+  const gameTitleLines = [`## ${gameTitlePart} Game Journal`];
+  if (statusLine) gameTitleLines.push(statusLine);
 
-  const headerSection = new SectionBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(headerLines.join("\n")),
+  const gameTitleSection = new SectionBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(gameTitleLines.join("\n")),
   );
   if (coverUrl) {
-    headerSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
+    gameTitleSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
   }
-  const headerContainer = new ContainerBuilder().addSectionComponents(headerSection);
+  const headerContainer = new ContainerBuilder().addSectionComponents(gameTitleSection);
 
   // Container 3: journal entries + footer
   const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
@@ -221,6 +220,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
   }
 
   const components: Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>> = [
+    userHeaderContainer,
     headerContainer,
     entriesContainer,
   ];

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -1,0 +1,10 @@
+import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
+import { getUserEmojiString } from "../services/UserEmojiService.js";
+
+export function buildUserHeaderContainer(userId: string, displayName: string): ContainerBuilder {
+  const emoji = getUserEmojiString(userId);
+  const text = emoji ? `${emoji} ${displayName}` : displayName;
+  return new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(text),
+  );
+}


### PR DESCRIPTION
## Summary
- New `src/functions/uiComponents.ts` exports `buildUserHeaderContainer(userId, displayName)` — a single `ContainerBuilder` with just the user emoji and display name
- `buildListComponents` (game list per user) now uses the shared component; `## Game Journals` moves into the list content container
- `buildJournalView` (single-game journal) now uses the shared component as its first container; the game title, status line, and cover thumbnail remain in a separate section container below it
- Note: PR #266 (all=true Components V2 conversion) is still pending; `buildAllEmbed` is untouched here since the all-users view has no specific user to header

## Test plan
- [ ] `/game-journal` — user header appears as its own container above the game list
- [ ] `/game-journal member:@someone` — same for another user
- [ ] Select a game — user header appears above the game title section in the journal entry view
- [ ] User emoji renders correctly in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)