### PR TITLE
fix: add Components V2 flags to Now Playing remove interactions

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3031,6 +3031,7 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^np-remove:[^:]+:\d+$/ })
   async handleRemoveNowPlayingButton(interaction: ButtonInteraction): Promise<void> {
+    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     const [, ownerId, gameIdRaw] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -3076,7 +3077,10 @@ export class NowPlayingCommand {
         const container = new ContainerBuilder().addTextDisplayComponents(
           new TextDisplayBuilder().setContent("Your Now Playing list is empty."),
         );
-        await interaction.update({ components: [container] });
+        await interaction.update({
+          components: [container],
+          flags: buildComponentsV2Flags(isEphemeral),
+        });
         return;
       }
       const includeImages = interaction.guildId != null;
@@ -3095,7 +3099,10 @@ export class NowPlayingCommand {
         interaction.guildId,
         components,
       );
-      await interaction.update(this.buildComponentPayload(pmComponents as any, files));
+      await interaction.update({
+        ...this.buildComponentPayload(pmComponents as any, files),
+        flags: buildComponentsV2Flags(isEphemeral),
+      });
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -4861,6 +4868,7 @@ export class NowPlayingCommand {
 
   @SelectMenuComponent({ id: /^nowplaying-remove-select:\d+$/ })
   async handleNowPlayingRemoveSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     const [, ownerId] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       await interaction.reply({
@@ -4883,7 +4891,10 @@ export class NowPlayingCommand {
     const loadingContainer = new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent("Updating your Now Playing remove list..."),
     );
-    await safeUpdate(interaction, { components: [loadingContainer] });
+    await safeUpdate(interaction, {
+      components: [loadingContainer],
+      flags: buildComponentsV2Flags(isEphemeral),
+    });
 
     try {
       const removed = await Member.removeNowPlaying(ownerId, gameId);
@@ -4893,7 +4904,10 @@ export class NowPlayingCommand {
             "Failed to remove that game (it may have been removed already).",
           ),
         );
-        await interaction.editReply({ components: [container] }).catch(() => {});
+        await interaction.editReply({
+          components: [container],
+          flags: buildComponentsV2Flags(isEphemeral),
+        }).catch(() => {});
         return;
       }
       await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
@@ -4907,7 +4921,10 @@ export class NowPlayingCommand {
           interaction.guildId,
           [container],
         );
-        await interaction.editReply({ components: pmComponents }).catch(() => {});
+        await interaction.editReply({
+          components: pmComponents,
+          flags: buildComponentsV2Flags(isEphemeral),
+        }).catch(() => {});
         return;
       }
       const includeImages = interaction.guildId != null;
@@ -4926,13 +4943,19 @@ export class NowPlayingCommand {
         interaction.guildId,
         components,
       );
-      await interaction.editReply(this.buildComponentPayload(pmComponents as any, files)).catch(() => {});
+      await interaction.editReply({
+        ...this.buildComponentPayload(pmComponents as any, files),
+        flags: buildComponentsV2Flags(isEphemeral),
+      }).catch(() => {});
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent(`Could not remove from Now Playing: ${msg}`),
       );
-      await interaction.editReply({ components: [container] }).catch(() => {});
+      await interaction.editReply({
+        components: [container],
+        flags: buildComponentsV2Flags(isEphemeral),
+      }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Summary
- `interaction.update()` and `editReply()` calls in both `handleRemoveNowPlayingButton` and `handleNowPlayingRemoveSelect` were missing the `IS_COMPONENTS_V2` flag
- Discord rejects `ContainerBuilder` (type 17) components at the top level unless the Components V2 flag is set, treating them as requiring ActionRow (type 1)
- The two-component failure (`components[0]` and `components[1]`) matched the DM code path where `withPmNowPlayingList` prepends a list container, resulting in two ContainerBuilders at indices 0 and 1

## Test plan
- [ ] Remove a game from Now Playing in a guild channel - should update successfully
- [ ] Remove a game from Now Playing in DMs (where `withPmNowPlayingList` prepends the list) - should no longer throw "Invalid Form Body"
- [ ] Remove the last game from Now Playing - should show "Your Now Playing list is empty." cleanly
- [ ] Trigger the "Failed to remove" and error paths to verify flags are applied there too

Fixes error reported by user 242859093377810433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)