### PR TITLE
fix(uiComponents): sort journal select options alphabetically by title

### DIFF
--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -23,7 +23,8 @@ export function buildJournalSelectRow(
   entries: JournalSelectEntry[],
 ): ActionRowBuilder<StringSelectMenuBuilder> | null {
   if (!entries.length) return null;
-  const options = entries.map((e) => {
+  const sorted = [...entries].sort((a, b) => a.title.localeCompare(b.title));
+  const options = sorted.map((e) => {
     const rawLabel = `${e.title} Game Journal`;
     const label = rawLabel.length > 100 ? `${rawLabel.slice(0, 97)}...` : rawLabel;
     const countText = e.journalCount === 1 ? "1 entry" : `${e.journalCount} entries`;


### PR DESCRIPTION
## Summary

Journal select menu options are now sorted A-Z by game title. The sort is applied in `buildJournalSelectRow` in `uiComponents.ts`, so both the completion list and now-playing list journal selects benefit.

## Test plan

- [ ] "View Game Journals" select on the completion list shows games in A-Z order
- [ ] "View Game Journals" select on the now-playing list shows games in A-Z order

🤖 Generated with [Claude Code](https://claude.com/claude-code)