### PR TITLE
fix(now-playing): use hasJournalEntry for Start a Game Journal button check

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3828,7 +3828,7 @@ export class NowPlayingCommand {
       return;
     }
     const entries = await Member.getNowPlaying(ownerId).then(getDisplayNowPlayingEntries);
-    const gamesWithoutJournal = entries.filter((e) => !e.journalEnabled);
+    const gamesWithoutJournal = entries.filter((e) => !e.hasJournalEntry);
     if (!gamesWithoutJournal.length) {
       await safeUpdate(interaction, {
         components: [await this.buildNowPlayingManageRow(ownerId)],
@@ -3872,7 +3872,7 @@ export class NowPlayingCommand {
     if (!gameId) return;
     const entries = await Member.getNowPlaying(ownerId).then(getDisplayNowPlayingEntries);
     const selected = entries.find((e) => e.gameId === gameId);
-    if (!selected || selected.journalEnabled) {
+    if (!selected || selected.hasJournalEntry) {
       await safeUpdate(interaction, {
         components: [await this.buildNowPlayingManageRow(ownerId)],
         flags: buildComponentsV2Flags(true),
@@ -4579,7 +4579,7 @@ export class NowPlayingCommand {
     ownerId: string,
   ): Promise<ActionRowBuilder<ButtonBuilder>> {
     const entries = await Member.getNowPlaying(ownerId).then(getDisplayNowPlayingEntries);
-    const hasGamesWithoutJournal = entries.some((e) => !e.journalEnabled);
+    const hasGamesWithoutJournal = entries.some((e) => !e.hasJournalEntry);
     const buttons: ButtonBuilder[] = [];
     if (hasGamesWithoutJournal) {
       buttons.push(


### PR DESCRIPTION
## Summary
- Fixes Start a Game Journal button never rendering
- `journalEnabled` is always `true` now that journals are the default for all games, so the original condition `!e.journalEnabled` was never satisfied
- Switched all three occurrences in the new code to `!e.hasJournalEntry`, which correctly identifies games that have no written journal entries

## Test plan
- [ ] Open your now-playing list as the owner and click Edit - confirm "Start a Game Journal" appears when games have no entries
- [ ] Confirm the button disappears after a journal entry is created for all games

🤖 Generated with [Claude Code](https://claude.com/claude-code)