### PR TITLE
feat: display raw API response in code block for /gamedb view source:api

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -329,6 +329,15 @@ export default class Game {
     }
   }
 
+  /**
+   * Returns the raw `data` payload from the Rails API for a game, without any
+   * field mapping. Useful for debugging what the API actually returns.
+   */
+  static async getGameRawFromApi(id: number): Promise<unknown> {
+    const result = await apiGet<{ data: unknown }>(`/api/v1/games/${id}`);
+    return result?.data ?? null;
+  }
+
   static async getGameById(
     id: number,
     source: GameSource = "oracleSQL",

--- a/src/commands/gamedb.command.ts
+++ b/src/commands/gamedb.command.ts
@@ -1936,6 +1936,17 @@ export class GameDb {
         const game = await Game.getGameById(gameId, source);
         if (game) {
           await this.showGameProfile(interaction, gameId, undefined, source);
+          if (source === "API") {
+            const raw = await Game.getGameRawFromApi(gameId);
+            const json = JSON.stringify(raw, null, 2);
+            const body = json.length > 1900
+              ? json.slice(0, 1900) + "\n...(truncated)"
+              : json;
+            await interaction.followUp({
+              content: `\`\`\`json\n${body}\n\`\`\``,
+              flags: MessageFlags.Ephemeral,
+            });
+          }
           return;
         }
       }


### PR DESCRIPTION
## Summary
When `/gamedb view title:<id> source:api` is used, follow up with an ephemeral code block containing the full raw JSON payload the Rails API returned -- before any field mapping.

## Details
- Adds `Game.getGameRawFromApi(id)` which hits `/api/v1/games/{id}` and returns the unmapped `data` object
- After `showGameProfile` renders, sends an ephemeral ````json```` follow-up with the raw response
- Truncates at 1900 chars with a `...(truncated)` marker to stay within Discord's 2000-char message limit
- Only fires on the API path; oracle lookups are unaffected

## Why
Makes it easy to inspect what the Rails API is actually returning for a given GameDB ID without adding permanent logging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)