### PR TITLE
fix(journal): preserve header button when refreshing guild journal message

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -547,6 +547,7 @@ export async function refreshPublicJournalMessages(
         `${NOW_PLAYING_JOURNAL_PAGE_PREFIX}:${ownerId}:${gameId}:prev:${p}`,
       nextPageCustomId: (p) =>
         `${NOW_PLAYING_JOURNAL_PAGE_PREFIX}:${ownerId}:${gameId}:next:${p}`,
+      headerButtonCustomId: `${NOW_PLAYING_JOURNAL_HEADER_PREFIX}:${ownerId}:${gameId}:1`,
       includeNowPlayingMeta: true,
       includeCompletions: true,
     });


### PR DESCRIPTION
## Root cause
`refreshPublicJournalMessages` rebuilds the tracked guild channel journal message via `buildJournalView` but omits `headerButtonCustomId`. This strips the manage-menu button from the message every time an entry is added or deleted, making the button unclickable for the rest of the session.

## Fix
Pass `headerButtonCustomId` when rebuilding. All contexts tracked in `nowPlayingJournalContexts` are the owner's journal messages, and the `handleNowPlayingJournalHeader` handler is already owner-gated (`safeDeferUpdate` for non-owners), so including the button unconditionally is correct and harmless.

## Test plan
- [ ] Open journal in a guild channel (owner view -- header button visible)
- [ ] Add a journal entry via the manage menu
- [ ] Dismiss the manage menu after adding
- [ ] Confirm the header button is still present on the journal message and re-opens the manage menu

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>