### PR TITLE
fix(completion-pagination): return early when deferUpdate fails on rapid clicks

### DIFF
--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -59,6 +59,7 @@ import {
   handleCompletionPageSelect,
   handleCompletionPaging,
   handleCompletionLeaderboardSelect,
+  handleCompletionYearSelect,
 } from "./game-completion/completion-pagination.service.js";
 import {
   handleCompletionDeleteMenu,
@@ -820,6 +821,11 @@ export class GameCompletionCommands {
   @SelectMenuComponent({ id: /^comp-leaderboard-select(?::.*)?$/ })
   async handleCompletionLeaderboardSelect(interaction: StringSelectMenuInteraction): Promise<void> {
     await handleCompletionLeaderboardSelect(interaction);
+  }
+
+  @SelectMenuComponent({ id: /^comp-year-select:.+$/ })
+  async handleCompletionYearSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+    await handleCompletionYearSelect(interaction);
   }
 
   @ButtonComponent({ id: /^completion-add-igdb-confirm:.+/ })

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -136,7 +136,7 @@ export async function renderCompletionPage(
     return;
   }
 
-  const { containers, totalPages, safePage } = result;
+  const { containers, totalPages, safePage, sortedYears, yearCounts } = result;
   const yearPart = year == null ? "" : String(year);
   const queryPart = query ? `:${query.slice(0, 50)}` : "";
   const paginationRows = buildPaginationRows(
@@ -146,11 +146,17 @@ export async function renderCompletionPage(
     `comp-list-page:${userId}:${yearPart}:${safePage}:next${queryPart}`,
   );
 
+  const yearJumpRow = buildYearJumpRow(userId, year, query, totalPages, sortedYears, yearCounts);
   const displayName = user.displayName ?? user.username ?? user.id;
   const header = buildUserHeaderContainer(userId, displayName, "Completed Games");
 
   await safeReply(interaction as any, {
-    components: [header, ...containers, ...paginationRows],
+    components: [
+      header,
+      ...containers,
+      ...(yearJumpRow ? [yearJumpRow] : []),
+      ...paginationRows,
+    ],
     flags: buildCompletionV2Flags(ephemeral),
   });
 }
@@ -231,6 +237,31 @@ export async function renderSelectionPage(
   }
 }
 
