### PR TITLE
fix(game-journal): only update the most recent message per channel during live refresh

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -487,6 +487,9 @@ export async function refreshJournalMessages(
   excludeMessageId?: string,
 ): Promise<void> {
   const now = Date.now();
+
+  // First pass: expire stale contexts and collect the most recent context per channel.
+  const latestByChannel = new Map<string, NowPlayingJournalContext>();
   for (const [key, ctx] of nowPlayingJournalContexts.entries()) {
     if (ctx.ownerUserId !== ownerId || ctx.gameId !== gameId) continue;
     if (ctx.messageId === excludeMessageId) continue;
@@ -496,8 +499,17 @@ export async function refreshJournalMessages(
         .catch((err) => console.error("[Journal] Failed to delete expired context:", err));
       continue;
     }
+    const existing = latestByChannel.get(ctx.channelId);
+    if (!existing || ctx.createdAt > existing.createdAt) {
+      latestByChannel.set(ctx.channelId, ctx);
+    }
+  }
+
+  // Second pass: update only the single most recent message per channel.
+  for (const ctx of latestByChannel.values()) {
     const channel = await client.channels.fetch(ctx.channelId).catch(() => null);
     if (!channel?.isTextBased()) {
+      const key = `${ctx.channelId}:${ctx.messageId}`;
       nowPlayingJournalContexts.delete(key);
       await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
         .catch((err) => console.error("[Journal] Failed to delete unreachable context:", err));
@@ -505,6 +517,7 @@ export async function refreshJournalMessages(
     }
     const message = await channel.messages.fetch(ctx.messageId).catch(() => null);
     if (!message) {
+      const key = `${ctx.channelId}:${ctx.messageId}`;
       nowPlayingJournalContexts.delete(key);
       await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
         .catch((err) => console.error("[Journal] Failed to delete missing context:", err));


### PR DESCRIPTION
## Summary
- `refreshJournalMessages` now groups matching contexts by channel and selects only the one with the highest `createdAt` timestamp
- Only that single most-recent message per channel is edited on journal changes
- The existing 2-hour TTL continues to gate which contexts are eligible; expired ones are still pruned during the same pass

## Test plan
- [ ] Post a journal message in a channel, then post another journal message in the same channel -- only the second (newer) message should live-update when entries are added/edited/deleted
- [ ] Verify a journal message older than 2 hours is not updated (TTL still applies)
- [ ] Verify journal messages in different channels still each receive their own update

🤖 Generated with [Claude Code](https://claude.com/claude-code)