### PR TITLE
fix(journal): remove ? button from public messages, rename nav buttons

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -42,12 +42,14 @@ const GJ_LIST_PAGE_PREFIX = "game-journal-list-page";
 const GJ_VIEW_PAGE_PREFIX = "game-journal-view-page";
 const GJ_ALL_SELECT_PREFIX = "game-journal-all-select";
 const GJ_ALL_PAGE_PREFIX = "game-journal-all-page";
+export const GJ_PUBLIC_CLOSE_PREFIX = "journal-public-close";
 
 // customId: GJ_LIST_SELECT_PREFIX:{callerId}:{targetUserId}:{page}  value=gameId
 // customId: GJ_LIST_PAGE_PREFIX:{callerId}:{targetUserId}:{page}
 // customId: GJ_VIEW_PAGE_PREFIX:{callerId}:{targetUserId}:{gameId}:{page}
 // customId: GJ_ALL_SELECT_PREFIX:{callerId}:{page}                  value=userId
 // customId: GJ_ALL_PAGE_PREFIX:{callerId}:{page}
+// customId: GJ_PUBLIC_CLOSE_PREFIX:{callerId}
 
 function gameLabel(n: number): string {
   return n === 1 ? "game" : "games";
@@ -155,6 +157,14 @@ function buildJournalViewPayload(
       `${GJ_VIEW_PAGE_PREFIX}:${callerId}:${targetUserId}:${gameId}:${p}`,
     nextPageCustomId: (p) =>
       `${GJ_VIEW_PAGE_PREFIX}:${callerId}:${targetUserId}:${gameId}:${p}`,
+    navRowTrailingButtons: guildId
+      ? [
+          new ButtonBuilder()
+            .setCustomId(`${GJ_PUBLIC_CLOSE_PREFIX}:${callerId}`)
+            .setLabel("Close")
+            .setStyle(ButtonStyle.Danger),
+        ]
+      : undefined,
     includeNowPlayingMeta: true,
     includeCompletions: true,
   });
@@ -452,5 +462,19 @@ export class GameJournalCommand {
       flags: payload.flags,
       allowedMentions: payload.allowedMentions,
     });
+  }
+
+  @ButtonComponent({ id: new RegExp(`^${GJ_PUBLIC_CLOSE_PREFIX}:\\d+$`) })
+  async handlePublicClose(interaction: ButtonInteraction): Promise<void> {
+    const [, callerId] = interaction.customId.split(":");
+    if (interaction.user.id !== callerId) {
+      await safeReply(interaction, {
+        content: "Only the person who opened this journal can close it.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    await interaction.deferUpdate();
+    await interaction.message.delete();
   }
 }

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -5610,12 +5610,14 @@ export class NowPlayingCommand {
               .setDisabled(!hasEntries),
           ]
         : undefined,
-      navRowTrailingButtons: [
-        new ButtonBuilder()
-          .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-view:${ownerId}`)
-          .setLabel("?")
-          .setStyle(ButtonStyle.Secondary),
-      ],
+      navRowTrailingButtons: guildId
+        ? undefined
+        : [
+            new ButtonBuilder()
+              .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-view:${ownerId}`)
+              .setLabel("?")
+              .setStyle(ButtonStyle.Secondary),
+          ],
       includeNowPlayingMeta: true,
       includeCompletions: true,
     });

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -94,6 +94,7 @@ import {
   NOW_PLAYING_HELP_PREFIX,
   NOW_PLAYING_HELP_TEXTS,
 } from "./now-playing-help.js";
+import { GJ_PUBLIC_CLOSE_PREFIX } from "./game-journal.command.js";
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 
 const MAX_NOW_PLAYING_NOTE_LEN = 500;
