### PR TITLE
feat(game-journal): render all:true leaderboard with v2 components

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -6,7 +6,6 @@ import {
   ButtonInteraction,
   ButtonStyle,
   CommandInteraction,
-  EmbedBuilder,
   Message,
   MessageFlags,
   ModalSubmitInteraction,
@@ -272,22 +271,29 @@ function buildJournalViewPayload(
   });
 }
 
-function buildAllEmbed(
+function buildAllComponents(
   summaries: IJournalUserSummary[],
   page: number,
   totalPages: number,
-): EmbedBuilder {
+): ContainerBuilder[] {
   const start = page * ALL_PAGE_SIZE;
   const pageSummaries = summaries.slice(start, start + ALL_PAGE_SIZE);
   const memberLabel = summaries.length === 1 ? "member" : "members";
-  const lines = pageSummaries.map((s) => {
-    return `${renderUsernameWithEmoji(s.userId, `<@${s.userId}>`)}`
-      + ` - ${s.gameCount} ${gameLabel(s.gameCount)}`;
-  });
-  return new EmbedBuilder()
-    .setTitle("Game Journal Users")
-    .setDescription(lines.join("\n"))
-    .setFooter({ text: `${summaries.length} ${memberLabel} • Page ${page + 1}/${totalPages}` });
+  const lines = ["## Game Journal Users"];
+  lines.push(
+    ...pageSummaries.map(
+      (s) =>
+        `${renderUsernameWithEmoji(s.userId, `<@${s.userId}>`)}`
+        + ` - ${s.gameCount} ${gameLabel(s.gameCount)}`,
+    ),
+  );
+  const pageInfo = totalPages > 1 ? ` • Page ${page + 1}/${totalPages}` : "";
+  lines.push(`-# ${summaries.length} ${memberLabel}${pageInfo}`);
+  return [
+    new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(lines.join("\n")),
+    ),
+  ];
 }
 
 function buildAllSelectRow(
@@ -550,11 +556,14 @@ export class GameJournalCommand {
       }
       const totalPages = Math.max(1, Math.ceil(summaries.length / ALL_PAGE_SIZE));
       const page = 0;
-      const embed = buildAllEmbed(summaries, page, totalPages);
+      const cvFlags = (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
+      const allContainers = buildAllComponents(summaries, page, totalPages);
       const selectRow = buildAllSelectRow(summaries, interaction.user.id, page);
       const pageRow = buildAllPageRow(interaction.user.id, page, totalPages);
-      const components = pageRow ? [selectRow, pageRow] : [selectRow];
-      await safeReply(interaction, { embeds: [embed], components, flags });
+      const components = pageRow
+        ? [...allContainers, selectRow, pageRow]
+        : [...allContainers, selectRow];
+      await safeReply(interaction, { embeds: [], components, flags: cvFlags });
       return;
     }
 
@@ -710,11 +719,13 @@ export class GameJournalCommand {
     const summaries = await Member.getAllJournalUsers();
     const totalPages = Math.max(1, Math.ceil(summaries.length / ALL_PAGE_SIZE));
     const safePage = Math.min(Math.max(page, 0), totalPages - 1);
-    const embed = buildAllEmbed(summaries, safePage, totalPages);
+    const allContainers = buildAllComponents(summaries, safePage, totalPages);
     const selectRow = buildAllSelectRow(summaries, callerId, safePage);
     const pageRow = buildAllPageRow(callerId, safePage, totalPages);
-    const components = pageRow ? [selectRow, pageRow] : [selectRow];
-    await safeUpdate(interaction, { embeds: [embed], components });
+    const components = pageRow
+      ? [...allContainers, selectRow, pageRow]
+      : [...allContainers, selectRow];
+    await safeUpdate(interaction, { embeds: [], components, flags: COMPONENTS_V2_FLAG });
   }
 
   @ButtonComponent({ id: new RegExp(`^${GJ_SEARCH_PAGE_PREFIX}:\\d+:\\d+:\\d+:\\d+:.+$`) })


### PR DESCRIPTION
## Summary
- Replaces `buildAllEmbed()` (EmbedBuilder) with `buildAllComponents()` (ContainerBuilder + TextDisplayBuilder) to match the v2 style of `/game-completion list all:true`
- Adds `COMPONENTS_V2_FLAG` to the initial slash command reply and the `handleAllPage` button handler
- Removes the now-unused `EmbedBuilder` import
- Leaderboard now renders with a `## Game Journal Users` heading, user mention lines with emoji, and a `-# N members` footer line

## Test plan
- [ ] `/game-journal all:true` renders as a v2 component message (no embed)
- [ ] Pagination via Previous/Next buttons continues rendering in v2 style
- [ ] Selecting a member from the dropdown still transitions to the per-user journal list correctly
- [ ] `/game-journal all:true private:true` renders as ephemeral v2 component

🤖 Generated with [Claude Code](https://claude.com/claude-code)