### PR TITLE
fix(profile): add 60 NBSP on blank lines between blocks to widen message

### DIFF
--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -195,7 +195,7 @@ function buildProfileContentContainer(
   }
 
   return new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(blocks.join("\n\n")),
+    new TextDisplayBuilder().setContent(blocks.join(`\n${" ".repeat(60)}\n`)),
   );
 }
 


### PR DESCRIPTION
Replaces the plain `\n\n` block separator with `\n` + 60 non-breaking spaces + `\n`, pushing the Discord message container wider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)