### PR TITLE
fix(game-journal): only delete the most recent journal message when paginating in a channel

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -5338,6 +5338,10 @@ export class NowPlayingCommand {
     }
 
     const now = Date.now();
+
+    // Expire stale entries and find the single most recent context for this channel.
+    let latestKey: string | null = null;
+    let latestContext: NowPlayingJournalContext | null = null;
     for (const [key, context] of nowPlayingJournalContexts.entries()) {
       if (now - context.createdAt > NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS) {
         nowPlayingJournalContexts.delete(key);
@@ -5345,34 +5349,36 @@ export class NowPlayingCommand {
           .catch((err) => console.error("[Journal] Failed to delete expired context from DB:", err));
         continue;
       }
-      if (context.channelId !== channelId) {
-        continue;
+      if (context.channelId !== channelId) continue;
+      if (context.ownerUserId !== ownerUserId || context.gameId !== gameId) continue;
+      if (!latestContext || context.createdAt > latestContext.createdAt) {
+        latestKey = key;
+        latestContext = context;
       }
-      if (context.ownerUserId !== ownerUserId || context.gameId !== gameId) {
-        continue;
-      }
-
-      const channel = await interaction.client.channels.fetch(context.channelId).catch(() => null);
-      if (!channel?.isTextBased()) {
-        nowPlayingJournalContexts.delete(key);
-        await Member.deleteJournalMessageContext(context.channelId, context.messageId)
-          .catch((err) => console.error("[Journal] Failed to delete unreachable context from DB:", err));
-        continue;
-      }
-
-      const message = await channel.messages.fetch(context.messageId).catch(() => null);
-      if (!message) {
-        nowPlayingJournalContexts.delete(key);
-        await Member.deleteJournalMessageContext(context.channelId, context.messageId)
-          .catch((err) => console.error("[Journal] Failed to delete missing context from DB:", err));
-        continue;
-      }
-
-      await message.delete().catch(() => null);
-      nowPlayingJournalContexts.delete(key);
-      await Member.deleteJournalMessageContext(context.channelId, context.messageId)
-        .catch((err) => console.error("[Journal] Failed to delete context from DB after message delete:", err));
     }
+
+    if (!latestKey || !latestContext) return;
+
+    const channel = await interaction.client.channels.fetch(latestContext.channelId).catch(() => null);
+    if (!channel?.isTextBased()) {
+      nowPlayingJournalContexts.delete(latestKey);
+      await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
+        .catch((err) => console.error("[Journal] Failed to delete unreachable context from DB:", err));
+      return;
+    }
+
+    const message = await channel.messages.fetch(latestContext.messageId).catch(() => null);
+    if (!message) {
+      nowPlayingJournalContexts.delete(latestKey);
+      await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
+        .catch((err) => console.error("[Journal] Failed to delete missing context from DB:", err));
+      return;
+    }
+
+    await message.delete().catch(() => null);
+    nowPlayingJournalContexts.delete(latestKey);
+    await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
+      .catch((err) => console.error("[Journal] Failed to delete context from DB after message delete:", err));
   }
 
   private async trackJournalReply(

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -3355,7 +3355,7 @@ export class NowPlayingCommand {
       interaction.user.id === ownerId,
     );
     if (interaction.guildId) {
-      await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
+      await this.deleteLatestJournalMessageInChannel(interaction, ownerId, gameId);
     }
     await safeReply(interaction, {
       components: payload.components,
@@ -3391,7 +3391,7 @@ export class NowPlayingCommand {
       interaction.user.id === ownerId,
     );
     if (interaction.guildId) {
-      await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
+      await this.deleteLatestJournalMessageInChannel(interaction, ownerId, gameId);
     }
     await safeReply(interaction, {
       components: payload.components,
@@ -3431,7 +3431,7 @@ export class NowPlayingCommand {
       interaction.user.id === ownerId,
     );
     if (interaction.guildId) {
-      await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
+      await this.deleteLatestJournalMessageInChannel(interaction, ownerId, gameId);
     }
     await safeReply(interaction, {
       components: payload.components,
@@ -3655,7 +3655,7 @@ export class NowPlayingCommand {
     if (!hasExistingTracked && interaction.guildId) {
       // First entry: post the journal message first so it appears before the manage buttons.
       // Skip journalOwnerMenu here to avoid its deletor pointing at the journal post.
-      await this.deleteRecentJournalMessagesInChannel(interaction, ownerId, gameId);
+      await this.deleteLatestJournalMessageInChannel(interaction, ownerId, gameId);
       const payload = await this.buildJournalComponents(
         ownerId,
         "__public__",
@@ -5327,7 +5327,7 @@ export class NowPlayingCommand {
     return false;
   }
 
-  private async deleteRecentJournalMessagesInChannel(
+  private async deleteLatestJournalMessageInChannel(
     interaction: ButtonInteraction | ModalSubmitInteraction | StringSelectMenuInteraction,
     ownerUserId: string,
     gameId: number,


### PR DESCRIPTION
## Summary
- `deleteRecentJournalMessagesInChannel` was looping all tracked journal contexts and deleting every message for the matching owner+game in the channel
- It now does a single pass to expire stale entries and identify the one with the highest `createdAt`, then deletes only that message before the new page reply is posted
- Consistent with the \"most recent only\" approach applied to `refreshJournalMessages` in #344

## Test plan
- [ ] Click next/prev page on the most recent journal message in a channel -- only that message is deleted and replaced with the new page
- [ ] Older journal messages in the same channel from the same owner/game are left untouched
- [ ] Messages older than 2 hours are still expired and cleaned up from tracking

🤖 Generated with [Claude Code](https://claude.com/claude-code)