### PR TITLE
feat: two-column layout for buildUserHeaderContainer

### DIFF
--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -1,10 +1,20 @@
-import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
+import { ContainerBuilder, SectionBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import { getUserEmojiString } from "../services/UserEmojiService.js";
 
-export function buildUserHeaderContainer(userId: string, displayName: string): ContainerBuilder {
+export function buildUserHeaderContainer(
+  userId: string,
+  displayName: string,
+  title = "DEFAULT TITLE VALUE",
+): ContainerBuilder {
   const emoji = getUserEmojiString(userId);
-  const text = emoji ? `${emoji} ${displayName}` : displayName;
-  return new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(text),
+  const userText = emoji ? `${emoji} ${displayName}` : displayName;
+
+  const titleSection = new SectionBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(title),
   );
+  const userSection = new SectionBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(userText),
+  );
+
+  return new ContainerBuilder().addSectionComponents(titleSection, userSection);
 }


### PR DESCRIPTION
## Summary
- Adds a configurable `title` parameter (default: `"DEFAULT TITLE VALUE"`) as the left column
- Moves existing emoji + username content to the right column
- Uses `SectionBuilder` for both columns inside the `ContainerBuilder`
- Both existing callers (`game-journal.command.ts`, `journalView.ts`) are unaffected -- they receive the default title

## Test plan
- [ ] Journal list view renders with two columns (left: default title, right: emoji + username)
- [ ] Journal view (per-game) renders the same two-column header
- [ ] Callers that pass a custom title display it correctly in the left column