### PR TITLE
fix(completion-list): preserve year-relative numbering across page breaks

### DIFF
--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -278,8 +278,8 @@ export class GameCompletionCommands {
     })
     yearRaw: string | undefined,
     @SlashOption({
-      description: "Filter by title (optional)",
-      name: "title",
+      description: "Filter by any search string (optional)",
+      name: "query",
       required: false,
       type: ApplicationCommandOptionType.String,
     })
@@ -388,8 +388,8 @@ export class GameCompletionCommands {
     })
     platformRaw: string | undefined,
     @SlashOption({
-      description: "Filter by title (optional).",
-      name: "title",
+      description: "Filter by any search string (optional).",
+      name: "query",
       required: false,
       type: ApplicationCommandOptionType.String,
     })

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -388,8 +388,8 @@ export class GameCompletionCommands {
     })
     platformRaw: string | undefined,
     @SlashOption({
-      description: "Filter by any search string (optional).",
-      name: "query",
+      description: "Filter by title (optional).",
+      name: "title",
       required: false,
       type: ApplicationCommandOptionType.String,
     })

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -388,8 +388,8 @@ export class GameCompletionCommands {
     })
     platformRaw: string | undefined,
     @SlashOption({
-      description: "Filter by title (optional).",
-      name: "title",
+      description: "Filter by any search string (optional).",
+      name: "query",
       required: false,
       type: ApplicationCommandOptionType.String,
     })

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -371,7 +371,8 @@ async function buildCompletionComponents(
     const count = yearCounts[yr] ?? 0;
     const lines = grouped[yr] ?? [];
 
-    let buffer = `### ${displayYear} (${count})`;
+    const gameWord = count === 1 ? "Game" : "Games";
+    let buffer = `### ${displayYear} (${count} ${gameWord} Completed)`;
     for (const line of lines) {
       const next = `${buffer}\n${line}`;
       if (next.length > CHUNK_LIMIT) {

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -313,68 +313,28 @@ async function buildCompletionComponents(
 
   if (!allCompletions.length) return null;
 
-  const yearCounts: Record<string, number> = {};
-  const yearIndices = new Map<number, number>();
-  for (const c of allCompletions) {
-    const yr = c.completedAt ? String(c.completedAt.getFullYear()) : "Unknown";
-    yearCounts[yr] = (yearCounts[yr] ?? 0) + 1;
-    yearIndices.set(c.completionId, yearCounts[yr]);
-  }
-
   const pageCompletions = allCompletions.slice(offset, offset + COMPLETION_PAGE_SIZE);
 
-  const grouped = pageCompletions.reduce<Record<string, string[]>>((acc, c) => {
-    const yr = c.completedAt ? String(c.completedAt.getFullYear()) : "Unknown";
-    acc[yr] = acc[yr] || [];
-
+  const buildEntryLine = (c: (typeof pageCompletions)[number], num: number): string => {
     const typeAbbrev =
       c.completionType === "Main Story"
         ? "M"
         : c.completionType === "Main Story + Side Content"
           ? "M+S"
           : "C";
-
     const rawPlatformName =
       c.platformId == null ? null : platformMap.get(c.platformId) ?? "Unknown Platform";
     const platformName = formatPlatformDisplayName(rawPlatformName);
     const platformLabel = platformName ? ` [${platformName}]` : "";
     const dateLabel = c.completedAt ? ` · ${formatTableDate(c.completedAt)}` : "";
-    const hoursLabel =
-      c.finalPlaytimeHours != null ? ` · ${c.finalPlaytimeHours} hrs` : "";
+    const hoursLabel = c.finalPlaytimeHours != null ? ` · ${c.finalPlaytimeHours} hrs` : "";
+    return `${num}. **${c.title}**${platformLabel} (${typeAbbrev})${dateLabel}${hoursLabel}`;
+  };
 
-    const num = yearIndices.get(c.completionId)!;
-    acc[yr].push(
-      `${num}. **${c.title}**${platformLabel} (${typeAbbrev})${dateLabel}${hoursLabel}`,
-    );
-    return acc;
-  }, {});
-
-  const sortedYears = Object.keys(grouped).sort((a, b) => {
-    if (a === "Unknown") return 1;
-    if (b === "Unknown") return -1;
-    return Number(b) - Number(a);
-  });
-
-  const containers: ContainerBuilder[] = [];
-
-  const queryLabel = query?.trim();
-  if (queryLabel) {
-    containers.push(
-      new ContainerBuilder().addTextDisplayComponents(
-        new TextDisplayBuilder().setContent(`-# Filter: "${queryLabel}"`),
-      ),
-    );
-  }
-
-  for (const yr of sortedYears) {
-    const displayYear = yr === "Unknown" ? "Unknown Date" : yr;
-    const count = yearCounts[yr] ?? 0;
-    const lines = grouped[yr] ?? [];
-
-    const gameWord = count === 1 ? "Game" : "Games";
-    let buffer = `### ${displayYear} (${count} ${gameWord} Completed)`;
+  const pushChunked = (containers: ContainerBuilder[], lines: string[]): void => {
+    let buffer = "";
     for (const line of lines) {
-      const next = `${buffer}\n${line}`;
+      const next = buffer ? `${buffer}\n${line}` : line;
       if (next.length > CHUNK_LIMIT) {
         containers.push(
           new ContainerBuilder().addTextDisplayComponents(
@@ -393,7 +353,10 @@ async function buildCompletionComponents(
         ),
       );
     }
-  }
+  };
+
+  const queryLabel = query?.trim();
+  const containers: ContainerBuilder[] = [];
 
   const footerLines = [
     "-# M = Main Story • M+S = Main Story + Side Content • C = Completionist",
@@ -401,6 +364,46 @@ async function buildCompletionComponents(
   if (totalPages > 1) {
     footerLines.push(`-# ${total} results. Page ${safePage + 1} of ${totalPages}.`);
   }
+
+  if (queryLabel) {
+    containers.push(
+      new ContainerBuilder().addTextDisplayComponents(
+        new TextDisplayBuilder().setContent(`-# Query: "${queryLabel}"`),
+      ),
+    );
+    const lines = pageCompletions.map((c, i) => buildEntryLine(c, offset + i + 1));
+    pushChunked(containers, lines);
+  } else {
+    const yearCounts: Record<string, number> = {};
+    const yearIndices = new Map<number, number>();
+    for (const c of allCompletions) {
+      const yr = c.completedAt ? String(c.completedAt.getFullYear()) : "Unknown";
+      yearCounts[yr] = (yearCounts[yr] ?? 0) + 1;
+      yearIndices.set(c.completionId, yearCounts[yr]);
+    }
+
+    const grouped = pageCompletions.reduce<Record<string, string[]>>((acc, c) => {
+      const yr = c.completedAt ? String(c.completedAt.getFullYear()) : "Unknown";
+      acc[yr] = acc[yr] || [];
+      acc[yr].push(buildEntryLine(c, yearIndices.get(c.completionId)!));
+      return acc;
+    }, {});
+
+    const sortedYears = Object.keys(grouped).sort((a, b) => {
+      if (a === "Unknown") return 1;
+      if (b === "Unknown") return -1;
+      return Number(b) - Number(a);
+    });
+
+    for (const yr of sortedYears) {
+      const displayYear = yr === "Unknown" ? "Unknown Date" : yr;
+      const count = yearCounts[yr] ?? 0;
+      const gameWord = count === 1 ? "Game" : "Games";
+      const heading = `### ${displayYear} (${count} ${gameWord} Completed)`;
+      pushChunked(containers, [heading, ...(grouped[yr] ?? [])]);
+    }
+  }
+
   containers.push(
     new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent(footerLines.join("\n")),

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -314,9 +314,11 @@ async function buildCompletionComponents(
   if (!allCompletions.length) return null;
 
   const yearCounts: Record<string, number> = {};
+  const yearIndices = new Map<number, number>();
   for (const c of allCompletions) {
     const yr = c.completedAt ? String(c.completedAt.getFullYear()) : "Unknown";
     yearCounts[yr] = (yearCounts[yr] ?? 0) + 1;
+    yearIndices.set(c.completionId, yearCounts[yr]);
   }
 
   const pageCompletions = allCompletions.slice(offset, offset + COMPLETION_PAGE_SIZE);
@@ -340,7 +342,7 @@ async function buildCompletionComponents(
     const hoursLabel =
       c.finalPlaytimeHours != null ? ` · ${c.finalPlaytimeHours} hrs` : "";
 
-    const num = acc[yr].length + 1;
+    const num = yearIndices.get(c.completionId)!;
     acc[yr].push(
       `${num}. **${c.title}**${platformLabel} (${typeAbbrev})${dateLabel}${hoursLabel}`,
     );


### PR DESCRIPTION
## Summary

- Fix year-relative numbering across page breaks: entry numbers now reflect each completion's global position within its year group, so a year spanning multiple pages continues from the correct number instead of resetting to 1
- Expand year headings from `### 2024 (3)` to `### 2024 (3 Games Completed)` (singular "Game" when count is 1)
- Rename the `/game-completion list` filter option from `title` to `query` (description updated to "Filter by any search string (optional)"); compare subcommand keeps `title`
- When `query` is active, render a flat numbered list with no year group containers or headers; numbering is globally offset-aware so it continues correctly across pages
- Non-query (year-grouped) view is unchanged

## Test plan

- [ ] A user with enough completions in one year to span multiple pages sees continuous numbering on page 2 (e.g. 11, 12... not 1, 2...)
- [ ] Year headings read "N Games Completed" (singular "Game" when N = 1)
- [ ] `/game-completion list query:zelda` shows a flat numbered list with no year headers; numbers continue across pages
- [ ] `/game-completion list` with no query shows the normal year-grouped view unchanged
- [ ] `/game-completion compare` still uses `title:` option

🤖 Generated with [Claude Code](https://claude.com/claude-code)