### PR TITLE
fix(game-journal): no user ping in search results; name with emoji

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -141,6 +141,8 @@ export interface IJournalUserSummary {
 export interface IJournalSearchResult {
   entryId: number;
   userId: string;
+  globalName: string | null;
+  username: string | null;
   gameId: number;
   gameTitle: string;
   entryTitle: string | null;
@@ -2663,6 +2665,8 @@ export default class Member {
         TOTAL_COUNT: number;
         ENTRY_ID: number;
         USER_ID: string;
+        GLOBAL_NAME: string | null;
+        USERNAME: string | null;
         GAMEDB_GAME_ID: number;
         GAME_TITLE: string;
         ENTRY_TITLE: string | null;
@@ -2672,6 +2676,8 @@ export default class Member {
         `SELECT COUNT(*) OVER () AS TOTAL_COUNT,
                 je.ENTRY_ID,
                 je.USER_ID,
+                u.GLOBAL_NAME,
+                u.USERNAME,
                 je.GAMEDB_GAME_ID,
                 g.TITLE         AS GAME_TITLE,
                 je.ENTRY_TITLE,
@@ -2679,6 +2685,7 @@ export default class Member {
                 je.CREATED_AT
            FROM USER_GAME_JOURNAL_ENTRIES je
            JOIN GAMEDB_GAMES g ON g.GAME_ID = je.GAMEDB_GAME_ID
+           JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
           WHERE (
                   UPPER(je.ENTRY_TITLE) LIKE '%' || UPPER(:searchTerm) || '%'
                OR UPPER(je.ENTRY_BODY)  LIKE '%' || UPPER(:searchTerm) || '%'
@@ -2703,6 +2710,8 @@ export default class Member {
         rows: rows.map((row) => ({
           entryId: Number(row.ENTRY_ID),
           userId: row.USER_ID,
+          globalName: row.GLOBAL_NAME ?? null,
+          username: row.USERNAME ?? null,
           gameId: Number(row.GAMEDB_GAME_ID),
           gameTitle: row.GAME_TITLE,
           entryTitle: row.ENTRY_TITLE ?? null,

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -390,8 +390,12 @@ function buildSearchResultComponents(
       ? `_${result.entryTitle.trim()}_`
       : "_(no title)_";
     const date = formatTableDate(result.createdAt);
+    const displayName = result.globalName ?? result.username ?? result.userId;
+    const userPart = targetUserName
+      ? ""
+      : ` | ${renderUsernameWithEmoji(result.userId, displayName)}`;
     resultLines.push(
-      `**${result.gameTitle}** | <@${result.userId}>\n`
+      `**${result.gameTitle}**${userPart}\n`
       + `-# ${entryLabel} • ${date}\n\n`
       + result.body,
     );


### PR DESCRIPTION
Follow-up to #360.

## Changes
- `searchJournalEntries` now joins `RPG_CLUB_USERS` to pull `GLOBAL_NAME` and `USERNAME` alongside each entry
- `IJournalSearchResult` gains `globalName` and `username` fields
- Result items render the author as `renderUsernameWithEmoji(userId, globalName ?? username ?? userId)` — no ping
- When the search is already filtered to a specific member (`member` option was used), the author is omitted from the result line entirely since it's redundant

## Test plan
- [ ] Cross-user search: result line shows `**Game Title** | emoji Name` with no ping
- [ ] Member-filtered search: result line shows `**Game Title**` with no user shown
- [ ] Emoji renders correctly for users who have one set

🤖 Generated with [Claude Code](https://claude.com/claude-code)