### PR TITLE
fix(journal): show owner action menu after add/delete instead of re-rendering journal

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3503,9 +3503,7 @@ export class NowPlayingCommand {
         ),
     );
     await interaction.showModal(modal);
-    if (interaction.guildId && interaction.message.flags?.has(MessageFlags.Ephemeral)) {
-      await interaction.message.delete().catch(() => null);
-    }
+    await journalOwnerMenu.dismiss(ownerId);
   }
 
   @ButtonComponent({ id: /^nowplaying-journal-edit:\d+:\d+:\d+$/ })
@@ -3723,20 +3721,10 @@ export class NowPlayingCommand {
         return;
       }
     }
-    const journalViewerId = interaction.guildId ? "__public__" : interaction.user.id;
-    const payload = await this.buildJournalComponents(
-      ownerId,
-      journalViewerId,
-      Number(gameIdRaw),
-      Number(pageRaw),
-      interaction.guildId,
-      true,
-    );
+    const row = await this.buildManageJournalButtonRow(ownerId, Number(gameIdRaw), Number(pageRaw));
     await safeUpdate(interaction, {
-      components: payload.components,
-      files: payload.files,
+      components: [row],
       flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
-      allowedMentions: payload.allowedMentions,
     });
     if (action === "yes") {
       await refreshPublicJournalMessages(
@@ -3769,21 +3757,9 @@ export class NowPlayingCommand {
       isPublic,
     });
     await Member.upsertGameJournalPreference(ownerId, Number(gameIdRaw), true, isPublic);
-    const journalViewerId = interaction.guildId ? "__public__" : interaction.user.id;
-    const payload = await this.buildJournalComponents(
-      ownerId,
-      journalViewerId,
-      Number(gameIdRaw),
-      Number(pageRaw),
-      interaction.guildId,
-      true,
-    );
-    await safeUpdate(interaction, {
-      components: payload.components,
-      files: payload.files,
-      flags: buildComponentsV2Flags(true),
-      allowedMentions: payload.allowedMentions,
-    });
+    const page = Number(pageRaw);
+    const row = await this.buildManageJournalButtonRow(ownerId, Number(gameIdRaw), page);
+    await journalOwnerMenu.show(interaction, ownerId, [row]);
     await refreshPublicJournalMessages(interaction.client, ownerId, Number(gameIdRaw));
   }
 


### PR DESCRIPTION
## Summary
- **Add entry**: after the add modal is submitted, show the manage journal buttons (via `journalOwnerMenu.show`) instead of re-rendering the full journal view
- **Delete/cancel delete**: after the delete confirm resolves either way, `safeUpdate` the confirm prompt in-place with the manage journal buttons instead of re-rendering the full journal view
- **Side-fix**: after showing the add modal, use `journalOwnerMenu.dismiss(ownerId)` to properly tear down the owner menu ephemeral (the previous `message.delete()` call was a no-op for ephemeral messages)

## Test plan
- [ ] Add a journal entry -- after submitting the modal, manage buttons appear (Add/Edit/Delete)
- [ ] Delete a journal entry (confirm Yes) -- after deletion, manage buttons appear
- [ ] Cancel a delete (confirm No) -- confirm prompt is replaced with manage buttons
- [ ] Click Add Entry then dismiss -- owner menu is properly dismissed

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>