### PR TITLE
fix(uiComponents): enable user header button with no-op handler

### DIFF
--- a/src/commands/shared-ui.handler.ts
+++ b/src/commands/shared-ui.handler.ts
@@ -1,0 +1,14 @@
+import { ButtonInteraction } from "discord.js";
+import { ButtonComponent, Discord } from "discordx";
+
+/**
+ * No-op handler for decorative/label buttons used in UI component headers.
+ * These buttons are enabled (so they render with full styling) but do nothing.
+ */
+@Discord()
+export class SharedUiHandler {
+  @ButtonComponent({ id: /^user-header-label:/ })
+  async handleUserHeaderLabel(interaction: ButtonInteraction): Promise<void> {
+    await interaction.deferUpdate().catch(() => {});
+  }
+}

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -21,8 +21,7 @@ export function buildUserHeaderContainer(
     let button = new ButtonBuilder()
       .setCustomId(`user-header-label:${userId}`)
       .setLabel(displayName)
-      .setStyle(ButtonStyle.Secondary)
-      .setDisabled(true);
+      .setStyle(ButtonStyle.Secondary);
     if (emojiString) {
       // setEmoji requires APIMessageComponentEmoji; parse <:name:id> format.
       const match = emojiString.match(/^<:([^:]+):(\d+)>$/);

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -5,28 +5,38 @@ import {
   SectionBuilder,
   TextDisplayBuilder,
 } from "@discordjs/builders";
-import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
+import {
+  getUserEmojiString,
+  renderUsernameWithEmoji,
+} from "../services/UserEmojiService.js";
 
 export function buildUserHeaderContainer(
   userId: string,
   displayName: string,
   title?: string,
 ): ContainerBuilder {
-  const userText = renderUsernameWithEmoji(userId, displayName);
-
   if (title) {
+    // Button labels do not render custom emoji markup -- use setEmoji() instead.
+    const emojiString = getUserEmojiString(userId);
+    let button = new ButtonBuilder()
+      .setCustomId(`user-header-label:${userId}`)
+      .setLabel(displayName)
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(true);
+    if (emojiString) {
+      // setEmoji requires APIMessageComponentEmoji; parse <:name:id> format.
+      const match = emojiString.match(/^<:([^:]+):(\d+)>$/);
+      if (match) {
+        button = button.setEmoji({ name: match[1], id: match[2] });
+      }
+    }
     const section = new SectionBuilder()
       .addTextDisplayComponents(new TextDisplayBuilder().setContent(`## ${title}`))
-      .setButtonAccessory(
-        new ButtonBuilder()
-          .setCustomId(`user-header-label:${userId}`)
-          .setLabel(userText)
-          .setStyle(ButtonStyle.Secondary)
-          .setDisabled(true),
-      );
+      .setButtonAccessory(button);
     return new ContainerBuilder().addSectionComponents(section);
   }
 
+  const userText = renderUsernameWithEmoji(userId, displayName);
   return new ContainerBuilder().addTextDisplayComponents(
     new TextDisplayBuilder().setContent(userText),
   );


### PR DESCRIPTION
## Summary

Removes `.setDisabled(true)` from the user header section button in `buildUserHeaderContainer`. The button now renders as an active button (full styling, not greyed out).

A new `SharedUiHandler` in `src/commands/shared-ui.handler.ts` silently acknowledges the interaction via `deferUpdate()`, so clicking the button does nothing visible -- no error, no response.

## Changes
- `src/functions/uiComponents.ts` -- removed `.setDisabled(true)`
- `src/commands/shared-ui.handler.ts` -- new no-op `@ButtonComponent` handler for `user-header-label:*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)