### PR TITLE
feat: two-column header layout for game journal views

### DIFF
--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -111,7 +111,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
 
   const gameTitle = game?.title ?? `Game #${gameId}`;
   const ownerName = memberRecord?.globalName ?? memberRecord?.username ?? ownerId;
-  const userHeaderContainer = buildUserHeaderContainer(ownerId, ownerName);
+  const userHeaderContainer = buildUserHeaderContainer(ownerId, ownerName, "Game Journal");
 
   // Container 2: game title + status + thumbnail
   const threadId = threadIds[0] ?? null;

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -1,4 +1,10 @@
-import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
+import { ButtonStyle } from "discord.js";
+import {
+  ButtonBuilder,
+  ContainerBuilder,
+  SectionBuilder,
+  TextDisplayBuilder,
+} from "@discordjs/builders";
 import { getUserEmojiString } from "../services/UserEmojiService.js";
 
 export function buildUserHeaderContainer(
@@ -8,10 +14,21 @@ export function buildUserHeaderContainer(
 ): ContainerBuilder {
   const emoji = getUserEmojiString(userId);
   const userText = emoji ? `${emoji} ${displayName}` : displayName;
-  const container = new ContainerBuilder();
+
   if (title) {
-    container.addTextDisplayComponents(new TextDisplayBuilder().setContent(`## ${title}`));
+    const section = new SectionBuilder()
+      .addTextDisplayComponents(new TextDisplayBuilder().setContent(`## ${title}`))
+      .setButtonAccessory(
+        new ButtonBuilder()
+          .setCustomId(`user-header-label:${userId}`)
+          .setLabel(userText)
+          .setStyle(ButtonStyle.Secondary)
+          .setDisabled(true),
+      );
+    return new ContainerBuilder().addSectionComponents(section);
   }
-  container.addTextDisplayComponents(new TextDisplayBuilder().setContent(userText));
-  return container;
+
+  return new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(userText),
+  );
 }


### PR DESCRIPTION
## Summary
- `buildUserHeaderContainer` now uses a `SectionBuilder` when a `title` is provided: title text on the left, username as a disabled secondary button on the right
- `journalView.ts` passes `"Game Journal"` as the title so the now-playing journal view gets the same two-column header as the game-journal list view

## Layout
```
## Game Journal     [ 🏆 merph518 ]
```
- Left column: `## {title}` as a TextDisplay
- Right column: emoji + display name as a disabled ButtonBuilder accessory

## Test plan
- [ ] Open journal via Now Playing button -- header shows "Game Journal" on left, username button on right
- [ ] Open `/gamejournal` list command -- header shows "Game Journals" on left, username button on right
- [ ] Verify disabled button is not clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)