### PR TITLE
fix(journal): show Close button on single-page public journal messages

### DIFF
--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -217,7 +217,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
         .setStyle(ButtonStyle.Secondary),
     );
   }
-  if (navRow.components.length > 0 && navRowTrailingButtons?.length) {
+  if (navRowTrailingButtons?.length) {
     navRow.addComponents(...navRowTrailingButtons);
   }
 


### PR DESCRIPTION
## Summary
- `navRowTrailingButtons` were only added when the nav row already had other components (owner buttons or prev/next pagination). Single-page public views had none of those, so the Close button was silently dropped.
- One-line fix: remove the `navRow.components.length > 0` guard so trailing buttons are always appended when provided.

## Test plan
- [ ] Open a public journal with only one page of entries -- Close button appears
- [ ] Multi-page journal in a public channel -- Close button still appears alongside pagination buttons
- [ ] DM/PM journal view -- no Close button, \`?\` help button unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)