### PR TITLE
fix(completion-list): move query label to footer, raise chunk limit

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -784,6 +784,70 @@ export default class Member {
     }
   }
 
+  static async getJournalStatusForGames(
+    userId: string,
+    gameIds: number[],
+  ): Promise<
+    Array<{
+      gameId: number;
+      journalEnabled: boolean;
+      hasJournalEntry: boolean;
+      journalCount: number;
+      lastJournalAt: Date | null;
+    }>
+  > {
+    if (!gameIds.length) return [];
+    const uniqueIds = [...new Set(gameIds.filter((id) => Number.isInteger(id) && id > 0))];
+    if (!uniqueIds.length) return [];
+    const connection = await getOraclePool().getConnection();
+    const inlineTable = uniqueIds
+      .map((_, idx) => `SELECT :id${idx} AS GAME_ID FROM DUAL`)
+      .join(" UNION ALL ");
+    const binds: Record<string, string | number> = { userId };
+    uniqueIds.forEach((id, idx) => {
+      binds[`id${idx}`] = id;
+    });
+    try {
+      const res = await connection.execute<{
+        GAME_ID: number;
+        JOURNAL_ENABLED: number | null;
+        HAS_JOURNAL_ENTRY: number;
+        JOURNAL_COUNT: number;
+        LAST_JOURNAL_AT: Date | string | null;
+      }>(
+        `SELECT gids.GAME_ID,
+                NVL(jp.IS_ENABLED, 1) AS JOURNAL_ENABLED,
+                CASE WHEN COUNT(je.ID) > 0 THEN 1 ELSE 0 END AS HAS_JOURNAL_ENTRY,
+                COUNT(je.ID) AS JOURNAL_COUNT,
+                MAX(je.CREATED_AT) AS LAST_JOURNAL_AT
+           FROM (${inlineTable}) gids
+           LEFT JOIN USER_GAME_JOURNAL_ENTRIES je
+             ON je.USER_ID = :userId
+            AND je.GAMEDB_GAME_ID = gids.GAME_ID
+           LEFT JOIN USER_GAME_JOURNAL_PREFS jp
+             ON jp.USER_ID = :userId
+            AND jp.GAMEDB_GAME_ID = gids.GAME_ID
+          GROUP BY gids.GAME_ID, jp.IS_ENABLED`,
+        binds,
+        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      );
+      return (res.rows ?? []).map((row) => ({
+        gameId: Number(row.GAME_ID),
+        journalEnabled: Number(row.JOURNAL_ENABLED ?? 1) === 1,
+        hasJournalEntry: Number(row.HAS_JOURNAL_ENTRY) === 1,
+        journalCount: Number(row.JOURNAL_COUNT),
+        lastJournalAt:
+          row.LAST_JOURNAL_AT instanceof Date
+            ? row.LAST_JOURNAL_AT
+            : row.LAST_JOURNAL_AT
+              ? new Date(row.LAST_JOURNAL_AT as any)
+              : null,
+      }));
+    } finally {
+      await connection.close();
+    }
+  }
+
   static async getGameJournalEntries(
     userId: string,
     gameId: number,

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -63,6 +63,7 @@ import {
   handleCompletionClearYearFilter,
   handleCompletionJournalViewSelect,
   handleCompletionJournalPage,
+  handleCompletionListHeader,
 } from "./game-completion/completion-pagination.service.js";
 import {
   handleCompletionDeleteMenu,
@@ -846,6 +847,11 @@ export class GameCompletionCommands {
   @ButtonComponent({ id: /^comp-journal-page:\d+:\d+:(prev|next):\d+$/ })
   async handleCompletionJournalPage(interaction: ButtonInteraction): Promise<void> {
     await handleCompletionJournalPage(interaction);
+  }
+
+  @ButtonComponent({ id: /^comp-list-header:\d+$/ })
+  async handleCompletionListHeader(interaction: ButtonInteraction): Promise<void> {
+    await handleCompletionListHeader(interaction);
   }
 
   @ButtonComponent({ id: /^completion-add-igdb-confirm:.+/ })

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -61,6 +61,8 @@ import {
   handleCompletionLeaderboardSelect,
   handleCompletionYearSelect,
   handleCompletionClearYearFilter,
+  handleCompletionJournalViewSelect,
+  handleCompletionJournalPage,
 } from "./game-completion/completion-pagination.service.js";
 import {
   handleCompletionDeleteMenu,
@@ -832,6 +834,18 @@ export class GameCompletionCommands {
   @ButtonComponent({ id: /^comp-clear-year-filter:.+$/ })
   async handleCompletionClearYearFilter(interaction: ButtonInteraction): Promise<void> {
     await handleCompletionClearYearFilter(interaction);
+  }
+
+  @SelectMenuComponent({ id: /^comp-journal-view-select:\d+$/ })
+  async handleCompletionJournalViewSelect(
+    interaction: StringSelectMenuInteraction,
+  ): Promise<void> {
+    await handleCompletionJournalViewSelect(interaction);
+  }
+
+  @ButtonComponent({ id: /^comp-journal-page:\d+:\d+:(prev|next):\d+$/ })
+  async handleCompletionJournalPage(interaction: ButtonInteraction): Promise<void> {
+    await handleCompletionJournalPage(interaction);
   }
 
   @ButtonComponent({ id: /^completion-add-igdb-confirm:.+/ })

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -18,7 +18,11 @@ import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { safeReply } from "../../functions/InteractionUtils.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
-import { buildUserHeaderContainer } from "../../functions/uiComponents.js";
+import {
+  buildJournalSelectRow,
+  buildUserHeaderContainer,
+  type JournalSelectEntry,
+} from "../../functions/uiComponents.js";
 
 function buildCompletionV2Flags(ephemeral: boolean): number {
   return (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
@@ -136,7 +140,7 @@ export async function renderCompletionPage(
     return;
   }
 
-  const { containers, totalPages, safePage, sortedYears, yearCounts } = result;
+  const { containers, totalPages, safePage, sortedYears, yearCounts, journalEntries } = result;
   const yearPart = year == null ? "" : String(year);
   const queryPart = query ? `:${query.slice(0, 50)}` : "";
   const clearFilterCustomId = year !== null ? `comp-clear-year-filter:${userId}` : undefined;
@@ -149,6 +153,10 @@ export async function renderCompletionPage(
   );
 
   const yearJumpRow = buildYearJumpRow(userId, year, query, totalPages, sortedYears, yearCounts);
+  const journalSelectRow = buildJournalSelectRow(
+    `comp-journal-view-select:${userId}`,
+    journalEntries,
+  );
   const displayName = user.displayName ?? user.username ?? user.id;
   const header = buildUserHeaderContainer(userId, displayName, "Completed Games");
 
@@ -157,6 +165,7 @@ export async function renderCompletionPage(
       header,
       ...containers,
       ...(yearJumpRow ? [yearJumpRow] : []),
+      ...(journalSelectRow ? [journalSelectRow] : []),
       ...paginationRows,
     ],
     flags: buildCompletionV2Flags(ephemeral),
@@ -320,6 +329,7 @@ async function buildCompletionComponents(
   pageCompletions: any[];
   sortedYears: string[];
   yearCounts: Record<string, number>;
+  journalEntries: JournalSelectEntry[];
 } | null> {
   const total = await Member.countCompletions(userId, year, query);
   if (total === 0) return null;
@@ -358,7 +368,13 @@ async function buildCompletionComponents(
 
   const pageCompletions = allCompletions.slice(offset, offset + COMPLETION_PAGE_SIZE);
 
+  const pageGameIds = [...new Set(pageCompletions.map((c) => c.gameId))];
+  const journalStatuses = await Member.getJournalStatusForGames(userId, pageGameIds);
+  const journalByGameId = new Map(journalStatuses.map((s) => [s.gameId, s]));
+
   const buildEntryLine = (c: (typeof pageCompletions)[number], num: number): string => {
+    const journal = journalByGameId.get(c.gameId);
+    const journalEmoji = journal?.journalEnabled && journal.hasJournalEntry ? " 📒" : "";
     const typeAbbrev =
       c.completionType === "Main Story"
         ? "M"
@@ -371,7 +387,7 @@ async function buildCompletionComponents(
     const platformLabel = platformName ? ` [${platformName}]` : "";
     const dateLabel = c.completedAt ? ` · ${formatTableDate(c.completedAt)}` : "";
     const hoursLabel = c.finalPlaytimeHours != null ? ` · ${c.finalPlaytimeHours} hrs` : "";
-    return `${num}. **${c.title}**${platformLabel} (${typeAbbrev})${dateLabel}${hoursLabel}`;
+    return `${num}. **${c.title}**${journalEmoji}${platformLabel} (${typeAbbrev})${dateLabel}${hoursLabel}`;
   };
 
   const pushChunked = (containers: ContainerBuilder[], lines: string[]): void => {
@@ -471,5 +487,29 @@ async function buildCompletionComponents(
     ),
   );
 
-  return { containers, total, totalPages, safePage, pageCompletions, sortedYears, yearCounts };
+  const journalEntries: JournalSelectEntry[] = pageCompletions
+    .filter((c) => {
+      const s = journalByGameId.get(c.gameId);
+      return s?.journalEnabled && s.hasJournalEntry;
+    })
+    .map((c) => {
+      const s = journalByGameId.get(c.gameId)!;
+      return {
+        gameId: c.gameId,
+        title: c.title,
+        journalCount: s.journalCount,
+        lastJournalAt: s.lastJournalAt,
+      };
+    });
+
+  return {
+    containers,
+    total,
+    totalPages,
+    safePage,
+    pageCompletions,
+    sortedYears,
+    yearCounts,
+    journalEntries,
+  };
 }

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -158,7 +158,9 @@ export async function renderCompletionPage(
     journalEntries,
   );
   const displayName = user.displayName ?? user.username ?? user.id;
-  const header = buildUserHeaderContainer(userId, displayName, "Completed Games");
+  const isOwner = interaction.user.id === userId;
+  const headerButtonCustomId = isOwner ? `comp-list-header:${userId}` : undefined;
+  const header = buildUserHeaderContainer(userId, displayName, "Completed Games", headerButtonCustomId);
 
   await safeReply(interaction as any, {
     components: [

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -304,7 +304,7 @@ function buildPaginationRows(
   return [new ActionRowBuilder<ButtonBuilder>().addComponents(...buttons)];
 }
 
-const CHUNK_LIMIT = 1500;
+const CHUNK_LIMIT = 3500;
 
 async function buildCompletionComponents(
   userId: string,
@@ -414,6 +414,9 @@ async function buildCompletionComponents(
     const yearLabel = year === "unknown" ? "Unknown Date" : String(year);
     footerLines.push(`-# Year filter: ${yearLabel}`);
   }
+  if (queryLabel) {
+    footerLines.push(`-# Query: "${queryLabel}"`);
+  }
   if (totalPages > 1) {
     let resultsText = `${total} results`;
     if (minYear !== null && maxYear !== null) {
@@ -429,11 +432,6 @@ async function buildCompletionComponents(
   const yearCounts: Record<string, number> = {};
 
   if (queryLabel) {
-    containers.push(
-      new ContainerBuilder().addTextDisplayComponents(
-        new TextDisplayBuilder().setContent(`-# Query: "${queryLabel}"`),
-      ),
-    );
     const lines = pageCompletions.map((c, i) => buildEntryLine(c, offset + i + 1));
     pushChunked(containers, lines);
   } else {

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -4,6 +4,7 @@ import {
   type StringSelectMenuInteraction,
 } from "discord.js";
 import { renderCompletionPage, renderSelectionPage } from "./completion-list.service.js";
+import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import Member from "../../classes/Member.js";
 import { buildJournalView } from "../../functions/journalView.js";
 import { safeReply } from "../../functions/InteractionUtils.js";
@@ -167,6 +168,38 @@ export async function handleCompletionJournalPage(
   const page = Number(pageRaw);
   if (!gameId || Number.isNaN(page)) return;
   await openCompletionJournalView(interaction, ownerId, gameId, page);
+}
+
+const COMPLETION_HELP_TEXT = [
+  "## Game Completion Commands",
+  "**/game-completion add** — Add a game completion",
+  "**/game-completion edit** — Edit one of your completion records",
+  "**/game-completion delete** — Delete one of your completion records",
+  "**/game-completion export** — Export your completions to a CSV file",
+  "**/game-completion import-completionator** — Import completions from a Completionator CSV",
+  "**/game-completion common** — Show shared completions between two members",
+].join("\n");
+
+/**
+ * Handles the header button click for the owner of a completion list
+ */
+export async function handleCompletionListHeader(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parts = interaction.customId.split(":");
+  const ownerId = parts[1];
+  if (interaction.user.id !== ownerId) {
+    await interaction.deferUpdate().catch(() => {});
+    return;
+  }
+  await interaction.reply({
+    components: [
+      new ContainerBuilder().addTextDisplayComponents(
+        new TextDisplayBuilder().setContent(COMPLETION_HELP_TEXT),
+      ),
+    ],
+    flags: MessageFlags.Ephemeral | COMPONENTS_V2_FLAG,
+  });
 }
 
 /**

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -4,6 +4,10 @@ import {
   type StringSelectMenuInteraction,
 } from "discord.js";
 import { renderCompletionPage, renderSelectionPage } from "./completion-list.service.js";
+import Member from "../../classes/Member.js";
+import { buildJournalView } from "../../functions/journalView.js";
+import { safeReply } from "../../functions/InteractionUtils.js";
+import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 
 /**
  * Parses a year filter string into a number, "unknown", or null
@@ -103,6 +107,66 @@ export async function handleCompletionPaging(interaction: ButtonInteraction): Pr
   } else {
     await renderSelectionPage(interaction, ownerId, nextPage, mode, year, query);
   }
+}
+
+async function openCompletionJournalView(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+  ownerId: string,
+  gameId: number,
+  page: number,
+): Promise<void> {
+  const statuses = await Member.getJournalStatusForGames(ownerId, [gameId]);
+  const status = statuses[0];
+  if (!status?.journalEnabled || !status.hasJournalEntry) {
+    await safeReply(interaction, {
+      content: "This game has no journal entries.",
+      flags: MessageFlags.Ephemeral | COMPONENTS_V2_FLAG,
+    });
+    return;
+  }
+  const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
+  const payload = await buildJournalView({
+    ownerId,
+    viewerId: interaction.user.id,
+    gameId,
+    page,
+    guildId: interaction.guildId,
+    prevPageCustomId: (p) => `comp-journal-page:${ownerId}:${gameId}:prev:${p}`,
+    nextPageCustomId: (p) => `comp-journal-page:${ownerId}:${gameId}:next:${p}`,
+  });
+  await safeReply(interaction, {
+    components: payload.components,
+    files: payload.files,
+    flags: (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG,
+    allowedMentions: payload.allowedMentions,
+  });
+}
+
+/**
+ * Handles journal select menu on the completion list — opens the journal for the selected game
+ */
+export async function handleCompletionJournalViewSelect(
+  interaction: StringSelectMenuInteraction,
+): Promise<void> {
+  const parts = interaction.customId.split(":");
+  const ownerId = parts[1];
+  const gameId = Number(interaction.values[0]);
+  if (!gameId) return;
+  const firstPage = 1;
+  await openCompletionJournalView(interaction, ownerId, gameId, firstPage);
+}
+
+/**
+ * Handles prev/next page buttons inside a completion-list journal view
+ */
+export async function handleCompletionJournalPage(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const [, ownerId, gameIdRaw, , pageRaw] = interaction.customId.split(":");
+  const gameId = Number(gameIdRaw);
+  const page = Number(pageRaw);
+  if (!gameId || Number.isNaN(page)) return;
+  await openCompletionJournalView(interaction, ownerId, gameId, page);
 }
 
 /**

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -56,7 +56,7 @@ import {
 } from "../functions/InteractionUtils.js";
 import Game, { type IGame } from "../classes/Game.js";
 import { buildJournalView } from "../functions/journalView.js";
-import { buildUserHeaderContainer } from "../functions/uiComponents.js";
+import { buildJournalSelectRow, buildUserHeaderContainer } from "../functions/uiComponents.js";
 import { EphemeralOwnerMenu } from "../functions/EphemeralOwnerMenu.js";
 import { igdbService } from "../services/IGDB/IgdbService.js";
 import {
@@ -4468,25 +4468,18 @@ export class NowPlayingCommand {
     entries: IMemberNowPlayingEntry[],
     ownerId: string,
   ): ActionRowBuilder<StringSelectMenuBuilder> | null {
-    const journalEntries = entries.filter(
-      (e) => e.journalEnabled && e.hasJournalEntry,
+    const journalEntries = entries
+      .filter((e) => e.journalEnabled && e.hasJournalEntry)
+      .map((e) => ({
+        gameId: e.gameId,
+        title: e.title,
+        journalCount: e.journalCount,
+        lastJournalAt: e.lastJournalAt,
+      }));
+    return buildJournalSelectRow(
+      `${NOW_PLAYING_JOURNAL_VIEW_SELECT_PREFIX}:${ownerId}`,
+      journalEntries,
     );
-    if (!journalEntries.length) return null;
-    const options = journalEntries.map((e) => {
-      const rawLabel = `${e.title} Game Journal`;
-      const label = rawLabel.length > 100 ? `${rawLabel.slice(0, 97)}...` : rawLabel;
-      const countText = e.journalCount === 1 ? "1 entry" : `${e.journalCount} entries`;
-      const lastPart = e.lastJournalAt
-        ? ` · Last entry ${formatTableDate(e.lastJournalAt)}`
-        : "";
-      const description = `${countText}${lastPart}`.slice(0, 100);
-      return { label, description, value: String(e.gameId) };
-    });
-    const select = new StringSelectMenuBuilder()
-      .setCustomId(`${NOW_PLAYING_JOURNAL_VIEW_SELECT_PREFIX}:${ownerId}`)
-      .setPlaceholder("View Game Journals")
-      .addOptions(options);
-    return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
   }
 
   private async buildNowPlayingCompositeImageUrl(

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -1,4 +1,4 @@
-import { ButtonStyle } from "discord.js";
+import { ActionRowBuilder, ButtonStyle, StringSelectMenuBuilder } from "discord.js";
 import {
   ButtonBuilder,
   ContainerBuilder,
@@ -9,6 +9,34 @@ import {
   getUserEmojiString,
   renderUsernameWithEmoji,
 } from "../services/UserEmojiService.js";
+import { formatTableDate } from "../commands/profile.command.js";
+
+export interface JournalSelectEntry {
+  gameId: number;
+  title: string;
+  journalCount: number;
+  lastJournalAt: Date | null;
+}
+
+export function buildJournalSelectRow(
+  selectCustomId: string,
+  entries: JournalSelectEntry[],
+): ActionRowBuilder<StringSelectMenuBuilder> | null {
+  if (!entries.length) return null;
+  const options = entries.map((e) => {
+    const rawLabel = `${e.title} Game Journal`;
+    const label = rawLabel.length > 100 ? `${rawLabel.slice(0, 97)}...` : rawLabel;
+    const countText = e.journalCount === 1 ? "1 entry" : `${e.journalCount} entries`;
+    const lastPart = e.lastJournalAt ? ` · Last entry ${formatTableDate(e.lastJournalAt)}` : "";
+    const description = `${countText}${lastPart}`.slice(0, 100);
+    return { label, description, value: String(e.gameId) };
+  });
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(selectCustomId)
+    .setPlaceholder("View Game Journals")
+    .addOptions(options);
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+}
 
 export function buildUserHeaderContainer(
   userId: string,


### PR DESCRIPTION
## Summary

- **Query label moved to footer**: `Query: "<string>"` is now in the shared footer container alongside the legend and page info, not its own floating container above the list
- **Chunk limit raised**: `CHUNK_LIMIT` increased from `1500` to `3500` (Discord's TextDisplay cap is 4000), eliminating the ~17-game-per-container ceiling
- **Journal emoji on titles**: Completion entries with at least one journal entry show 📒 after the title (`journalEnabled && hasJournalEntry`)
- **Journal select menu**: When any game on the current page has journal entries, a "View Game Journals" select menu appears above the nav buttons
- **Shared `buildJournalSelectRow`**: Extracted from now-playing's private class method into `uiComponents.ts`; now-playing delegates to it, completion list uses it with its own custom ID
- **`Member.getJournalStatusForGames`**: New static method — queries journal enabled/entry count/last-entry date for a list of gameIds in one DB round-trip
- **Journal page navigation**: `comp-journal-page` button handlers open journals via `buildJournalView` without requiring the game to be in the user's now-playing list
- **Owner header help button**: When the list owner clicks the header button, an ephemeral Components v2 message is shown listing all `/game-completion` subcommands with descriptions (excluding `/game-completion list`). Non-owners fall through to the existing silent no-op `user-header-label` handler.

## Test plan

- [ ] Query-filtered lists show `Query: "..."` in the footer, not above the list
- [ ] More than ~17 entries appear per container (chunk limit raised)
- [ ] Completed games with journal entries show 📒 after their title
- [ ] A "View Game Journals" select menu appears when any game on the page has journals; absent otherwise
- [ ] Selecting a game opens its journal; prev/next navigation works within the journal
- [ ] Works for games not in the user's now-playing list
- [ ] Clicking the header button as the owner shows an ephemeral help message with all /game-completion commands except list
- [ ] Clicking the header button as a non-owner does nothing (silent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)