+function buildYearJumpRow(
+  userId: string,
+  activeYear: number | "unknown" | null,
+  query: string | undefined,
+  totalPages: number,
+  sortedYears: string[],
+  yearCounts: Record<string, number>,
+): ActionRowBuilder<StringSelectMenuBuilder> | null {
+  if (activeYear !== null || query || totalPages <= 5 || sortedYears.length <= 3) return null;
+
+  const options = sortedYears.slice(0, 25).map((yr) => {
+    const count = yearCounts[yr] ?? 0;
+    const label = yr === "Unknown" ? "Unknown Date" : yr;
+    const gameWord = count === 1 ? "game" : "games";
+    return { label, value: yr === "Unknown" ? "unknown" : yr, description: `${count} ${gameWord}` };
+  });
+
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(`comp-year-select:${userId}`)
+    .setPlaceholder("Jump to year")
+    .addOptions(options);
+
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+}
+
 function buildPaginationRows(
   totalPages: number,
   safePage: number,
@@ -277,6 +308,8 @@ async function buildCompletionComponents(
   totalPages: number;
   safePage: number;
   pageCompletions: any[];
+  sortedYears: string[];
+  yearCounts: Record<string, number>;
 } | null> {
   const total = await Member.countCompletions(userId, year, query);
   if (total === 0) return null;
@@ -365,6 +398,9 @@ async function buildCompletionComponents(
     footerLines.push(`-# ${total} results. Page ${safePage + 1} of ${totalPages}.`);
   }
 
+  let sortedYears: string[] = [];
+  const yearCounts: Record<string, number> = {};
+
   if (queryLabel) {
     containers.push(
       new ContainerBuilder().addTextDisplayComponents(
@@ -374,7 +410,6 @@ async function buildCompletionComponents(
     const lines = pageCompletions.map((c, i) => buildEntryLine(c, offset + i + 1));
     pushChunked(containers, lines);
   } else {
-    const yearCounts: Record<string, number> = {};
     const yearIndices = new Map<number, number>();
     for (const c of allCompletions) {
       const yr = c.completedAt ? String(c.completedAt.getFullYear()) : "Unknown";
@@ -389,13 +424,14 @@ async function buildCompletionComponents(
       return acc;
     }, {});
 
-    const sortedYears = Object.keys(grouped).sort((a, b) => {
+    sortedYears = Object.keys(yearCounts).sort((a, b) => {
       if (a === "Unknown") return 1;
       if (b === "Unknown") return -1;
       return Number(b) - Number(a);
     });
 
     for (const yr of sortedYears) {
+      if (!grouped[yr]) continue;
       const displayYear = yr === "Unknown" ? "Unknown Date" : yr;
       const count = yearCounts[yr] ?? 0;
       const gameWord = count === 1 ? "Game" : "Games";
@@ -410,5 +446,5 @@ async function buildCompletionComponents(
     ),
   );
 
-  return { containers, total, totalPages, safePage, pageCompletions };
+  return { containers, total, totalPages, safePage, pageCompletions, sortedYears, yearCounts };
 }

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -391,11 +391,24 @@ async function buildCompletionComponents(
   const queryLabel = query?.trim();
   const containers: ContainerBuilder[] = [];
 
+  const knownYears = allCompletions
+    .map((c) => c.completedAt?.getFullYear())
+    .filter((y): y is number => y != null);
+  const minYear = knownYears.length ? Math.min(...knownYears) : null;
+  const maxYear = knownYears.length ? Math.max(...knownYears) : null;
+
   const footerLines = [
     "-# M = Main Story • M+S = Main Story + Side Content • C = Completionist",
   ];
   if (totalPages > 1) {
-    footerLines.push(`-# ${total} results. Page ${safePage + 1} of ${totalPages}.`);
+    let resultsText = `${total} results`;
+    if (minYear !== null && maxYear !== null) {
+      resultsText +=
+        minYear === maxYear
+          ? ` recorded in ${minYear}`
+          : ` recorded between ${minYear}-${maxYear}`;
+    }
+    footerLines.push(`-# ${resultsText}. Page ${safePage + 1} of ${totalPages}.`);
   }
 
   let sortedYears: string[] = [];

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -123,7 +123,8 @@ export async function handleCompletionYearSelect(
     return;
   }
 
-  await renderCompletionPage(interaction, userId, 0, year, ephemeral);
+  const firstPage = 0;
+  await renderCompletionPage(interaction, userId, firstPage, year, ephemeral);
 }
 
 /**
@@ -137,5 +138,7 @@ export async function handleCompletionLeaderboardSelect(
   const userId = interaction.values[0];
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
   await interaction.deferReply({ flags: ephemeral ? MessageFlags.Ephemeral : undefined });
-  await renderCompletionPage(interaction, userId, 0, null, ephemeral, query);
+  const firstPage = 0;
+  const noYearFilter = null;
+  await renderCompletionPage(interaction, userId, firstPage, noYearFilter, ephemeral, query);
 }

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -43,7 +43,7 @@ export async function handleCompletionPageSelect(
   try {
     await interaction.deferUpdate();
   } catch {
-    // ignore
+    return;
   }
 
   if (mode === "list") {
@@ -88,7 +88,7 @@ export async function handleCompletionPaging(interaction: ButtonInteraction): Pr
   try {
     await interaction.deferUpdate();
   } catch {
-    // ignore
+    return;
   }
 
   if (mode === "list") {

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -106,6 +106,27 @@ export async function handleCompletionPaging(interaction: ButtonInteraction): Pr
 }
 
 /**
+ * Handles year-jump select menu on the completion list
+ */
+export async function handleCompletionYearSelect(
+  interaction: StringSelectMenuInteraction,
+): Promise<void> {
+  const parts = interaction.customId.split(":");
+  const userId = parts[1];
+  const selectedYear = interaction.values[0];
+  const year = parseCompletionYearFilter(selectedYear);
+  const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
+
+  try {
+    await interaction.deferUpdate();
+  } catch {
+    return;
+  }
+
+  await renderCompletionPage(interaction, userId, 0, year, ephemeral);
+}
+
+/**
  * Handles leaderboard member selection to view their completions
  */
 export async function handleCompletionLeaderboardSelect(

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -135,6 +135,7 @@ export async function handleCompletionLeaderboardSelect(
   const parts = interaction.customId.split(":");
   const query = parts.slice(1).join(":") || undefined;
   const userId = interaction.values[0];
-  await interaction.deferReply({ flags: MessageFlags.Ephemeral });
-  await renderCompletionPage(interaction, userId, 0, null, true, query);
+  const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
+  await interaction.deferReply({ flags: ephemeral ? MessageFlags.Ephemeral : undefined });
+  await renderCompletionPage(interaction, userId, 0, null, ephemeral, query);
 }


### PR DESCRIPTION
## Summary

- Fix rapid-click "This interaction failed": changed the `deferUpdate()` catch from `// ignore` to `return`; a duplicate interaction silently no-ops instead of proceeding to `editReply` with an undeferred interaction
- Add year-jump select menu to the single-user completion list: when the unfiltered (no year, no query) view has more than 5 pages **and** more than 3 distinct years, a "Jump to year" select menu appears below the content and above the prev/next buttons; selecting a year reloads the list filtered to that year from page 1
- Public leaderboard passthrough: when the leaderboard is shown publicly, selecting a member from its select menu now renders their completion list publicly (previously always forced ephemeral)
- Footer results line now reads `N results recorded between YYYY-YYYY.` (or `recorded in YYYY.` when all results share one year); falls back gracefully when all completion dates are unknown
- Replace bare `0` and `null` literals in `renderCompletionPage` call sites with named variables (`firstPage`, `noYearFilter`)

## Test plan

- [ ] Rapidly pressing "Next Page" / "Previous Page" no longer shows "This interaction failed"
- [ ] Single button presses still paginate correctly
- [ ] A user with >5 pages and >3 distinct years sees a "Jump to year" select menu
- [ ] Selecting a year from the menu navigates to page 1 filtered by that year
- [ ] Users with ≤5 pages or ≤3 years do not see the year-jump menu
- [ ] Year-filtered and query-filtered views do not show the year-jump menu
- [ ] Selecting a member from a public leaderboard shows their list publicly
- [ ] Selecting a member from an ephemeral leaderboard shows their list ephemerally
- [ ] Footer on multi-page lists shows year range (e.g. "47 results recorded between 2018-2024.")
- [ ] Footer shows single year when all completions are in the same year
- [ ] Footer omits year info when no completion dates are recorded

🤖 Generated with [Claude Code](https://claude.com/claude-code)