### PR TITLE
feat(journal): remove private entry concept

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -96,9 +96,9 @@ export interface IMemberNowPlayingEntry {
   noteUpdatedAt: Date | null;
   sortOrder: number | null;
   journalEnabled: boolean;
-  hasPublicJournalEntry: boolean;
-  publicJournalCount: number;
-  lastPublicJournalAt: Date | null;
+  hasJournalEntry: boolean;
+  journalCount: number;
+  lastJournalAt: Date | null;
 }
 
 export interface IMemberNowPlayingList {
@@ -115,7 +115,6 @@ export interface IGameJournalEntry {
   gameId: number;
   title: string | null;
   body: string;
-  isPublic: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -124,14 +123,12 @@ export interface IGameJournalPreference {
   userId: string;
   gameId: number;
   isEnabled: boolean;
-  defaultIsPublic: boolean;
 }
 
 export interface IGameJournalListEntry {
   gameId: number;
   title: string;
   totalEntries: number;
-  publicEntries: number;
 }
 
 export interface IJournalUserSummary {
@@ -265,9 +262,9 @@ export default class Member {
         NOTE_UPDATED_AT: Date | string | null;
         SORT_ORDER: number | null;
         JOURNAL_ENABLED: number | null;
-        HAS_PUBLIC_JOURNAL_ENTRY: number | null;
-        PUBLIC_JOURNAL_COUNT: number | null;
-        LAST_PUBLIC_JOURNAL_AT: Date | string | null;
+        HAS_JOURNAL_ENTRY: number | null;
+        JOURNAL_COUNT: number | null;
+        LAST_JOURNAL_AT: Date | string | null;
       }>(
         `SELECT g.GAME_ID,
                 g.TITLE,
@@ -286,20 +283,17 @@ export default class Member {
                     FROM USER_GAME_JOURNAL_ENTRIES je
                     WHERE je.USER_ID = u.USER_ID
                       AND je.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
-                      AND je.IS_PUBLIC = 1
                   ) THEN 1
                   ELSE 0
-                END AS HAS_PUBLIC_JOURNAL_ENTRY,
+                END AS HAS_JOURNAL_ENTRY,
                 (SELECT COUNT(*)
                    FROM USER_GAME_JOURNAL_ENTRIES je2
                   WHERE je2.USER_ID = u.USER_ID
-                    AND je2.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
-                    AND je2.IS_PUBLIC = 1) AS PUBLIC_JOURNAL_COUNT,
+                    AND je2.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID) AS JOURNAL_COUNT,
                 (SELECT MAX(je3.CREATED_AT)
                    FROM USER_GAME_JOURNAL_ENTRIES je3
                   WHERE je3.USER_ID = u.USER_ID
-                    AND je3.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
-                    AND je3.IS_PUBLIC = 1) AS LAST_PUBLIC_JOURNAL_AT
+                    AND je3.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID) AS LAST_JOURNAL_AT
            FROM USER_NOW_PLAYING u
            JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
            LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
@@ -333,12 +327,12 @@ export default class Member {
               : null,
           sortOrder: r.SORT_ORDER == null ? null : Number(r.SORT_ORDER),
           journalEnabled: Number(r.JOURNAL_ENABLED ?? 0) === 1,
-          hasPublicJournalEntry: Number(r.HAS_PUBLIC_JOURNAL_ENTRY ?? 0) === 1,
-          publicJournalCount: Number(r.PUBLIC_JOURNAL_COUNT ?? 0),
-          lastPublicJournalAt: r.LAST_PUBLIC_JOURNAL_AT instanceof Date
-            ? r.LAST_PUBLIC_JOURNAL_AT
-            : r.LAST_PUBLIC_JOURNAL_AT
-              ? new Date(r.LAST_PUBLIC_JOURNAL_AT as any)
+          hasJournalEntry: Number(r.HAS_JOURNAL_ENTRY ?? 0) === 1,
+          journalCount: Number(r.JOURNAL_COUNT ?? 0),
+          lastJournalAt: r.LAST_JOURNAL_AT instanceof Date
+            ? r.LAST_JOURNAL_AT
+            : r.LAST_JOURNAL_AT
+              ? new Date(r.LAST_JOURNAL_AT as any)
               : null,
         }))
         .slice(0, MAX_NOW_PLAYING);
@@ -425,9 +419,9 @@ export default class Member {
                 : null,
             sortOrder: null,
             journalEnabled: false,
-            hasPublicJournalEntry: false,
-            publicJournalCount: 0,
-            lastPublicJournalAt: null,
+            hasJournalEntry: false,
+            journalCount: 0,
+            lastJournalAt: null,
           });
         }
       }
@@ -533,7 +527,7 @@ export default class Member {
     noteUpdatedAt: Date | null;
     sortOrder: number | null;
     journalEnabled: boolean;
-    hasPublicJournalEntry: boolean;
+    hasJournalEntry: boolean;
   }[]> {
     const connection = await getOraclePool().getConnection();
     try {
@@ -590,7 +584,7 @@ export default class Member {
             : null,
         sortOrder: r.SORT_ORDER == null ? null : Number(r.SORT_ORDER),
         journalEnabled: Number(r.JOURNAL_ENABLED ?? 0) === 1,
-        hasPublicJournalEntry: false,
+        hasJournalEntry: false,
       }));
     } finally {
       await connection.close();
@@ -738,12 +732,10 @@ export default class Member {
         USER_ID: string;
         GAMEDB_GAME_ID: number;
         IS_ENABLED: number;
-        DEFAULT_IS_PUBLIC: number;
       }>(
         `SELECT USER_ID,
                 GAMEDB_GAME_ID,
-                IS_ENABLED,
-                DEFAULT_IS_PUBLIC
+                IS_ENABLED
            FROM USER_GAME_JOURNAL_PREFS
           WHERE USER_ID = :userId
             AND GAMEDB_GAME_ID = :gameId`,
@@ -756,7 +748,6 @@ export default class Member {
         userId: row.USER_ID,
         gameId: Number(row.GAMEDB_GAME_ID),
         isEnabled: Number(row.IS_ENABLED) === 1,
-        defaultIsPublic: Number(row.DEFAULT_IS_PUBLIC) === 1,
       };
     } finally {
       await connection.close();
@@ -767,7 +758,6 @@ export default class Member {
     userId: string,
     gameId: number,
     isEnabled: boolean,
-    defaultIsPublic: boolean,
   ): Promise<void> {
     const connection = await getOraclePool().getConnection();
     try {
@@ -777,16 +767,15 @@ export default class Member {
             ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
           WHEN MATCHED THEN
             UPDATE SET IS_ENABLED = :isEnabled,
-                       DEFAULT_IS_PUBLIC = :defaultIsPublic,
+                       DEFAULT_IS_PUBLIC = 1,
                        UPDATED_AT = SYSTIMESTAMP
           WHEN NOT MATCHED THEN
             INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
-            VALUES (:userId, :gameId, :isEnabled, :defaultIsPublic)`,
+            VALUES (:userId, :gameId, :isEnabled, 1)`,
         {
           userId,
           gameId,
           isEnabled: isEnabled ? 1 : 0,
-          defaultIsPublic: defaultIsPublic ? 1 : 0,
         },
         { autoCommit: true },
       );
@@ -798,10 +787,9 @@ export default class Member {
   static async getGameJournalEntries(
     userId: string,
     gameId: number,
-    params?: { viewerUserId?: string | null; limit?: number; offset?: number },
+    params?: { limit?: number; offset?: number },
   ): Promise<IGameJournalEntry[]> {
     const connection = await getOraclePool().getConnection();
-    const viewerUserId = params?.viewerUserId ?? null;
     const safeLimit = Math.min(Math.max(params?.limit ?? 5, 1), 25);
     const safeOffset = Math.max(params?.offset ?? 0, 0);
     try {
@@ -811,7 +799,6 @@ export default class Member {
         GAMEDB_GAME_ID: number;
         ENTRY_TITLE: string | null;
         ENTRY_BODY: string;
-        IS_PUBLIC: number;
         CREATED_AT: Date | string;
         UPDATED_AT: Date | string;
         ENTRY_NUMBER: number;
@@ -822,7 +809,6 @@ export default class Member {
                   GAMEDB_GAME_ID,
                   ENTRY_TITLE,
                   ENTRY_BODY,
-                  IS_PUBLIC,
                   CREATED_AT,
                   UPDATED_AT,
                   ROW_NUMBER() OVER (ORDER BY CREATED_AT ASC, ENTRY_ID ASC) AS ENTRY_NUMBER
@@ -835,15 +821,13 @@ export default class Member {
                 GAMEDB_GAME_ID,
                 ENTRY_TITLE,
                 ENTRY_BODY,
-                IS_PUBLIC,
                 CREATED_AT,
                 UPDATED_AT,
                 ENTRY_NUMBER
            FROM all_entries
-          WHERE :viewerUserId = :userId OR IS_PUBLIC = 1
           ORDER BY CREATED_AT DESC, ENTRY_ID DESC
           OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-        { userId, gameId, viewerUserId, offset: safeOffset, limit: safeLimit },
+        { userId, gameId, offset: safeOffset, limit: safeLimit },
         { outFormat: oracledb.OUT_FORMAT_OBJECT },
       );
       return (res.rows ?? []).map((row) => ({
@@ -853,7 +837,6 @@ export default class Member {
         gameId: Number(row.GAMEDB_GAME_ID),
         title: row.ENTRY_TITLE ?? null,
         body: row.ENTRY_BODY,
-        isPublic: Number(row.IS_PUBLIC) === 1,
         createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT),
         updatedAt: row.UPDATED_AT instanceof Date ? row.UPDATED_AT : new Date(row.UPDATED_AT),
       }));
@@ -862,30 +845,15 @@ export default class Member {
     }
   }
 
-  static async countGameJournalEntries(
-    userId: string,
-    gameId: number,
-    viewerUserId?: string | null,
-  ): Promise<number> {
+  static async countGameJournalEntries(userId: string, gameId: number): Promise<number> {
     const connection = await getOraclePool().getConnection();
-    const isPublicOnly = viewerUserId === "__public__";
     try {
       const res = await connection.execute<{ CNT: number }>(
         `SELECT COUNT(*) AS CNT
            FROM USER_GAME_JOURNAL_ENTRIES
           WHERE USER_ID = :userId
-            AND GAMEDB_GAME_ID = :gameId
-            AND (
-              (:publicOnly = 1 AND IS_PUBLIC = 1)
-              OR
-              (:publicOnly = 0 AND (:viewerUserId = :userId OR IS_PUBLIC = 1))
-            )`,
-        {
-          userId,
-          gameId,
-          viewerUserId: viewerUserId ?? null,
-          publicOnly: isPublicOnly ? 1 : 0,
-        },
+            AND GAMEDB_GAME_ID = :gameId`,
+        { userId, gameId },
         { outFormat: oracledb.OUT_FORMAT_OBJECT },
       );
       return Number((res.rows ?? [])[0]?.CNT ?? 0);
@@ -899,7 +867,6 @@ export default class Member {
     gameId: number;
     title?: string | null;
     body: string;
-    isPublic?: boolean;
   }): Promise<void> {
     const connection = await getOraclePool().getConnection();
     const titleValue = params.title?.trim() ? params.title.trim() : null;
@@ -912,13 +879,12 @@ export default class Member {
         `INSERT INTO USER_GAME_JOURNAL_ENTRIES
           (USER_ID, GAMEDB_GAME_ID, ENTRY_TITLE, ENTRY_BODY, IS_PUBLIC)
          VALUES
-          (:userId, :gameId, :title, :body, :isPublic)`,
+          (:userId, :gameId, :title, :body, 1)`,
         {
           userId: params.userId,
           gameId: params.gameId,
           title: titleValue,
           body: bodyValue,
-          isPublic: params.isPublic === true ? 1 : 0,
         },
         { autoCommit: true },
       );
@@ -939,7 +905,6 @@ export default class Member {
         GAMEDB_GAME_ID: number;
         ENTRY_TITLE: string | null;
         ENTRY_BODY: string;
-        IS_PUBLIC: number;
         CREATED_AT: Date | string;
         UPDATED_AT: Date | string;
         ENTRY_NUMBER: number;
@@ -949,7 +914,6 @@ export default class Member {
                 e.GAMEDB_GAME_ID,
                 e.ENTRY_TITLE,
                 e.ENTRY_BODY,
-                e.IS_PUBLIC,
                 e.CREATED_AT,
                 e.UPDATED_AT,
                 (SELECT COUNT(*) + 1
@@ -975,7 +939,6 @@ export default class Member {
         gameId: Number(row.GAMEDB_GAME_ID),
         title: row.ENTRY_TITLE ?? null,
         body: row.ENTRY_BODY,
-        isPublic: Number(row.IS_PUBLIC) === 1,
         createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT),
         updatedAt: row.UPDATED_AT instanceof Date ? row.UPDATED_AT : new Date(row.UPDATED_AT),
       };
@@ -989,7 +952,6 @@ export default class Member {
     entryId: number;
     title?: string | null;
     body?: string;
-    isPublic?: boolean;
   }): Promise<boolean> {
     const connection = await getOraclePool().getConnection();
     const fields: string[] = [];
@@ -1009,10 +971,6 @@ export default class Member {
       }
       fields.push("ENTRY_BODY = :body");
       binds.body = bodyValue;
-    }
-    if (params.isPublic !== undefined) {
-      fields.push("IS_PUBLIC = :isPublic");
-      binds.isPublic = params.isPublic ? 1 : 0;
     }
     if (!fields.length) return false;
     fields.push("UPDATED_AT = SYSTIMESTAMP");
@@ -2564,12 +2522,10 @@ export default class Member {
         GAME_ID: number;
         TITLE: string;
         TOTAL_ENTRIES: number;
-        PUBLIC_ENTRIES: number;
       }>(
         `SELECT g.GAME_ID,
                 g.TITLE,
-                COUNT(e.ENTRY_ID) AS TOTAL_ENTRIES,
-                SUM(CASE WHEN e.IS_PUBLIC = 1 THEN 1 ELSE 0 END) AS PUBLIC_ENTRIES
+                COUNT(e.ENTRY_ID) AS TOTAL_ENTRIES
            FROM USER_GAME_JOURNAL_PREFS jp
            JOIN GAMEDB_GAMES g ON g.GAME_ID = jp.GAMEDB_GAME_ID
            LEFT JOIN USER_GAME_JOURNAL_ENTRIES e
@@ -2586,7 +2542,6 @@ export default class Member {
         gameId: Number(row.GAME_ID),
         title: row.TITLE,
         totalEntries: Number(row.TOTAL_ENTRIES ?? 0),
-        publicEntries: Number(row.PUBLIC_ENTRIES ?? 0),
       }));
     } finally {
       await connection.close();

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -19,8 +19,6 @@ import {
   ModalBuilder as ComponentsModalBuilder,
   ActionRowBuilder as ComponentsActionRowBuilder,
   TextInputBuilder as ComponentsTextInputBuilder,
-  LabelBuilder,
-  RadioGroupBuilder,
 } from "@discordjs/builders";
 import { TextInputStyle as ApiTextInputStyle } from "discord-api-types/v10";
 import {
@@ -47,15 +45,14 @@ import { buildJournalView } from "../functions/journalView.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { buildUserHeaderContainer } from "../functions/uiComponents.js";
 import {
-  GJ_PUBLIC_CLOSE_PREFIX,
+  GJ_CLOSE_PREFIX,
   JOURNAL_TITLE_INPUT_ID,
   JOURNAL_BODY_INPUT_ID,
-  JOURNAL_PRIVACY_INPUT_ID,
 } from "../config/journalConstants.js";
 import { formatTableDate } from "./profile.command.js";
 import {
   trackNowPlayingJournalContext,
-  refreshPublicJournalMessages,
+  refreshJournalMessages,
 } from "./now-playing.command.js";
 import { NOW_PLAYING_HELP_PREFIX } from "./now-playing-help.js";
 
@@ -76,7 +73,7 @@ const GJ_HMENU_DELETE_SELECT_PREFIX = "game-journal-hmenu-delete-select";
 const GJ_HMENU_DELETE_CONFIRM_PREFIX = "game-journal-hmenu-delete-confirm";
 const GJ_HMENU_ADD_MODAL_ID = "game-journal-hmenu-add-modal";
 const GJ_HMENU_EDIT_MODAL_ID = "game-journal-hmenu-edit-modal";
-export { GJ_PUBLIC_CLOSE_PREFIX };
+export { GJ_CLOSE_PREFIX };
 
 // customId: GJ_LIST_SELECT_PREFIX:{callerId}:{targetUserId}:{page}  value=gameId
 // customId: GJ_LIST_PAGE_PREFIX:{callerId}:{targetUserId}:{page}
@@ -97,29 +94,6 @@ export { GJ_PUBLIC_CLOSE_PREFIX };
 
 function buildComponentsV2Flags(isEphemeral: boolean): number {
   return (isEphemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
-}
-
-function extractGjPrivacyFromInteraction(interaction: ModalSubmitInteraction): boolean {
-  const components = (interaction.components ?? []) as Array<{
-    components?: Array<{ customId?: string; value?: unknown; values?: unknown }>;
-    component?: { customId?: string; value?: unknown; values?: unknown };
-  }>;
-  const fields: Array<{ customId?: string; value?: unknown; values?: unknown }> = [];
-  for (const topLevel of components) {
-    if (Array.isArray(topLevel.components)) {
-      fields.push(...topLevel.components);
-    } else if (topLevel.component) {
-      fields.push(topLevel.component);
-    }
-  }
-  for (const field of fields) {
-    if (field.customId !== JOURNAL_PRIVACY_INPUT_ID) continue;
-    if (typeof field.value === "string") return field.value.toLowerCase() === "public";
-    if (Array.isArray(field.values) && typeof field.values[0] === "string") {
-      return field.values[0].toLowerCase() === "public";
-    }
-  }
-  return false;
 }
 
 function buildHmenuActionRow(ownerId: string, gameId: number): ActionRowBuilder<ButtonBuilder> {
@@ -148,7 +122,6 @@ function buildHmenuModal(
   modalTitle: string,
   prefillTitle?: string,
   prefillBody?: string,
-  defaultPublic?: boolean,
 ): ComponentsModalBuilder {
   const modal = new ComponentsModalBuilder()
     .setCustomId(modalId)
@@ -173,30 +146,6 @@ function buildHmenuModal(
         .setValue((prefillBody ?? "").slice(0, 2000)),
     ),
   );
-  modal.addLabelComponents(
-    new LabelBuilder()
-      .setLabel("Privacy")
-      .setDescription("Choose who can view this entry")
-      .setRadioGroupComponent(
-        new RadioGroupBuilder()
-          .setCustomId(JOURNAL_PRIVACY_INPUT_ID)
-          .setRequired(true)
-          .setOptions(
-            {
-              label: "Private",
-              value: "private",
-              description: "Only you can view it",
-              default: defaultPublic === false,
-            },
-            {
-              label: "Public",
-              value: "public",
-              description: "Visible to other members",
-              default: defaultPublic === true,
-            },
-          ),
-      ),
-  );
   return modal;
 }
 
@@ -211,7 +160,6 @@ function entryLabel(n: number): string {
 function buildListComponents(
   target: User,
   entries: IGameJournalListEntry[],
-  isSelf: boolean,
   page: number,
   totalPages: number,
 ): ContainerBuilder[] {
@@ -223,10 +171,7 @@ function buildListComponents(
   // const lines = [`## Game Journals`];
   const lines = [];
   lines.push(
-    ...pageEntries.map((e) => {
-      const count = isSelf ? e.totalEntries : e.publicEntries;
-      return `**${e.title}** - ${count} ${entryLabel(count)}`;
-    }),
+    ...pageEntries.map((e) => `**${e.title}** - ${e.totalEntries} ${entryLabel(e.totalEntries)}`),
   );
   const pageInfo = totalPages > 1 ? ` • Page ${page + 1}/${totalPages}` : "";
   lines.push(`-# ${entries.length} ${gameLabel(entries.length)}${pageInfo}`);
@@ -250,7 +195,7 @@ function buildListSelectRow(
   const options = pageEntries.map((e) => ({
     label: e.title.slice(0, 100),
     value: String(e.gameId),
-    description: `${e.publicEntries} public ${entryLabel(e.publicEntries)}`,
+    description: `${e.totalEntries} ${entryLabel(e.totalEntries)}`,
   }));
 
   const select = new StringSelectMenuBuilder()
@@ -432,7 +377,6 @@ export class GameJournalCommand {
     }
 
     const target = member ?? interaction.user;
-    const isSelf = target.id === interaction.user.id;
     const entries = await Member.getGameJournalList(target.id);
 
     if (!entries.length) {
@@ -446,7 +390,7 @@ export class GameJournalCommand {
 
     const totalPages = Math.max(1, Math.ceil(entries.length / LIST_PAGE_SIZE));
     const page = 0;
-    const listComponents = buildListComponents(target, entries, isSelf, page, totalPages);
+    const listComponents = buildListComponents(target, entries, page, totalPages);
     const selectRow = buildListSelectRow(entries, interaction.user.id, target.id, page);
     const pageRow = buildListPageRow(interaction.user.id, target.id, page, totalPages);
     const cvFlags = (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
@@ -511,12 +455,11 @@ export class GameJournalCommand {
     const target = await interaction.client.users.fetch(targetUserId).catch(() => null);
     if (!target) return;
 
-    const isSelf = targetUserId === callerId;
     const entries = await Member.getGameJournalList(targetUserId);
     const totalPages = Math.max(1, Math.ceil(entries.length / LIST_PAGE_SIZE));
     const safePage = Math.min(Math.max(page, 0), totalPages - 1);
 
-    const listComponents = buildListComponents(target, entries, isSelf, safePage, totalPages);
+    const listComponents = buildListComponents(target, entries, safePage, totalPages);
     const selectRow = buildListSelectRow(entries, callerId, targetUserId, safePage);
     const pageRow = buildListPageRow(callerId, targetUserId, safePage, totalPages);
 
@@ -557,7 +500,7 @@ export class GameJournalCommand {
 
     const totalPages = Math.max(1, Math.ceil(entries.length / LIST_PAGE_SIZE));
     const page = 0;
-    const listComponents = buildListComponents(target, entries, false, page, totalPages);
+    const listComponents = buildListComponents(target, entries, page, totalPages);
     const selectRow = buildListSelectRow(entries, callerId, targetUserId, page);
     const pageRow = buildListPageRow(callerId, targetUserId, page, totalPages);
     const components = pageRow
@@ -666,7 +609,6 @@ export class GameJournalCommand {
     }
     const gameId = Number(gameIdRaw);
     const entries = await Member.getGameJournalEntries(ownerId, gameId, {
-      viewerUserId: ownerId,
       limit: 5,
       offset: 0,
     });
@@ -690,7 +632,7 @@ export class GameJournalCommand {
     const options = entries.map((e) => ({
       label: (e.title ?? `Entry #${e.entryNumber}`).slice(0, 100),
       value: String(e.entryId),
-      description: `${formatTableDate(e.createdAt)} | ${e.isPublic ? "Public" : "Private"}`,
+      description: formatTableDate(e.createdAt),
     }));
     const select = new StringSelectMenuBuilder()
       .setCustomId(`${GJ_HMENU_EDIT_SELECT_PREFIX}:${ownerId}:${gameId}`)
@@ -732,7 +674,6 @@ export class GameJournalCommand {
       "Edit Journal Entry",
       entry.title ?? "",
       entry.body,
-      entry.isPublic,
     );
     await interaction.showModal(modal);
   }
@@ -746,7 +687,6 @@ export class GameJournalCommand {
     }
     const gameId = Number(gameIdRaw);
     const entries = await Member.getGameJournalEntries(ownerId, gameId, {
-      viewerUserId: ownerId,
       limit: 5,
       offset: 0,
     });
@@ -770,7 +710,7 @@ export class GameJournalCommand {
     const options = entries.map((e) => ({
       label: (e.title ?? `Entry #${e.entryNumber}`).slice(0, 100),
       value: String(e.entryId),
-      description: `${formatTableDate(e.createdAt)} | ${e.isPublic ? "Public" : "Private"}`,
+      description: formatTableDate(e.createdAt),
     }));
     const select = new StringSelectMenuBuilder()
       .setCustomId(`${GJ_HMENU_DELETE_SELECT_PREFIX}:${ownerId}:${gameId}`)
@@ -863,7 +803,7 @@ export class GameJournalCommand {
       flags: buildComponentsV2Flags(true),
     });
     if (action === "yes") {
-      await refreshPublicJournalMessages(interaction.client, ownerId, gameId);
+      await refreshJournalMessages(interaction.client, ownerId, gameId);
     }
   }
 
@@ -882,16 +822,9 @@ export class GameJournalCommand {
       interaction.fields.getTextInputValue(JOURNAL_BODY_INPUT_ID),
       { preserveNewlines: true, maxLength: 2000 },
     );
-    const isPublic = extractGjPrivacyFromInteraction(interaction);
     const gameId = Number(gameIdRaw);
-    await Member.addGameJournalEntry({
-      userId: ownerId,
-      gameId,
-      title: title || null,
-      body,
-      isPublic,
-    });
-    await Member.upsertGameJournalPreference(ownerId, gameId, true, isPublic);
+    await Member.addGameJournalEntry({ userId: ownerId, gameId, title: title || null, body });
+    await Member.upsertGameJournalPreference(ownerId, gameId, true);
     const container = new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent("## Manage Journal"),
     );
@@ -900,7 +833,7 @@ export class GameJournalCommand {
       components: [container, row],
       flags: buildComponentsV2Flags(true),
     });
-    await refreshPublicJournalMessages(interaction.client, ownerId, gameId);
+    await refreshJournalMessages(interaction.client, ownerId, gameId);
   }
 
   @ModalComponent({ id: /^game-journal-hmenu-edit-modal:\d+:\d+:\d+$/ })
@@ -925,9 +858,7 @@ export class GameJournalCommand {
       interaction.fields.getTextInputValue(JOURNAL_BODY_INPUT_ID),
       { preserveNewlines: true, maxLength: 2000 },
     );
-    const isPublic = extractGjPrivacyFromInteraction(interaction);
-    await Member.updateGameJournalEntry({ userId: ownerId, entryId, title: title || null, body,
-      isPublic });
+    await Member.updateGameJournalEntry({ userId: ownerId, entryId, title: title || null, body });
     const container = new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent("## Manage Journal"),
     );
@@ -936,10 +867,10 @@ export class GameJournalCommand {
       components: [container, row],
       flags: buildComponentsV2Flags(true),
     });
-    await refreshPublicJournalMessages(interaction.client, ownerId, gameId);
+    await refreshJournalMessages(interaction.client, ownerId, gameId);
   }
 
-  @ButtonComponent({ id: new RegExp(`^${GJ_PUBLIC_CLOSE_PREFIX}:\\d+$`) })
+  @ButtonComponent({ id: new RegExp(`^${GJ_CLOSE_PREFIX}:\\d+$`) })
   async handlePublicClose(interaction: ButtonInteraction): Promise<void> {
     const [, callerId] = interaction.customId.split(":");
     if (interaction.user.id !== callerId) {

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -35,8 +35,6 @@ import {
   ModalBuilder as ComponentsModalBuilder,
   ActionRowBuilder as ComponentsActionRowBuilder,
   TextInputBuilder as ComponentsTextInputBuilder,
-  LabelBuilder,
-  RadioGroupBuilder,
   MediaGalleryBuilder,
   MediaGalleryItemBuilder,
   ButtonBuilder as V2ButtonBuilder,
@@ -149,7 +147,6 @@ const NOW_PLAYING_JOURNAL_MODAL_ID = "nowplaying-journal-modal";
 const NOW_PLAYING_JOURNAL_EDIT_MODAL_ID = "nowplaying-journal-edit-modal";
 const NOW_PLAYING_JOURNAL_TITLE_INPUT_ID = "nowplaying-journal-title";
 const NOW_PLAYING_JOURNAL_BODY_INPUT_ID = "nowplaying-journal-body";
-const NOW_PLAYING_JOURNAL_PRIVACY_INPUT_ID = "nowplaying-journal-privacy";
 type NowPlayingAddSession = {
   userId: string;
   query: string;
@@ -232,32 +229,7 @@ type NowPlayingMessageComponents = Array<
   ContainerBuilder | MediaGalleryBuilder | ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>
 >;
 
-function extractJournalPrivacyFromInteraction(interaction: ModalSubmitInteraction): boolean {
-  const components = (interaction.components ?? []) as Array<{
-    components?: Array<{ customId?: string; value?: unknown; values?: unknown }>;
-    component?: { customId?: string; value?: unknown; values?: unknown };
-  }>;
-  const fields: Array<{ customId?: string; value?: unknown; values?: unknown }> = [];
-  for (const topLevel of components) {
-    if (Array.isArray(topLevel.components)) {
-      fields.push(...topLevel.components);
-    } else if (topLevel.component) {
-      fields.push(topLevel.component);
-    }
-  }
-  for (const field of fields) {
-    if (field.customId !== NOW_PLAYING_JOURNAL_PRIVACY_INPUT_ID) {
-      continue;
-    }
-    if (typeof field.value === "string") {
-      return field.value.toLowerCase() === "public";
-    }
-    if (Array.isArray(field.values) && typeof field.values[0] === "string") {
-      return field.values[0].toLowerCase() === "public";
-    }
-  }
-  return false;
-}
+
 type NowPlayingListComponents = ContainerBuilder[];
 type NowPlayingPayloadComponents = Array<ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder>>;
 
@@ -506,7 +478,7 @@ export async function trackNowPlayingJournalContext(
   ).catch((err) => console.error("[Journal] Failed to persist message context:", err));
 }
 
-export async function refreshPublicJournalMessages(
+export async function refreshJournalMessages(
   client: Client,
   ownerId: string,
   gameId: number,
@@ -764,7 +736,6 @@ export class NowPlayingCommand {
           userId: interaction.user.id,
           gameId: game.id,
           body: trimmedNote,
-          isPublic: true,
         });
       }
     } catch (err: any) {
@@ -2149,7 +2120,6 @@ export class NowPlayingCommand {
           userId: session.userId,
           gameId: session.gameId,
           body: trimmedSessionNote,
-          isPublic: true,
         });
       }
       nowPlayingAddPlatformSessions.delete(platformSessionId);
@@ -3308,11 +3278,7 @@ export class NowPlayingCommand {
     gameId: number,
     page: number,
   ): Promise<ActionRowBuilder<ButtonBuilder>> {
-    const entries = await Member.getGameJournalEntries(ownerId, gameId, {
-      viewerUserId: ownerId,
-      limit: 1,
-      offset: 0,
-    });
+    const entries = await Member.getGameJournalEntries(ownerId, gameId, { limit: 1, offset: 0 });
     const hasEntries = entries.length > 0;
     return new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
@@ -3358,7 +3324,7 @@ export class NowPlayingCommand {
       });
       return;
     }
-    if (interaction.guildId && !selected.hasPublicJournalEntry) {
+    if (interaction.guildId && !selected.hasJournalEntry) {
       await safeReply(interaction, {
         content: "This game's journal has no public entries to show in channel.",
         flags: buildComponentsV2Flags(true),
@@ -3394,7 +3360,7 @@ export class NowPlayingCommand {
     if (!gameId) return;
     const nowPlayingEntries = getDisplayNowPlayingEntries(await Member.getNowPlaying(ownerId));
     const selected = nowPlayingEntries.find((e) => e.gameId === gameId);
-    if (!selected?.journalEnabled || !selected.hasPublicJournalEntry) {
+    if (!selected?.journalEnabled || !selected.hasJournalEntry) {
       await safeReply(interaction, {
         content: "This game has no public journal entries.",
         flags: buildComponentsV2Flags(true),
@@ -3434,7 +3400,7 @@ export class NowPlayingCommand {
       });
       return;
     }
-    if (interaction.guildId && !selected.hasPublicJournalEntry) {
+    if (interaction.guildId && !selected.hasJournalEntry) {
       await safeReply(interaction, {
         content: "This game's journal has no public entries to show in channel.",
         flags: buildComponentsV2Flags(true),
@@ -3489,20 +3455,6 @@ export class NowPlayingCommand {
           .setMaxLength(2000),
       ),
     );
-    modal.addLabelComponents(
-      new LabelBuilder()
-        .setLabel("Privacy")
-        .setDescription("Choose who can view this entry")
-        .setRadioGroupComponent(
-          new RadioGroupBuilder()
-            .setCustomId(NOW_PLAYING_JOURNAL_PRIVACY_INPUT_ID)
-            .setRequired(true)
-            .setOptions(
-              { label: "Private", value: "private", description: "Only you can view it" },
-              { label: "Public", value: "public", description: "Visible to other members" },
-            ),
-        ),
-    );
     await interaction.showModal(modal);
     await journalOwnerMenu.dismiss(ownerId);
   }
@@ -3517,11 +3469,7 @@ export class NowPlayingCommand {
     const gameId = Number(gameIdRaw);
     const page = Number(pageRaw);
     const offset = (Math.max(1, page) - 1) * 5;
-    const entries = await Member.getGameJournalEntries(ownerId, gameId, {
-      viewerUserId: ownerId,
-      limit: 5,
-      offset,
-    });
+    const entries = await Member.getGameJournalEntries(ownerId, gameId, { limit: 5, offset });
     if (!entries.length) {
       await safeReply(interaction, { content: "No journal entries available to edit." });
       return;
@@ -3529,7 +3477,7 @@ export class NowPlayingCommand {
     const options = entries.map((entry) => ({
       label: (entry.title ?? `Entry #${entry.entryNumber}`).slice(0, 100),
       value: String(entry.entryId),
-      description: `${formatTableDate(entry.createdAt)} | ${entry.isPublic ? "Public" : "Private"}`,
+      description: formatTableDate(entry.createdAt),
     }));
     const select = new StringSelectMenuBuilder()
       .setCustomId(`${NOW_PLAYING_JOURNAL_EDIT_SELECT_PREFIX}:${ownerId}:${gameId}:${page}`)
@@ -3588,30 +3536,6 @@ export class NowPlayingCommand {
           .setValue(entry.body.slice(0, 2000)),
       ),
     );
-    modal.addLabelComponents(
-      new LabelBuilder()
-        .setLabel("Privacy")
-        .setDescription("Choose who can view this entry")
-        .setRadioGroupComponent(
-          new RadioGroupBuilder()
-            .setCustomId(NOW_PLAYING_JOURNAL_PRIVACY_INPUT_ID)
-            .setRequired(true)
-            .setOptions(
-              {
-                label: "Private",
-                value: "private",
-                description: "Only you can view it",
-                default: !entry.isPublic,
-              },
-              {
-                label: "Public",
-                value: "public",
-                description: "Visible to other members",
-                default: entry.isPublic,
-              },
-            ),
-        ),
-    );
     await interaction.showModal(modal);
     const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     if (isEphemeral) {
@@ -3631,11 +3555,7 @@ export class NowPlayingCommand {
     const gameId = Number(gameIdRaw);
     const page = Number(pageRaw);
     const offset = (Math.max(1, page) - 1) * 5;
-    const entries = await Member.getGameJournalEntries(ownerId, gameId, {
-      viewerUserId: ownerId,
-      limit: 5,
-      offset,
-    });
+    const entries = await Member.getGameJournalEntries(ownerId, gameId, { limit: 5, offset });
     if (!entries.length) {
       await safeReply(interaction, { content: "No journal entries available to delete." });
       return;
@@ -3643,7 +3563,7 @@ export class NowPlayingCommand {
     const options = entries.map((entry) => ({
       label: (entry.title ?? `Entry #${entry.entryNumber}`).slice(0, 100),
       value: String(entry.entryId),
-      description: `${formatTableDate(entry.createdAt)} | ${entry.isPublic ? "Public" : "Private"}`,
+      description: formatTableDate(entry.createdAt),
     }));
     const select = new StringSelectMenuBuilder()
       .setCustomId(`${NOW_PLAYING_JOURNAL_DELETE_SELECT_PREFIX}:${ownerId}:${gameId}:${page}`)
@@ -3728,7 +3648,7 @@ export class NowPlayingCommand {
       flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
     });
     if (action === "yes") {
-      await refreshPublicJournalMessages(
+      await refreshJournalMessages(
         interaction.client, ownerId, Number(gameIdRaw), interaction.message.id,
       );
     }
@@ -3749,19 +3669,17 @@ export class NowPlayingCommand {
       interaction.fields.getTextInputValue(NOW_PLAYING_JOURNAL_BODY_INPUT_ID),
       { preserveNewlines: true, maxLength: 2000 },
     );
-    const isPublic = extractJournalPrivacyFromInteraction(interaction);
     await Member.addGameJournalEntry({
       userId: ownerId,
       gameId: Number(gameIdRaw),
       title: title || null,
       body,
-      isPublic,
     });
-    await Member.upsertGameJournalPreference(ownerId, Number(gameIdRaw), true, isPublic);
+    await Member.upsertGameJournalPreference(ownerId, Number(gameIdRaw), true);
     const page = Number(pageRaw);
     const row = await this.buildManageJournalButtonRow(ownerId, Number(gameIdRaw), page);
     await journalOwnerMenu.show(interaction, ownerId, [row]);
-    await refreshPublicJournalMessages(interaction.client, ownerId, Number(gameIdRaw));
+    await refreshJournalMessages(interaction.client, ownerId, Number(gameIdRaw));
   }
 
   @ModalComponent({ id: /^nowplaying-journal-edit-modal:\d+:\d+:\d+:\d+$/ })
@@ -3788,21 +3706,14 @@ export class NowPlayingCommand {
       interaction.fields.getTextInputValue(NOW_PLAYING_JOURNAL_BODY_INPUT_ID),
       { preserveNewlines: true, maxLength: 2000 },
     );
-    const isPublic = extractJournalPrivacyFromInteraction(interaction);
-    await Member.updateGameJournalEntry({
-      userId: ownerId,
-      entryId,
-      title: title || null,
-      body,
-      isPublic,
-    });
+    await Member.updateGameJournalEntry({ userId: ownerId, entryId, title: title || null, body });
     const page = Number(pageRaw);
     const row = await this.buildManageJournalButtonRow(ownerId, gameId, page);
     await safeReply(interaction, {
       components: [row],
       flags: buildComponentsV2Flags(true),
     });
-    await refreshPublicJournalMessages(interaction.client, ownerId, gameId);
+    await refreshJournalMessages(interaction.client, ownerId, gameId);
   }
 
   @ButtonComponent({ id: /^nowplaying-list-edit:\d+$/ })
@@ -4577,15 +4488,15 @@ export class NowPlayingCommand {
     ownerId: string,
   ): ActionRowBuilder<StringSelectMenuBuilder> | null {
     const journalEntries = entries.filter(
-      (e) => e.journalEnabled && e.hasPublicJournalEntry,
+      (e) => e.journalEnabled && e.hasJournalEntry,
     );
     if (!journalEntries.length) return null;
     const options = journalEntries.map((e) => {
       const rawLabel = `${e.title} Game Journal`;
       const label = rawLabel.length > 100 ? `${rawLabel.slice(0, 97)}...` : rawLabel;
-      const countText = e.publicJournalCount === 1 ? "1 entry" : `${e.publicJournalCount} entries`;
-      const lastPart = e.lastPublicJournalAt
-        ? ` · Last entry ${formatTableDate(e.lastPublicJournalAt)}`
+      const countText = e.journalCount === 1 ? "1 entry" : `${e.journalCount} entries`;
+      const lastPart = e.lastJournalAt
+        ? ` · Last entry ${formatTableDate(e.lastJournalAt)}`
         : "";
       const description = `${countText}${lastPart}`.slice(0, 100);
       return { label, description, value: String(e.gameId) };
@@ -5645,7 +5556,7 @@ export class NowPlayingCommand {
       }
       const content = this.trimTextDisplayContent(lines.join("\n"));
       const shouldShowJournalButton = entry.journalEnabled &&
-        (showPrivateOnlyJournalButtons || entry.hasPublicJournalEntry);
+        (showPrivateOnlyJournalButtons || entry.hasJournalEntry);
       if (shouldShowJournalButton) {
         const section = new SectionBuilder().addTextDisplayComponents(
           new TextDisplayBuilder().setContent(content),

--- a/src/config/journalConstants.ts
+++ b/src/config/journalConstants.ts
@@ -1,6 +1,5 @@
-export const GJ_PUBLIC_CLOSE_PREFIX = "journal-public-close";
+export const GJ_CLOSE_PREFIX = "journal-public-close";
 
 export const JOURNAL_ADD_MODAL_ID = "nowplaying-journal-modal";
 export const JOURNAL_TITLE_INPUT_ID = "nowplaying-journal-title";
 export const JOURNAL_BODY_INPUT_ID = "nowplaying-journal-body";
-export const JOURNAL_PRIVACY_INPUT_ID = "nowplaying-journal-privacy";

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -29,7 +29,7 @@ function entryLabel(n: number): string {
 
 export interface JournalViewOptions {
   ownerId: string;
-  /** null or "__public__" = public-only view; ownerId = owner view (includes private entries) */
+  /** null or "__public__" = viewer-only; ownerId = owner view (shows management controls) */
   viewerId: string | null;
   gameId: number;
   page: number;
@@ -75,12 +75,10 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
 
   const isOwnerView =
     viewerId !== null && viewerId !== "__public__" && viewerId === ownerId;
-  const countViewerId = isOwnerView ? ownerId : "__public__";
-  const entriesViewerId: string | null = isOwnerView ? ownerId : null;
 
   const [game, total, threadIds, memberRecord] = await Promise.all([
     Game.getGameById(gameId),
-    Member.countGameJournalEntries(ownerId, gameId, countViewerId),
+    Member.countGameJournalEntries(ownerId, gameId),
     getThreadsByGameId(gameId),
     Member.getByUserId(ownerId),
   ]);
@@ -91,7 +89,6 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
 
   const [entries, nowPlayingMeta, completions] = await Promise.all([
     Member.getGameJournalEntries(ownerId, gameId, {
-      viewerUserId: entriesViewerId,
       limit: JOURNAL_PAGE_SIZE,
       offset,
     }),
@@ -142,24 +139,16 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
 
   // Container 2: entries + footer
   const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
-  const publicQualifier = isOwnerView ? "" : "public ";
-  const footer = `-# ${total} ${publicQualifier}${entryLabel(total)}${pageInfo}`;
+  const footer = `-# ${total} ${entryLabel(total)}${pageInfo}`;
 
   const entryParts: string[] = [];
   if (!entries.length) {
     entryParts.push("No journal entries yet.");
   } else {
     for (const entry of entries) {
-      if (!isOwnerView && !entry.isPublic) {
-        entryParts.push(
-          `### Private Entry\n-# ${formatTableDate(entry.createdAt)}\nThis entry is private.`,
-        );
-        continue;
-      }
       const titleLine = entry.title ? `### ${entry.title}` : `### Entry #${entry.entryNumber}`;
       const date = formatTableDate(entry.createdAt);
-      const privacyLabel = isOwnerView ? ` | ${entry.isPublic ? "Public" : "Private"}` : "";
-      entryParts.push(`${titleLine}\n-# ${date}${privacyLabel}\n${trimContent(entry.body)}`);
+      entryParts.push(`${titleLine}\n-# ${date}\n${trimContent(entry.body)}`);
     }
   }
 

--- a/src/tests/now-playing-journal-components.test.ts
+++ b/src/tests/now-playing-journal-components.test.ts
@@ -46,9 +46,9 @@ test("now-playing list components serialize with mixed journal-enabled entries",
     noteUpdatedAt: null,
     sortOrder: null,
     journalEnabled: true,
-    hasPublicJournalEntry: true,
-    publicJournalCount: 3,
-    lastPublicJournalAt: null,
+    hasJournalEntry: true,
+    journalCount: 3,
+    lastJournalAt: null,
   }, {
     gameId: 102,
     title: "Notes Only Game",
@@ -61,9 +61,9 @@ test("now-playing list components serialize with mixed journal-enabled entries",
     noteUpdatedAt: null,
     sortOrder: null,
     journalEnabled: false,
-    hasPublicJournalEntry: false,
-    publicJournalCount: 0,
-    lastPublicJournalAt: null,
+    hasJournalEntry: false,
+    journalCount: 0,
+    lastJournalAt: null,
   }];
 
   const components = command.buildNowPlayingEntryComponents(
@@ -99,9 +99,9 @@ test("owner list shows journal buttons for multiple journal-enabled entries", ()
     noteUpdatedAt: null,
     sortOrder: null,
     journalEnabled: true,
-    hasPublicJournalEntry: false,
-    publicJournalCount: 0,
-    lastPublicJournalAt: null,
+    hasJournalEntry: false,
+    journalCount: 0,
+    lastJournalAt: null,
   }, {
     gameId: 202,
     title: "Journal Entry Two",
@@ -114,9 +114,9 @@ test("owner list shows journal buttons for multiple journal-enabled entries", ()
     noteUpdatedAt: null,
     sortOrder: null,
     journalEnabled: true,
-    hasPublicJournalEntry: true,
-    publicJournalCount: 2,
-    lastPublicJournalAt: null,
+    hasJournalEntry: true,
+    journalCount: 2,
+    lastJournalAt: null,
   }];
 
   const components = command.buildNowPlayingEntryComponents(
@@ -148,9 +148,9 @@ test("owner list with 10 entries stays serializable and keeps journal buttons", 
     noteUpdatedAt: null,
     sortOrder: null,
     journalEnabled: true,
-    hasPublicJournalEntry: false,
-    publicJournalCount: 0,
-    lastPublicJournalAt: null,
+    hasJournalEntry: false,
+    journalCount: 0,
+    lastJournalAt: null,
   }));
 
   const components = command.buildNowPlayingEntryComponents(
@@ -191,7 +191,6 @@ test("journal single-page view omits pager buttons and page count", async () => 
       userId: "123",
       gameId: 1,
       isEnabled: true,
-      defaultIsPublic: false,
     })) as any;
     Member.countGameJournalEntries = (async () => 1) as any;
     Member.getGameJournalEntries = (async () => ([{
@@ -200,7 +199,6 @@ test("journal single-page view omits pager buttons and page count", async () => 
       gameId: 1,
       title: "Entry",
       body: "Body",
-      isPublic: false,
       createdAt: new Date(),
       updatedAt: new Date(),
     }])) as any;
@@ -245,7 +243,6 @@ test("journal public view redacts private entry content and count", async () => 
       userId: "123",
       gameId: 1,
       isEnabled: true,
-      defaultIsPublic: false,
     })) as any;
     Member.countGameJournalEntries = (async (_userId: string, _gameId: number, viewerUserId?: string | null) => {
       countViewerArg = viewerUserId;
@@ -261,7 +258,6 @@ test("journal public view redacts private entry content and count", async () => 
       gameId: 1,
       title: "Testing a Private Entry",
       body: "This text should not render.",
-      isPublic: false,
       createdAt: new Date("2026-05-11T00:00:00.000Z"),
       updatedAt: new Date("2026-05-11T00:00:00.000Z"),
     }, {
@@ -270,7 +266,6 @@ test("journal public view redacts private entry content and count", async () => 
       gameId: 1,
       title: "Finally",
       body: "5 hours played.",
-      isPublic: true,
       createdAt: new Date("2026-05-11T00:00:00.000Z"),
       updatedAt: new Date("2026-05-11T00:00:00.000Z"),
     }];
@@ -308,7 +303,6 @@ test("journal edit modal submit shows manage journal buttons", async () => {
       gameId: 1,
       title: "Private Edit",
       body: "Top secret body.",
-      isPublic: false,
       createdAt: new Date("2026-05-11T00:00:00.000Z"),
       updatedAt: new Date("2026-05-11T00:00:00.000Z"),
     })) as any;
@@ -319,7 +313,6 @@ test("journal edit modal submit shows manage journal buttons", async () => {
       gameId: 1,
       title: "Private Edit",
       body: "Top secret body.",
-      isPublic: false,
       createdAt: new Date("2026-05-11T00:00:00.000Z"),
       updatedAt: new Date("2026-05-11T00:00:00.000Z"),
     }])) as any;
@@ -337,9 +330,7 @@ test("journal edit modal submit shows manage journal buttons", async () => {
           return "";
         },
       },
-      components: [{
-        components: [{ customId: "nowplaying-journal-privacy", value: "private" }],
-      }],
+      components: [],
       reply: async (payload: any) => {
         replyPayload = payload;
       },
@@ -374,7 +365,6 @@ test("journal edit select in guild deletes prompt message after opening modal", 
       gameId: 1,
       title: "Private Edit",
       body: "Top secret body.",
-      isPublic: false,
       createdAt: new Date("2026-05-11T00:00:00.000Z"),
       updatedAt: new Date("2026-05-11T00:00:00.000Z"),
     })) as any;
@@ -430,7 +420,6 @@ test("journal delete confirm removes entry on yes and skips removal on no", asyn
       userId: "123",
       gameId: 1,
       isEnabled: true,
-      defaultIsPublic: false,
     })) as any;
     Member.countGameJournalEntries = (async () => 1) as any;
     Member.getGameJournalEntries = (async () => ([{
@@ -439,7 +428,6 @@ test("journal delete confirm removes entry on yes and skips removal on no", asyn
       gameId: 1,
       title: "Entry",
       body: "Body",
-      isPublic: true,
       createdAt: new Date("2026-05-11T00:00:00.000Z"),
       updatedAt: new Date("2026-05-11T00:00:00.000Z"),
     }])) as any;


### PR DESCRIPTION
## Summary
- Removes the concept of private journal entries entirely; all entries are now public
- Strips privacy radio group from add/edit journal modals in both `game-journal` and `now-playing` commands
- Renames `hasPublicJournalEntry`/`publicJournalCount`/`lastPublicJournalAt` to `hasJournalEntry`/`journalCount`/`lastJournalAt` on `IMemberNowPlayingEntry`
- Simplifies DB queries to remove `IS_PUBLIC` filtering (new inserts still write `IS_PUBLIC=1` for DB compat); removes `publicEntries` from journal list queries
- Renames `refreshPublicJournalMessages` → `refreshJournalMessages` and `GJ_PUBLIC_CLOSE_PREFIX` → `GJ_CLOSE_PREFIX` (stable custom ID value unchanged)
- Updates test fixtures to match removed privacy fields

## Test plan
- [ ] Add a new journal entry and confirm no privacy selector appears
- [ ] Edit an existing journal entry and confirm no privacy selector appears
- [ ] View another user's journal and confirm all entries display (not filtered by IS_PUBLIC)
- [ ] Verify entry select menus (edit/delete) show date only, no Public/Private label
- [ ] Verify journal list shows total entry count (not public-only count)
- [ ] `tsc --noEmit` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)