### PR TITLE
fix: remove bare SectionBuilder usage that crashes journal view

### DIFF
--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -134,12 +134,8 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
   const gameTitleLines = [`## ${gameTitlePart} Game Journal`];
   if (statusLine) gameTitleLines.push(statusLine);
 
-  const gameTitleSection = new SectionBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(gameTitleLines.join("\n")),
-  );
-  if (coverUrl) {
-    gameTitleSection.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
-  }
+  const gameTitleText = new TextDisplayBuilder().setContent(gameTitleLines.join("\n"));
+
   // Container 2: game title + entries + footer
   const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
   const publicQualifier = isOwnerView ? "" : "public ";
@@ -188,11 +184,19 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
 
   entryParts.push(footer);
 
-  const gameContainer = new ContainerBuilder()
-    .addSectionComponents(gameTitleSection)
-    .addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(entryParts.join(`\n${ENTRY_SEPARATOR}\n`)),
+  const gameContainer = new ContainerBuilder();
+  if (coverUrl) {
+    gameContainer.addSectionComponents(
+      new SectionBuilder()
+        .addTextDisplayComponents(gameTitleText)
+        .setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl)),
     );
+  } else {
+    gameContainer.addTextDisplayComponents(gameTitleText);
+  }
+  gameContainer.addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(entryParts.join(`\n${ENTRY_SEPARATOR}\n`)),
+  );
 
   // Nav row
   const navRow = new ActionRowBuilder<ButtonBuilder>();

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -1,20 +1,17 @@
-import { ContainerBuilder, SectionBuilder, TextDisplayBuilder } from "@discordjs/builders";
+import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import { getUserEmojiString } from "../services/UserEmojiService.js";
 
 export function buildUserHeaderContainer(
   userId: string,
   displayName: string,
-  title = "DEFAULT TITLE VALUE",
+  title?: string,
 ): ContainerBuilder {
   const emoji = getUserEmojiString(userId);
   const userText = emoji ? `${emoji} ${displayName}` : displayName;
-
-  const titleSection = new SectionBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(title),
-  );
-  const userSection = new SectionBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(userText),
-  );
-
-  return new ContainerBuilder().addSectionComponents(titleSection, userSection);
+  const container = new ContainerBuilder();
+  if (title) {
+    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`## ${title}`));
+  }
+  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(userText));
+  return container;
 }


### PR DESCRIPTION
## Summary
- `buildUserHeaderContainer` was creating `SectionBuilder` instances with no accessory, which always causes a shapeshift `_UnionValidator` error when Discord.js serializes the component
- `journalView.ts` had the same problem for games with no cover image (no thumbnail to attach to the section)
- Replaced bare `SectionBuilder` usage with `addTextDisplayComponents` directly on the container; the section is now only used in `journalView.ts` when a cover image is present (and a `ThumbnailBuilder` accessory can be attached)
- The optional `title` parameter on `buildUserHeaderContainer` is preserved and rendered as a `## ` heading text display

## Test plan
- [ ] Open journal via Now Playing button for a game **with** a cover image -- section with thumbnail renders
- [ ] Open journal via Now Playing button for a game **without** a cover image -- no crash, plain title text displays
- [ ] Open Game Journals list command -- header shows "Game Journals" title above user name

Fixes: `Error: Received one or more errors` at `SectionBuilder.toJSON`

🤖 Generated with [Claude Code](https://claude.com/claude-code)