### PR TITLE
fix(game-journal): skip entry selection on edit, rename nav buttons

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -67,7 +67,6 @@ const GJ_ALL_PAGE_PREFIX = "game-journal-all-page";
 const GJ_HEADER_ADD_PREFIX = "game-journal-header-add";
 const GJ_HMENU_ADD_PREFIX = "game-journal-hmenu-add";
 const GJ_HMENU_EDIT_PREFIX = "game-journal-hmenu-edit";
-const GJ_HMENU_EDIT_SELECT_PREFIX = "game-journal-hmenu-edit-select";
 const GJ_HMENU_DELETE_PREFIX = "game-journal-hmenu-delete";
 const GJ_HMENU_DELETE_SELECT_PREFIX = "game-journal-hmenu-delete-select";
 const GJ_HMENU_DELETE_CONFIRM_PREFIX = "game-journal-hmenu-delete-confirm";
@@ -81,10 +80,9 @@ export { GJ_CLOSE_PREFIX };
 // customId: GJ_ALL_SELECT_PREFIX:{callerId}:{page}                  value=userId
 // customId: GJ_ALL_PAGE_PREFIX:{callerId}:{page}
 // customId: GJ_PUBLIC_CLOSE_PREFIX:{callerId}
-// customId: GJ_HEADER_ADD_PREFIX:{ownerId}:{gameId}
+// customId: GJ_HEADER_ADD_PREFIX:{ownerId}:{gameId}:{page}
 // customId: GJ_HMENU_ADD_PREFIX:{ownerId}:{gameId}
-// customId: GJ_HMENU_EDIT_PREFIX:{ownerId}:{gameId}
-// customId: GJ_HMENU_EDIT_SELECT_PREFIX:{ownerId}:{gameId}          value=entryId
+// customId: GJ_HMENU_EDIT_PREFIX:{ownerId}:{gameId}:{page}
 // customId: GJ_HMENU_DELETE_PREFIX:{ownerId}:{gameId}
 // customId: GJ_HMENU_DELETE_SELECT_PREFIX:{ownerId}:{gameId}        value=entryId
 // customId: GJ_HMENU_DELETE_CONFIRM_PREFIX:(yes|no):{ownerId}:{gameId}:{entryId}
