### PR TITLE
fix(game-journal): only count games with entries in all-users view

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -2561,14 +2561,13 @@ export default class Member {
         `SELECT u.USER_ID,
                 u.USERNAME,
                 u.GLOBAL_NAME,
-                COUNT(DISTINCT jp.GAMEDB_GAME_ID) AS GAME_COUNT
-           FROM USER_GAME_JOURNAL_PREFS jp
-           JOIN RPG_CLUB_USERS u ON u.USER_ID = jp.USER_ID
-          WHERE jp.IS_ENABLED = 1
-            AND NVL(u.IS_BOT, 0) = 0
+                COUNT(DISTINCT je.GAMEDB_GAME_ID) AS GAME_COUNT
+           FROM RPG_CLUB_USER_GAME_JOURNAL_ENTRIES je
+           JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
+          WHERE NVL(u.IS_BOT, 0) = 0
             AND u.SERVER_LEFT_AT IS NULL
           GROUP BY u.USER_ID, u.USERNAME, u.GLOBAL_NAME
-          ORDER BY COUNT(DISTINCT jp.GAMEDB_GAME_ID) DESC,
+          ORDER BY COUNT(DISTINCT je.GAMEDB_GAME_ID) DESC,
                    u.GLOBAL_NAME NULLS LAST,
                    u.USERNAME NULLS LAST`,
         {},


### PR DESCRIPTION
## Summary
- Changes `getAllJournalUsers` to drive from `RPG_CLUB_USER_GAME_JOURNAL_ENTRIES` instead of `USER_GAME_JOURNAL_PREFS`
- Users only appear in the `all` list if they have at least one actual journal entry
- `gameCount` now reflects games with entries, not games with journal prefs enabled

## Test plan
- [ ] Run `/game-journal all:True` and confirm only users with actual entries appear
- [ ] Confirm game counts match the number of games each user has entries for (not just prefs)
- [ ] Confirm selecting a user from the list still shows their journal correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)