### PR TITLE
fix(game-journal): delete ephemeral menu message when edit modal opens

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -639,6 +639,7 @@ export class GameJournalCommand {
       entry.body,
     );
     await interaction.showModal(modal);
+    await interaction.message.delete().catch(() => null);
   }
 
   @ButtonComponent({ id: /^game-journal-hmenu-delete:\d+:\d+$/ })


### PR DESCRIPTION
## Summary
- Deletes the ephemeral "Manage Journal" message after the edit modal opens, so it doesn't linger after the user clicks Edit Entry

## Test plan
- [ ] Open game journal context menu, click Edit Entry — ephemeral menu should disappear when the modal opens
- [ ] Verify modal still opens and edits save correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)