### PR TITLE
fix: include request/response headers in /gamedb view API log; capture 401 as value

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -3,7 +3,11 @@ import axios from "axios";
 import { getOraclePool } from "../db/oracleClient.js";
 import { IGDBGameDetails, igdbService } from "../services/IGDB/IgdbService.js";
 import GameSearchSynonym from "./GameSearchSynonym.js";
-import { apiGet, apiGetRaw } from "../services/RpgClubApiClient.js";
+import {
+  apiGet,
+  apiGetRaw,
+  type ApiGetRawMeta,
+} from "../services/RpgClubApiClient.js";
 
 // Interfaces
 export interface IGame {
@@ -339,24 +343,16 @@ export default class Game {
   }
 
   /**
-   * Like `getGameRawFromApi` but also returns HTTP status and full request URL
-   * so callers can log the complete request/response details.
+   * Like `getGameRawFromApi` but also returns HTTP status, request/response
+   * headers, and the full raw response body so callers can log diagnostics.
+   * HTTP errors (4xx/5xx) are returned as values; check `errorMessage`.
    */
-  static async getGameRawFromApiWithMeta(id: number): Promise<{
-    rawResponse: unknown;
-    gameData: unknown;
-    status: number;
-    url: string;
-  }> {
-    const { rawData, status, url } = await apiGetRaw<{ data: unknown }>(
-      `/api/v1/games/${id}`,
-    );
-    return {
-      rawResponse: rawData,
-      gameData: rawData?.data ?? null,
-      status,
-      url,
-    };
+  static async getGameRawFromApiWithMeta(
+    id: number,
+  ): Promise<ApiGetRawMeta & { gameData: unknown }> {
+    const meta = await apiGetRaw<{ data: unknown }>(`/api/v1/games/${id}`);
+    const body = meta.rawData as { data?: unknown } | null;
+    return { ...meta, gameData: body?.data ?? null };
   }
 
   static async getGameById(

--- a/src/commands/gamedb.command.ts
+++ b/src/commands/gamedb.command.ts
@@ -387,13 +387,24 @@ function buildChoiceRows(
 
 type ISendableChannel = { send: (options: MessageCreateOptions) => Promise<unknown> };
 
+function formatHeadersBlock(headers: Record<string, string>): string {
+  const lines = Object.entries(headers)
+    .map(([k, v]) => `${k}: ${v}`)
+    .join("\n");
+  return lines ? `\`\`\`\n${lines}\n\`\`\`` : "`(none)`";
+}
+
 async function sendGameDbApiLog(
   interaction: CommandInteraction,
   gameId: number,
-  url: string,
-  status: number,
-  rawResponse: unknown,
-  error: string | null,
+  meta: {
+    url: string;
+    status: number;
+    rawData: unknown;
+    requestHeaders: Record<string, string>;
+    responseHeaders: Record<string, string>;
+    errorMessage: string | null;
+  },
 ): Promise<void> {
   try {
     const channel = await interaction.client.channels
@@ -405,42 +416,52 @@ async function sendGameDbApiLog(
 
     const userId = interaction.user.id;
     const timestamp = new Date().toISOString();
+    const { url, status, rawData, requestHeaders, responseHeaders, errorMessage } = meta;
 
-    const requestBlock = [
+    const header = [
       `**[GameDB API View]**`,
-      `**User:** <@${userId}>`,
-      `**Game ID:** ${gameId}`,
+      `**User:** <@${userId}>  **Game ID:** ${gameId}`,
       `**URL:** \`${url}\``,
       `**Time:** ${timestamp}`,
+      `**Status:** ${status || "N/A (network error)"}`,
     ].join("\n");
 
-    if (error) {
-      const errBlock = error.length > 1800
-        ? `${error.slice(0, 1800)}...(truncated)`
-        : error;
+    const reqSection = `**Request Headers:**\n${formatHeadersBlock(requestHeaders)}`;
+    const resHeaderSection =
+      `**Response Headers:**\n${formatHeadersBlock(responseHeaders)}`;
+
+    if (errorMessage) {
+      const errBlock = errorMessage.length > 900
+        ? `${errorMessage.slice(0, 900)}...(truncated)`
+        : errorMessage;
       await sendable.send({
-        content: `${requestBlock}\n\n**Status:** Error\n\`\`\`\n${errBlock}\n\`\`\``,
+        content: [
+          header,
+          reqSection,
+          resHeaderSection,
+          `**Error:**\n\`\`\`\n${errBlock}\n\`\`\``,
+        ].join("\n\n"),
       });
       return;
     }
 
-    const statusLine = `**Status:** ${status}`;
-    const json = JSON.stringify(rawResponse, null, 2);
+    const json = JSON.stringify(rawData, null, 2);
+    const preamble = [header, reqSection, resHeaderSection].join("\n\n");
 
-    if (json.length > 1800) {
+    if (json.length > 1200) {
       const buf = Buffer.from(json, "utf8");
       const attachment = new AttachmentBuilder(buf, {
         name: `gamedb-api-${gameId}.json`,
       });
       await sendable.send({
-        content: `${requestBlock}\n\n${statusLine}\n**Response:** (see attachment)`,
+        content: `${preamble}\n\n**Response:** (see attachment)`,
         files: [attachment],
       });
       return;
     }
 
     await sendable.send({
-      content: `${requestBlock}\n\n${statusLine}\n**Response:**\n\`\`\`json\n${json}\n\`\`\``,
+      content: `${preamble}\n\n**Response:**\n\`\`\`json\n${json}\n\`\`\``,
     });
   } catch {
     // Do not let logging failures surface to the user
@@ -2007,26 +2028,29 @@ export class GameDb {
       }
       let rawContent: string;
       try {
-        const { rawResponse, gameData, status, url } =
-          await Game.getGameRawFromApiWithMeta(gameId);
-        void sendGameDbApiLog(interaction, gameId, url, status, rawResponse, null);
-        const json = JSON.stringify(gameData, null, 2);
-        const body = json.length > 1900
-          ? json.slice(0, 1900) + "\n...(truncated)"
-          : json;
-        rawContent = `\`\`\`json\n${body}\n\`\`\``;
+        const meta = await Game.getGameRawFromApiWithMeta(gameId);
+        void sendGameDbApiLog(interaction, gameId, meta);
+        if (meta.errorMessage) {
+          rawContent = `API error: ${meta.errorMessage}`;
+        } else {
+          const json = JSON.stringify(meta.gameData, null, 2);
+          const body = json.length > 1900
+            ? json.slice(0, 1900) + "\n...(truncated)"
+            : json;
+          rawContent = `\`\`\`json\n${body}\n\`\`\``;
+        }
       } catch (err: any) {
+        // Only non-Axios errors (network failures) reach here
         const errMsg: string = err?.message ?? String(err);
-        const apiPath = `/api/v1/games/${gameId}`;
         const baseUrl = process.env.RPGCLUB_API_BASE_URL ?? "";
-        void sendGameDbApiLog(
-          interaction,
-          gameId,
-          `${baseUrl}${apiPath}`,
-          0,
-          null,
-          errMsg,
-        );
+        void sendGameDbApiLog(interaction, gameId, {
+          url: `${baseUrl}/api/v1/games/${gameId}`,
+          status: 0,
+          rawData: null,
+          requestHeaders: {},
+          responseHeaders: {},
+          errorMessage: errMsg,
+        });
         rawContent = `API error: ${errMsg}`;
       }
       await safeReply(interaction, {

--- a/src/services/RpgClubApiClient.ts
+++ b/src/services/RpgClubApiClient.ts
@@ -59,23 +59,64 @@ export async function apiGet<T>(
   }
 }
 
+export type ApiGetRawMeta = {
+  rawData: unknown;
+  status: number;
+  url: string;
+  /** Request headers actually sent (Authorization value is masked). */
+  requestHeaders: Record<string, string>;
+  /** Response headers returned by the server. */
+  responseHeaders: Record<string, string>;
+  /** Non-null when the request produced an HTTP or network error. */
+  errorMessage: string | null;
+};
+
+function maskHeaders(raw: Record<string, unknown>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    const key = String(k);
+    const val = String(v ?? "");
+    out[key] = key.toLowerCase() === "authorization" ? "Bearer ***" : val;
+  }
+  return out;
+}
+
 /**
- * GET a resource and return raw response metadata alongside the parsed body.
- * Unlike `apiGet`, this never returns `null` -- 404 responses have `status: 404`
- * and `rawData: null`. Non-2xx errors (other than 404) still throw.
+ * GET a resource and return full response metadata alongside the parsed body.
+ * Unlike `apiGet`, HTTP errors (4xx/5xx) are returned as values rather than
+ * thrown -- check `errorMessage` and `status` to detect them. Only non-Axios
+ * errors (e.g. network failure before a response arrives) still throw.
  */
 export async function apiGetRaw<T>(
   path: string,
   config?: AxiosRequestConfig,
-): Promise<{ rawData: T | null; status: number; url: string }> {
+): Promise<ApiGetRawMeta> {
   const baseURL = process.env.RPGCLUB_API_BASE_URL ?? "";
   const url = `${baseURL}${path}`;
   try {
     const response = await getClient().get<T>(path, config);
-    return { rawData: response.data, status: response.status, url };
+    return {
+      rawData: response.data,
+      status: response.status,
+      url,
+      requestHeaders: maskHeaders(
+        (response.config.headers ?? {}) as Record<string, unknown>,
+      ),
+      responseHeaders: response.headers as Record<string, string>,
+      errorMessage: null,
+    };
   } catch (err: unknown) {
-    if (axios.isAxiosError(err) && err.response?.status === 404) {
-      return { rawData: null, status: 404, url };
+    if (axios.isAxiosError(err)) {
+      return {
+        rawData: err.response?.data ?? null,
+        status: err.response?.status ?? 0,
+        url,
+        requestHeaders: maskHeaders(
+          (err.config?.headers ?? {}) as Record<string, unknown>,
+        ),
+        responseHeaders: (err.response?.headers ?? {}) as Record<string, string>,
+        errorMessage: err.message,
+      };
     }
     throw err;
   }


### PR DESCRIPTION
## Problem
The first log showed a doubled `/api/api/` path (already fixed by #286 merging). The second request hit the correct URL but returned a 401, but the log only said `Request failed with status code 401` with no visibility into what headers were actually sent.

## Changes

### `RpgClubApiClient.ts`
- `apiGetRaw` now captures **all** HTTP errors (4xx/5xx) as return values instead of throwing -- check `errorMessage` field; only non-Axios network errors still throw
- Returns `requestHeaders` (Authorization value masked as `Bearer ***`) and `responseHeaders` alongside status and body

### `Game.ts`
- `getGameRawFromApiWithMeta` spreads the new `ApiGetRawMeta` fields through

### `gamedb.command.ts`
- `sendGameDbApiLog` now renders request headers, response headers, status, and error/response body -- 401s show the full picture instead of surfacing as a thrown exception
- View command's API branch uses `errorMessage` field to detect HTTP errors without a separate catch

## What the log will now show
- **Request Headers** block (Authorization masked)
- **Response Headers** block (includes `www-authenticate` etc.)
- **Status** code on every response including 4xx
- Response body or file attachment

🤖 Generated with [Claude Code](https://claude.com/claude-code)