### PR TITLE
fix(now-playing): allow anyone to use the journal view select

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3276,12 +3276,9 @@ export class NowPlayingCommand {
     const [, ownerId] = interaction.customId.split(":");
     const gameId = Number(interaction.values?.[0]);
     if (!gameId) return;
-    if (
-      !(await this.canUseJournalFeature(ownerId)) ||
-      !(await this.canUseJournalFeature(interaction.user.id))
-    ) {
+    if (!(await this.canUseJournalFeature(ownerId))) {
       await safeReply(interaction, {
-        content: "Journal requires the Regulars role.",
+        content: "This user's journal is not available.",
         flags: buildComponentsV2Flags(true),
       });
       return;


### PR DESCRIPTION
## Summary
- Removes the viewer Regulars role check from the journal view select handler
- The select only surfaces public entries, so it should be accessible to all users
- The owner check is kept since non-Regulars cannot have journals

## Test plan
- [ ] Non-Regular uses the journal select on a Regular's now-playing list -- journal opens
- [ ] Regular uses the journal select -- still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)