### PR TITLE
feat(completion-list): year filter footer label and Clear Filter button

### DIFF
--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -60,6 +60,7 @@ import {
   handleCompletionPaging,
   handleCompletionLeaderboardSelect,
   handleCompletionYearSelect,
+  handleCompletionClearYearFilter,
 } from "./game-completion/completion-pagination.service.js";
 import {
   handleCompletionDeleteMenu,
@@ -826,6 +827,11 @@ export class GameCompletionCommands {
   @SelectMenuComponent({ id: /^comp-year-select:.+$/ })
   async handleCompletionYearSelect(interaction: StringSelectMenuInteraction): Promise<void> {
     await handleCompletionYearSelect(interaction);
+  }
+
+  @ButtonComponent({ id: /^comp-clear-year-filter:.+$/ })
+  async handleCompletionClearYearFilter(interaction: ButtonInteraction): Promise<void> {
+    await handleCompletionClearYearFilter(interaction);
   }
 
   @ButtonComponent({ id: /^completion-add-igdb-confirm:.+/ })

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -139,11 +139,13 @@ export async function renderCompletionPage(
   const { containers, totalPages, safePage, sortedYears, yearCounts } = result;
   const yearPart = year == null ? "" : String(year);
   const queryPart = query ? `:${query.slice(0, 50)}` : "";
+  const clearFilterCustomId = year !== null ? `comp-clear-year-filter:${userId}` : undefined;
   const paginationRows = buildPaginationRows(
     totalPages,
     safePage,
     `comp-list-page:${userId}:${yearPart}:${safePage}:prev${queryPart}`,
     `comp-list-page:${userId}:${yearPart}:${safePage}:next${queryPart}`,
+    clearFilterCustomId,
   );
 
   const yearJumpRow = buildYearJumpRow(userId, year, query, totalPages, sortedYears, yearCounts);
@@ -267,12 +269,12 @@ function buildPaginationRows(
   safePage: number,
   prevCustomId: string,
   nextCustomId: string,
+  clearFilterCustomId?: string,
 ): ActionRowBuilder<ButtonBuilder>[] {
-  if (totalPages <= 1) return [];
+  const showPrev = totalPages > 1 && safePage > 0;
+  const showNext = totalPages > 1 && safePage < totalPages - 1;
 
-  const showPrev = safePage > 0;
-  const showNext = safePage < totalPages - 1;
-  if (!showPrev && !showNext) return [];
+  if (!showPrev && !showNext && !clearFilterCustomId) return [];
 
   const buttons: ButtonBuilder[] = [];
   if (showPrev) {
@@ -280,6 +282,14 @@ function buildPaginationRows(
       new ButtonBuilder()
         .setCustomId(prevCustomId)
         .setLabel("Previous Page")
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+  if (clearFilterCustomId) {
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(clearFilterCustomId)
+        .setLabel("Clear Filter")
         .setStyle(ButtonStyle.Secondary),
     );
   }
@@ -400,6 +410,10 @@ async function buildCompletionComponents(
   const footerLines = [
     "-# M = Main Story • M+S = Main Story + Side Content • C = Completionist",
   ];
+  if (year !== null) {
+    const yearLabel = year === "unknown" ? "Unknown Date" : String(year);
+    footerLines.push(`-# Year filter: ${yearLabel}`);
+  }
   if (totalPages > 1) {
     let resultsText = `${total} results`;
     if (minYear !== null && maxYear !== null) {

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -106,6 +106,27 @@ export async function handleCompletionPaging(interaction: ButtonInteraction): Pr
 }
 
 /**
+ * Handles the "Clear Filter" button that removes the active year filter
+ */
+export async function handleCompletionClearYearFilter(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parts = interaction.customId.split(":");
+  const userId = parts[1];
+  const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
+
+  try {
+    await interaction.deferUpdate();
+  } catch {
+    return;
+  }
+
+  const firstPage = 0;
+  const noYearFilter = null;
+  await renderCompletionPage(interaction, userId, firstPage, noYearFilter, ephemeral);
+}
+
+/**
  * Handles year-jump select menu on the completion list
  */
 export async function handleCompletionYearSelect(


### PR DESCRIPTION
## Summary

- Footer now shows `Year filter: YYYY` (or `Year filter: Unknown Date`) when the list is filtered by a year, so the active filter is always visible
- A **Clear Filter** button (`comp-clear-year-filter:<userId>`) is added to the nav action row when a year filter is active:
  - Positioned between Previous Page and Next Page
  - Appears alone if the filtered result fits on a single page (no nav buttons needed)
  - Clicking it navigates back to the full unfiltered list at page 1

## Test plan

- [ ] Selecting a year from the year-jump menu shows "Year filter: YYYY" in the footer
- [ ] "Unknown Date" appears in the footer when the unknown-date bucket is selected
- [ ] "Clear Filter" button appears between Previous Page / Next Page on multi-page filtered results
- [ ] "Clear Filter" appears alone (no nav buttons) on single-page filtered results
- [ ] Clicking "Clear Filter" returns to the unfiltered list at page 1 with the year-jump menu restored
- [ ] Unfiltered list shows no "Year filter" footer line and no "Clear Filter" button

🤖 Generated with [Claude Code](https://claude.com/claude-code)