### PR TITLE
fix(journal): always show owner menu on header click, dismiss previous ephemeral first

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -212,6 +212,10 @@ type NowPlayingJournalContext = {
 const nowPlayingJournalContexts = new Map<string, NowPlayingJournalContext>();
 const NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS = 2 * 60 * 60 * 1000;
 
+// Tracks the deleteReply closure for the last owner manage-journal menu per owner,
+// so repeated header-button clicks always dismiss the previous ephemeral before showing a new one.
+const journalOwnerMenuDeletors = new Map<string, () => Promise<unknown>>();
+
 export async function restoreJournalMessageContextsFromDb(): Promise<void> {
   try {
     await Member.pruneExpiredJournalMessageContexts(NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS);
@@ -3336,6 +3340,8 @@ export class NowPlayingCommand {
       await safeDeferUpdate(interaction);
       return;
     }
+    await journalOwnerMenuDeletors.get(ownerId)?.().catch(() => null);
+    journalOwnerMenuDeletors.delete(ownerId);
     const gameId = Number(gameIdRaw);
     const page = Number(pageRaw);
     const row = await this.buildManageJournalButtonRow(ownerId, gameId, page);
@@ -3343,6 +3349,7 @@ export class NowPlayingCommand {
       components: [row],
       flags: buildComponentsV2Flags(true),
     });
+    journalOwnerMenuDeletors.set(ownerId, () => interaction.deleteReply());
   }
 
   @ButtonComponent({ id: /^nowplaying-journal-open:\d+:\d+:\d+$/ })


### PR DESCRIPTION
## Summary
- Adds a module-level `journalOwnerMenuDeletors` Map (keyed by `ownerId`) that tracks a `deleteReply` closure for each owner's last manage-journal ephemeral menu
- On every header button click, the previous ephemeral is deleted before a new one is sent -- so the button always works, even after the prior menu was dismissed

## Test plan
- [ ] Click the journal header button -- manage buttons appear (ephemeral)
- [ ] Dismiss the message, click the header button again -- menu reappears
- [ ] Click the header button without dismissing -- old ephemeral disappears and new one appears

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>