### PR TITLE
feat(game-journal): journal entry search

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -138,6 +138,17 @@ export interface IJournalUserSummary {
   gameCount: number;
 }
 
+export interface IJournalSearchResult {
+  entryId: number;
+  userId: string;
+  gameId: number;
+  gameTitle: string;
+  entryTitle: string | null;
+  bodySnippet: string;
+  createdAt: Date;
+  isPublic: number;
+}
+
 export interface IAvatarHistoryRecord {
   eventId: number;
   userId: string;
@@ -2632,6 +2643,82 @@ export default class Member {
         globalName: row.GLOBAL_NAME ?? null,
         gameCount: Number(row.GAME_COUNT ?? 0),
       }));
+    } finally {
+      await connection.close();
+    }
+  }
+
+  static async searchJournalEntries(params: {
+    query: string;
+    callerId: string;
+    userId?: string;
+    gameId?: number;
+    limit: number;
+    offset: number;
+  }): Promise<{ rows: IJournalSearchResult[]; total: number }> {
+    const connection = await getOraclePool().getConnection();
+    const safeLimit = Math.min(Math.max(params.limit, 1), 25);
+    const safeOffset = Math.max(params.offset, 0);
+    const searchTerm = params.query.trim();
+    try {
+      const res = await connection.execute<{
+        TOTAL_COUNT: number;
+        ENTRY_ID: number;
+        USER_ID: string;
+        GAMEDB_GAME_ID: number;
+        GAME_TITLE: string;
+        ENTRY_TITLE: string | null;
+        BODY_SNIPPET: string;
+        CREATED_AT: Date | string;
+        IS_PUBLIC: number;
+      }>(
+        `SELECT COUNT(*) OVER () AS TOTAL_COUNT,
+                je.ENTRY_ID,
+                je.USER_ID,
+                je.GAMEDB_GAME_ID,
+                g.TITLE         AS GAME_TITLE,
+                je.ENTRY_TITLE,
+                SUBSTR(je.ENTRY_BODY, 1, 200) AS BODY_SNIPPET,
+                je.CREATED_AT,
+                je.IS_PUBLIC
+           FROM USER_GAME_JOURNAL_ENTRIES je
+           JOIN GAMEDB_GAMES g ON g.GAME_ID = je.GAMEDB_GAME_ID
+          WHERE (
+                  UPPER(je.ENTRY_TITLE) LIKE '%' || UPPER(:searchTerm) || '%'
+               OR UPPER(je.ENTRY_BODY)  LIKE '%' || UPPER(:searchTerm) || '%'
+                )
+            AND (je.IS_PUBLIC = 1 OR je.USER_ID = :callerId)
+            AND (:userId IS NULL OR je.USER_ID = :userId)
+            AND (:gameId IS NULL OR je.GAMEDB_GAME_ID = :gameId)
+          ORDER BY je.CREATED_AT DESC, je.ENTRY_ID DESC
+          OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+        {
+          searchTerm,
+          callerId: params.callerId,
+          userId: params.userId ?? null,
+          gameId: params.gameId ?? null,
+          offset: safeOffset,
+          limit: safeLimit,
+        },
+        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      );
+      const rows = res.rows ?? [];
+      const total = rows.length > 0 ? Number(rows[0].TOTAL_COUNT) : 0;
+      return {
+        total,
+        rows: rows.map((row) => ({
+          entryId: Number(row.ENTRY_ID),
+          userId: row.USER_ID,
+          gameId: Number(row.GAMEDB_GAME_ID),
+          gameTitle: row.GAME_TITLE,
+          entryTitle: row.ENTRY_TITLE ?? null,
+          bodySnippet: row.BODY_SNIPPET,
+          createdAt: row.CREATED_AT instanceof Date
+            ? row.CREATED_AT
+            : new Date(row.CREATED_AT),
+          isPublic: Number(row.IS_PUBLIC),
+        })),
+      };
     } finally {
       await connection.close();
     }

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -1,6 +1,7 @@
 import {
   ActionRowBuilder,
   ApplicationCommandOptionType,
+  AutocompleteInteraction,
   ButtonBuilder,
   ButtonInteraction,
   ButtonStyle,
@@ -31,8 +32,10 @@ import {
 } from "discordx";
 import Member, {
   type IGameJournalListEntry,
+  type IJournalSearchResult,
   type IJournalUserSummary,
 } from "../classes/Member.js";
+import Game from "../classes/Game.js";
 import {
   safeDeferReply,
   safeDeferUpdate,
@@ -40,12 +43,14 @@ import {
   safeReply,
   safeUpdate,
 } from "../functions/InteractionUtils.js";
+import { formatGameTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { buildJournalView } from "../functions/journalView.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { buildUserHeaderContainer } from "../functions/uiComponents.js";
 import {
   GJ_CLOSE_PREFIX,
+  GJ_SEARCH_PAGE_PREFIX,
   JOURNAL_TITLE_INPUT_ID,
   JOURNAL_BODY_INPUT_ID,
 } from "../config/journalConstants.js";
@@ -61,6 +66,8 @@ const gjHmenu = new EphemeralOwnerMenu();
 
 const LIST_PAGE_SIZE = 15;
 const ALL_PAGE_SIZE = 20;
+const SEARCH_PAGE_SIZE = 5;
+const SEARCH_QUERY_MAX_LENGTH = 35;
 
 const GJ_LIST_SELECT_PREFIX = "game-journal-list-select";
 const GJ_LIST_PAGE_PREFIX = "game-journal-list-page";
@@ -328,6 +335,115 @@ function buildAllPageRow(
   return row.components.length > 0 ? row : null;
 }
 
+async function autocompleteJournalSearchGame(
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  const rawQuery = focused?.value ? String(focused.value) : "";
+  const query = sanitizeUserInput(rawQuery, { preserveNewlines: false }).trim();
+  if (!query) {
+    await interaction.respond([]);
+    return;
+  }
+  const results = await Game.searchGamesAutocomplete(query);
+  await interaction.respond(
+    results.slice(0, 25).map((game) => ({
+      name: formatGameTitleWithYear(game).slice(0, 100),
+      value: String(game.id),
+    })),
+  );
+}
+
+function buildSearchCustomId(
+  callerId: string,
+  targetUserId: string,
+  gameId: string,
+  page: number,
+  query: string,
+): string {
+  return `${GJ_SEARCH_PAGE_PREFIX}:${callerId}:${targetUserId}:${gameId}:${page}:${query}`;
+}
+
+function buildSearchResultComponents(
+  targetUserId: string,
+  gameId: string,
+  query: string,
+  results: IJournalSearchResult[],
+  total: number,
+  page: number,
+  totalPages: number,
+): ContainerBuilder[] {
+  const scopeParts: string[] = [];
+  if (targetUserId !== "0") scopeParts.push(`<@${targetUserId}>`);
+  if (gameId !== "0") {
+    const gameResult = results.find((r) => String(r.gameId) === gameId);
+    if (gameResult) scopeParts.push(`**${gameResult.gameTitle}**`);
+  }
+  const scopeLabel = scopeParts.length ? ` in ${scopeParts.join(", ")}` : "";
+  const pageInfo = totalPages > 1 ? ` • Page ${page + 1}/${totalPages}` : "";
+
+  const headerContainer = new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(`## Journal Search: "${query}"${scopeLabel}`),
+  );
+
+  const lines: string[] = [];
+  if (!results.length) {
+    lines.push(`No journal entries matched **"${query}"**.`);
+  } else {
+    for (const result of results) {
+      const entryLabel = result.entryTitle?.trim()
+        ? `_${result.entryTitle.trim()}_`
+        : "_(no title)_";
+      const date = formatTableDate(result.createdAt);
+      const snippet = result.bodySnippet.length > 120
+        ? `${result.bodySnippet.slice(0, 117)}...`
+        : result.bodySnippet;
+      lines.push(
+        `**${result.gameTitle}** | <@${result.userId}>\n`
+        + `-# ${entryLabel} • ${date}\n`
+        + `> ${snippet.replace(/\n/g, " ")}`,
+      );
+    }
+  }
+  const resultLabel = total === 1 ? "result" : "results";
+  lines.push(`-# ${total} ${resultLabel}${pageInfo}`);
+
+  const resultsContainer = new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(lines.join("\n\n")),
+  );
+
+  return [headerContainer, resultsContainer];
+}
+
+function buildSearchPageRow(
+  callerId: string,
+  targetUserId: string,
+  gameId: string,
+  query: string,
+  page: number,
+  totalPages: number,
+): ActionRowBuilder<ButtonBuilder> | null {
+  if (totalPages <= 1) return null;
+  const row = new ActionRowBuilder<ButtonBuilder>();
+  if (page > 0) {
+    row.addComponents(
+      new ButtonBuilder()
+        .setCustomId(buildSearchCustomId(callerId, targetUserId, gameId, page - 1, query))
+        .setLabel("Previous")
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+  if (page < totalPages - 1) {
+    row.addComponents(
+      new ButtonBuilder()
+        .setCustomId(buildSearchCustomId(callerId, targetUserId, gameId, page + 1, query))
+        .setLabel("Next")
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+  return row.components.length > 0 ? row : null;
+}
+
 @Discord()
 export class GameJournalCommand {
   @Slash({
@@ -356,11 +472,69 @@ export class GameJournalCommand {
       type: ApplicationCommandOptionType.Boolean,
     })
     isPrivate: boolean | undefined,
+    @SlashOption({
+      description: "Search for a term across journal entries",
+      name: "query",
+      required: false,
+      type: ApplicationCommandOptionType.String,
+    })
+    query: string | undefined,
+    @SlashOption({
+      autocomplete: autocompleteJournalSearchGame,
+      description: "Filter search to a specific game (autocomplete from GameDB)",
+      name: "game",
+      required: false,
+      type: ApplicationCommandOptionType.String,
+    })
+    gameRaw: string | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
     const ephemeral = isPrivate === true;
     const flags = ephemeral ? MessageFlags.Ephemeral : undefined;
     await safeDeferReply(interaction, { flags });
+
+    if (query !== undefined) {
+      const cleanQuery = sanitizeUserInput(query, { preserveNewlines: false })
+        .trim()
+        .slice(0, SEARCH_QUERY_MAX_LENGTH);
+      if (!cleanQuery) {
+        await safeReply(interaction, {
+          content: "Please enter a search term.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+      const targetUserId = member?.id ?? "0";
+      const gameIdParsed = gameRaw ? Number(gameRaw) : NaN;
+      const gameId = Number.isInteger(gameIdParsed) && gameIdParsed > 0
+        ? gameIdParsed
+        : undefined;
+      const gameIdStr = gameId ? String(gameId) : "0";
+      const callerId = interaction.user.id;
+
+      const { rows, total } = await Member.searchJournalEntries({
+        query: cleanQuery,
+        callerId,
+        userId: targetUserId !== "0" ? targetUserId : undefined,
+        gameId,
+        limit: SEARCH_PAGE_SIZE,
+        offset: 0,
+      });
+
+      const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
+      const searchComponents = buildSearchResultComponents(
+        targetUserId, gameIdStr, cleanQuery, rows, total, 0, totalPages,
+      );
+      const pageRow = buildSearchPageRow(
+        callerId, targetUserId, gameIdStr, cleanQuery, 0, totalPages,
+      );
+      const cvFlags = (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
+      const allComponents = pageRow
+        ? [...searchComponents, pageRow]
+        : searchComponents;
+      await safeReply(interaction, { embeds: [], components: allComponents, flags: cvFlags });
+      return;
+    }
 
     if (all === true && member === undefined) {
       const summaries = await Member.getAllJournalUsers();
@@ -538,6 +712,55 @@ export class GameJournalCommand {
     const pageRow = buildAllPageRow(callerId, safePage, totalPages);
     const components = pageRow ? [selectRow, pageRow] : [selectRow];
     await safeUpdate(interaction, { embeds: [embed], components });
+  }
+
+  @ButtonComponent({ id: new RegExp(`^${GJ_SEARCH_PAGE_PREFIX}:\\d+:\\d+:\\d+:\\d+:.+$`) })
+  async handleSearchPage(interaction: ButtonInteraction): Promise<void> {
+    const parts = interaction.customId.split(":");
+    const [, callerId, targetUserId, gameIdStr, pageRaw, ...queryParts] = parts;
+    if (interaction.user.id !== callerId) {
+      await safeReply(interaction, {
+        content: "This search isn't yours to navigate.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const page = Number(pageRaw);
+    if (Number.isNaN(page)) return;
+
+    const query = queryParts.join(":");
+    if (!query) return;
+
+    await safeDeferUpdate(interaction);
+
+    const gameId = gameIdStr !== "0" && Number(gameIdStr) > 0
+      ? Number(gameIdStr)
+      : undefined;
+    const userId = targetUserId !== "0" ? targetUserId : undefined;
+
+    const { rows, total } = await Member.searchJournalEntries({
+      query,
+      callerId,
+      userId,
+      gameId,
+      limit: SEARCH_PAGE_SIZE,
+      offset: page * SEARCH_PAGE_SIZE,
+    });
+
+    const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
+    const safePage = Math.min(Math.max(page, 0), totalPages - 1);
+
+    const searchComponents = buildSearchResultComponents(
+      targetUserId, gameIdStr, query, rows, total, safePage, totalPages,
+    );
+    const nextPageRow = buildSearchPageRow(
+      callerId, targetUserId, gameIdStr, query, safePage, totalPages,
+    );
+    const allComponents = nextPageRow
+      ? [...searchComponents, nextPageRow]
+      : searchComponents;
+    await safeUpdate(interaction, { embeds: [], components: allComponents, flags: COMPONENTS_V2_FLAG });
   }
 
   @ButtonComponent({ id: new RegExp(`^${GJ_VIEW_PAGE_PREFIX}:\\d+:\\d+:\\d+:\\d+$`) })

--- a/src/config/journalConstants.ts
+++ b/src/config/journalConstants.ts
@@ -1,4 +1,5 @@
 export const GJ_CLOSE_PREFIX = "journal-public-close";
+export const GJ_SEARCH_PAGE_PREFIX = "gj-search-page";
 
 export const JOURNAL_ADD_MODAL_ID = "nowplaying-journal-modal";
 export const JOURNAL_TITLE_INPUT_ID = "nowplaying-journal-title";


### PR DESCRIPTION
Closes #348

## Summary
- Adds a `query` option to `/game-journal` that searches `ENTRY_TITLE` and `ENTRY_BODY` across all journal entries (case-insensitive)
- Adds a `game` autocomplete option to filter the search to a specific GameDB title
- Results page with 5 entries per page, Components V2 layout matching existing journal style; Previous/Next buttons for pagination
- Search scope: all public entries by default; caller's own private entries are also included; can be narrowed to a specific member (`member` option) or game (`game` option)

## New method: `Member.searchJournalEntries()`
Oracle query using `LIKE '%' || UPPER(:term) || '%'` on both title and body columns with `COUNT(*) OVER()` for total count in one round-trip.

## Custom ID format
`gj-search-page:{callerId}:{userId|0}:{gameId|0}:{page}:{query}` (query max 35 chars via slash option; query placed last so colons inside it are safely rejoined on parse).

## Test plan
- [ ] `/game-journal query:boss` returns matching entries across all users
- [ ] `/game-journal query:boss member:@someone` scopes to that member
- [ ] `/game-journal query:boss game:<autocomplete>` scopes to the selected game
- [ ] Private entries for the caller appear; private entries from others do not
- [ ] Zero results shows the empty state message
- [ ] Pagination Previous/Next works correctly across pages
- [ ] Existing `/game-journal` usage (no `query`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)