### PR TITLE
feat(now-playing): render entries as numbered list with journal indicator

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -5508,22 +5508,10 @@ export class NowPlayingCommand {
       );
     }
     if (singleUserMode) {
-      const entryBlocks = entries.map((entry) => {
+      const entryBlocks = entries.map((entry, index) => {
         const entryTitle = formatEntry(entry, guildId);
-        const lines = [`**${entryTitle}**`];
-        if (entry.addedAt) {
-          const addedLabel = `Added ${formatTableDate(entry.addedAt)}`;
-          if (entry.noteUpdatedAt) {
-            const updatedLabel = `last updated ${formatTableDate(entry.noteUpdatedAt)}`;
-            if (formatTableDate(entry.addedAt) === formatTableDate(entry.noteUpdatedAt)) {
-              lines.push(`-# *${addedLabel}.*`);
-            } else {
-              lines.push(`-# *${addedLabel}, ${updatedLabel}.*`);
-            }
-          } else {
-            lines.push(`-# *${addedLabel}.*`);
-          }
-        }
+        const journalMark = entry.hasJournalEntry ? " 📒" : "";
+        const lines = [`${index + 1}. ${entryTitle}${journalMark}`];
         if (showNotes && entry.note && !entry.journalEnabled) {
           const quotedNote = entry.note
             .split("\n")
@@ -5558,20 +5546,8 @@ export class NowPlayingCommand {
         );
       }
       const entryTitle = formatEntry(entry, guildId);
-      const lines = [`**${entryTitle}**`];
-      if (entry.addedAt) {
-        const addedLabel = `Added ${formatTableDate(entry.addedAt)}`;
-        if (entry.noteUpdatedAt) {
-          const updatedLabel = `last updated ${formatTableDate(entry.noteUpdatedAt)}`;
-          if (formatTableDate(entry.addedAt) === formatTableDate(entry.noteUpdatedAt)) {
-            lines.push(`-# *${addedLabel}.*`);
-          } else {
-            lines.push(`-# *${addedLabel}, ${updatedLabel}.*`);
-          }
-        } else {
-          lines.push(`-# *${addedLabel}.*`);
-        }
-      }
+      const journalMark = entry.hasJournalEntry ? " 📒" : "";
+      const lines = [`${index + 1}. ${entryTitle}${journalMark}`];
       if (showNotes && entry.note && !entry.journalEnabled) {
         const quotedNote = entry.note
           .split("\n")


### PR DESCRIPTION
## Summary
- Entries under the media gallery are now rendered as a numbered list (`1. Title`, `2. Title`, etc.) instead of bold text blocks
- Thread links are preserved in the numbered list items
- Removed the "Added [date]" subtext from each entry
- Added 📒 emoji after the game title when the entry has journal entries

## Test plan
- [ ] `/now-playing list` shows numbered entries (no dates shown)
- [ ] Games linked to a thread show as `1. [Title](discord-link) 📒` or `1. [Title](discord-link)` appropriately
- [ ] Games with journal entries show the 📒 emoji after the title
- [ ] Games without journal entries do not show 📒
- [ ] Notes still display correctly when toggled

🤖 Generated with [Claude Code](https://claude.com/claude-code)