### PR TITLE
fix(uiComponents): use setEmoji() for user header button instead of label markup

### DIFF
--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -5,28 +5,38 @@ import {
   SectionBuilder,
   TextDisplayBuilder,
 } from "@discordjs/builders";
-import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
+import {
+  getUserEmojiString,
+  renderUsernameWithEmoji,
+} from "../services/UserEmojiService.js";
 
 export function buildUserHeaderContainer(
   userId: string,
   displayName: string,
   title?: string,
 ): ContainerBuilder {
-  const userText = renderUsernameWithEmoji(userId, displayName);
-
   if (title) {
+    // Button labels do not render custom emoji markup -- use setEmoji() instead.
+    const emojiString = getUserEmojiString(userId);
+    let button = new ButtonBuilder()
+      .setCustomId(`user-header-label:${userId}`)
+      .setLabel(displayName)
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(true);
+    if (emojiString) {
+      // setEmoji requires APIMessageComponentEmoji; parse <:name:id> format.
+      const match = emojiString.match(/^<:([^:]+):(\d+)>$/);
+      if (match) {
+        button = button.setEmoji({ name: match[1], id: match[2] });
+      }
+    }
     const section = new SectionBuilder()
       .addTextDisplayComponents(new TextDisplayBuilder().setContent(`## ${title}`))
-      .setButtonAccessory(
-        new ButtonBuilder()
-          .setCustomId(`user-header-label:${userId}`)
-          .setLabel(userText)
-          .setStyle(ButtonStyle.Secondary)
-          .setDisabled(true),
-      );
+      .setButtonAccessory(button);
     return new ContainerBuilder().addSectionComponents(section);
   }
 
+  const userText = renderUsernameWithEmoji(userId, displayName);
   return new ContainerBuilder().addTextDisplayComponents(
     new TextDisplayBuilder().setContent(userText),
   );


### PR DESCRIPTION
## Problem
Discord button labels do not render custom emoji syntax (`<:name:id>`). The user avatar emoji was showing as raw text (e.g. `<:u_merph518:150886331477053041> merph518`) instead of rendering as an emoji.

## Root Cause
`buildUserHeaderContainer` was calling `renderUsernameWithEmoji()` to produce a combined `emoji + displayName` string, then passing that whole string to `.setLabel()`. Discord renders emoji markup in message content but **not** in button labels.

## Fix
- Split the emoji lookup and button construction.
- Call `.setEmoji({ name, id })` (the `APIMessageComponentEmoji` form required by `@discordjs/builders`) for the emoji.
- Keep the plain `displayName` as `.setLabel()`.
- The `renderUsernameWithEmoji` path (for text-display components, not buttons) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)