### PR TITLE
fix(now-playing): remove Close button from public journal view

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -94,7 +94,7 @@ import {
   NOW_PLAYING_HELP_PREFIX,
   NOW_PLAYING_HELP_TEXTS,
 } from "./now-playing-help.js";
-import { GJ_PUBLIC_CLOSE_PREFIX } from "../config/journalConstants.js";
+
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 
 const MAX_NOW_PLAYING_NOTE_LEN = 500;
@@ -3325,7 +3325,6 @@ export class NowPlayingCommand {
       gameId,
       Number(pageRaw),
       interaction.guildId,
-      interaction.user.id,
     );
     if (interaction.guildId) {
       await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
@@ -3361,7 +3360,6 @@ export class NowPlayingCommand {
       gameId,
       1,
       interaction.guildId,
-      interaction.user.id,
     );
     if (interaction.guildId) {
       await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
@@ -3401,7 +3399,6 @@ export class NowPlayingCommand {
       gameId,
       Number(pageRaw),
       interaction.guildId,
-      interaction.user.id,
     );
     if (interaction.guildId) {
       await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
@@ -3682,7 +3679,6 @@ export class NowPlayingCommand {
       Number(gameIdRaw),
       Number(pageRaw),
       interaction.guildId,
-      interaction.user.id,
     );
     await safeUpdate(interaction, {
       components: payload.components,
@@ -3728,7 +3724,6 @@ export class NowPlayingCommand {
       Number(gameIdRaw),
       Number(pageRaw),
       interaction.guildId,
-      interaction.user.id,
     );
     await safeUpdate(interaction, {
       components: payload.components,
@@ -3778,7 +3773,6 @@ export class NowPlayingCommand {
       gameId,
       Number(pageRaw),
       interaction.guildId,
-      interaction.user.id,
     );
     await safeReply(interaction, {
       components: payload.components,
@@ -5667,7 +5661,6 @@ export class NowPlayingCommand {
     gameId: number,
     page: number,
     guildId?: string | null,
-    callerId?: string,
   ) {
     const isOwnerView = viewerId === ownerId;
     return buildJournalView({
@@ -5700,21 +5693,14 @@ export class NowPlayingCommand {
               .setDisabled(!hasEntries),
           ]
         : undefined,
-      navRowTrailingButtons: guildId && callerId
+      navRowTrailingButtons: !guildId
         ? [
             new ButtonBuilder()
-              .setCustomId(`${GJ_PUBLIC_CLOSE_PREFIX}:${callerId}`)
-              .setLabel("Close")
-              .setStyle(ButtonStyle.Danger),
+              .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-view:${ownerId}`)
+              .setLabel("?")
+              .setStyle(ButtonStyle.Secondary),
           ]
-        : !guildId
-          ? [
-              new ButtonBuilder()
-                .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-view:${ownerId}`)
-                .setLabel("?")
-                .setStyle(ButtonStyle.Secondary),
-            ]
-          : undefined,
+        : undefined,
       includeNowPlayingMeta: true,
       includeCompletions: true,
     });


### PR DESCRIPTION
## Summary

- Removes the Close button from the `navRowTrailingButtons` when a journal is viewed in a guild channel.
- Cleans up the now-unused `GJ_PUBLIC_CLOSE_PREFIX` import and the `callerId` parameter from `buildJournalComponents` and all six of its call sites.

## Test plan

- [ ] Open a game journal from the Now Playing list in a guild channel — verify the Close button is gone
- [ ] Verify journal pagination and other buttons still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)