@@ -3250,6 +3251,7 @@ export class NowPlayingCommand {
       gameId,
       Number(pageRaw),
       interaction.guildId,
+      interaction.user.id,
     );
     if (interaction.guildId) {
       await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
@@ -3285,6 +3287,7 @@ export class NowPlayingCommand {
       gameId,
       1,
       interaction.guildId,
+      interaction.user.id,
     );
     if (interaction.guildId) {
       await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
@@ -3324,6 +3327,7 @@ export class NowPlayingCommand {
       gameId,
       Number(pageRaw),
       interaction.guildId,
+      interaction.user.id,
     );
     if (interaction.guildId) {
       await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
@@ -3604,6 +3608,7 @@ export class NowPlayingCommand {
       Number(gameIdRaw),
       Number(pageRaw),
       interaction.guildId,
+      interaction.user.id,
     );
     await safeUpdate(interaction, {
       components: payload.components,
@@ -3644,6 +3649,7 @@ export class NowPlayingCommand {
       Number(gameIdRaw),
       Number(pageRaw),
       interaction.guildId,
+      interaction.user.id,
     );
     await safeUpdate(interaction, {
       components: payload.components,
@@ -3692,6 +3698,7 @@ export class NowPlayingCommand {
       gameId,
       Number(pageRaw),
       interaction.guildId,
+      interaction.user.id,
     );
     if (interaction.guildId) {
       await interaction.message?.delete().catch(() => null);
@@ -5578,6 +5585,7 @@ export class NowPlayingCommand {
     gameId: number,
     page: number,
     guildId?: string | null,
+    callerId?: string,
   ) {
     const isOwnerView = viewerId === ownerId;
     return buildJournalView({
@@ -5610,14 +5618,21 @@ export class NowPlayingCommand {
               .setDisabled(!hasEntries),
           ]
         : undefined,
-      navRowTrailingButtons: guildId
-        ? undefined
-        : [
+      navRowTrailingButtons: guildId && callerId
+        ? [
             new ButtonBuilder()
-              .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-view:${ownerId}`)
-              .setLabel("?")
-              .setStyle(ButtonStyle.Secondary),
-          ],
+              .setCustomId(`${GJ_PUBLIC_CLOSE_PREFIX}:${callerId}`)
+              .setLabel("Close")
+              .setStyle(ButtonStyle.Danger),
+          ]
+        : !guildId
+          ? [
+              new ButtonBuilder()
+                .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-view:${ownerId}`)
+                .setLabel("?")
+                .setStyle(ButtonStyle.Secondary),
+            ]
+          : undefined,
       includeNowPlayingMeta: true,
       includeCompletions: true,
     });

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -205,7 +205,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
     navRow.addComponents(
       new ButtonBuilder()
         .setCustomId(prevPageCustomId(safePage - 1))
-        .setLabel("Previous")
+        .setLabel("Previous Page")
         .setStyle(ButtonStyle.Secondary),
     );
   }
@@ -213,7 +213,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
     navRow.addComponents(
       new ButtonBuilder()
         .setCustomId(nextPageCustomId(safePage + 1))
-        .setLabel("Next")
+        .setLabel("Next Page")
         .setStyle(ButtonStyle.Secondary),
     );
   }


### PR DESCRIPTION
## Summary
- Remove the \`?\` (help) button from Game Journal messages posted in public guild channels; it now only appears in DM/PM context
- Rename pagination buttons from "Previous" / "Next" to "Previous Page" / "Next Page"
- Add a **Close** button to public channel Game Journal messages that deletes the message; only the person who triggered the command can use it (others get an ephemeral error)

## Test plan
- [ ] View a Game Journal in a public channel -- confirm no \`?\` button, pagination shows "Previous Page" / "Next Page", and a red Close button appears
- [ ] Click Close as the person who opened it -- message is deleted
- [ ] Click Close as a different user -- ephemeral error appears, message stays
- [ ] View a Game Journal in DM -- confirm \`?\` button still appears, no Close button

🤖 Generated with [Claude Code](https://claude.com/claude-code)