### PR TITLE
feat(now-playing): post journal message to channel on first entry submission

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3672,17 +3672,39 @@ export class NowPlayingCommand {
       interaction.fields.getTextInputValue(NOW_PLAYING_JOURNAL_BODY_INPUT_ID),
       { preserveNewlines: true, maxLength: 2000 },
     );
+    const gameId = Number(gameIdRaw);
+    const hasExistingTracked = Array.from(nowPlayingJournalContexts.values())
+      .some((ctx) => ctx.ownerUserId === ownerId && ctx.gameId === gameId);
     await Member.addGameJournalEntry({
       userId: ownerId,
-      gameId: Number(gameIdRaw),
+      gameId,
       title: title || null,
       body,
     });
-    await Member.upsertGameJournalPreference(ownerId, Number(gameIdRaw), true);
+    await Member.upsertGameJournalPreference(ownerId, gameId, true);
     const page = Number(pageRaw);
-    const row = await this.buildManageJournalButtonRow(ownerId, Number(gameIdRaw), page);
+    const row = await this.buildManageJournalButtonRow(ownerId, gameId, page);
     await journalOwnerMenu.show(interaction, ownerId, [row]);
-    await refreshJournalMessages(interaction.client, ownerId, Number(gameIdRaw));
+    await refreshJournalMessages(interaction.client, ownerId, gameId);
+    if (!hasExistingTracked && interaction.guildId) {
+      await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
+      const payload = await this.buildJournalComponents(
+        ownerId,
+        "__public__",
+        gameId,
+        page,
+        interaction.guildId,
+        true,
+      );
+      const posted = await interaction.followUp({
+        components: payload.components as any[],
+        files: payload.files,
+        allowedMentions: payload.allowedMentions,
+      }).catch(() => null);
+      if (posted) {
+        await trackNowPlayingJournalContext(posted as Message<boolean>, ownerId, gameId);
+      }
+    }
   }
 
   @ModalComponent({ id: /^nowplaying-journal-edit-modal:\d+:\d+:\d+:\d+$/ })


### PR DESCRIPTION
## Summary
- After a journal entry is submitted via the modal (`handleNowPlayingJournalModal`), check whether any tracked journal channel messages exist for that owner/game before saving
- If none exist (first entry ever, or all previous messages have expired/been deleted) **and** the interaction is in a guild, post the journal view as a non-ephemeral `followUp` to the channel and track it so future edits can refresh it
- The ephemeral owner manage row still shows as before; the journal message appears in the channel separately
- Subsequent submissions continue to use `refreshJournalMessages` to update the existing tracked message -- no duplicate posts

## Test plan
- [ ] Submit first journal entry for a game via "Start a Game Journal" flow -- confirm journal message appears in channel
- [ ] Submit first journal entry via the normal journal header Add Entry button -- confirm journal message also appears in channel
- [ ] Add a second entry to a game that already has a tracked message -- confirm existing message is updated, no new post
- [ ] Verify behavior in DMs (no guild): no channel post, only the ephemeral manage row

🤖 Generated with [Claude Code](https://claude.com/claude-code)