### PR TITLE
fix(Member): use COUNT(*) in getJournalStatusForGames — ORA-00904 fix

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -817,8 +817,8 @@ export default class Member {
       }>(
         `SELECT gids.GAME_ID,
                 NVL(jp.IS_ENABLED, 1) AS JOURNAL_ENABLED,
-                CASE WHEN COUNT(je.ID) > 0 THEN 1 ELSE 0 END AS HAS_JOURNAL_ENTRY,
-                COUNT(je.ID) AS JOURNAL_COUNT,
+                CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END AS HAS_JOURNAL_ENTRY,
+                COUNT(*) AS JOURNAL_COUNT,
                 MAX(je.CREATED_AT) AS LAST_JOURNAL_AT
            FROM (${inlineTable}) gids
            LEFT JOIN USER_GAME_JOURNAL_ENTRIES je


### PR DESCRIPTION
## Summary

`getJournalStatusForGames` used `COUNT(je.ID)` to count journal entries, but `USER_GAME_JOURNAL_ENTRIES` has no column named `ID` (the primary key is `ENTRY_ID`). Changed both occurrences to `COUNT(*)`, matching the pattern used in the existing `getNowPlaying` query.

**Error fixed:**
```
ORA-00904: "JE"."ID": invalid identifier
```

## Test plan

- [ ] `/game-completion list` no longer errors
- [ ] 📒 emoji appears on games that have journal entries
- [ ] "View Game Journals" select menu renders when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)