### PR TITLE
fix(game-journal): hide games with 0 entries from journal list

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -2534,6 +2534,7 @@ export default class Member {
           WHERE jp.USER_ID = :userId
             AND jp.IS_ENABLED = 1
           GROUP BY g.GAME_ID, g.TITLE
+         HAVING COUNT(e.ENTRY_ID) > 0
           ORDER BY g.TITLE`,
         { userId },
         { outFormat: oracledb.OUT_FORMAT_OBJECT },


### PR DESCRIPTION
## Summary
- Adds `HAVING COUNT(e.ENTRY_ID) > 0` to the `getGameJournalList` SQL query
- Games that have the journal preference enabled but no entries written are no longer shown in the `/game-journal` list view

## Test plan
- [ ] Run `/game-journal` for a user who has games with 0 entries tracked — confirm they do not appear in the list
- [ ] Run `/game-journal` for a user with entries — confirm all games with entries still appear normally
- [ ] Confirm the footer count reflects only games with entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)