### PR TITLE
feat: log /gamedb view source:api request and response to console log channel

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import { getOraclePool } from "../db/oracleClient.js";
 import { IGDBGameDetails, igdbService } from "../services/IGDB/IgdbService.js";
 import GameSearchSynonym from "./GameSearchSynonym.js";
-import { apiGet } from "../services/RpgClubApiClient.js";
+import { apiGet, apiGetRaw } from "../services/RpgClubApiClient.js";
 
 // Interfaces
 export interface IGame {
@@ -336,6 +336,27 @@ export default class Game {
   static async getGameRawFromApi(id: number): Promise<unknown> {
     const result = await apiGet<{ data: unknown }>(`/api/v1/games/${id}`);
     return result?.data ?? null;
+  }
+
+  /**
+   * Like `getGameRawFromApi` but also returns HTTP status and full request URL
+   * so callers can log the complete request/response details.
+   */
+  static async getGameRawFromApiWithMeta(id: number): Promise<{
+    rawResponse: unknown;
+    gameData: unknown;
+    status: number;
+    url: string;
+  }> {
+    const { rawData, status, url } = await apiGetRaw<{ data: unknown }>(
+      `/api/v1/games/${id}`,
+    );
+    return {
+      rawResponse: rawData,
+      gameData: rawData?.data ?? null,
+      status,
+      url,
+    };
   }
 
   static async getGameById(

--- a/src/commands/gamedb.command.ts
+++ b/src/commands/gamedb.command.ts
@@ -88,7 +88,10 @@ import {
 } from "../functions/CompletionHelpers.js";
 import { searchHltb } from "../scripts/SearchHltb.js";
 import { formatPlatformDisplayName } from "../functions/PlatformDisplay.js";
-import { NOW_PLAYING_FORUM_ID } from "../config/channels.js";
+import {
+  DISCORD_CONSOLE_LOG_CHANNEL_ID,
+  NOW_PLAYING_FORUM_ID,
+} from "../config/channels.js";
 import { NOW_PLAYING_SIDEGAME_TAG_ID } from "../config/tags.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { STANDARD_PLATFORM_IDS } from "../config/standardPlatforms.js";
@@ -380,6 +383,68 @@ function buildChoiceRows(
     rows.push(row);
   }
   return rows;
+}
+
+type ISendableChannel = { send: (options: MessageCreateOptions) => Promise<unknown> };
+
+async function sendGameDbApiLog(
+  interaction: CommandInteraction,
+  gameId: number,
+  url: string,
+  status: number,
+  rawResponse: unknown,
+  error: string | null,
+): Promise<void> {
+  try {
+    const channel = await interaction.client.channels
+      .fetch(DISCORD_CONSOLE_LOG_CHANNEL_ID)
+      .catch(() => null);
+    if (!channel || !channel.isTextBased()) return;
+    if (!("send" in channel)) return;
+    const sendable = channel as unknown as ISendableChannel;
+
+    const userId = interaction.user.id;
+    const timestamp = new Date().toISOString();
+
+    const requestBlock = [
+      `**[GameDB API View]**`,
+      `**User:** <@${userId}>`,
+      `**Game ID:** ${gameId}`,
+      `**URL:** \`${url}\``,
+      `**Time:** ${timestamp}`,
+    ].join("\n");
+
+    if (error) {
+      const errBlock = error.length > 1800
+        ? `${error.slice(0, 1800)}...(truncated)`
+        : error;
+      await sendable.send({
+        content: `${requestBlock}\n\n**Status:** Error\n\`\`\`\n${errBlock}\n\`\`\``,
+      });
+      return;
+    }
+
+    const statusLine = `**Status:** ${status}`;
+    const json = JSON.stringify(rawResponse, null, 2);
+
+    if (json.length > 1800) {
+      const buf = Buffer.from(json, "utf8");
+      const attachment = new AttachmentBuilder(buf, {
+        name: `gamedb-api-${gameId}.json`,
+      });
+      await sendable.send({
+        content: `${requestBlock}\n\n${statusLine}\n**Response:** (see attachment)`,
+        files: [attachment],
+      });
+      return;
+    }
+
+    await sendable.send({
+      content: `${requestBlock}\n\n${statusLine}\n**Response:**\n\`\`\`json\n${json}\n\`\`\``,
+    });
+  } catch {
+    // Do not let logging failures surface to the user
+  }
 }
 
 @Discord()
@@ -1942,14 +2007,27 @@ export class GameDb {
       }
       let rawContent: string;
       try {
-        const raw = await Game.getGameRawFromApi(gameId);
-        const json = JSON.stringify(raw, null, 2);
+        const { rawResponse, gameData, status, url } =
+          await Game.getGameRawFromApiWithMeta(gameId);
+        void sendGameDbApiLog(interaction, gameId, url, status, rawResponse, null);
+        const json = JSON.stringify(gameData, null, 2);
         const body = json.length > 1900
           ? json.slice(0, 1900) + "\n...(truncated)"
           : json;
         rawContent = `\`\`\`json\n${body}\n\`\`\``;
       } catch (err: any) {
-        rawContent = `API error: ${err?.message ?? String(err)}`;
+        const errMsg: string = err?.message ?? String(err);
+        const apiPath = `/api/v1/games/${gameId}`;
+        const baseUrl = process.env.RPGCLUB_API_BASE_URL ?? "";
+        void sendGameDbApiLog(
+          interaction,
+          gameId,
+          `${baseUrl}${apiPath}`,
+          0,
+          null,
+          errMsg,
+        );
+        rawContent = `API error: ${errMsg}`;
       }
       await safeReply(interaction, {
         content: rawContent,

--- a/src/services/RpgClubApiClient.ts
+++ b/src/services/RpgClubApiClient.ts
@@ -50,13 +50,32 @@ export async function apiGet<T>(
 ): Promise<T | null> {
   try {
     const response = await getClient().get<T>(path, config);
-    console.log('path', path);
-    console.log('config', config);
-    console.log('response', response);
     return response.data;
   } catch (err: unknown) {
     if (axios.isAxiosError(err) && err.response?.status === 404) {
       return null;
+    }
+    throw err;
+  }
+}
+
+/**
+ * GET a resource and return raw response metadata alongside the parsed body.
+ * Unlike `apiGet`, this never returns `null` -- 404 responses have `status: 404`
+ * and `rawData: null`. Non-2xx errors (other than 404) still throw.
+ */
+export async function apiGetRaw<T>(
+  path: string,
+  config?: AxiosRequestConfig,
+): Promise<{ rawData: T | null; status: number; url: string }> {
+  const baseURL = process.env.RPGCLUB_API_BASE_URL ?? "";
+  const url = `${baseURL}${path}`;
+  try {
+    const response = await getClient().get<T>(path, config);
+    return { rawData: response.data, status: response.status, url };
+  } catch (err: unknown) {
+    if (axios.isAxiosError(err) && err.response?.status === 404) {
+      return { rawData: null, status: 404, url };
     }
     throw err;
   }


### PR DESCRIPTION
## Summary
Whenever `/gamedb view source:api` is used, all request and response data is now sent to the gamedb logs channel (`DISCORD_CONSOLE_LOG_CHANNEL_ID` `1439333324547035428`).

## Changes

### `RpgClubApiClient.ts`
- Removed leftover temp `console.log` calls from `apiGet`
- Added `apiGetRaw` helper that returns `{ rawData, status, url }` alongside the parsed body, keeping 404 as a value instead of null

### `Game.ts`
- Added `Game.getGameRawFromApiWithMeta(id)` which calls `apiGetRaw` and returns `{ rawResponse, gameData, status, url }`

### `gamedb.command.ts`
- Added `sendGameDbApiLog` function that posts to the log channel with:
  - User mention, game ID, full request URL, ISO timestamp
  - HTTP status code
  - Response as inline ```json``` code block, or as a `.json` file attachment when the payload exceeds 1800 chars
  - Error message block on thrown errors
- `/gamedb view source:api` now calls `getGameRawFromApiWithMeta` instead of `getGameRawFromApi` and fires `sendGameDbApiLog` (non-blocking via `void`) before replying to the user

🤖 Generated with [Claude Code](https://claude.com/claude-code)