### PR TITLE
fix: isolate API source path in /gamedb view, log response/error, skip import flow

### DIFF
--- a/src/commands/gamedb.command.ts
+++ b/src/commands/gamedb.command.ts
@@ -1930,24 +1930,41 @@ export class GameDb {
 
     const source: GameSource = sourceChoice === "api" ? "API" : "oracleSQL";
     const searchTerm = sanitizeUserInput(query, { preserveNewlines: false });
+
+    if (source === "API") {
+      const gameId = /^\d+$/.test(searchTerm) ? Number(searchTerm) : NaN;
+      if (!Number.isInteger(gameId) || gameId <= 0) {
+        await safeReply(interaction, {
+          content: "API source requires a numeric game ID.",
+          flags: COMPONENTS_V2_FLAG,
+        });
+        return;
+      }
+      let rawContent: string;
+      try {
+        const raw = await Game.getGameRawFromApi(gameId);
+        const json = JSON.stringify(raw, null, 2);
+        const body = json.length > 1900
+          ? json.slice(0, 1900) + "\n...(truncated)"
+          : json;
+        rawContent = `\`\`\`json\n${body}\n\`\`\``;
+      } catch (err: any) {
+        rawContent = `API error: ${err?.message ?? String(err)}`;
+      }
+      await safeReply(interaction, {
+        content: rawContent,
+        flags: COMPONENTS_V2_FLAG,
+        __forceFollowUp: true,
+      });
+      return;
+    }
+
     if (/^\d+$/.test(searchTerm)) {
       const gameId = Number(searchTerm);
       if (Number.isInteger(gameId) && gameId > 0) {
         const game = await Game.getGameById(gameId, source);
         if (game) {
           await this.showGameProfile(interaction, gameId, undefined, source);
-          if (source === "API") {
-            const raw = await Game.getGameRawFromApi(gameId);
-            const json = JSON.stringify(raw, null, 2);
-            const body = json.length > 1900
-              ? json.slice(0, 1900) + "\n...(truncated)"
-              : json;
-            await safeReply(interaction, {
-              content: `\`\`\`json\n${body}\n\`\`\``,
-              flags: COMPONENTS_V2_FLAG,
-              __forceFollowUp: true,
-            });
-          }
           return;
         }
       }


### PR DESCRIPTION
## Problem

When `source=api` and the API call failed (or returned null), `getGameById` returned null, the code fell through to `runSearchFlow`, and the game import path was triggered unintentionally.

## Fix

Pull the `source=api` case into its own early-return block **before** the oracle path:

- Validate that the query is a numeric ID; bail early with a message if not
- Call `getGameRawFromApi` wrapped in `try/catch`
- Post the raw JSON response or error string as a follow-up to the channel
- Always `return` -- `runSearchFlow` is never reached when `source=api`

The oracle path (numeric ID lookup -> search flow -> import) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)