### PR TITLE
fix(game-journal): show journal and entry counts in all:true leaderboard

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -136,6 +136,7 @@ export interface IJournalUserSummary {
   username: string | null;
   globalName: string | null;
   gameCount: number;
+  entryCount: number;
 }
 
 export interface IJournalSearchResult {
@@ -2622,11 +2623,13 @@ export default class Member {
         USERNAME: string | null;
         GLOBAL_NAME: string | null;
         GAME_COUNT: number;
+        ENTRY_COUNT: number;
       }>(
         `SELECT u.USER_ID,
                 u.USERNAME,
                 u.GLOBAL_NAME,
-                COUNT(DISTINCT je.GAMEDB_GAME_ID) AS GAME_COUNT
+                COUNT(DISTINCT je.GAMEDB_GAME_ID) AS GAME_COUNT,
+                COUNT(je.ENTRY_ID) AS ENTRY_COUNT
            FROM USER_GAME_JOURNAL_ENTRIES je
            JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
           WHERE NVL(u.IS_BOT, 0) = 0
@@ -2643,6 +2646,7 @@ export default class Member {
         username: row.USERNAME ?? null,
         globalName: row.GLOBAL_NAME ?? null,
         gameCount: Number(row.GAME_COUNT ?? 0),
+        entryCount: Number(row.ENTRY_COUNT ?? 0),
       }));
     } finally {
       await connection.close();

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -279,18 +279,16 @@ function buildAllComponents(
 ): ContainerBuilder[] {
   const start = page * ALL_PAGE_SIZE;
   const pageSummaries = summaries.slice(start, start + ALL_PAGE_SIZE);
-  const memberLabel = summaries.length === 1 ? "member" : "members";
   const lines = ["## Game Journal Users"];
   lines.push(
     ...pageSummaries.map((s, idx) => {
       const displayName = s.globalName ?? s.username ?? s.userId;
-      const journalLabel = s.gameCount === 1 ? "Game Journal" : "Game Journals";
+      const journalLabel = s.gameCount === 1 ? "Journal" : "Journals";
+      const entryLabel = s.entryCount === 1 ? "entry" : "entries";
       return `${start + idx + 1}. **${renderUsernameWithEmoji(s.userId, displayName)}**:`
-        + ` ${s.gameCount} ${journalLabel}`;
+        + ` ${s.gameCount} ${journalLabel} with ${s.entryCount} total ${entryLabel}`;
     }),
   );
-  const pageInfo = totalPages > 1 ? ` • Page ${page + 1}/${totalPages}` : "";
-  lines.push(`-# ${summaries.length} ${memberLabel}${pageInfo}`);
   return [
     new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent(lines.join("\n")),


### PR DESCRIPTION
## Summary
- Added `entryCount` to `IJournalUserSummary` interface and `getAllJournalUsers` query (`COUNT(ENTRY_ID)`)
- Each leaderboard line now reads: `1. **Name**: 3 Journals with 12 total entries`
- Removed the `-# N members` footer line

## Test plan
- [ ] `/game-journal all:true` shows journal and entry counts per user
- [ ] Singular forms: `1 Journal with 1 total entry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)