### PR TITLE
fix(completion-list): remove journalEnabled check, use journalCount > 0

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -790,8 +790,6 @@ export default class Member {
   ): Promise<
     Array<{
       gameId: number;
-      journalEnabled: boolean;
-      hasJournalEntry: boolean;
       journalCount: number;
       lastJournalAt: Date | null;
     }>
@@ -810,31 +808,22 @@ export default class Member {
     try {
       const res = await connection.execute<{
         GAME_ID: number;
-        JOURNAL_ENABLED: number | null;
-        HAS_JOURNAL_ENTRY: number;
         JOURNAL_COUNT: number;
         LAST_JOURNAL_AT: Date | string | null;
       }>(
         `SELECT gids.GAME_ID,
-                NVL(jp.IS_ENABLED, 1) AS JOURNAL_ENABLED,
-                CASE WHEN COUNT(*) > 0 THEN 1 ELSE 0 END AS HAS_JOURNAL_ENTRY,
                 COUNT(*) AS JOURNAL_COUNT,
                 MAX(je.CREATED_AT) AS LAST_JOURNAL_AT
            FROM (${inlineTable}) gids
            LEFT JOIN USER_GAME_JOURNAL_ENTRIES je
              ON je.USER_ID = :userId
             AND je.GAMEDB_GAME_ID = gids.GAME_ID
-           LEFT JOIN USER_GAME_JOURNAL_PREFS jp
-             ON jp.USER_ID = :userId
-            AND jp.GAMEDB_GAME_ID = gids.GAME_ID
-          GROUP BY gids.GAME_ID, jp.IS_ENABLED`,
+          GROUP BY gids.GAME_ID`,
         binds,
         { outFormat: oracledb.OUT_FORMAT_OBJECT },
       );
       return (res.rows ?? []).map((row) => ({
         gameId: Number(row.GAME_ID),
-        journalEnabled: Number(row.JOURNAL_ENABLED ?? 1) === 1,
-        hasJournalEntry: Number(row.HAS_JOURNAL_ENTRY) === 1,
         journalCount: Number(row.JOURNAL_COUNT),
         lastJournalAt:
           row.LAST_JOURNAL_AT instanceof Date

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -376,7 +376,7 @@ async function buildCompletionComponents(
 
   const buildEntryLine = (c: (typeof pageCompletions)[number], num: number): string => {
     const journal = journalByGameId.get(c.gameId);
-    const journalEmoji = journal?.journalEnabled && journal.hasJournalEntry ? " 📒" : "";
+    const journalEmoji = (journal?.journalCount ?? 0) > 0 ? " 📒" : "";
     const typeAbbrev =
       c.completionType === "Main Story"
         ? "M"
@@ -492,7 +492,7 @@ async function buildCompletionComponents(
   const journalEntries: JournalSelectEntry[] = pageCompletions
     .filter((c) => {
       const s = journalByGameId.get(c.gameId);
-      return s?.journalEnabled && s.hasJournalEntry;
+      return (s?.journalCount ?? 0) > 0;
     })
     .map((c) => {
       const s = journalByGameId.get(c.gameId)!;

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -118,7 +118,7 @@ async function openCompletionJournalView(
 ): Promise<void> {
   const statuses = await Member.getJournalStatusForGames(ownerId, [gameId]);
   const status = statuses[0];
-  if (!status?.journalEnabled || !status.hasJournalEntry) {
+  if ((status?.journalCount ?? 0) === 0) {
     await safeReply(interaction, {
       content: "This game has no journal entries.",
       flags: MessageFlags.Ephemeral | COMPONENTS_V2_FLAG,


### PR DESCRIPTION
## Summary

- **Removed `USER_GAME_JOURNAL_PREFS` join** from `getJournalStatusForGames` — the `journalEnabled` field is deprecated and its lookup was causing errors
- **Simplified return type**: `getJournalStatusForGames` now returns only `{ gameId, journalCount, lastJournalAt }`
- **All journal visibility checks** now use `journalCount > 0` exclusively:
  - 📒 emoji in entry lines
  - Filter for the "View Game Journals" select menu options
  - Guard in `openCompletionJournalView` before loading the journal

## Test plan

- [ ] `/game-completion list` loads without errors
- [ ] 📒 emoji appears on games that have at least one journal entry
- [ ] Games with zero journal entries show no emoji and no select option
- [ ] "View Game Journals" select menu only lists games with journal entries
- [ ] Opening a journal from the select still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)