### PR TITLE
fix(now-playing): reduce edit platform components at 10 entries

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -4966,40 +4966,41 @@ export class NowPlayingCommand {
       ),
     );
 
-    const components: Array<ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>> = [
-      container,
-    ];
+    const rows: Array<ActionRowBuilder<StringSelectMenuBuilder>> = [];
     for (let slotIndex = 0; slotIndex < entries.length; slotIndex += 1) {
       const entry = entries[slotIndex];
       const options = platformOptions[slotIndex] ?? [];
       if (!options.length) {
-        components.push(
-          new ContainerBuilder().addTextDisplayComponents(
-            new TextDisplayBuilder().setContent(
-              `### ${formatEntryTitleWithPlatform(entry)}\n-# No platform choices available for this game.`,
-            ),
+        container.addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(
+            `-# ${entry.title.slice(0, 80)}: No platform choices available.`,
           ),
         );
         continue;
       }
       const selectedIndex = parsedState[slotIndex];
-      components.push(new ContainerBuilder().addTextDisplayComponents(
-        new TextDisplayBuilder().setContent(
-          `### ${formatEntryTitleWithPlatform(entry)}`,
-        ),
-      ));
+      const currentPlatformName = selectedIndex >= 0 ? (options[selectedIndex]?.label ?? null) : null;
+      const placeholder = currentPlatformName
+        ? `${entry.title.slice(0, 50)} - ${currentPlatformName}`.slice(0, 100)
+        : entry.title.slice(0, 100);
       const select = new StringSelectMenuBuilder()
         .setCustomId(`${NOW_PLAYING_EDIT_PLATFORM_SLOT_PREFIX}:${ownerId}:${slotIndex}:${stateToken}`)
-        .setPlaceholder(`Platform for ${entry.title.slice(0, 70)}`)
+        .setPlaceholder(placeholder)
         .setMinValues(1)
         .setMaxValues(1)
         .addOptions(options.map((option, optionIndex) => ({
-          label: option.label,
+          label: optionIndex === selectedIndex
+            ? `${entry.title.slice(0, 50)} - ${option.label}`.slice(0, 100)
+            : option.label,
           value: option.value,
           default: selectedIndex === optionIndex,
         })));
-      components.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
+      rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
     }
+    const components: Array<ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>> = [
+      container,
+      ...rows,
+    ];
 
     const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()


### PR DESCRIPTION
## Summary

- Removes the per-entry title `ContainerBuilder` from the Edit Platform view, cutting top-level component count from 22 down to 12 at 10 entries (1 header + N selects + 1 button row)
- Games with no platform options now appear as a sub-line note inside the header container instead of their own container
- The game title and current platform are surfaced via the default selected option label (`Title - Platform`) and the select placeholder, so context is preserved without extra components

## Test plan

- [ ] Open Edit Platform with 10 now-playing entries -- form renders without error
- [ ] Each select shows the game title and current platform as the selected/default value
- [ ] Changing a platform updates the select correctly
- [ ] Save and Reset still work as expected
- [ ] Entries with no available platforms show the inline note in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)