### PR TITLE
fix(now-playing): fix sort feedback and duplicate slot accumulation

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -2833,6 +2833,11 @@ export class NowPlayingCommand {
         return;
       }
 
+      for (let i = 0; i < parsed.length; i += 1) {
+        if (i !== slotIndex && parsed[i] === selectedIndex) {
+          parsed[i] = -1;
+        }
+      }
       parsed[slotIndex] = selectedIndex;
       const components = this.buildNowPlayingSortComponents(
         entries,
@@ -2914,7 +2919,7 @@ export class NowPlayingCommand {
     }
 
     await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
-    await this.returnToNowPlayingEditMenu(interaction, ownerId);
+    await this.returnToNowPlayingEditMenu(interaction, ownerId, "Sort order saved.");
   }
 
   @ButtonComponent({ id: /^nowplaying-sort-reset:\d+$/ })
@@ -4655,11 +4660,14 @@ export class NowPlayingCommand {
     ownerId: string,
     entries: IMemberNowPlayingEntry[],
     guildId: string | null,
+    statusMessage: string | null = null,
   ): Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>> {
+    const introLines = ["## Now Playing Edit\nChoose an edit action. All edits happen in this DM."];
+    if (statusMessage) {
+      introLines.push(`-# ${statusMessage}`);
+    }
     const introContainer = new ContainerBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(
-        "## Now Playing Edit\nChoose an edit action. All edits happen in this DM.",
-      ),
+      new TextDisplayBuilder().setContent(introLines.join("\n")),
     );
     const listContainer = entries.length
       ? this.buildNowPlayingEntryComponents(
@@ -4706,10 +4714,12 @@ export class NowPlayingCommand {
   private async returnToNowPlayingEditMenu(
     interaction: ButtonInteraction,
     ownerId: string,
+    statusMessage: string | null = null,
   ): Promise<void> {
     const menuComponents = await this.buildNowPlayingEditInitialComponents(
       ownerId,
       interaction.guildId,
+      statusMessage,
     );
     const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? true;
     await safeReply(interaction, {
@@ -4721,9 +4731,10 @@ export class NowPlayingCommand {
   private async buildNowPlayingEditInitialComponents(
     ownerId: string,
     guildId: string | null,
+    statusMessage: string | null = null,
   ): Promise<Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>>> {
     const entries = await Member.getNowPlaying(ownerId).then(getDisplayNowPlayingEntries);
-    return this.buildNowPlayingEditMenuComponents(ownerId, entries, guildId);
+    return this.buildNowPlayingEditMenuComponents(ownerId, entries, guildId, statusMessage);
   }
 
   private async withPmNowPlayingList(


### PR DESCRIPTION
## Summary

- When the user changed a slot in the sort UI, any other slot already holding the same game was auto-cleared (set to unassigned). Previously, duplicate values would accumulate silently until Save was clicked, at which point the user saw a validation error but had no clear path to fix it.
- After a successful save, the edit menu now shows `-# Sort order saved.` in its header so users have confirmation the change took effect.

## Root cause

The slot handler wrote the new selection into `parsed[slotIndex]` but left any other slot with the same entry index unchanged, causing guaranteed duplicates any time a user re-assigned a game. The save handler's duplicate check then blocked the save with an error message, but since the initial token uses the identity mapping (slot 0 = entry 0, etc.), a user who only changed one dropdown would always hit this error.

## Test plan

- [ ] Open sort UI with 3+ games
- [ ] Change Position 1 to a game already shown in another slot — verify that slot auto-clears to unassigned
- [ ] Complete a valid assignment and press Save — verify the edit menu shows "Sort order saved."
- [ ] Run `/now-playing list` — verify the new sort order is reflected

🤖 Generated with [Claude Code](https://claude.com/claude-code)