### PR TITLE
fix(game-journal): full text, per-result pagination, game in header

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -144,9 +144,8 @@ export interface IJournalSearchResult {
   gameId: number;
   gameTitle: string;
   entryTitle: string | null;
-  bodySnippet: string;
+  body: string;
   createdAt: Date;
-  isPublic: number;
 }
 
 export interface IAvatarHistoryRecord {
@@ -2650,7 +2649,6 @@ export default class Member {
 
   static async searchJournalEntries(params: {
     query: string;
-    callerId: string;
     userId?: string;
     gameId?: number;
     limit: number;
@@ -2668,9 +2666,8 @@ export default class Member {
         GAMEDB_GAME_ID: number;
         GAME_TITLE: string;
         ENTRY_TITLE: string | null;
-        BODY_SNIPPET: string;
+        ENTRY_BODY: string;
         CREATED_AT: Date | string;
-        IS_PUBLIC: number;
       }>(
         `SELECT COUNT(*) OVER () AS TOTAL_COUNT,
                 je.ENTRY_ID,
@@ -2678,23 +2675,20 @@ export default class Member {
                 je.GAMEDB_GAME_ID,
                 g.TITLE         AS GAME_TITLE,
                 je.ENTRY_TITLE,
-                SUBSTR(je.ENTRY_BODY, 1, 200) AS BODY_SNIPPET,
-                je.CREATED_AT,
-                je.IS_PUBLIC
+                je.ENTRY_BODY,
+                je.CREATED_AT
            FROM USER_GAME_JOURNAL_ENTRIES je
            JOIN GAMEDB_GAMES g ON g.GAME_ID = je.GAMEDB_GAME_ID
           WHERE (
                   UPPER(je.ENTRY_TITLE) LIKE '%' || UPPER(:searchTerm) || '%'
                OR UPPER(je.ENTRY_BODY)  LIKE '%' || UPPER(:searchTerm) || '%'
                 )
-            AND (je.IS_PUBLIC = 1 OR je.USER_ID = :callerId)
             AND (:userId IS NULL OR je.USER_ID = :userId)
             AND (:gameId IS NULL OR je.GAMEDB_GAME_ID = :gameId)
           ORDER BY je.CREATED_AT DESC, je.ENTRY_ID DESC
           OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
         {
           searchTerm,
-          callerId: params.callerId,
           userId: params.userId ?? null,
           gameId: params.gameId ?? null,
           offset: safeOffset,
@@ -2712,11 +2706,10 @@ export default class Member {
           gameId: Number(row.GAMEDB_GAME_ID),
           gameTitle: row.GAME_TITLE,
           entryTitle: row.ENTRY_TITLE ?? null,
-          bodySnippet: row.BODY_SNIPPET,
+          body: row.ENTRY_BODY,
           createdAt: row.CREATED_AT instanceof Date
             ? row.CREATED_AT
             : new Date(row.CREATED_AT),
-          isPublic: Number(row.IS_PUBLIC),
         })),
       };
     } finally {

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -365,7 +365,7 @@ function buildSearchCustomId(
 }
 
 function buildSearchResultComponents(
-  targetUserId: string,
+  targetUserName: string | null,
   gameTitle: string | null,
   query: string,
   results: IJournalSearchResult[],
@@ -374,8 +374,8 @@ function buildSearchResultComponents(
   totalPages: number,
 ): ContainerBuilder[] {
   const gameLabel = gameTitle ? ` in **${gameTitle}**` : "";
-  const headerLines = [`## Journal Search: "${query}"${gameLabel}`];
-  if (targetUserId !== "0") headerLines.push(`-# for <@${targetUserId}>`);
+  const headerLines = [`## Game Journal Search: "${query}"${gameLabel}`];
+  if (targetUserName) headerLines.push(`-# for ${targetUserName}`);
 
   const headerContainer = new ContainerBuilder().addTextDisplayComponents(
     new TextDisplayBuilder().setContent(headerLines.join("\n")),
@@ -516,9 +516,10 @@ export class GameJournalCommand {
       ]);
 
       const gameTitle = gameRecord?.title ?? null;
+      const targetUserName = member ? (member.displayName ?? member.username) : null;
       const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
       const searchComponents = buildSearchResultComponents(
-        targetUserId, gameTitle, cleanQuery, rows, total, 0, totalPages,
+        targetUserName, gameTitle, cleanQuery, rows, total, 0, totalPages,
       );
       const pageRow = buildSearchPageRow(
         callerId, targetUserId, gameIdStr, cleanQuery, 0, totalPages,
@@ -746,11 +747,17 @@ export class GameJournalCommand {
     ]);
 
     const gameTitle = gameRecord?.title ?? null;
+    const targetUser = targetUserId !== "0"
+      ? await interaction.client.users.fetch(targetUserId).catch(() => null)
+      : null;
+    const targetUserName = targetUser
+      ? (targetUser.displayName ?? targetUser.username)
+      : null;
     const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
     const safePage = Math.min(Math.max(page, 0), totalPages - 1);
 
     const searchComponents = buildSearchResultComponents(
-      targetUserId, gameTitle, query, rows, total, safePage, totalPages,
+      targetUserName, gameTitle, query, rows, total, safePage, totalPages,
     );
     const nextPageRow = buildSearchPageRow(
       callerId, targetUserId, gameIdStr, query, safePage, totalPages,

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -66,7 +66,7 @@ const gjHmenu = new EphemeralOwnerMenu();
 
 const LIST_PAGE_SIZE = 15;
 const ALL_PAGE_SIZE = 20;
-const SEARCH_PAGE_SIZE = 5;
+const SEARCH_PAGE_SIZE = 1;
 const SEARCH_QUERY_MAX_LENGTH = 35;
 
 const GJ_LIST_SELECT_PREFIX = "game-journal-list-select";
@@ -366,50 +366,42 @@ function buildSearchCustomId(
 
 function buildSearchResultComponents(
   targetUserId: string,
-  gameId: string,
+  gameTitle: string | null,
   query: string,
   results: IJournalSearchResult[],
   total: number,
   page: number,
   totalPages: number,
 ): ContainerBuilder[] {
-  const scopeParts: string[] = [];
-  if (targetUserId !== "0") scopeParts.push(`<@${targetUserId}>`);
-  if (gameId !== "0") {
-    const gameResult = results.find((r) => String(r.gameId) === gameId);
-    if (gameResult) scopeParts.push(`**${gameResult.gameTitle}**`);
-  }
-  const scopeLabel = scopeParts.length ? ` in ${scopeParts.join(", ")}` : "";
-  const pageInfo = totalPages > 1 ? ` • Page ${page + 1}/${totalPages}` : "";
+  const gameLabel = gameTitle ? ` in **${gameTitle}**` : "";
+  const headerLines = [`## Journal Search: "${query}"${gameLabel}`];
+  if (targetUserId !== "0") headerLines.push(`-# for <@${targetUserId}>`);
 
   const headerContainer = new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(`## Journal Search: "${query}"${scopeLabel}`),
+    new TextDisplayBuilder().setContent(headerLines.join("\n")),
   );
 
-  const lines: string[] = [];
-  if (!results.length) {
-    lines.push(`No journal entries matched **"${query}"**.`);
+  const result = results[0];
+  const resultLines: string[] = [];
+  if (!result) {
+    resultLines.push(`No journal entries matched **"${query}"**.`);
   } else {
-    for (const result of results) {
-      const entryLabel = result.entryTitle?.trim()
-        ? `_${result.entryTitle.trim()}_`
-        : "_(no title)_";
-      const date = formatTableDate(result.createdAt);
-      const snippet = result.bodySnippet.length > 120
-        ? `${result.bodySnippet.slice(0, 117)}...`
-        : result.bodySnippet;
-      lines.push(
-        `**${result.gameTitle}** | <@${result.userId}>\n`
-        + `-# ${entryLabel} • ${date}\n`
-        + `> ${snippet.replace(/\n/g, " ")}`,
-      );
-    }
+    const entryLabel = result.entryTitle?.trim()
+      ? `_${result.entryTitle.trim()}_`
+      : "_(no title)_";
+    const date = formatTableDate(result.createdAt);
+    resultLines.push(
+      `**${result.gameTitle}** | <@${result.userId}>\n`
+      + `-# ${entryLabel} • ${date}\n\n`
+      + result.body,
+    );
   }
-  const resultLabel = total === 1 ? "result" : "results";
-  lines.push(`-# ${total} ${resultLabel}${pageInfo}`);
+  const resultCountLabel = total === 1 ? "result" : "results";
+  const resultInfo = total > 0 ? `-# Result ${page + 1} of ${total}` : `-# 0 ${resultCountLabel}`;
+  resultLines.push(resultInfo);
 
   const resultsContainer = new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(lines.join("\n\n")),
+    new TextDisplayBuilder().setContent(resultLines.join("\n\n")),
   );
 
   return [headerContainer, resultsContainer];
@@ -429,7 +421,7 @@ function buildSearchPageRow(
     row.addComponents(
       new ButtonBuilder()
         .setCustomId(buildSearchCustomId(callerId, targetUserId, gameId, page - 1, query))
-        .setLabel("Previous")
+        .setLabel("Previous Result")
         .setStyle(ButtonStyle.Secondary),
     );
   }
@@ -437,7 +429,7 @@ function buildSearchPageRow(
     row.addComponents(
       new ButtonBuilder()
         .setCustomId(buildSearchCustomId(callerId, targetUserId, gameId, page + 1, query))
-        .setLabel("Next")
+        .setLabel("Next Result")
         .setStyle(ButtonStyle.Secondary),
     );
   }
@@ -512,18 +504,21 @@ export class GameJournalCommand {
       const gameIdStr = gameId ? String(gameId) : "0";
       const callerId = interaction.user.id;
 
-      const { rows, total } = await Member.searchJournalEntries({
-        query: cleanQuery,
-        callerId,
-        userId: targetUserId !== "0" ? targetUserId : undefined,
-        gameId,
-        limit: SEARCH_PAGE_SIZE,
-        offset: 0,
-      });
+      const [{ rows, total }, gameRecord] = await Promise.all([
+        Member.searchJournalEntries({
+          query: cleanQuery,
+          userId: targetUserId !== "0" ? targetUserId : undefined,
+          gameId,
+          limit: SEARCH_PAGE_SIZE,
+          offset: 0,
+        }),
+        gameId ? Game.getGameById(gameId) : Promise.resolve(null),
+      ]);
 
+      const gameTitle = gameRecord?.title ?? null;
       const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
       const searchComponents = buildSearchResultComponents(
-        targetUserId, gameIdStr, cleanQuery, rows, total, 0, totalPages,
+        targetUserId, gameTitle, cleanQuery, rows, total, 0, totalPages,
       );
       const pageRow = buildSearchPageRow(
         callerId, targetUserId, gameIdStr, cleanQuery, 0, totalPages,
@@ -739,20 +734,23 @@ export class GameJournalCommand {
       : undefined;
     const userId = targetUserId !== "0" ? targetUserId : undefined;
 
-    const { rows, total } = await Member.searchJournalEntries({
-      query,
-      callerId,
-      userId,
-      gameId,
-      limit: SEARCH_PAGE_SIZE,
-      offset: page * SEARCH_PAGE_SIZE,
-    });
+    const [{ rows, total }, gameRecord] = await Promise.all([
+      Member.searchJournalEntries({
+        query,
+        userId,
+        gameId,
+        limit: SEARCH_PAGE_SIZE,
+        offset: page * SEARCH_PAGE_SIZE,
+      }),
+      gameId ? Game.getGameById(gameId) : Promise.resolve(null),
+    ]);
 
+    const gameTitle = gameRecord?.title ?? null;
     const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
     const safePage = Math.min(Math.max(page, 0), totalPages - 1);
 
     const searchComponents = buildSearchResultComponents(
-      targetUserId, gameIdStr, query, rows, total, safePage, totalPages,
+      targetUserId, gameTitle, query, rows, total, safePage, totalPages,
     );
     const nextPageRow = buildSearchPageRow(
       callerId, targetUserId, gameIdStr, query, safePage, totalPages,

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -516,7 +516,9 @@ export class GameJournalCommand {
       ]);
 
       const gameTitle = gameRecord?.title ?? null;
-      const targetUserName = member ? (member.displayName ?? member.username) : null;
+      const targetUserName = member
+        ? renderUsernameWithEmoji(member.id, member.displayName ?? member.username)
+        : null;
       const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
       const searchComponents = buildSearchResultComponents(
         targetUserName, gameTitle, cleanQuery, rows, total, 0, totalPages,
@@ -751,7 +753,7 @@ export class GameJournalCommand {
       ? await interaction.client.users.fetch(targetUserId).catch(() => null)
       : null;
     const targetUserName = targetUser
-      ? (targetUser.displayName ?? targetUser.username)
+      ? renderUsernameWithEmoji(targetUser.id, targetUser.displayName ?? targetUser.username)
       : null;
     const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
     const safePage = Math.min(Math.max(page, 0), totalPages - 1);


### PR DESCRIPTION
Follow-up to #359 based on feedback.

## Changes
- **Full entry body**: removed `SUBSTR(..., 200)` truncation; `ENTRY_BODY` is returned in full and rendered as-is
- **Per-result pagination**: `SEARCH_PAGE_SIZE` reduced from 5 to 1 so each result occupies its own page; footer reads `Result X of N`; nav buttons labeled "Previous Result" / "Next Result"
- **Game title in header**: when a game filter is active, the header renders as `Journal Search: "query" in **Game Title**`; title is fetched via `Game.getGameById` so it's reliable regardless of result count
- **Dropped deprecated private-entry handling**: removed `IS_PUBLIC`/`callerId` filter that was missed in the original merge
- **Interface cleanup**: `IJournalSearchResult.bodySnippet` renamed to `body`

## Test plan
- [ ] `/game-journal query:boss` shows full entry text for each result, paginated one per page
- [ ] `/game-journal query:boss game:<Elden Ring>` shows `Journal Search: "boss" in **Elden Ring**` in the header
- [ ] `/game-journal query:boss member:@someone` shows the member subheader line
- [ ] Header game title shows correctly even when zero results are found
- [ ] Previous Result / Next Result navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)