### PR TITLE
fix(game-journal): show one entry per page

### DIFF
--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -17,7 +17,7 @@ import { formatTableDate, formatPlaytimeHours } from "../commands/profile.comman
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { buildUserHeaderContainer } from "./uiComponents.js";
 
-const JOURNAL_PAGE_SIZE = 3;
+const JOURNAL_PAGE_SIZE = 1;
 
 function trimContent(text: string): string {
   return text.length <= 4000 ? text : `${text.slice(0, 3997)}...`;


### PR DESCRIPTION
## Summary
- Changes `JOURNAL_PAGE_SIZE` from `3` to `1` in `journalView.ts` so the game journal view displays a single entry per page with previous/next navigation.

## Test plan
- [ ] Open a game journal with multiple entries and confirm only one entry is shown per page
- [ ] Confirm Previous Page / Next Page buttons navigate correctly between entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)