### PR TITLE
fix(now-playing): remove blank lines between numbered list entries

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -5521,7 +5521,7 @@ export class NowPlayingCommand {
         }
         return lines.join("\n");
       });
-      const combined = this.trimTextDisplayContent(entryBlocks.join("\n\n"));
+      const combined = this.trimTextDisplayContent(entryBlocks.join("\n"));
       if (hasDisplayableNotes) {
         const notesAction = showNotes ? "hide" : "show";
         const notesLabel = showNotes ? "Hide Notes" : "Show Notes";


### PR DESCRIPTION
## Summary
- Changes entry join separator from `\n\n` to `\n` so list items are tightly packed with no blank lines between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)