### PR TITLE
fix(journal): remove prompt on edit select, show manage buttons after edit

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3300,25 +3300,18 @@ export class NowPlayingCommand {
     });
   }
 
-  @ButtonComponent({ id: /^nowplaying-journal-header:\d+:\d+:\d+$/ })
-  async handleNowPlayingJournalHeader(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
-    if (interaction.user.id !== ownerId) {
-      await safeDeferUpdate(interaction);
-      return;
-    }
-    const gameId = Number(gameIdRaw);
-    const page = Number(pageRaw);
+  private async buildManageJournalButtonRow(
+    ownerId: string,
+    gameId: number,
+    page: number,
+  ): Promise<ActionRowBuilder<ButtonBuilder>> {
     const entries = await Member.getGameJournalEntries(ownerId, gameId, {
       viewerUserId: ownerId,
       limit: 1,
       offset: 0,
     });
     const hasEntries = entries.length > 0;
-    const container = new ContainerBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent("## Manage Journal"),
-    );
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
         .setCustomId(`${NOW_PLAYING_JOURNAL_ADD_PREFIX}:${ownerId}:${gameId}:${page}`)
         .setLabel("Add Entry")
@@ -3334,8 +3327,20 @@ export class NowPlayingCommand {
         .setStyle(ButtonStyle.Danger)
         .setDisabled(!hasEntries),
     );
+  }
+
+  @ButtonComponent({ id: /^nowplaying-journal-header:\d+:\d+:\d+$/ })
+  async handleNowPlayingJournalHeader(interaction: ButtonInteraction): Promise<void> {
+    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    if (interaction.user.id !== ownerId) {
+      await safeDeferUpdate(interaction);
+      return;
+    }
+    const gameId = Number(gameIdRaw);
+    const page = Number(pageRaw);
+    const row = await this.buildManageJournalButtonRow(ownerId, gameId, page);
     await safeReply(interaction, {
-      components: [container, row],
+      components: [row],
       flags: buildComponentsV2Flags(true),
     });
   }
@@ -3610,7 +3615,10 @@ export class NowPlayingCommand {
         ),
     );
     await interaction.showModal(modal);
-    if (interaction.guildId) {
+    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
+    if (isEphemeral) {
+      await interaction.deleteReply().catch(() => null);
+    } else if (interaction.guildId) {
       await interaction.message.delete().catch(() => null);
     }
   }
@@ -3812,20 +3820,11 @@ export class NowPlayingCommand {
       body,
       isPublic,
     });
-    const journalViewerId = interaction.guildId ? "__public__" : interaction.user.id;
-    const payload = await this.buildJournalComponents(
-      ownerId,
-      journalViewerId,
-      gameId,
-      Number(pageRaw),
-      interaction.guildId,
-      true,
-    );
+    const page = Number(pageRaw);
+    const row = await this.buildManageJournalButtonRow(ownerId, gameId, page);
     await safeReply(interaction, {
-      components: payload.components,
-      files: payload.files,
+      components: [row],
       flags: buildComponentsV2Flags(true),
-      allowedMentions: payload.allowedMentions,
     });
     await refreshPublicJournalMessages(interaction.client, ownerId, gameId);
   }

--- a/src/tests/now-playing-journal-components.test.ts
+++ b/src/tests/now-playing-journal-components.test.ts
@@ -291,23 +291,15 @@ test("journal public view redacts private entry content and count", async () => 
   }
 });
 
