### PR TITLE
fix: add Components V2 flags to remaining now-playing update calls

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -2240,6 +2240,7 @@ export class NowPlayingCommand {
     interaction: ButtonInteraction,
     ownerId: string,
   ): Promise<void> {
+    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     const entries = getDisplayNowPlayingEntries(
       await Member.getNowPlaying(ownerId),
     ).slice(0, 10);
@@ -2248,7 +2249,7 @@ export class NowPlayingCommand {
         new TextDisplayBuilder().setContent("Your Now Playing list is empty."),
       );
       const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, [container]);
-      await interaction.update({ components: pmComponents });
+      await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(isEphemeral) });
       return;
     }
     const stateToken = buildNowPlayingSortStateToken(entries.length);
@@ -2258,7 +2259,7 @@ export class NowPlayingCommand {
       interaction.guildId,
       components,
     );
-    await interaction.update({ components: pmComponents });
+    await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(isEphemeral) });
   }
 
   private parseNowPlayingCompletionDate(value: string): Date | null {
@@ -2318,7 +2319,7 @@ export class NowPlayingCommand {
         [container],
       );
       if (mode === "update" && "update" in interaction) {
-        await interaction.update({ components: pmComponents });
+        await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(true) });
       } else {
         await safeReply(interaction, {
           components: pmComponents,
@@ -2349,7 +2350,7 @@ export class NowPlayingCommand {
         [container],
       );
       if (mode === "update" && "update" in interaction) {
-        await interaction.update({ components: pmComponents });
+        await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(true) });
       } else {
         await safeReply(interaction, {
           components: pmComponents,
@@ -2397,7 +2398,7 @@ export class NowPlayingCommand {
         [container],
       );
       if (mode === "update" && "update" in interaction) {
-        await interaction.update({ components: pmComponents });
+        await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(true) });
       } else {
         await safeReply(interaction, {
           components: pmComponents,
@@ -2422,7 +2423,7 @@ export class NowPlayingCommand {
     );
 
     if (mode === "update" && "update" in interaction) {
-      await interaction.update({ components: pmComponents });
+      await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(true) });
       return;
     }
     await safeReply(interaction, {
@@ -2476,7 +2477,7 @@ export class NowPlayingCommand {
         new TextDisplayBuilder().setContent("That game could not be found."),
       );
       if (mode === "update" && "update" in interaction) {
-        await interaction.update({ components: [container] });
+        await interaction.update({ components: [container], flags: buildComponentsV2Flags(true) });
       } else {
         await safeReply(interaction, {
           components: [container],
@@ -2492,7 +2493,7 @@ export class NowPlayingCommand {
         new TextDisplayBuilder().setContent("No platform data is available for this game."),
       );
       if (mode === "update" && "update" in interaction) {
-        await interaction.update({ components: [container] });
+        await interaction.update({ components: [container], flags: buildComponentsV2Flags(true) });
       } else {
         await safeReply(interaction, {
           components: [container],
@@ -2534,6 +2535,7 @@ export class NowPlayingCommand {
 
   @SelectMenuComponent({ id: /^nowplaying-edit-platform-slot:\d+:\d+:[a-z0-9_]+$/ })
   async handleEditPlatformSlot(interaction: StringSelectMenuInteraction): Promise<void> {
+    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     const [, ownerId, slotRaw, stateToken] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       await interaction.reply({
@@ -2584,7 +2586,7 @@ export class NowPlayingCommand {
       encodeNowPlayingPlatformState(parsed),
     );
     const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, components);
-    await interaction.update({ components: pmComponents });
+    await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(isEphemeral) });
   }
 
   @SelectMenuComponent({ id: /^nowplaying-edit-note-select:\d+$/ })
@@ -2684,6 +2686,7 @@ export class NowPlayingCommand {
 
   @SelectMenuComponent({ id: /^nowplaying-sort-slot:\d+:\d+:[a-z0-9_]+$/ })
   async handleNowPlayingSortSlot(interaction: StringSelectMenuInteraction): Promise<void> {
+    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     const [, ownerId, slotRaw, stateToken] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -2723,7 +2726,7 @@ export class NowPlayingCommand {
         const container = new ContainerBuilder().addTextDisplayComponents(
           new TextDisplayBuilder().setContent("This sort form has expired. Open Sort again."),
         );
-        await interaction.update({ components: [container] });
+        await interaction.update({ components: [container], flags: buildComponentsV2Flags(isEphemeral) });
         return;
       }
 
@@ -2734,12 +2737,15 @@ export class NowPlayingCommand {
         encodeNowPlayingSortState(parsed),
       );
       const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, components);
-      await interaction.update({ components: pmComponents });
+      await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(isEphemeral) });
     } catch {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("Could not update the sort form right now."),
       );
-      await interaction.update({ components: [container] }).catch(() => {});
+      await interaction.update({
+        components: [container],
+        flags: buildComponentsV2Flags(isEphemeral),
+      }).catch(() => {});
     }
   }
 

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3031,6 +3031,7 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^np-remove:[^:]+:\d+$/ })
   async handleRemoveNowPlayingButton(interaction: ButtonInteraction): Promise<void> {
+    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     const [, ownerId, gameIdRaw] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -3076,7 +3077,10 @@ export class NowPlayingCommand {
         const container = new ContainerBuilder().addTextDisplayComponents(
           new TextDisplayBuilder().setContent("Your Now Playing list is empty."),
         );
-        await interaction.update({ components: [container] });
+        await interaction.update({
+          components: [container],
+          flags: buildComponentsV2Flags(isEphemeral),
+        });
         return;
       }
       const includeImages = interaction.guildId != null;
@@ -3095,7 +3099,10 @@ export class NowPlayingCommand {
         interaction.guildId,
         components,
       );
-      await interaction.update(this.buildComponentPayload(pmComponents as any, files));
+      await interaction.update({
+        ...this.buildComponentPayload(pmComponents as any, files),
+        flags: buildComponentsV2Flags(isEphemeral),
+      });
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -4861,6 +4868,7 @@ export class NowPlayingCommand {
 
   @SelectMenuComponent({ id: /^nowplaying-remove-select:\d+$/ })
   async handleNowPlayingRemoveSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     const [, ownerId] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       await interaction.reply({
@@ -4883,7 +4891,10 @@ export class NowPlayingCommand {
     const loadingContainer = new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent("Updating your Now Playing remove list..."),
     );
-    await safeUpdate(interaction, { components: [loadingContainer] });
+    await safeUpdate(interaction, {
+      components: [loadingContainer],
+      flags: buildComponentsV2Flags(isEphemeral),
+    });
 
     try {
       const removed = await Member.removeNowPlaying(ownerId, gameId);
@@ -4893,7 +4904,10 @@ export class NowPlayingCommand {
             "Failed to remove that game (it may have been removed already).",
           ),
         );
-        await interaction.editReply({ components: [container] }).catch(() => {});
+        await interaction.editReply({
+          components: [container],
+          flags: buildComponentsV2Flags(isEphemeral),
+        }).catch(() => {});
         return;
       }
       await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
@@ -4907,7 +4921,10 @@ export class NowPlayingCommand {
           interaction.guildId,
           [container],
         );
-        await interaction.editReply({ components: pmComponents }).catch(() => {});
+        await interaction.editReply({
+          components: pmComponents,
+          flags: buildComponentsV2Flags(isEphemeral),
+        }).catch(() => {});
         return;
       }
       const includeImages = interaction.guildId != null;
@@ -4926,13 +4943,19 @@ export class NowPlayingCommand {
         interaction.guildId,
         components,
       );
-      await interaction.editReply(this.buildComponentPayload(pmComponents as any, files)).catch(() => {});
+      await interaction.editReply({
+        ...this.buildComponentPayload(pmComponents as any, files),
+        flags: buildComponentsV2Flags(isEphemeral),
+      }).catch(() => {});
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent(`Could not remove from Now Playing: ${msg}`),
       );
-      await interaction.editReply({ components: [container] }).catch(() => {});
+      await interaction.editReply({
+        components: [container],
+        flags: buildComponentsV2Flags(isEphemeral),
+      }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## Summary

- Adds `flags: buildComponentsV2Flags(...)` to 12 `interaction.update()` calls in `now-playing.command.ts` that were passing `ContainerBuilder` (type 17) components without the `IS_COMPONENTS_V2` flag
- Discord rejects these with \"type must be one of (1,)\" without the flag
- Follows the same pattern established in PR #270 for the remove-game handlers

**Handlers fixed:**
- `promptSortNowPlayingButtons` - adds `isEphemeral` from `interaction.message`; fixes 2 update calls
- `promptEditNowPlayingNote` - fixes 2 update calls with `buildComponentsV2Flags(true)` (always ephemeral)
- `promptEditNowPlayingPlatform` - fixes 2 update calls with `buildComponentsV2Flags(true)`
- `promptNowPlayingEditPlatformSelection` - fixes 2 update calls with `buildComponentsV2Flags(true)`
- `handleEditPlatformSlot` - adds `isEphemeral` from `interaction.message`; fixes 1 update call
- `handleNowPlayingSortSlot` - adds `isEphemeral` from `interaction.message`; fixes 3 update calls (including catch block)

## Test plan

- [ ] `tsc --noEmit` passes (verified clean)
- [ ] Sort Now Playing button opens sort UI without Discord type error
- [ ] Edit Notes button responds correctly when list is empty or all entries use Game Journal
- [ ] Edit Platform button responds correctly when list is empty or no game found
- [ ] Platform slot select updates without Discord rejection
- [ ] Sort slot select updates and handles expired-state error gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)