### PR TITLE
feat(now-playing): header edit button shows ephemeral action row only

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -210,6 +210,7 @@ type NowPlayingJournalContext = {
 const nowPlayingJournalContexts = new Map<string, NowPlayingJournalContext>();
 const NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS = 2 * 60 * 60 * 1000;
 const journalOwnerMenu = new EphemeralOwnerMenu();
+const nowPlayingOwnerMenu = new EphemeralOwnerMenu();
 
 export async function restoreJournalMessageContextsFromDb(): Promise<void> {
   try {
@@ -2900,7 +2901,7 @@ export class NowPlayingCommand {
     }
 
     await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
-    await this.returnToNowPlayingEditMenu(interaction, ownerId, "Sort order saved.");
+    await this.returnToNowPlayingEditMenu(interaction, ownerId);
   }
 
   @ButtonComponent({ id: /^nowplaying-sort-reset:\d+$/ })
@@ -3733,11 +3734,7 @@ export class NowPlayingCommand {
     }
 
     setNowPlayingListContext(ownerId, interaction.message);
-    const components = await this.buildNowPlayingEditInitialComponents(ownerId);
-    await safeReply(interaction, {
-      components,
-      flags: buildComponentsV2Flags(true),
-    });
+    await nowPlayingOwnerMenu.show(interaction, ownerId, [this.buildNowPlayingManageRow(ownerId)]);
   }
 
   @ButtonComponent({ id: /^nowplaying-help:[a-z-]+:\d+$/ })
@@ -4485,6 +4482,27 @@ export class NowPlayingCommand {
     );
   }
 
+  private buildNowPlayingManageRow(ownerId: string): ActionRowBuilder<ButtonBuilder> {
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`${NOW_PLAYING_EDIT_MENU_SORT_PREFIX}:${ownerId}`)
+        .setLabel("Sort")
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId(`${NOW_PLAYING_EDIT_MENU_PLATFORM_PREFIX}:${ownerId}`)
+        .setLabel("Edit Platform")
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId(`${NOW_PLAYING_EDIT_MENU_COMPLETE_PREFIX}:${ownerId}`)
+        .setLabel("Add Completion")
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId(`${NOW_PLAYING_EDIT_MENU_REMOVE_PREFIX}:${ownerId}`)
+        .setLabel("Remove Game")
+        .setStyle(ButtonStyle.Danger),
+    );
+  }
+
   private buildNowPlayingEditMenuComponents(
     ownerId: string,
     entries: IMemberNowPlayingEntry[],
@@ -4536,17 +4554,8 @@ export class NowPlayingCommand {
   private async returnToNowPlayingEditMenu(
     interaction: ButtonInteraction,
     ownerId: string,
-    statusMessage: string | null = null,
   ): Promise<void> {
-    const menuComponents = await this.buildNowPlayingEditInitialComponents(
-      ownerId,
-      statusMessage,
-    );
-    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? true;
-    await safeReply(interaction, {
-      components: menuComponents,
-      flags: buildComponentsV2Flags(isEphemeral),
-    });
+    await nowPlayingOwnerMenu.show(interaction, ownerId, [this.buildNowPlayingManageRow(ownerId)]);
   }
 
   private async buildNowPlayingEditInitialComponents(

--- a/src/tests/now-playing-list-edit-menu.test.ts
+++ b/src/tests/now-playing-list-edit-menu.test.ts
@@ -6,8 +6,6 @@ test("nowplaying list edit opens ephemeral manage menu for owner", async () => {
   const command = new NowPlayingCommand() as any;
   const replies: any[] = [];
 
-  command.buildNowPlayingEditInitialComponents = async () => [{ kind: "manage-menu" }];
-
   const interaction: any = {
     customId: "nowplaying-list-edit:123",
     user: { id: "123" },
@@ -27,6 +25,7 @@ test("nowplaying list edit opens ephemeral manage menu for owner", async () => {
     editReply: async () => {
       throw new Error("editReply should not be called");
     },
+    deleteReply: async () => {},
   };
 
   await command.handleNowPlayingListEdit(interaction);


### PR DESCRIPTION
## Summary

- Replaces the full manage-menu ephemeral (intro container + game list + two action rows) with a single compact action row containing all four buttons (Sort, Edit Platform, Add Completion, Remove Game)
- Uses `EphemeralOwnerMenu` so any existing row is deleted before a new one is shown, matching the Game Journal header button pattern
- All sub-flows (sort, platform, completion, remove) update the ephemeral in-place as before; when done they edit back to the compact action row via the same `EphemeralOwnerMenu.show()` call
- Removed the unused `statusMessage` parameter from `returnToNowPlayingEditMenu`

## Test plan

- [ ] Click the Edit button on a Now Playing list header -- only the four action buttons appear ephemerally, no header text or game list
- [ ] Click Edit again before dismissing -- previous row is deleted, new one appears
- [ ] Run Sort, Edit Platform, Add Completion, Remove Game flows -- each transitions the ephemeral in-place and returns to the four-button row when done
- [ ] Non-owner clicking Edit still gets the "only the owner" rejection

🤖 Generated with [Claude Code](https://claude.com/claude-code)