-test("journal edit modal submit from guild context re-renders redacted private entry", async () => {
+test("journal edit modal submit shows manage journal buttons", async () => {
   const command = new NowPlayingCommand() as any;
   command.canUseJournalFeature = () => true;
 
   const originalGetEntry = Member.getGameJournalEntryForUser;
   const originalUpdateEntry = Member.updateGameJournalEntry;
-  const originalGetGameById = Game.getGameById;
-  const originalGetByUserId = Member.getByUserId;
-  const originalGetMeta = Member.getNowPlayingEntryMeta;
-  const originalGetCompletions = Member.getCompletionsForGame;
-  const originalGetPref = Member.getGameJournalPreference;
-  const originalCount = Member.countGameJournalEntries;
   const originalEntries = Member.getGameJournalEntries;
 
   let replyPayload: any = null;
-  let renderViewerId: string | null = null;
-  let sourcePromptDeleted = false;
 
   try {
     Member.getGameJournalEntryForUser = (async () => ({
@@ -321,17 +313,6 @@ test("journal edit modal submit from guild context re-renders redacted private e
       updatedAt: new Date("2026-05-11T00:00:00.000Z"),
     })) as any;
     Member.updateGameJournalEntry = (async () => {}) as any;
-    Game.getGameById = (async () => ({ id: 1, title: "Pragmata" })) as any;
-    Member.getByUserId = (async () => ({ globalName: "merph518", username: "merph518" })) as any;
-    Member.getNowPlayingEntryMeta = (async () => null) as any;
-    Member.getCompletionsForGame = (async () => []) as any;
-    Member.getGameJournalPreference = (async () => ({
-      userId: "123",
-      gameId: 1,
-      isEnabled: true,
-      defaultIsPublic: false,
-    })) as any;
-    Member.countGameJournalEntries = (async () => 1) as any;
     Member.getGameJournalEntries = (async () => ([{
       entryId: 10,
       userId: "123",
@@ -342,16 +323,6 @@ test("journal edit modal submit from guild context re-renders redacted private e
       createdAt: new Date("2026-05-11T00:00:00.000Z"),
       updatedAt: new Date("2026-05-11T00:00:00.000Z"),
     }])) as any;
-    const originalBuildJournalComponents = command.buildJournalComponents;
-    command.buildJournalComponents = async (
-      ownerId: string,
-      viewerId: string,
-      gameId: number,
-      page: number,
-    ) => {
-      renderViewerId = viewerId;
-      return originalBuildJournalComponents.call(command, ownerId, viewerId, gameId, page);
-    };
 
     const interaction: any = {
       customId: "nowplaying-journal-edit-modal:123:1:1:10",
@@ -359,11 +330,6 @@ test("journal edit modal submit from guild context re-renders redacted private e
       guildId: "987654321",
       deferred: false,
       replied: false,
-      message: {
-        delete: async () => {
-          sourcePromptDeleted = true;
-        },
-      },
       fields: {
         getTextInputValue: (id: string) => {
           if (id === "nowplaying-journal-title") return "Private Edit";
@@ -379,123 +345,16 @@ test("journal edit modal submit from guild context re-renders redacted private e
       },
       followUp: async () => null,
       editReply: async () => null,
+      client: { guilds: { cache: new Map() } },
     };
 
     await command.handleNowPlayingJournalEditModal(interaction);
 
-    assert.equal(renderViewerId, "__public__");
-    assert.equal(sourcePromptDeleted, true);
-    assert.ok(replyPayload);
+    assert.ok(replyPayload, "reply should be called");
+    assert.equal(replyPayload.components.length, 1, "should reply with one action row");
   } finally {
     Member.getGameJournalEntryForUser = originalGetEntry;
     Member.updateGameJournalEntry = originalUpdateEntry;
-    Game.getGameById = originalGetGameById;
-    Member.getByUserId = originalGetByUserId;
-    Member.getNowPlayingEntryMeta = originalGetMeta;
-    Member.getCompletionsForGame = originalGetCompletions;
-    Member.getGameJournalPreference = originalGetPref;
-    Member.countGameJournalEntries = originalCount;
-    Member.getGameJournalEntries = originalEntries;
-  }
-});
-
-test("journal edit modal submit from DM context keeps private body visible to owner", async () => {
-  const command = new NowPlayingCommand() as any;
-  command.canUseJournalFeature = () => true;
-
-  const originalGetEntry = Member.getGameJournalEntryForUser;
-  const originalUpdateEntry = Member.updateGameJournalEntry;
-  const originalGetGameById = Game.getGameById;
-  const originalGetByUserId = Member.getByUserId;
-  const originalGetMeta = Member.getNowPlayingEntryMeta;
-  const originalGetCompletions = Member.getCompletionsForGame;
-  const originalGetPref = Member.getGameJournalPreference;
-  const originalCount = Member.countGameJournalEntries;
-  const originalEntries = Member.getGameJournalEntries;
-
-  let replyPayload: any = null;
-  let renderViewerId: string | null = null;
-
-  try {
-    Member.getGameJournalEntryForUser = (async () => ({
-      entryId: 10,
-      userId: "123",
-      gameId: 1,
-      title: "Private Edit",
-      body: "Top secret body.",
-      isPublic: false,
-      createdAt: new Date("2026-05-11T00:00:00.000Z"),
-      updatedAt: new Date("2026-05-11T00:00:00.000Z"),
-    })) as any;
-    Member.updateGameJournalEntry = (async () => {}) as any;
-    Game.getGameById = (async () => ({ id: 1, title: "Pragmata" })) as any;
-    Member.getByUserId = (async () => ({ globalName: "merph518", username: "merph518" })) as any;
-    Member.getNowPlayingEntryMeta = (async () => null) as any;
-    Member.getCompletionsForGame = (async () => []) as any;
-    Member.getGameJournalPreference = (async () => ({
-      userId: "123",
-      gameId: 1,
-      isEnabled: true,
-      defaultIsPublic: false,
-    })) as any;
-    Member.countGameJournalEntries = (async () => 1) as any;
-    Member.getGameJournalEntries = (async () => ([{
-      entryId: 10,
-      userId: "123",
-      gameId: 1,
-      title: "Private Edit",
-      body: "Top secret body.",
-      isPublic: false,
-      createdAt: new Date("2026-05-11T00:00:00.000Z"),
-      updatedAt: new Date("2026-05-11T00:00:00.000Z"),
-    }])) as any;
-    const originalBuildJournalComponents = command.buildJournalComponents;
-    command.buildJournalComponents = async (
-      ownerId: string,
-      viewerId: string,
-      gameId: number,
-      page: number,
-    ) => {
-      renderViewerId = viewerId;
-      return originalBuildJournalComponents.call(command, ownerId, viewerId, gameId, page);
-    };
-
-    const interaction: any = {
-      customId: "nowplaying-journal-edit-modal:123:1:1:10",
-      user: { id: "123" },
-      guildId: null,
-      deferred: false,
-      replied: false,
-      fields: {
-        getTextInputValue: (id: string) => {
-          if (id === "nowplaying-journal-title") return "Private Edit";
-          if (id === "nowplaying-journal-body") return "Top secret body.";
-          return "";
-        },
-      },
-      components: [{
-        components: [{ customId: "nowplaying-journal-privacy", value: "private" }],
-      }],
-      reply: async (payload: any) => {
-        replyPayload = payload;
-      },
-      followUp: async () => null,
-      editReply: async () => null,
-    };
-
-    await command.handleNowPlayingJournalEditModal(interaction);
-
-    assert.equal(renderViewerId, "123");
-    assert.ok(replyPayload);
-  } finally {
-    Member.getGameJournalEntryForUser = originalGetEntry;
-    Member.updateGameJournalEntry = originalUpdateEntry;
-    Game.getGameById = originalGetGameById;
-    Member.getByUserId = originalGetByUserId;
-    Member.getNowPlayingEntryMeta = originalGetMeta;
-    Member.getCompletionsForGame = originalGetCompletions;
-    Member.getGameJournalPreference = originalGetPref;
-    Member.countGameJournalEntries = originalCount;
     Member.getGameJournalEntries = originalEntries;
   }
 });


### PR DESCRIPTION
## Summary
- Deletes the ephemeral \"Edit Journal Entry\" prompt after the user selects an entry (fixes silent failure on ephemeral messages by using `deleteReply()` instead of `message.delete()`)
- After submitting the edit modal, renders the manage journal buttons instead of re-rendering the full journal view
- Removes the \"Manage Journal\" text container from the header action menu (buttons alone are sufficient)
- Extracts `buildManageJournalButtonRow` private helper to share button-row logic between `handleNowPlayingJournalHeader` and `handleNowPlayingJournalEditModal`

## Test plan
- [ ] Click edit button on a journal -- see the entry select dropdown (ephemeral)
- [ ] Select an entry -- modal opens and the prompt message disappears
- [ ] Submit the modal -- manage journal buttons appear (Add/Edit/Delete), no full journal re-render
- [ ] Verify clicking the header button shows only the 3 action buttons with no "Manage Journal" heading

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>