### PR TITLE
fix(game-journal): numbered list, bold display name, colon in all:true leaderboard

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -282,11 +282,11 @@ function buildAllComponents(
   const memberLabel = summaries.length === 1 ? "member" : "members";
   const lines = ["## Game Journal Users"];
   lines.push(
-    ...pageSummaries.map(
-      (s) =>
-        `${renderUsernameWithEmoji(s.userId, `<@${s.userId}>`)}`
-        + ` - ${s.gameCount} ${gameLabel(s.gameCount)}`,
-    ),
+    ...pageSummaries.map((s, idx) => {
+      const displayName = s.globalName ?? s.username ?? s.userId;
+      return `${start + idx + 1}. **${renderUsernameWithEmoji(s.userId, displayName)}**:`
+        + ` ${s.gameCount} ${gameLabel(s.gameCount)}`;
+    }),
   );
   const pageInfo = totalPages > 1 ? ` • Page ${page + 1}/${totalPages}` : "";
   lines.push(`-# ${summaries.length} ${memberLabel}${pageInfo}`);


### PR DESCRIPTION
## Summary
- Numbered list: each entry is prefixed with `1.`, `2.`, etc. (accounting for page offset)
- Display name instead of mention: uses `globalName ?? username ?? userId` bolded, no `<@tag>`
- Colon separator instead of hyphen: `**Name**: N games`

## Test plan
- [ ] `/game-journal all:true` shows numbered entries with bold names and colons
- [ ] Numbers continue correctly on page 2+ (offset-aware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)