### PR TITLE
feat(journal): remove Close button, add header Add Entry button, auto-refresh public messages

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -6,15 +6,26 @@ import {
   ButtonStyle,
   CommandInteraction,
   EmbedBuilder,
+  Message,
   MessageFlags,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
   User,
 } from "discord.js";
-import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
+import {
+  ContainerBuilder,
+  TextDisplayBuilder,
+  ModalBuilder as ComponentsModalBuilder,
+  ActionRowBuilder as ComponentsActionRowBuilder,
+  TextInputBuilder as ComponentsTextInputBuilder,
+  LabelBuilder,
+  RadioGroupBuilder,
+} from "@discordjs/builders";
+import { TextInputStyle as ApiTextInputStyle } from "discord-api-types/v10";
 import {
   ButtonComponent,
   Discord,
+  ModalComponent,
   SelectMenuComponent,
   Slash,
   SlashOption,
@@ -33,6 +44,17 @@ import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { buildJournalView } from "../functions/journalView.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { buildUserHeaderContainer } from "../functions/uiComponents.js";
+import {
+  GJ_PUBLIC_CLOSE_PREFIX,
+  JOURNAL_ADD_MODAL_ID,
+  JOURNAL_TITLE_INPUT_ID,
+  JOURNAL_BODY_INPUT_ID,
+  JOURNAL_PRIVACY_INPUT_ID,
+} from "../config/journalConstants.js";
+import {
+  trackNowPlayingJournalContext,
+  refreshPublicJournalMessages,
+} from "./now-playing.command.js";
 
 const LIST_PAGE_SIZE = 15;
 const ALL_PAGE_SIZE = 20;
@@ -42,7 +64,8 @@ const GJ_LIST_PAGE_PREFIX = "game-journal-list-page";
 const GJ_VIEW_PAGE_PREFIX = "game-journal-view-page";
 const GJ_ALL_SELECT_PREFIX = "game-journal-all-select";
 const GJ_ALL_PAGE_PREFIX = "game-journal-all-page";
-export const GJ_PUBLIC_CLOSE_PREFIX = "journal-public-close";
+const GJ_HEADER_ADD_PREFIX = "game-journal-header-add";
+export { GJ_PUBLIC_CLOSE_PREFIX };
 
 // customId: GJ_LIST_SELECT_PREFIX:{callerId}:{targetUserId}:{page}  value=gameId
 // customId: GJ_LIST_PAGE_PREFIX:{callerId}:{targetUserId}:{page}
@@ -50,6 +73,8 @@ export const GJ_PUBLIC_CLOSE_PREFIX = "journal-public-close";
 // customId: GJ_ALL_SELECT_PREFIX:{callerId}:{page}                  value=userId
 // customId: GJ_ALL_PAGE_PREFIX:{callerId}:{page}
 // customId: GJ_PUBLIC_CLOSE_PREFIX:{callerId}
+// customId: GJ_HEADER_ADD_PREFIX:{ownerId}:{gameId}
+// modal:    JOURNAL_ADD_MODAL_ID:{ownerId}:{gameId}:{page}
 
 function gameLabel(n: number): string {
   return n === 1 ? "game" : "games";
@@ -146,6 +171,7 @@ function buildJournalViewPayload(
   gameId: number,
   page: number,
   guildId?: string | null,
+  isOwner?: boolean,
 ) {
   return buildJournalView({
     ownerId: targetUserId,
@@ -157,13 +183,8 @@ function buildJournalViewPayload(
       `${GJ_VIEW_PAGE_PREFIX}:${callerId}:${targetUserId}:${gameId}:${p}`,
     nextPageCustomId: (p) =>
       `${GJ_VIEW_PAGE_PREFIX}:${callerId}:${targetUserId}:${gameId}:${p}`,
-    navRowTrailingButtons: guildId
-      ? [
-          new ButtonBuilder()
-            .setCustomId(`${GJ_PUBLIC_CLOSE_PREFIX}:${callerId}`)
-            .setLabel("Close")
-            .setStyle(ButtonStyle.Danger),
-        ]
+    headerButtonCustomId: isOwner
+      ? `${GJ_HEADER_ADD_PREFIX}:${targetUserId}:${gameId}`
       : undefined,
     includeNowPlayingMeta: true,
     includeCompletions: true,
@@ -329,7 +350,10 @@ export class GameJournalCommand {
 
     await safeDeferUpdate(interaction);
 
-    const payload = await buildJournalViewPayload(callerId, targetUserId, gameId, 1, interaction.guildId);
+    const isOwner = callerId === targetUserId;
+    const payload = await buildJournalViewPayload(
+      callerId, targetUserId, gameId, 1, interaction.guildId, isOwner,
+    );
     await safeUpdate(interaction, {
       embeds: [],
       components: payload.components,
@@ -337,6 +361,11 @@ export class GameJournalCommand {
       flags: payload.flags,
       allowedMentions: payload.allowedMentions,
     });
+    if (interaction.guildId && interaction.message) {
+      await trackNowPlayingJournalContext(
+        interaction.message as Message<boolean>, targetUserId, gameId,
+      );
+    }
   }
 
   @ButtonComponent({ id: new RegExp(`^${GJ_LIST_PAGE_PREFIX}:\\d+:\\d+:\\d+$`) })
@@ -455,13 +484,69 @@ export class GameJournalCommand {
     if (Number.isNaN(gameId) || Number.isNaN(page)) return;
 
     await safeDeferUpdate(interaction);
-    const payload = await buildJournalViewPayload(callerId, targetUserId, gameId, page, interaction.guildId);
+    const isOwner = callerId === targetUserId;
+    const payload = await buildJournalViewPayload(
+      callerId, targetUserId, gameId, page, interaction.guildId, isOwner,
+    );
     await safeUpdate(interaction, {
       components: payload.components,
       files: payload.files,
       flags: payload.flags,
       allowedMentions: payload.allowedMentions,
     });
+    if (interaction.guildId && interaction.message) {
+      await trackNowPlayingJournalContext(
+        interaction.message as Message<boolean>, targetUserId, gameId,
+      );
+    }
+  }
+
+  @ButtonComponent({ id: /^game-journal-header-add:\d+:\d+$/ })
+  async handleHeaderAdd(interaction: ButtonInteraction): Promise<void> {
+    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    if (interaction.user.id !== ownerId) {
+      await safeReply(interaction, {
+        content: "Only the journal owner can add entries.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+    const modal = new ComponentsModalBuilder()
+      .setCustomId(`${JOURNAL_ADD_MODAL_ID}:${ownerId}:${gameIdRaw}:1`)
+      .setTitle("Add Journal Entry");
+    modal.addActionRowComponents(
+      new ComponentsActionRowBuilder<ComponentsTextInputBuilder>().addComponents(
+        new ComponentsTextInputBuilder()
+          .setCustomId(JOURNAL_TITLE_INPUT_ID)
+          .setLabel("Title (optional)")
+          .setStyle(ApiTextInputStyle.Short)
+          .setRequired(false)
+          .setMaxLength(120),
+      ),
+      new ComponentsActionRowBuilder<ComponentsTextInputBuilder>().addComponents(
+        new ComponentsTextInputBuilder()
+          .setCustomId(JOURNAL_BODY_INPUT_ID)
+          .setLabel("Entry")
+          .setStyle(ApiTextInputStyle.Paragraph)
+          .setRequired(true)
+          .setMaxLength(2000),
+      ),
+    );
+    modal.addLabelComponents(
+      new LabelBuilder()
+        .setLabel("Privacy")
+        .setDescription("Choose who can view this entry")
+        .setRadioGroupComponent(
+          new RadioGroupBuilder()
+            .setCustomId(JOURNAL_PRIVACY_INPUT_ID)
+            .setRequired(true)
+            .setOptions(
+              { label: "Private", value: "private", description: "Only you can view it" },
+              { label: "Public", value: "public", description: "Visible to other members" },
+            ),
+        ),
+    );
+    await interaction.showModal(modal);
   }
 
   @ButtonComponent({ id: new RegExp(`^${GJ_PUBLIC_CLOSE_PREFIX}:\\d+$`) })

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -25,7 +25,6 @@ import { TextInputStyle as ApiTextInputStyle } from "discord-api-types/v10";
 import {
   ButtonComponent,
   Discord,
-  ModalComponent,
   SelectMenuComponent,
   Slash,
   SlashOption,
@@ -53,7 +52,6 @@ import {
 } from "../config/journalConstants.js";
 import {
   trackNowPlayingJournalContext,
-  refreshPublicJournalMessages,
 } from "./now-playing.command.js";
 
 const LIST_PAGE_SIZE = 15;

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -129,7 +129,6 @@ const NOW_PLAYING_COMPOSITE_MAX = 10;
 const NOW_PLAYING_ALL_SELECT_ID = "nowplaying-all-select:v1";
 const NOW_PLAYING_LIST_NOTES_PREFIX = "nowplaying-list-notes";
 const NOW_PLAYING_LIST_EDIT_PREFIX = "nowplaying-list-edit";
-const NOW_PLAYING_EDIT_MENU_NOTE_PREFIX = "nowplaying-edit-menu-note";
 const NOW_PLAYING_EDIT_MENU_SORT_PREFIX = "nowplaying-edit-menu-sort";
 const NOW_PLAYING_EDIT_MENU_PLATFORM_PREFIX = "nowplaying-edit-menu-platform";
 const NOW_PLAYING_EDIT_MENU_COMPLETE_PREFIX = "nowplaying-edit-menu-complete";

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -94,7 +94,7 @@ import {
   NOW_PLAYING_HELP_PREFIX,
   NOW_PLAYING_HELP_TEXTS,
 } from "./now-playing-help.js";
-import { GJ_PUBLIC_CLOSE_PREFIX } from "./game-journal.command.js";
+import { GJ_PUBLIC_CLOSE_PREFIX } from "../config/journalConstants.js";
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 
 const MAX_NOW_PLAYING_NOTE_LEN = 500;
@@ -477,7 +477,7 @@ function setNowPlayingListContext(userId: string, message: Message<boolean>): vo
   });
 }
 
-async function trackNowPlayingJournalContext(
+export async function trackNowPlayingJournalContext(
   message: Message<boolean>,
   ownerUserId: string,
   gameId: number,
@@ -502,6 +502,57 @@ async function trackNowPlayingJournalContext(
     ownerUserId,
     gameId,
   ).catch((err) => console.error("[Journal] Failed to persist message context:", err));
+}
+
+export async function refreshPublicJournalMessages(
+  client: Client,
+  ownerId: string,
+  gameId: number,
+  excludeMessageId?: string,
+): Promise<void> {
+  const now = Date.now();
+  for (const [key, ctx] of nowPlayingJournalContexts.entries()) {
+    if (ctx.ownerUserId !== ownerId || ctx.gameId !== gameId) continue;
+    if (ctx.messageId === excludeMessageId) continue;
+    if (now - ctx.createdAt > NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS) {
+      nowPlayingJournalContexts.delete(key);
+      await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
+        .catch((err) => console.error("[Journal] Failed to delete expired context:", err));
+      continue;
+    }
+    const channel = await client.channels.fetch(ctx.channelId).catch(() => null);
+    if (!channel?.isTextBased()) {
+      nowPlayingJournalContexts.delete(key);
+      await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
+        .catch((err) => console.error("[Journal] Failed to delete unreachable context:", err));
+      continue;
+    }
+    const message = await channel.messages.fetch(ctx.messageId).catch(() => null);
+    if (!message) {
+      nowPlayingJournalContexts.delete(key);
+      await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
+        .catch((err) => console.error("[Journal] Failed to delete missing context:", err));
+      continue;
+    }
+    const guildId = channel.isDMBased() ? null : (channel as any).guildId as string;
+    const payload = await buildJournalView({
+      ownerId,
+      viewerId: null,
+      gameId,
+      page: 1,
+      guildId,
+      prevPageCustomId: (p) =>
+        `${NOW_PLAYING_JOURNAL_PAGE_PREFIX}:${ownerId}:${gameId}:prev:${p}`,
+      nextPageCustomId: (p) =>
+        `${NOW_PLAYING_JOURNAL_PAGE_PREFIX}:${ownerId}:${gameId}:next:${p}`,
+      includeNowPlayingMeta: true,
+      includeCompletions: true,
+    });
+    await message.edit({
+      components: payload.components as any[],
+      files: payload.files,
+    }).catch((err) => console.error("[Journal] Failed to refresh public message:", err));
+  }
 }
 
 function resolvePlatformLabel(entry: IMemberNowPlayingEntry): string | null {
@@ -3396,7 +3447,7 @@ export class NowPlayingCommand {
         ),
     );
     await interaction.showModal(modal);
-    if (interaction.guildId) {
+    if (interaction.guildId && interaction.message.flags?.has(MessageFlags.Ephemeral)) {
       await interaction.message.delete().catch(() => null);
     }
   }
@@ -3628,6 +3679,11 @@ export class NowPlayingCommand {
       flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
       allowedMentions: payload.allowedMentions,
     });
+    if (action === "yes") {
+      await refreshPublicJournalMessages(
+        interaction.client, ownerId, Number(gameIdRaw), interaction.message.id,
+      );
+    }
   }
 
   @ModalComponent({ id: /^nowplaying-journal-modal:\d+:\d+:\d+$/ })
@@ -3669,6 +3725,7 @@ export class NowPlayingCommand {
       flags: buildComponentsV2Flags(true),
       allowedMentions: payload.allowedMentions,
     });
+    await refreshPublicJournalMessages(interaction.client, ownerId, Number(gameIdRaw));
   }
 
   @ModalComponent({ id: /^nowplaying-journal-edit-modal:\d+:\d+:\d+:\d+$/ })
@@ -3712,17 +3769,13 @@ export class NowPlayingCommand {
       interaction.guildId,
       interaction.user.id,
     );
-    if (interaction.guildId) {
-      await interaction.message?.delete().catch(() => null);
-      await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
-    }
     await safeReply(interaction, {
       components: payload.components,
       files: payload.files,
       flags: buildComponentsV2Flags(true),
       allowedMentions: payload.allowedMentions,
     });
-    await this.trackJournalReply(interaction, ownerId, gameId);
+    await refreshPublicJournalMessages(interaction.client, ownerId, gameId);
   }
 
   @ButtonComponent({ id: /^nowplaying-list-edit:\d+$/ })

--- a/src/config/journalConstants.ts
+++ b/src/config/journalConstants.ts
@@ -1,0 +1,6 @@
+export const GJ_PUBLIC_CLOSE_PREFIX = "journal-public-close";
+
+export const JOURNAL_ADD_MODAL_ID = "nowplaying-journal-modal";
+export const JOURNAL_TITLE_INPUT_ID = "nowplaying-journal-title";
+export const JOURNAL_BODY_INPUT_ID = "nowplaying-journal-body";
+export const JOURNAL_PRIVACY_INPUT_ID = "nowplaying-journal-privacy";

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -43,6 +43,8 @@ export interface JournalViewOptions {
   navRowTrailingButtons?: ButtonBuilder[];
   /** Extra rows appended after the nav row */
   extraRows?: Array<ActionRowBuilder<ButtonBuilder>>;
+  /** Custom ID for the header section button; defaults to a non-interactive label button */
+  headerButtonCustomId?: string;
   /** Fetch and display the Now Playing / completion status in the game info container */
   includeNowPlayingMeta?: boolean;
   /** Fetch and display completions in the game info container and entries container */
@@ -66,6 +68,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
     buildOwnerButtons,
     navRowTrailingButtons,
     extraRows,
+    headerButtonCustomId,
     includeNowPlayingMeta,
     includeCompletions,
   } = options;
@@ -134,6 +137,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
     ownerId,
     ownerName,
     headerTitleLines.join("\n"),
+    headerButtonCustomId,
   );
 
   // Container 2: entries + footer


### PR DESCRIPTION
## Summary

- **Remove Close button** from game-journal public view (the red Close button that appeared at the bottom)
- **Header button opens Add Entry modal** when the viewer is the journal owner — clicking the avatar/name button in the upper-right of the journal header now opens the Add Entry modal (instead of doing nothing)
- **Auto-refresh public forum messages** — when an entry is added, edited, or deleted, all tracked public journal messages in forum channels are updated in-place; only ephemeral messages are deleted after showing the Add modal

## Technical details

- Extracted shared constants (`GJ_PUBLIC_CLOSE_PREFIX`, modal/input IDs) to `src/config/journalConstants.ts` to break the circular import between `game-journal.command.ts` and `now-playing.command.ts`
- Added `headerButtonCustomId` option to `JournalViewOptions` / `buildJournalView` so callers can wire the header section button
- `game-journal.command.ts` detects owner (callerId === targetUserId) and passes the add-entry button ID to the header; reuses the `nowplaying-journal-modal` modal ID so now-playing's submission handler processes it
- Game-journal messages are now tracked in `nowPlayingJournalContexts` on select/page-nav interactions
- Exported `trackNowPlayingJournalContext` and new `refreshPublicJournalMessages` from `now-playing.command.ts`
- `refreshPublicJournalMessages` rebuilds all tracked non-expired public messages for a given (ownerId, gameId) as a public view and calls `message.edit()`

## Test plan

- [ ] `/game-journal` → select a game you own → header button (your avatar) opens Add Entry modal
- [ ] `/game-journal` → select someone else's game → header button does not open modal (non-interactive label)
- [ ] Add a journal entry via the header button → entry appears in the journal
- [ ] If the same journal is open in another channel, it updates automatically after adding
- [ ] Edit/delete via now-playing journal → other public forum messages auto-refresh
- [ ] Close button is gone from game-journal public messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)