### PR TITLE
fix(now-playing): add IS_COMPONENTS_V2 flag to remove prompt update calls

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -2195,6 +2195,9 @@ export class NowPlayingCommand {
     const userId = interaction.user.id;
     const useDeferredEditPath = mode === "update" &&
       Boolean((interaction as any).__rpgDeferred ?? (interaction as any).deferred);
+    const isEphemeral = mode === "update"
+      ? ((interaction as any).message?.flags?.has(MessageFlags.Ephemeral) ?? false)
+      : true;
     try {
       const entries = getDisplayNowPlayingEntries(await Member.getNowPlaying(userId));
       if (!entries.length) {
@@ -2207,7 +2210,10 @@ export class NowPlayingCommand {
           [container],
         );
         if (mode === "update" && !useDeferredEditPath) {
-          await safeUpdate(interaction, { components: pmComponents });
+          await safeUpdate(interaction, {
+            components: pmComponents,
+            flags: buildComponentsV2Flags(isEphemeral),
+          });
         } else if (mode === "update") {
           await safeReply(interaction, {
             components: pmComponents,
@@ -2239,7 +2245,10 @@ export class NowPlayingCommand {
         components,
       );
       if (mode === "update" && !useDeferredEditPath) {
-        await safeUpdate(interaction, this.buildComponentPayload(pmComponents as any, files));
+        await safeUpdate(interaction, {
+          ...this.buildComponentPayload(pmComponents as any, files),
+          flags: buildComponentsV2Flags(isEphemeral),
+        });
       } else if (mode === "update") {
         await safeReply(interaction, {
           ...this.buildComponentPayload(pmComponents as any, files),
@@ -2262,7 +2271,10 @@ export class NowPlayingCommand {
         [container],
       );
       if (mode === "update" && !useDeferredEditPath) {
-        await safeUpdate(interaction, { components: pmComponents });
+        await safeUpdate(interaction, {
+          components: pmComponents,
+          flags: buildComponentsV2Flags(isEphemeral),
+        });
       } else if (mode === "update") {
         await safeReply(interaction, {
           components: pmComponents,


### PR DESCRIPTION
## Summary
- `promptRemoveNowPlaying` was calling `safeUpdate` without the `IS_COMPONENTS_V2` flag, causing Discord to reject `ContainerBuilder` components with `type must be one of (1,)`
- Added `isEphemeral` detection from the source interaction's message flags
- All three `safeUpdate` branches (empty list, main, error) now include `flags: buildComponentsV2Flags(isEphemeral)`, matching the pattern used correctly in `handleRemoveNowPlayingButton`

## Root cause
Discord requires the `IS_COMPONENTS_V2` flag (1 << 15) on every interaction response that contains V2 components (Container, TextDisplay, etc.). Without it, Discord validates components as traditional ActionRows and rejects anything that isn't type 1.

## Test plan
- [ ] Click "Remove Game" from the Now Playing list view (public message)
- [ ] Click "Remove Game" from the Now Playing edit menu (ephemeral message)
- [ ] Verify the remove select UI renders without error in both contexts
- [ ] Verify removing a game succeeds and the updated list renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)