### PR TITLE
feat(now-playing): add journal select dropdown to list view

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -97,6 +97,8 @@ export interface IMemberNowPlayingEntry {
   sortOrder: number | null;
   journalEnabled: boolean;
   hasPublicJournalEntry: boolean;
+  publicJournalCount: number;
+  lastPublicJournalAt: Date | null;
 }
 
 export interface IMemberNowPlayingList {
@@ -264,6 +266,8 @@ export default class Member {
         SORT_ORDER: number | null;
         JOURNAL_ENABLED: number | null;
         HAS_PUBLIC_JOURNAL_ENTRY: number | null;
+        PUBLIC_JOURNAL_COUNT: number | null;
+        LAST_PUBLIC_JOURNAL_AT: Date | string | null;
       }>(
         `SELECT g.GAME_ID,
                 g.TITLE,
@@ -285,7 +289,17 @@ export default class Member {
                       AND je.IS_PUBLIC = 1
                   ) THEN 1
                   ELSE 0
-                END AS HAS_PUBLIC_JOURNAL_ENTRY
+                END AS HAS_PUBLIC_JOURNAL_ENTRY,
+                (SELECT COUNT(*)
+                   FROM USER_GAME_JOURNAL_ENTRIES je2
+                  WHERE je2.USER_ID = u.USER_ID
+                    AND je2.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
+                    AND je2.IS_PUBLIC = 1) AS PUBLIC_JOURNAL_COUNT,
+                (SELECT MAX(je3.CREATED_AT)
+                   FROM USER_GAME_JOURNAL_ENTRIES je3
+                  WHERE je3.USER_ID = u.USER_ID
+                    AND je3.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
+                    AND je3.IS_PUBLIC = 1) AS LAST_PUBLIC_JOURNAL_AT
            FROM USER_NOW_PLAYING u
            JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
            LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
@@ -320,6 +334,12 @@ export default class Member {
           sortOrder: r.SORT_ORDER == null ? null : Number(r.SORT_ORDER),
           journalEnabled: Number(r.JOURNAL_ENABLED ?? 0) === 1,
           hasPublicJournalEntry: Number(r.HAS_PUBLIC_JOURNAL_ENTRY ?? 0) === 1,
+          publicJournalCount: Number(r.PUBLIC_JOURNAL_COUNT ?? 0),
+          lastPublicJournalAt: r.LAST_PUBLIC_JOURNAL_AT instanceof Date
+            ? r.LAST_PUBLIC_JOURNAL_AT
+            : r.LAST_PUBLIC_JOURNAL_AT
+              ? new Date(r.LAST_PUBLIC_JOURNAL_AT as any)
+              : null,
         }))
         .slice(0, MAX_NOW_PLAYING);
     } finally {
@@ -406,6 +426,8 @@ export default class Member {
             sortOrder: null,
             journalEnabled: false,
             hasPublicJournalEntry: false,
+            publicJournalCount: 0,
+            lastPublicJournalAt: null,
           });
         }
       }

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -138,6 +138,7 @@ const NOW_PLAYING_EDIT_MENU_JOURNAL_PREFIX = "nowplaying-edit-menu-journal";
 const NOW_PLAYING_JOURNAL_OPTIN_SELECT_PREFIX = "nowplaying-journal-optin-select";
 const NOW_PLAYING_REMOVE_SELECT_PREFIX = "nowplaying-remove-select";
 const NOW_PLAYING_JOURNAL_OPEN_PREFIX = "nowplaying-journal-open";
+const NOW_PLAYING_JOURNAL_VIEW_SELECT_PREFIX = "nowplaying-journal-view-select";
 const NOW_PLAYING_JOURNAL_ADD_PREFIX = "nowplaying-journal-add";
 const NOW_PLAYING_JOURNAL_EDIT_PREFIX = "nowplaying-journal-edit";
 const NOW_PLAYING_JOURNAL_EDIT_SELECT_PREFIX = "nowplaying-journal-edit-select";
@@ -228,7 +229,7 @@ export async function restoreJournalMessageContextsFromDb(): Promise<void> {
 }
 
 type NowPlayingMessageComponents = Array<
-  ContainerBuilder | MediaGalleryBuilder | ActionRowBuilder<ButtonBuilder>
+  ContainerBuilder | MediaGalleryBuilder | ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>
 >;
 
 function extractJournalPrivacyFromInteraction(interaction: ModalSubmitInteraction): boolean {
@@ -258,6 +259,7 @@ function extractJournalPrivacyFromInteraction(interaction: ModalSubmitInteractio
   return false;
 }
 type NowPlayingListComponents = ContainerBuilder[];
+type NowPlayingPayloadComponents = Array<ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder>>;
 
 function buildComponentsV2Flags(isEphemeral: boolean): number {
   return (isEphemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
@@ -3267,6 +3269,51 @@ export class NowPlayingCommand {
     await this.trackJournalReply(interaction, ownerId, gameId);
   }
 
+  @SelectMenuComponent({ id: /^nowplaying-journal-view-select:\d+$/ })
+  async handleNowPlayingJournalViewSelect(
+    interaction: StringSelectMenuInteraction,
+  ): Promise<void> {
+    const [, ownerId] = interaction.customId.split(":");
+    const gameId = Number(interaction.values?.[0]);
+    if (!gameId) return;
+    if (
+      !(await this.canUseJournalFeature(ownerId)) ||
+      !(await this.canUseJournalFeature(interaction.user.id))
+    ) {
+      await safeReply(interaction, {
+        content: "Journal requires the Regulars role.",
+        flags: buildComponentsV2Flags(true),
+      });
+      return;
+    }
+    const nowPlayingEntries = getDisplayNowPlayingEntries(await Member.getNowPlaying(ownerId));
+    const selected = nowPlayingEntries.find((e) => e.gameId === gameId);
+    if (!selected?.journalEnabled || !selected.hasPublicJournalEntry) {
+      await safeReply(interaction, {
+        content: "This game has no public journal entries.",
+        flags: buildComponentsV2Flags(true),
+      });
+      return;
+    }
+    const payload = await this.buildJournalComponents(
+      ownerId,
+      interaction.guildId ? "__public__" : interaction.user.id,
+      gameId,
+      1,
+      interaction.guildId,
+    );
+    if (interaction.guildId) {
+      await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
+    }
+    await safeReply(interaction, {
+      components: payload.components,
+      files: payload.files,
+      flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
+      allowedMentions: payload.allowedMentions,
+    });
+    await this.trackJournalReply(interaction, ownerId, gameId);
+  }
+
   @ButtonComponent({ id: /^nowplaying-journal-page:\d+:\d+:(prev|next):\d+$/ })
   async handleNowPlayingJournalPage(interaction: ButtonInteraction): Promise<void> {
     const [, ownerId, gameIdRaw, , pageRaw] = interaction.customId.split(":");
@@ -4556,7 +4603,7 @@ export class NowPlayingCommand {
     showNotes: boolean = false,
     showPrivateOnlyJournalButtons: boolean = false,
     singleUserMode: boolean = false,
-  ): Promise<{ components: NowPlayingListComponents; files: AttachmentBuilder[] }> {
+  ): Promise<{ components: NowPlayingPayloadComponents; files: AttachmentBuilder[] }> {
     const [{ files, covers }, ownerCanUseJournal] = await Promise.all([
       this.buildNowPlayingAttachments(entries, NOW_PLAYING_COMPOSITE_MAX),
       this.canUseJournalFeature(target.id),
@@ -4584,7 +4631,34 @@ export class NowPlayingCommand {
       "Now Playing",
       headerCustomId,
     );
-    return { components: [headerContainer, ...listComponents], files };
+    const journalSelectRow = this.buildJournalSelectRow(entries, target.id);
+    const trailingComponents: NowPlayingPayloadComponents = journalSelectRow ? [journalSelectRow] : [];
+    return { components: [headerContainer, ...listComponents, ...trailingComponents], files };
+  }
+
+  private buildJournalSelectRow(
+    entries: IMemberNowPlayingEntry[],
+    ownerId: string,
+  ): ActionRowBuilder<StringSelectMenuBuilder> | null {
+    const journalEntries = entries.filter(
+      (e) => e.journalEnabled && e.hasPublicJournalEntry,
+    );
+    if (!journalEntries.length) return null;
+    const options = journalEntries.map((e) => {
+      const rawLabel = `${e.title} Game Journal`;
+      const label = rawLabel.length > 100 ? `${rawLabel.slice(0, 97)}...` : rawLabel;
+      const countText = e.publicJournalCount === 1 ? "1 entry" : `${e.publicJournalCount} entries`;
+      const lastPart = e.lastPublicJournalAt
+        ? ` · Last entry ${formatTableDate(e.lastPublicJournalAt)}`
+        : "";
+      const description = `${countText}${lastPart}`.slice(0, 100);
+      return { label, description, value: String(e.gameId) };
+    });
+    const select = new StringSelectMenuBuilder()
+      .setCustomId(`${NOW_PLAYING_JOURNAL_VIEW_SELECT_PREFIX}:${ownerId}`)
+      .setPlaceholder("View Game Journals")
+      .addOptions(options);
+    return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
   }
 
   private async buildNowPlayingCompositeImageUrl(
@@ -5206,7 +5280,7 @@ export class NowPlayingCommand {
   private withNowPlayingActions(
     isOwnList: boolean,
     ownerId: string,
-    components: NowPlayingListComponents,
+    components: NowPlayingPayloadComponents,
     showNotes: boolean,
     hasDisplayableNotes: boolean = true,
     includeEditButton: boolean = true,
@@ -5484,7 +5558,7 @@ export class NowPlayingCommand {
   }
 
   private async deleteRecentJournalMessagesInChannel(
-    interaction: ButtonInteraction | ModalSubmitInteraction,
+    interaction: ButtonInteraction | ModalSubmitInteraction | StringSelectMenuInteraction,
     ownerUserId: string,
     gameId: number,
   ): Promise<void> {
@@ -5532,7 +5606,7 @@ export class NowPlayingCommand {
   }
 
   private async trackJournalReply(
-    interaction: ButtonInteraction | ModalSubmitInteraction,
+    interaction: ButtonInteraction | ModalSubmitInteraction | StringSelectMenuInteraction,
     ownerUserId: string,
     gameId: number,
   ): Promise<void> {

--- a/src/tests/now-playing-journal-components.test.ts
+++ b/src/tests/now-playing-journal-components.test.ts
@@ -47,6 +47,8 @@ test("now-playing list components serialize with mixed journal-enabled entries",
     sortOrder: null,
     journalEnabled: true,
     hasPublicJournalEntry: true,
+    publicJournalCount: 3,
+    lastPublicJournalAt: null,
   }, {
     gameId: 102,
     title: "Notes Only Game",
@@ -60,6 +62,8 @@ test("now-playing list components serialize with mixed journal-enabled entries",
     sortOrder: null,
     journalEnabled: false,
     hasPublicJournalEntry: false,
+    publicJournalCount: 0,
+    lastPublicJournalAt: null,
   }];
 
   const components = command.buildNowPlayingEntryComponents(
@@ -96,6 +100,8 @@ test("owner list shows journal buttons for multiple journal-enabled entries", ()
     sortOrder: null,
     journalEnabled: true,
     hasPublicJournalEntry: false,
+    publicJournalCount: 0,
+    lastPublicJournalAt: null,
   }, {
     gameId: 202,
     title: "Journal Entry Two",
@@ -109,6 +115,8 @@ test("owner list shows journal buttons for multiple journal-enabled entries", ()
     sortOrder: null,
     journalEnabled: true,
     hasPublicJournalEntry: true,
+    publicJournalCount: 2,
+    lastPublicJournalAt: null,
   }];
 
   const components = command.buildNowPlayingEntryComponents(
@@ -141,6 +149,8 @@ test("owner list with 10 entries stays serializable and keeps journal buttons", 
     sortOrder: null,
     journalEnabled: true,
     hasPublicJournalEntry: false,
+    publicJournalCount: 0,
+    lastPublicJournalAt: null,
   }));
 
   const components = command.buildNowPlayingEntryComponents(


### PR DESCRIPTION
## Summary
- When a user's now-playing list contains games with journals enabled and at least one public entry, a **\"View Game Journals\"** select dropdown is added below the main list container
- Each option is labeled `<Game Name> Game Journal` with a description showing the public entry count and date of the last public entry
- Selecting an option opens that game's journal view (same behavior as the per-entry Game Journal button)

## Implementation details
- Extended `IMemberNowPlayingEntry` with `publicJournalCount` and `lastPublicJournalAt`, fetched via scalar subqueries in `getNowPlaying`
- Added `buildJournalSelectRow` private method and `NOW_PLAYING_JOURNAL_VIEW_SELECT_PREFIX` constant
- Added `handleNowPlayingJournalViewSelect` handler (`@SelectMenuComponent`) with resume-after-restart support via stable custom ID format `nowplaying-journal-view-select:{ownerId}`
- Introduced `NowPlayingPayloadComponents` type to accommodate the mixed container + action row return from `buildNowPlayingListPayload`

## Test plan
- [ ] Run `/now-playing list` as a user with at least one journal-enabled game with a public entry -- dropdown appears below the list
- [ ] Run `/now-playing list` with no journal-eligible games -- no dropdown appears
- [ ] Select a game from the dropdown -- journal opens correctly
- [ ] Verify the option description shows correct entry count and last entry date
- [ ] Confirm bot restart doesn't break the select (stable custom ID)

🤖 Generated with [Claude Code](https://claude.com/claude-code)