### PR TITLE
fix(game-journal): correct table name in getAllJournalUsers query

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -2562,7 +2562,7 @@ export default class Member {
                 u.USERNAME,
                 u.GLOBAL_NAME,
                 COUNT(DISTINCT je.GAMEDB_GAME_ID) AS GAME_COUNT
-           FROM RPG_CLUB_USER_GAME_JOURNAL_ENTRIES je
+           FROM USER_GAME_JOURNAL_ENTRIES je
            JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
           WHERE NVL(u.IS_BOT, 0) = 0
             AND u.SERVER_LEFT_AT IS NULL


### PR DESCRIPTION
## Summary
- Fixes `ORA-00942` crash introduced in #342
- `RPG_CLUB_USER_GAME_JOURNAL_ENTRIES` does not exist in the schema; the correct name is `USER_GAME_JOURNAL_ENTRIES`, matching every other query in `Member.ts`

## Test plan
- [ ] Run `/game-journal all:True` and confirm the list loads without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)