### PR TITLE
fix(now-playing): show loading state while sort saves and generates cover

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -2907,6 +2907,13 @@ export class NowPlayingCommand {
       return;
     }
 
+    const loadingContainer = new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        "## Now Loading\nSaving sort order and generating cover layout...",
+      ),
+    );
+    await safeUpdate(interaction, { components: [loadingContainer], flags: responseFlags });
+
     const orderedIds = parsed.map((index) => entries[index].gameId);
     const updated = await Member.updateNowPlayingSort(ownerId, orderedIds);
     if (!updated) {


### PR DESCRIPTION
## Summary

- After sort validation passes and the user clicks Save, the message immediately updates to show **"## Now Loading\nSaving sort order and generating cover layout..."** before the DB update and image generation run.
- Matches the wording pattern used by the all-members select and similar flows.

## Test plan

- [ ] Open sort UI, assign all positions, press Save
- [ ] Verify the loading message appears before the edit menu comes back
- [ ] Verify "Sort order saved." still appears in the edit menu header on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)