### PR TITLE
fix: use safeReply with forceFollowUp and COMPONENTS_V2_FLAG for /gamedb view source:api raw JSON

### DIFF
--- a/src/commands/gamedb.command.ts
+++ b/src/commands/gamedb.command.ts
@@ -1942,9 +1942,10 @@ export class GameDb {
             const body = json.length > 1900
               ? json.slice(0, 1900) + "\n...(truncated)"
               : json;
-            await interaction.followUp({
+            await safeReply(interaction, {
               content: `\`\`\`json\n${body}\n\`\`\``,
-              flags: MessageFlags.Ephemeral,
+              flags: COMPONENTS_V2_FLAG,
+              __forceFollowUp: true,
             });
           }
           return;


### PR DESCRIPTION
## Problem

The raw API JSON follow-up in `/gamedb view source:api` was not sending correctly due to two issues:

1. **Wrong state management**: After `showGameProfile` calls `safeReply` -> `editReply`, the interaction state remains `deferred=true, replied=false`. Calling `interaction.followUp` directly bypasses the `safeReply` helper; using `safeReply` with `__forceFollowUp: true` ensures the message is correctly queued as a follow-up and not treated as an edit.

2. **Missing `COMPONENTS_V2_FLAG`**: The interaction was deferred with `COMPONENTS_V2_FLAG` (IS_COMPONENTS_V2, 1<<15). Discord rejects follow-up messages that omit this flag on an interaction that was originally deferred with it.

3. **Ephemeral removed** per request.

## Change

```diff
- await interaction.followUp({
-   content: `...`,
-   flags: MessageFlags.Ephemeral,
- });
+ await safeReply(interaction, {
+   content: `...`,
+   flags: COMPONENTS_V2_FLAG,
+   __forceFollowUp: true,
+ });
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)