### PR TITLE
feat(completion-list): migrate to Components v2 with shared user header

### DIFF
--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -1,5 +1,4 @@
 import {
-  EmbedBuilder,
   ActionRowBuilder,
   StringSelectMenuBuilder,
   ButtonBuilder,
@@ -11,6 +10,7 @@ import {
   type ModalSubmitInteraction,
   type User,
 } from "discord.js";
+import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import Member from "../../classes/Member.js";
 import Game from "../../classes/Game.js";
 import { COMPLETION_PAGE_SIZE, formatDiscordTimestamp, formatTableDate } from "../profile.command.js";
@@ -18,6 +18,12 @@ import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { safeReply } from "../../functions/InteractionUtils.js";
 import { shouldRenderPrevNextButtons } from "../../functions/PaginationUtils.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
+import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
+import { buildUserHeaderContainer } from "../../functions/uiComponents.js";
+
+function buildCompletionV2Flags(ephemeral: boolean): number {
+  return (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
+}
 
 /**
  * Renders a leaderboard showing all members with completions, optionally filtered by game title
@@ -29,11 +35,16 @@ export async function renderCompletionLeaderboard(
 ): Promise<void> {
   const leaderboard = await Member.getCompletionLeaderboard(25, query);
   if (!leaderboard.length) {
+    const text = query
+      ? `No completions found matching "${query}".`
+      : "No completions recorded yet.";
     await safeReply(interaction, {
-      content: query
-        ? `No completions found matching "${query}".`
-        : "No completions recorded yet.",
-      flags: ephemeral ? MessageFlags.Ephemeral : undefined,
+      components: [
+        new ContainerBuilder().addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(text),
+        ),
+      ],
+      flags: buildCompletionV2Flags(ephemeral),
     });
     return;
   }
@@ -44,13 +55,15 @@ export async function renderCompletionLeaderboard(
     return `${idx + 1}. **${renderUsernameWithEmoji(m.userId, name)}**: ${m.count} ${suffix}`;
   });
 
-  const embed = new EmbedBuilder()
-    .setTitle("Game Completion Leaderboard")
-    .setDescription(lines.join("\n"));
   const trimmedQuery = query?.trim();
+  const contentParts = ["## Game Completion Leaderboard", lines.join("\n")];
   if (trimmedQuery) {
-    embed.setFooter({ text: `Filter: "${trimmedQuery}"` });
+    contentParts.push(`-# Filter: "${trimmedQuery}"`);
   }
+
+  const container = new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(contentParts.join("\n")),
+  );
 
   const options = leaderboard.map((m) => ({
     label: (m.globalName ?? m.username ?? m.userId).slice(0, 100),
@@ -59,14 +72,18 @@ export async function renderCompletionLeaderboard(
   }));
 
   const select = new StringSelectMenuBuilder()
-    .setCustomId(`comp-leaderboard-select${trimmedQuery ? `:${trimmedQuery.slice(0, 50)}` : ""}`)
+    .setCustomId(
+      `comp-leaderboard-select${trimmedQuery ? `:${trimmedQuery.slice(0, 50)}` : ""}`,
+    )
     .setPlaceholder("View completions for a member")
     .addOptions(options);
 
   await safeReply(interaction, {
-    embeds: [embed],
-    components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
-    flags: ephemeral ? MessageFlags.Ephemeral : undefined,
+    components: [
+      container,
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+    ],
+    flags: buildCompletionV2Flags(ephemeral),
   });
 }
 
@@ -90,82 +107,53 @@ export async function renderCompletionPage(
       ? interaction.user
       : await interaction.client.users.fetch(userId).catch(() => interaction.user);
 
-  const result = await buildCompletionEmbed(userId, page, year, user, query);
+  const result = await buildCompletionComponents(userId, page, year, user, query);
 
   if (!result) {
     if (year === "unknown") {
       await safeReply(interaction as any, {
-        content: "You have no recorded completions with unknown dates.",
-        flags: ephemeral ? MessageFlags.Ephemeral : undefined,
+        components: [
+          new ContainerBuilder().addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(
+              "You have no recorded completions with unknown dates.",
+            ),
+          ),
+        ],
+        flags: buildCompletionV2Flags(ephemeral),
       });
       return;
     }
+    const text = year
+      ? `You have no recorded completions for ${year}.`
+      : "You have no recorded completions yet.";
     await safeReply(interaction as any, {
-      content: year
-        ? `You have no recorded completions for ${year}.`
-        : "You have no recorded completions yet.",
-      flags: ephemeral ? MessageFlags.Ephemeral : undefined,
+      components: [
+        new ContainerBuilder().addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(text),
+        ),
+      ],
+      flags: buildCompletionV2Flags(ephemeral),
     });
     return;
   }
 
-  const { embed, totalPages, safePage } = result;
-
+  const { containers, totalPages, safePage } = result;
   const yearPart = year == null ? "" : String(year);
   const queryPart = query ? `:${query.slice(0, 50)}` : "";
-  const components: any[] = [];
+  const paginationRows = buildPaginationRows(
+    totalPages,
+    safePage,
+    `comp-page-select:${userId}:${yearPart}:list${queryPart}`,
+    `comp-list-page:${userId}:${yearPart}:${safePage}:prev${queryPart}`,
+    `comp-list-page:${userId}:${yearPart}:${safePage}:next${queryPart}`,
+  );
 
-  if (totalPages > 1) {
-    const options = [];
-    const maxOptions = 25;
-    let startPage = 0;
-    let endPage = totalPages - 1;
-
-    if (totalPages > maxOptions) {
-      const half = Math.floor(maxOptions / 2);
-      startPage = Math.max(0, safePage - half);
-      endPage = Math.min(totalPages - 1, startPage + maxOptions - 1);
-      startPage = Math.max(0, endPage - maxOptions + 1);
-    }
-
-    for (let i = startPage; i <= endPage; i++) {
-      options.push({
-        label: `Page ${i + 1}`,
-        value: String(i),
-        default: i === safePage,
-      });
-    }
-
-    const select = new StringSelectMenuBuilder()
-      .setCustomId(`comp-page-select:${userId}:${yearPart}:list${queryPart}`)
-      .setPlaceholder(`Page ${safePage + 1} of ${totalPages}`)
-      .addOptions(options);
-
-    components.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
-
-    const prevDisabled = safePage <= 0;
-    const nextDisabled = safePage >= totalPages - 1;
-
-    const prev = new ButtonBuilder()
-      .setCustomId(`comp-list-page:${userId}:${yearPart}:${safePage}:prev${queryPart}`)
-      .setLabel("Previous")
-      .setStyle(ButtonStyle.Secondary)
-      .setDisabled(prevDisabled);
-    const next = new ButtonBuilder()
-      .setCustomId(`comp-list-page:${userId}:${yearPart}:${safePage}:next${queryPart}`)
-      .setLabel("Next")
-      .setStyle(ButtonStyle.Secondary)
-      .setDisabled(nextDisabled);
-
-    if (shouldRenderPrevNextButtons(prevDisabled, nextDisabled)) {
-      components.push(new ActionRowBuilder<ButtonBuilder>().addComponents(prev, next));
-    }
-  }
+  const displayName = user.displayName ?? user.username ?? user.id;
+  const header = buildUserHeaderContainer(userId, displayName, "Completed Games");
 
   await safeReply(interaction as any, {
-    embeds: [embed],
-    components,
-    flags: ephemeral ? MessageFlags.Ephemeral : undefined,
+    components: [header, ...containers, ...paginationRows],
+    flags: buildCompletionV2Flags(ephemeral),
   });
 }
 
@@ -185,7 +173,7 @@ export async function renderSelectionPage(
       ? interaction.user
       : await interaction.client.users.fetch(userId).catch(() => interaction.user);
 
-  const result = await buildCompletionEmbed(userId, page, year, user, query);
+  const result = await buildCompletionComponents(userId, page, year, user, query);
 
   if (!result) {
     const msg =
@@ -200,15 +188,14 @@ export async function renderSelectionPage(
     return;
   }
 
-  const { embed, totalPages, safePage, pageCompletions } = result;
+  const { containers, totalPages, safePage, pageCompletions } = result;
 
   const selectOptions = pageCompletions.map((c) => ({
     label: c.title.slice(0, 100),
     value: String(c.completionId),
-    description: `${c.completionType} (${c.completedAt ? formatDiscordTimestamp(c.completedAt) : "No date"})`.slice(
-      0,
-      100,
-    ),
+    description: `${c.completionType} (${
+      c.completedAt ? formatDiscordTimestamp(c.completedAt) : "No date"
+    })`.slice(0, 100),
   }));
 
   const selectId = mode === "edit" ? "comp-edit-menu" : "comp-del-menu";
@@ -219,83 +206,102 @@ export async function renderSelectionPage(
 
   const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
 
+  const yearPart = year == null ? "" : String(year);
   const queryPart = query ? `:${query.slice(0, 50)}` : "";
-  const components: any[] = [selectRow];
+  const paginationRows = buildPaginationRows(
+    totalPages,
+    safePage,
+    `comp-page-select:${userId}:${yearPart}:${mode}${queryPart}`,
+    `comp-${mode}-page:${userId}:${yearPart}:${safePage}:prev${queryPart}`,
+    `comp-${mode}-page:${userId}:${yearPart}:${safePage}:next${queryPart}`,
+  );
 
-  if (totalPages > 1) {
-    const options = [];
-    const maxOptions = 25;
-    let startPage = 0;
-    let endPage = totalPages - 1;
-
-    if (totalPages > maxOptions) {
-      const half = Math.floor(maxOptions / 2);
-      startPage = Math.max(0, safePage - half);
-      endPage = Math.min(totalPages - 1, startPage + maxOptions - 1);
-      startPage = Math.max(0, endPage - maxOptions + 1);
-    }
-
-    for (let i = startPage; i <= endPage; i++) {
-      options.push({
-        label: `Page ${i + 1}`,
-        value: String(i),
-        default: i === safePage,
-      });
-    }
-
-    const yearPart = year == null ? "" : String(year);
-    const pageSelect = new StringSelectMenuBuilder()
-      .setCustomId(`comp-page-select:${userId}:${yearPart}:${mode}${queryPart}`)
-      .setPlaceholder(`Page ${safePage + 1} of ${totalPages}`)
-      .addOptions(options);
-
-    components.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(pageSelect));
-
-    const prevDisabled = safePage <= 0;
-    const nextDisabled = safePage >= totalPages - 1;
-
-    const prev = new ButtonBuilder()
-      .setCustomId(`comp-${mode}-page:${userId}:${yearPart}:${safePage}:prev${queryPart}`)
-      .setLabel("Previous")
-      .setStyle(ButtonStyle.Secondary)
-      .setDisabled(prevDisabled);
-    const next = new ButtonBuilder()
-      .setCustomId(`comp-${mode}-page:${userId}:${yearPart}:${safePage}:next${queryPart}`)
-      .setLabel("Next")
-      .setStyle(ButtonStyle.Secondary)
-      .setDisabled(nextDisabled);
-
-    if (shouldRenderPrevNextButtons(prevDisabled, nextDisabled)) {
-      components.push(new ActionRowBuilder<ButtonBuilder>().addComponents(prev, next));
-    }
-  }
+  const displayName = user.displayName ?? user.username ?? user.id;
+  const header = buildUserHeaderContainer(userId, displayName, "Completed Games");
+  const allComponents = [header, ...containers, selectRow, ...paginationRows];
 
   if (interaction.isMessageComponent()) {
     if (interaction.deferred || interaction.replied) {
-      await interaction.editReply({ embeds: [embed], components });
+      await (interaction as any).editReply({ components: allComponents, flags: COMPONENTS_V2_FLAG });
     } else {
-      await interaction.update({ embeds: [embed], components });
+      await (interaction as any).update({ components: allComponents, flags: COMPONENTS_V2_FLAG });
     }
   } else {
     await safeReply(interaction, {
-      embeds: [embed],
-      components,
-      flags: MessageFlags.Ephemeral,
+      components: allComponents,
+      flags: MessageFlags.Ephemeral | COMPONENTS_V2_FLAG,
     });
   }
 }
 
-/**
- * Builds an embed showing a user's game completions with pagination support
- */
-async function buildCompletionEmbed(
+type PaginationRow =
+  | ActionRowBuilder<StringSelectMenuBuilder>
+  | ActionRowBuilder<ButtonBuilder>;
+
+function buildPaginationRows(
+  totalPages: number,
+  safePage: number,
+  selectCustomId: string,
+  prevCustomId: string,
+  nextCustomId: string,
+): PaginationRow[] {
+  if (totalPages <= 1) return [];
+
+  const maxOptions = 25;
+  let startPage = 0;
+  let endPage = totalPages - 1;
+
+  if (totalPages > maxOptions) {
+    const half = Math.floor(maxOptions / 2);
+    startPage = Math.max(0, safePage - half);
+    endPage = Math.min(totalPages - 1, startPage + maxOptions - 1);
+    startPage = Math.max(0, endPage - maxOptions + 1);
+  }
+
+  const options: { label: string; value: string; default: boolean }[] = [];
+  for (let i = startPage; i <= endPage; i++) {
+    options.push({ label: `Page ${i + 1}`, value: String(i), default: i === safePage });
+  }
+
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(selectCustomId)
+    .setPlaceholder(`Page ${safePage + 1} of ${totalPages}`)
+    .addOptions(options);
+
+  const rows: PaginationRow[] = [
+    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+  ];
+
+  const prevDisabled = safePage <= 0;
+  const nextDisabled = safePage >= totalPages - 1;
+
+  if (shouldRenderPrevNextButtons(prevDisabled, nextDisabled)) {
+    const prev = new ButtonBuilder()
+      .setCustomId(prevCustomId)
+      .setLabel("Previous")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(prevDisabled);
+    const next = new ButtonBuilder()
+      .setCustomId(nextCustomId)
+      .setLabel("Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(nextDisabled);
+    rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(prev, next));
+  }
+
+  return rows;
+}
+
+const CHUNK_LIMIT = 1500;
+
+async function buildCompletionComponents(
   userId: string,
   page: number,
   year: number | "unknown" | null,
   interactionUser: User,
   query?: string,
 ): Promise<{
-  embed: EmbedBuilder;
+  containers: ContainerBuilder[];
   total: number;
   totalPages: number;
   safePage: number;
@@ -324,14 +330,10 @@ async function buildCompletionEmbed(
     const yearA = a.completedAt ? a.completedAt.getFullYear() : null;
     const yearB = b.completedAt ? b.completedAt.getFullYear() : null;
 
-    if (yearA == null && yearB == null) {
-      return a.title.localeCompare(b.title);
-    }
+    if (yearA == null && yearB == null) return a.title.localeCompare(b.title);
     if (yearA == null) return 1;
     if (yearB == null) return -1;
-    if (yearA !== yearB) {
-      return yearB - yearA;
-    }
+    if (yearA !== yearB) return yearB - yearA;
 
     const dateA = a.completedAt ? a.completedAt.getTime() : 0;
     const dateB = b.completedAt ? b.completedAt.getTime() : 0;
@@ -375,16 +377,14 @@ async function buildCompletionEmbed(
 
     const idxBlock = `\`${idxLabel}\``;
     const dateBlock = dateLabel ? `\`${dateLabel}\`` : "";
-    const rawPlatformName = c.platformId == null
-      ? null
-      : platformMap.get(c.platformId) ?? "Unknown Platform";
+    const rawPlatformName =
+      c.platformId == null ? null : platformMap.get(c.platformId) ?? "Unknown Platform";
     const platformName = formatPlatformDisplayName(rawPlatformName);
     const platformLabel = platformName ? ` [${platformName}]` : "";
-    const line = `${idxBlock} ${dateBlock} **${c.title}**${platformLabel} (${typeAbbrev})`
-      .replace(
-        /\s{2,}/g,
-        " ",
-      );
+    const line = `${idxBlock} ${dateBlock} **${c.title}**${platformLabel} (${typeAbbrev})`.replace(
+      /\s{2,}/g,
+      " ",
+    );
     acc[yr].push(line);
     if (c.note) {
       acc[yr].push(`> ${c.note}`);
@@ -392,78 +392,62 @@ async function buildCompletionEmbed(
     return acc;
   }, {});
 
-  const authorName = interactionUser.displayName ?? interactionUser.username ?? "User";
-  const authorIcon = interactionUser.displayAvatarURL?.({
-    size: 64,
-    forceStatic: false,
-  });
-  const embed = new EmbedBuilder().setTitle(`${authorName}'s Completed Games (${total} total)`);
-  const queryLabel = query?.trim();
-  if (queryLabel) {
-    embed.setDescription(`Filter: "${queryLabel}"`);
-  }
-
-  embed.setAuthor({
-    name: authorName,
-    iconURL: authorIcon ?? undefined,
-  });
-
   const sortedYears = Object.keys(grouped).sort((a, b) => {
     if (a === "Unknown") return 1;
     if (b === "Unknown") return -1;
     return Number(b) - Number(a);
   });
 
-  const addChunkedField = (yr: string, content: string, chunkIndex: number): void => {
-    let name = "";
-    if (chunkIndex === 0) {
-      const count = yearCounts[yr] ?? 0;
-      const displayYear = yr === "Unknown" ? "Unknown Date" : yr;
-      name = `${displayYear} (${count})`;
-    }
-    embed.addFields({ name, value: content || "None", inline: false });
-  };
+  const containers: ContainerBuilder[] = [];
+
+  const queryLabel = query?.trim();
+  if (queryLabel) {
+    containers.push(
+      new ContainerBuilder().addTextDisplayComponents(
+        new TextDisplayBuilder().setContent(`-# Filter: "${queryLabel}"`),
+      ),
+    );
+  }
 
   for (const yr of sortedYears) {
-    const lines = grouped[yr];
-    if (!lines || !lines.length) {
-      addChunkedField(yr, "None", 0);
-      continue;
-    }
+    const displayYear = yr === "Unknown" ? "Unknown Date" : yr;
+    const count = yearCounts[yr] ?? 0;
+    const lines = grouped[yr] ?? [];
 
-    let buffer = "";
-    let chunkIndex = 0;
-    const flush = (): void => {
-      if (buffer) {
-        addChunkedField(yr, buffer, chunkIndex);
-        chunkIndex++;
-        buffer = "";
-      }
-    };
-
+    let buffer = `### ${displayYear} (${count})`;
     for (const line of lines) {
-      const next = buffer ? `${buffer}\n${line}` : line;
-      if (next.length > 1000) {
-        flush();
+      const next = `${buffer}\n${line}`;
+      if (next.length > CHUNK_LIMIT) {
+        containers.push(
+          new ContainerBuilder().addTextDisplayComponents(
+            new TextDisplayBuilder().setContent(buffer),
+          ),
+        );
         buffer = line;
       } else {
         buffer = next;
       }
     }
-    flush();
+    if (buffer) {
+      containers.push(
+        new ContainerBuilder().addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(buffer),
+        ),
+      );
+    }
   }
 
-  const footerLines = ["M = Main Story • M+S = Main Story + Side Content • C = Completionist"];
+  const footerLines = [
+    "-# M = Main Story • M+S = Main Story + Side Content • C = Completionist",
+  ];
   if (totalPages > 1) {
-    footerLines.push(`${total} results. Page ${safePage + 1} of ${totalPages}.`);
+    footerLines.push(`-# ${total} results. Page ${safePage + 1} of ${totalPages}.`);
   }
-  embed.setFooter({ text: footerLines.join("\n") });
+  containers.push(
+    new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(footerLines.join("\n")),
+    ),
+  );
 
-  return {
-    embed,
-    total,
-    totalPages,
-    safePage,
-    pageCompletions,
-  };
+  return { containers, total, totalPages, safePage, pageCompletions };
 }


### PR DESCRIPTION
## Summary

- Replaces `EmbedBuilder` with `ContainerBuilder` / `TextDisplayBuilder` from `@discordjs/builders` across all three completion list render functions
- Single-user views (`renderCompletionPage`, `renderSelectionPage`) now open with `buildUserHeaderContainer("Completed Games")`, matching the `/now-playing list` pattern
- The all-users leaderboard (`renderCompletionLeaderboard`) is also migrated to Components v2 but uses no user header, consistent with the `/now-playing` everyone view
- Duplicated pagination-building logic is extracted into a `buildPaginationRows` helper
- `buildCompletionEmbed` is replaced by `buildCompletionComponents`, which returns `ContainerBuilder[]` grouped by year with subtext (-#) footers for the legend and page count
- All messages use `buildCompletionV2Flags(ephemeral)` combining `COMPONENTS_V2_FLAG` with the ephemeral flag where appropriate

## Test plan

- [ ] `/completion list` (own list) shows shared user header with "Completed Games" title
- [ ] `/completion list @user` (another user) shows shared user header for that user
- [ ] Pagination (page select + prev/next) works across pages
- [ ] Edit and delete selection views show the shared header and correct select menu
- [ ] Leaderboard view renders without a user header, with the member select menu intact
- [ ] Query filter displays as subtext above the year groups
- [ ] Year groups chunk correctly for users with many completions in one year

Closes #308

🤖 Generated with [Claude Code](https://claude.com/claude-code)