### PR TITLE
fix(now-playing): post journal before manage buttons on first entry

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3684,9 +3684,9 @@ export class NowPlayingCommand {
     await Member.upsertGameJournalPreference(ownerId, gameId, true);
     const page = Number(pageRaw);
     const row = await this.buildManageJournalButtonRow(ownerId, gameId, page);
-    await journalOwnerMenu.show(interaction, ownerId, [row]);
-    await refreshJournalMessages(interaction.client, ownerId, gameId);
     if (!hasExistingTracked && interaction.guildId) {
+      // First entry: post the journal message first so it appears before the manage buttons.
+      // Skip journalOwnerMenu here to avoid its deletor pointing at the journal post.
       await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
       const payload = await this.buildJournalComponents(
         ownerId,
@@ -3696,15 +3696,20 @@ export class NowPlayingCommand {
         interaction.guildId,
         true,
       );
-      const posted = await interaction.followUp({
+      await safeReply(interaction, {
         components: payload.components as any[],
         files: payload.files,
         flags: buildComponentsV2Flags(false),
         allowedMentions: payload.allowedMentions,
+      });
+      await this.trackJournalReply(interaction, ownerId, gameId);
+      await interaction.followUp({
+        components: [row],
+        flags: buildComponentsV2Flags(true),
       }).catch(() => null);
-      if (posted) {
-        await trackNowPlayingJournalContext(posted as Message<boolean>, ownerId, gameId);
-      }
+    } else {
+      await journalOwnerMenu.show(interaction, ownerId, [row]);
+      await refreshJournalMessages(interaction.client, ownerId, gameId);
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes button/journal ordering: journal message now appears above the manage buttons
- Root cause: `journalOwnerMenu.show` consumed the interaction's reply slot first, pushing the journal to a followUp that appeared below
- For the first-entry case (no existing tracked journal message + guild context): reply with the journal non-ephemerally, track it, then send the manage buttons as an ephemeral followUp
- `journalOwnerMenu` is deliberately skipped in this path so its deletor cannot target the journal post
- Normal path (existing tracked messages) is unchanged: `journalOwnerMenu.show` + `refreshJournalMessages`

## Test plan
- [ ] Submit first journal entry via "Start a Game Journal" -- journal message should appear first, manage buttons (ephemeral) below it
- [ ] Submit additional entries via the manage row Add Entry button -- existing message refreshes, no new post, manage buttons appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)