@@ -96,14 +94,18 @@ function buildComponentsV2Flags(isEphemeral: boolean): number {
   return (isEphemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
 }
 
-function buildHmenuActionRow(ownerId: string, gameId: number): ActionRowBuilder<ButtonBuilder> {
+function buildHmenuActionRow(
+  ownerId: string,
+  gameId: number,
+  page = 1,
+): ActionRowBuilder<ButtonBuilder> {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
       .setCustomId(`${GJ_HMENU_ADD_PREFIX}:${ownerId}:${gameId}`)
       .setLabel("Add Entry")
       .setStyle(ButtonStyle.Success),
     new ButtonBuilder()
-      .setCustomId(`${GJ_HMENU_EDIT_PREFIX}:${ownerId}:${gameId}`)
+      .setCustomId(`${GJ_HMENU_EDIT_PREFIX}:${ownerId}:${gameId}:${page}`)
       .setLabel("Edit Entry")
       .setStyle(ButtonStyle.Primary),
     new ButtonBuilder()
@@ -253,7 +255,7 @@ function buildJournalViewPayload(
     nextPageCustomId: (p) =>
       `${GJ_VIEW_PAGE_PREFIX}:${callerId}:${targetUserId}:${gameId}:${p}`,
     headerButtonCustomId: isOwner
-      ? `${GJ_HEADER_ADD_PREFIX}:${targetUserId}:${gameId}`
+      ? `${GJ_HEADER_ADD_PREFIX}:${targetUserId}:${gameId}:${page}`
       : undefined,
     includeNowPlayingMeta: true,
     includeCompletions: true,
@@ -568,18 +570,19 @@ export class GameJournalCommand {
     }
   }
 
-  @ButtonComponent({ id: /^game-journal-header-add:\d+:\d+$/ })
+  @ButtonComponent({ id: /^game-journal-header-add:\d+:\d+:\d+$/ })
   async handleHeaderAdd(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
     }
     const gameId = Number(gameIdRaw);
+    const page = Number(pageRaw);
     const container = new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent("## Manage Journal"),
     );
-    const row = buildHmenuActionRow(ownerId, gameId);
+    const row = buildHmenuActionRow(ownerId, gameId, page);
     await safeReply(interaction, {
       components: [container, row],
       flags: buildComponentsV2Flags(true),
@@ -600,18 +603,17 @@ export class GameJournalCommand {
     await interaction.showModal(modal);
   }
 
-  @ButtonComponent({ id: /^game-journal-hmenu-edit:\d+:\d+$/ })
+  @ButtonComponent({ id: /^game-journal-hmenu-edit:\d+:\d+:\d+$/ })
   async handleGjHmenuEdit(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
     }
     const gameId = Number(gameIdRaw);
-    const entries = await Member.getGameJournalEntries(ownerId, gameId, {
-      limit: 5,
-      offset: 0,
-    });
+    const page = Number(pageRaw);
+    const offset = Math.max(0, page - 1);
+    const entries = await Member.getGameJournalEntries(ownerId, gameId, { limit: 1, offset });
     if (!entries.length) {
       await safeUpdate(interaction, {
         components: [
@@ -629,48 +631,9 @@ export class GameJournalCommand {
       });
       return;
     }
-    const options = entries.map((e) => ({
-      label: (e.title ?? `Entry #${e.entryNumber}`).slice(0, 100),
-      value: String(e.entryId),
-      description: formatTableDate(e.createdAt),
-    }));
-    const select = new StringSelectMenuBuilder()
-      .setCustomId(`${GJ_HMENU_EDIT_SELECT_PREFIX}:${ownerId}:${gameId}`)
-      .setPlaceholder("Choose an entry to edit")
-      .addOptions(options);
-    const container = new ContainerBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent("## Edit Journal Entry\nSelect an entry to edit."),
-    );
-    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
-    const helpRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-edit:${ownerId}`)
-        .setLabel("?")
-        .setStyle(ButtonStyle.Secondary),
-    );
-    await safeUpdate(interaction, {
-      components: [container, row, helpRow],
-      flags: buildComponentsV2Flags(true),
-    });
-  }
-
-  @SelectMenuComponent({ id: /^game-journal-hmenu-edit-select:\d+:\d+$/ })
-  async handleGjHmenuEditSelect(
-    interaction: StringSelectMenuInteraction,
-  ): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
-    if (interaction.user.id !== ownerId) {
-      await safeDeferUpdate(interaction);
-      return;
-    }
-    const entryId = Number(interaction.values[0]);
-    const entry = await Member.getGameJournalEntryForUser(ownerId, entryId);
-    if (!entry || entry.gameId !== Number(gameIdRaw)) {
-      await safeReply(interaction, { content: "That journal entry was not found." });
-      return;
-    }
+    const entry = entries[0];
     const modal = buildHmenuModal(
-      `${GJ_HMENU_EDIT_MODAL_ID}:${ownerId}:${gameIdRaw}:${entryId}`,
+      `${GJ_HMENU_EDIT_MODAL_ID}:${ownerId}:${gameIdRaw}:${entry.entryId}`,
       "Edit Journal Entry",
       entry.title ?? "",
       entry.body,

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -139,7 +139,6 @@ const NOW_PLAYING_JOURNAL_OPEN_PREFIX = "nowplaying-journal-open";
 const NOW_PLAYING_JOURNAL_VIEW_SELECT_PREFIX = "nowplaying-journal-view-select";
 const NOW_PLAYING_JOURNAL_ADD_PREFIX = "nowplaying-journal-add";
 const NOW_PLAYING_JOURNAL_EDIT_PREFIX = "nowplaying-journal-edit";
-const NOW_PLAYING_JOURNAL_EDIT_SELECT_PREFIX = "nowplaying-journal-edit-select";
 const NOW_PLAYING_JOURNAL_DELETE_PREFIX = "nowplaying-journal-delete";
 const NOW_PLAYING_JOURNAL_DELETE_SELECT_PREFIX = "nowplaying-journal-delete-select";
 const NOW_PLAYING_JOURNAL_DELETE_CONFIRM_PREFIX = "nowplaying-journal-delete-confirm";
@@ -3471,53 +3470,15 @@ export class NowPlayingCommand {
     }
     const gameId = Number(gameIdRaw);
     const page = Number(pageRaw);
-    const offset = (Math.max(1, page) - 1) * 5;
-    const entries = await Member.getGameJournalEntries(ownerId, gameId, { limit: 5, offset });
+    const offset = Math.max(0, page - 1);
+    const entries = await Member.getGameJournalEntries(ownerId, gameId, { limit: 1, offset });
     if (!entries.length) {
       await safeReply(interaction, { content: "No journal entries available to edit." });
       return;
     }
-    const options = entries.map((entry) => ({
-      label: (entry.title ?? `Entry #${entry.entryNumber}`).slice(0, 100),
-      value: String(entry.entryId),
-      description: formatTableDate(entry.createdAt),
-    }));
-    const select = new StringSelectMenuBuilder()
-      .setCustomId(`${NOW_PLAYING_JOURNAL_EDIT_SELECT_PREFIX}:${ownerId}:${gameId}:${page}`)
-      .setPlaceholder("Choose an entry to edit")
-      .addOptions(options);
-    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
-    const container = new ContainerBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent("## Edit Journal Entry\nSelect an entry to edit."),
-    );
-    const helpRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-edit:${ownerId}`)
-        .setLabel("?")
-        .setStyle(ButtonStyle.Secondary),
-    );
-    await safeUpdate(interaction, {
-      components: [container, row, helpRow],
-      flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
-    });
-  }
-
-  @SelectMenuComponent({ id: /^nowplaying-journal-edit-select:\d+:\d+:\d+$/ })
-  async handleNowPlayingJournalEditSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
-    if (interaction.user.id !== ownerId) {
-      await safeReply(interaction, { content: "Only the owner can edit journal entries." });
-      return;
-    }
-    const entryId = Number(interaction.values[0]);
-    const entry = await Member.getGameJournalEntryForUser(ownerId, entryId);
-    if (!entry || entry.gameId !== Number(gameIdRaw)) {
-      await safeReply(interaction, { content: "That journal entry was not found." });
-      return;
-    }
-
+    const entry = entries[0];
     const modal = new ComponentsModalBuilder()
-      .setCustomId(`${NOW_PLAYING_JOURNAL_EDIT_MODAL_ID}:${ownerId}:${gameIdRaw}:${pageRaw}:${entryId}`)
+      .setCustomId(`${NOW_PLAYING_JOURNAL_EDIT_MODAL_ID}:${ownerId}:${gameIdRaw}:${pageRaw}:${entry.entryId}`)
       .setTitle("Edit Journal Entry");
     modal.addActionRowComponents(
       new ComponentsActionRowBuilder<ComponentsTextInputBuilder>().addComponents(
@@ -3540,12 +3501,6 @@ export class NowPlayingCommand {
       ),
     );
     await interaction.showModal(modal);
-    const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
-    if (isEphemeral) {
-      await interaction.deleteReply().catch(() => null);
-    } else if (interaction.guildId) {
-      await interaction.message.delete().catch(() => null);
-    }
   }
 
   @ButtonComponent({ id: /^nowplaying-journal-delete:\d+:\d+:\d+$/ })

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -134,8 +134,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
   );
 
   // Container 2: entries + footer
-  const pageInfo = totalPages > 1 ? `, page ${safePage} of ${totalPages}` : "";
-  const footer = `-# ${total} ${entryLabel(total)}${pageInfo}`;
+  const footer = `-# ${total} ${entryLabel(total)}`;
 
   const entryParts: string[] = [];
   if (!entries.length) {
@@ -194,7 +193,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
     navRow.addComponents(
       new ButtonBuilder()
         .setCustomId(prevPageCustomId(safePage - 1))
-        .setLabel("Previous Page")
+        .setLabel("Next Entry")
         .setStyle(ButtonStyle.Secondary),
     );
   }
@@ -202,7 +201,7 @@ export async function buildJournalView(options: JournalViewOptions): Promise<{
     navRow.addComponents(
       new ButtonBuilder()
         .setCustomId(nextPageCustomId(safePage + 1))
-        .setLabel("Next Page")
+        .setLabel("Previous Entry")
         .setStyle(ButtonStyle.Secondary),
     );
   }


### PR DESCRIPTION
## Summary

- Edit button now opens the modal directly for the entry on the current page, skipping the old select-menu step. Works for both the Now Playing inline edit and the game-journal hmenu (page is threaded through the header-add button).
- Renamed journal nav buttons: \"Previous Page\" -> \"Next Entry\", \"Next Page\" -> \"Previous Entry\" (reflecting chronological order since entries are sorted newest-first).
- Removed the \"page X of Y\" count from the journal entry footer.

## Test plan

- [ ] View a journal with multiple entries and navigate pages; confirm buttons say \"Next Entry\" / \"Previous Entry\" and footer shows only total count.
- [ ] Click \"Edit Entry\" from the Now Playing journal view -- modal should open immediately with the entry on the current page pre-filled.
- [ ] Click the header manage button on the game-journal view, then \"Edit Entry\" -- modal should open immediately with the entry on the current page pre-filled.
- [ ] Confirm edit modal submit still updates the entry correctly and refreshes the journal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)