### PR TITLE
fix(UserEmojiService): add FORCE_EMOJI_REFRESH startup flag to re-upload all emojis

### DIFF
--- a/src/services/UserEmojiService.ts
+++ b/src/services/UserEmojiService.ts
@@ -109,12 +109,16 @@ export function renderUsernameWithEmoji(userId: string, displayName: string): st
 export async function startUserEmojiService(client: Client): Promise<void> {
   if (initialized) return;
   initialized = true;
-  syncAllRegularsEmoji(client).catch((err) => {
+  const forceRefresh = process.env["FORCE_EMOJI_REFRESH"] === "true";
+  if (forceRefresh) {
+    console.log("[UserEmojiService] FORCE_EMOJI_REFRESH detected -- all emojis will be re-uploaded.");
+  }
+  syncAllRegularsEmoji(client, forceRefresh).catch((err) => {
     console.error("[UserEmojiService] Initial sync failed:", err);
   });
 }
 
-async function syncAllRegularsEmoji(client: Client): Promise<void> {
+async function syncAllRegularsEmoji(client: Client, forceRefresh = false): Promise<void> {
   const app = client.application;
   if (!app) {
     console.error("[UserEmojiService] client.application not available.");
@@ -151,12 +155,19 @@ async function syncAllRegularsEmoji(client: Client): Promise<void> {
 
     if (storedName) {
       const emojiId = discordEmojis.get(storedName);
-      if (emojiId) {
+      if (emojiId && !forceRefresh) {
         emojiCache.set(userId, { emojiId, emojiName: storedName });
         claimedNames.add(storedName);
         continue;
       }
-      // Emoji missing from Discord but DB has a name -- recreate it
+      // Delete the existing emoji so it can be re-uploaded (force refresh or missing from Discord)
+      if (emojiId) {
+        try {
+          await app.emojis.delete(emojiId);
+        } catch (err) {
+          console.error(`[UserEmojiService] Failed to delete emoji for refresh (${member.displayName}):`, err);
+        }
+      }
       const avatarUrl = member.displayAvatarURL({ extension: "png", size: 128, forceStatic: true });
       try {
         const emoji = await app.emojis.create({


### PR DESCRIPTION
## Summary

Existing emojis created before the circular-crop change will stay square indefinitely because the sync skips re-uploading any emoji that already exists in Discord. This adds a one-time escape hatch.

## Usage

On the desktop/bot host, start the bot once with the env var set:

```
FORCE_EMOJI_REFRESH=true npm start
```

The service will log `FORCE_EMOJI_REFRESH detected`, delete every existing `u_` emoji, and re-upload them all with the circular crop applied. On the next restart (without the flag) normal sync resumes.

## Changes

- `startUserEmojiService` reads `process.env.FORCE_EMOJI_REFRESH` and passes it into the sync
- `syncAllRegularsEmoji` accepts `forceRefresh = false`; when true, the early-exit `continue` is skipped and the existing emoji is deleted before re-creation
- Normal (non-force) behaviour is unchanged

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)