### PR TITLE
fix(game-journal): correctly delete ephemeral menu on edit via EphemeralOwnerMenu

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -55,6 +55,9 @@ import {
   refreshJournalMessages,
 } from "./now-playing.command.js";
 import { NOW_PLAYING_HELP_PREFIX } from "./now-playing-help.js";
+import { EphemeralOwnerMenu } from "../functions/EphemeralOwnerMenu.js";
+
+const gjHmenu = new EphemeralOwnerMenu();
 
 const LIST_PAGE_SIZE = 15;
 const ALL_PAGE_SIZE = 20;
@@ -583,10 +586,7 @@ export class GameJournalCommand {
       new TextDisplayBuilder().setContent("## Manage Journal"),
     );
     const row = buildHmenuActionRow(ownerId, gameId, page);
-    await safeReply(interaction, {
-      components: [container, row],
-      flags: buildComponentsV2Flags(true),
-    });
+    await gjHmenu.show(interaction, ownerId, [container, row]);
   }
 
   @ButtonComponent({ id: /^game-journal-hmenu-add:\d+:\d+$/ })
@@ -639,7 +639,7 @@ export class GameJournalCommand {
       entry.body,
     );
     await interaction.showModal(modal);
-    await interaction.message.delete().catch(() => null);
+    await gjHmenu.dismiss(ownerId);
   }
 
   @ButtonComponent({ id: /^game-journal-hmenu-delete:\d+:\d+$/ })


### PR DESCRIPTION
## Summary
- Previous fix used `interaction.message.delete()` which silently fails for ephemeral messages — Discord's REST delete endpoint returns 403 for them
- The correct approach is `interaction.deleteReply()` on the **original** interaction that created the ephemeral reply
- Wired `handleHeaderAdd` through the existing `EphemeralOwnerMenu` pattern (which stores the original interaction's `deleteReply` callback), then calls `gjHmenu.dismiss(ownerId)` after `showModal` in the edit handler

## Test plan
- [ ] Click the journal icon to open the Manage Journal ephemeral menu
- [ ] Click Edit Entry — the ephemeral menu should disappear and the edit modal should open
- [ ] Confirm the edit modal saves correctly and the journal updates
- [ ] Open the menu again; clicking Add Entry and Delete Entry should still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)