### PR TITLE
fix: prefer game_id over id in mapGameFromApi to use Oracle GameDB ID

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -149,10 +149,14 @@ export type GameSource = "oracleSQL" | "API";
 /**
  * Maps a Rails API JSON response (snake_case) to IGame.
  * imageData and artData are always null from the API (blobs are not serialized).
+ *
+ * The Rails API uses its own auto-increment PK in `data.id` (which differs from
+ * the Oracle GameDB GAME_ID). The Oracle ID is serialized as `data.game_id`, so
+ * we prefer that field and fall back to `data.id` only if absent.
  */
 function mapGameFromApi(data: any): IGame {
   return {
-    id: Number(data.id ?? data.game_id),
+    id: Number(data.game_id ?? data.id),
     title: String(data.title),
     description: data.description ? String(data.description) : null,
     imageData: null,


### PR DESCRIPTION
## Problem
`/gamedb view title: 1928 source: api` was displaying GameDB ID 8241 instead of 1928.

## Root cause
`mapGameFromApi` was written with `data.id ?? data.game_id`. The Rails API serializes its own auto-increment primary key as `data.id`, which is a different value than the Oracle `GAME_ID`. The Oracle ID is serialized separately as `data.game_id`.

So when the bot called `/api/v1/games/1928`, the API correctly found the record with GameDB ID 1928, but the response contained `data.id = 8241` (Rails PK) and `data.game_id = 1928` (Oracle ID). The old code read the Rails PK and displayed that as the GameDB ID.

## Fix
Swap the field priority to `data.game_id ?? data.id` so the Oracle GameDB ID is used when present, with the Rails PK only as a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)