### PR TITLE
fix(game-journal): numbered list, bold display name, colon, and Game Journal(s) label

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -282,11 +282,12 @@ function buildAllComponents(
   const memberLabel = summaries.length === 1 ? "member" : "members";
   const lines = ["## Game Journal Users"];
   lines.push(
-    ...pageSummaries.map(
-      (s) =>
-        `${renderUsernameWithEmoji(s.userId, `<@${s.userId}>`)}`
-        + ` - ${s.gameCount} ${gameLabel(s.gameCount)}`,
-    ),
+    ...pageSummaries.map((s, idx) => {
+      const displayName = s.globalName ?? s.username ?? s.userId;
+      const journalLabel = s.gameCount === 1 ? "Game Journal" : "Game Journals";
+      return `${start + idx + 1}. **${renderUsernameWithEmoji(s.userId, displayName)}**:`
+        + ` ${s.gameCount} ${journalLabel}`;
+    }),
   );
   const pageInfo = totalPages > 1 ? ` • Page ${page + 1}/${totalPages}` : "";
   lines.push(`-# ${summaries.length} ${memberLabel}${pageInfo}`);


### PR DESCRIPTION
## Summary
- Numbered list with page-offset-aware index
- Bold display name (`globalName ?? username ?? userId`) instead of `<@mention>`
- Colon separator instead of hyphen
- Count suffix is now "Game Journal" / "Game Journals" instead of "game" / "games"

Note: #365 was not yet merged, so this PR incorporates all those formatting changes as well.

## Test plan
- [ ] `/game-journal all:true` shows `1. **Name**: 3 Game Journals`
- [ ] Singular: `1 Game Journal` for a member with one game
- [ ] Numbers continue correctly on page 2+

🤖 Generated with [Claude Code](https://claude.com/claude-code)