### PR TITLE
fix(igdb): remove noisy Twitch access token log

### DIFF
--- a/src/services/IGDB/IgdbService.ts
+++ b/src/services/IGDB/IgdbService.ts
@@ -103,7 +103,6 @@ class IgdbService {
 
       this.accessToken = response.data.access_token;
       this.tokenExpiry = Date.now() + (response.data.expires_in * 1000) - 60000;
-      console.log("IGDB: Fetched new Twitch access token.");
       return this.accessToken;
     } catch (error) {
       console.error("IGDB: Failed to fetch Twitch access token:", error);


### PR DESCRIPTION
## Summary

- Removes the `console.log("IGDB: Fetched new Twitch access token.")` line from `IgdbService.ts` — it fires on every token refresh and adds noise to the logs with no actionable signal.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)