### PR TITLE
fix(game-journal): user header component + name-with-emoji in results

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -141,6 +141,8 @@ export interface IJournalUserSummary {
 export interface IJournalSearchResult {
   entryId: number;
   userId: string;
+  globalName: string | null;
+  username: string | null;
   gameId: number;
   gameTitle: string;
   entryTitle: string | null;
@@ -2663,6 +2665,8 @@ export default class Member {
         TOTAL_COUNT: number;
         ENTRY_ID: number;
         USER_ID: string;
+        GLOBAL_NAME: string | null;
+        USERNAME: string | null;
         GAMEDB_GAME_ID: number;
         GAME_TITLE: string;
         ENTRY_TITLE: string | null;
@@ -2672,6 +2676,8 @@ export default class Member {
         `SELECT COUNT(*) OVER () AS TOTAL_COUNT,
                 je.ENTRY_ID,
                 je.USER_ID,
+                u.GLOBAL_NAME,
+                u.USERNAME,
                 je.GAMEDB_GAME_ID,
                 g.TITLE         AS GAME_TITLE,
                 je.ENTRY_TITLE,
@@ -2679,6 +2685,7 @@ export default class Member {
                 je.CREATED_AT
            FROM USER_GAME_JOURNAL_ENTRIES je
            JOIN GAMEDB_GAMES g ON g.GAME_ID = je.GAMEDB_GAME_ID
+           JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
           WHERE (
                   UPPER(je.ENTRY_TITLE) LIKE '%' || UPPER(:searchTerm) || '%'
                OR UPPER(je.ENTRY_BODY)  LIKE '%' || UPPER(:searchTerm) || '%'
@@ -2703,6 +2710,8 @@ export default class Member {
         rows: rows.map((row) => ({
           entryId: Number(row.ENTRY_ID),
           userId: row.USER_ID,
+          globalName: row.GLOBAL_NAME ?? null,
+          username: row.USERNAME ?? null,
           gameId: Number(row.GAMEDB_GAME_ID),
           gameTitle: row.GAME_TITLE,
           entryTitle: row.ENTRY_TITLE ?? null,

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -365,7 +365,7 @@ function buildSearchCustomId(
 }
 
 function buildSearchResultComponents(
-  targetUserName: string | null,
+  targetUser: { id: string; displayName: string } | null,
   gameTitle: string | null,
   query: string,
   results: IJournalSearchResult[],
@@ -373,13 +373,14 @@ function buildSearchResultComponents(
   page: number,
   totalPages: number,
 ): ContainerBuilder[] {
-  const gameLabel = gameTitle ? ` in **${gameTitle}**` : "";
-  const headerLines = [`## Game Journal Search: "${query}"${gameLabel}`];
-  if (targetUserName) headerLines.push(`-# for ${targetUserName}`);
+  const gamePart = gameTitle ? ` in **${gameTitle}**` : "";
+  const headerTitle = `Game Journal Search: "${query}"${gamePart}`;
 
-  const headerContainer = new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(headerLines.join("\n")),
-  );
+  const headerContainer = targetUser
+    ? buildUserHeaderContainer(targetUser.id, targetUser.displayName, headerTitle)
+    : new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(`## ${headerTitle}`),
+    );
 
   const result = results[0];
   const resultLines: string[] = [];
@@ -390,8 +391,12 @@ function buildSearchResultComponents(
       ? `_${result.entryTitle.trim()}_`
       : "_(no title)_";
     const date = formatTableDate(result.createdAt);
+    const displayName = result.globalName ?? result.username ?? result.userId;
+    const userPart = targetUser
+      ? ""
+      : ` | ${renderUsernameWithEmoji(result.userId, displayName)}`;
     resultLines.push(
-      `**${result.gameTitle}** | <@${result.userId}>\n`
+      `**${result.gameTitle}**${userPart}\n`
       + `-# ${entryLabel} • ${date}\n\n`
       + result.body,
     );
@@ -516,12 +521,12 @@ export class GameJournalCommand {
       ]);
 
       const gameTitle = gameRecord?.title ?? null;
-      const targetUserName = member
-        ? renderUsernameWithEmoji(member.id, member.displayName ?? member.username)
+      const targetUser = member
+        ? { id: member.id, displayName: member.displayName ?? member.username }
         : null;
       const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
       const searchComponents = buildSearchResultComponents(
-        targetUserName, gameTitle, cleanQuery, rows, total, 0, totalPages,
+        targetUser, gameTitle, cleanQuery, rows, total, 0, totalPages,
       );
       const pageRow = buildSearchPageRow(
         callerId, targetUserId, gameIdStr, cleanQuery, 0, totalPages,
@@ -749,17 +754,17 @@ export class GameJournalCommand {
     ]);
 
     const gameTitle = gameRecord?.title ?? null;
-    const targetUser = targetUserId !== "0"
+    const fetchedUser = targetUserId !== "0"
       ? await interaction.client.users.fetch(targetUserId).catch(() => null)
       : null;
-    const targetUserName = targetUser
-      ? renderUsernameWithEmoji(targetUser.id, targetUser.displayName ?? targetUser.username)
+    const targetUser = fetchedUser
+      ? { id: fetchedUser.id, displayName: fetchedUser.displayName ?? fetchedUser.username }
       : null;
     const totalPages = Math.max(1, Math.ceil(total / SEARCH_PAGE_SIZE));
     const safePage = Math.min(Math.max(page, 0), totalPages - 1);
 
     const searchComponents = buildSearchResultComponents(
-      targetUserName, gameTitle, query, rows, total, safePage, totalPages,
+      targetUser, gameTitle, query, rows, total, safePage, totalPages,
     );
     const nextPageRow = buildSearchPageRow(
       callerId, targetUserId, gameIdStr, query, safePage, totalPages,


### PR DESCRIPTION
Supersedes #361 — incorporates all those changes plus this new feedback.

## Changes

**Header when user-filtered**
Uses `buildUserHeaderContainer(userId, displayName, title)` so the member's name and emoji appear as the standard action button accessory, matching the rest of the journal UI.

**Header when not user-filtered**
Plain `## Game Journal Search: "query"` text container (unchanged).

**Result items**
- Joins `RPG_CLUB_USERS` in `searchJournalEntries` to fetch `GLOBAL_NAME` / `USERNAME`
- `IJournalSearchResult` gains `globalName` and `username` fields
- Result line renders author via `renderUsernameWithEmoji(userId, globalName ?? username ?? userId)` — no ping
- When filtered to a member, author is omitted from the result line entirely

## Test plan
- [ ] Member-filtered search: header shows `buildUserHeaderContainer` with name + emoji button accessory
- [ ] Unfiltered search: plain text header
- [ ] Result line shows emoji name, no ping
- [ ] Member-filtered result line omits the author entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)