### PR TITLE
feat(avatar-history): add all param to list members with avatar counts

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -160,6 +160,13 @@ export interface IAvatarHistoryRecord {
   changedAt: Date;
 }
 
+export interface IMemberAvatarHistoryCount {
+  userId: string;
+  username: string | null;
+  globalName: string | null;
+  count: number;
+}
+
 export interface ICompletionRecord {
   completionId: number;
   gameId: number;
@@ -2387,6 +2394,39 @@ export default class Member {
       );
       const row = result.rows?.[0];
       return Number(row?.TOTAL ?? 0);
+    } finally {
+      await connection.close();
+    }
+  }
+
+  static async getAllMembersAvatarHistoryCounts(): Promise<IMemberAvatarHistoryCount[]> {
+    const connection = await getOraclePool().getConnection();
+    try {
+      const result = await connection.execute<{
+        USER_ID: string;
+        USERNAME: string | null;
+        GLOBAL_NAME: string | null;
+        TOTAL: number;
+      }>(
+        `SELECT h.USER_ID,
+                u.USERNAME,
+                u.GLOBAL_NAME,
+                COUNT(*) AS TOTAL
+           FROM RPG_CLUB_USER_AVATAR_HISTORY h
+           JOIN RPG_CLUB_USERS u ON u.USER_ID = h.USER_ID
+          WHERE NVL(u.IS_BOT, 0) = 0
+            AND u.SERVER_LEFT_AT IS NULL
+          GROUP BY h.USER_ID, u.USERNAME, u.GLOBAL_NAME
+          ORDER BY COALESCE(u.GLOBAL_NAME, u.USERNAME, h.USER_ID)`,
+        {},
+        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      );
+      return (result.rows ?? []).map((row) => ({
+        userId: String(row.USER_ID),
+        username: row.USERNAME ?? null,
+        globalName: row.GLOBAL_NAME ?? null,
+        count: Number(row.TOTAL),
+      }));
     } finally {
       await connection.close();
     }

--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -7,6 +7,7 @@ import {
   MessageFlags,
   User,
 } from "discord.js";
+import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import { ButtonComponent, Discord, Slash, SlashOption } from "discordx";
 import { ephemeralFlag, safeDeferReply, safeReply } from "../functions/InteractionUtils.js";
 import {
@@ -15,6 +16,8 @@ import {
   shouldRenderPrevNextButtons,
 } from "../functions/PaginationUtils.js";
 import Member from "../classes/Member.js";
+import { COMPONENTS_V2_FLAG } from "../config/flags.js";
+import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 
 const AVATAR_HISTORY_PAGE_SIZE = 10;
 
@@ -98,9 +101,54 @@ export class AvatarHistoryCommand {
       type: ApplicationCommandOptionType.Boolean,
     })
     showInChat: boolean | undefined,
+    @SlashOption({
+      description: "List all members with avatar history and their stored count.",
+      name: "all",
+      required: false,
+      type: ApplicationCommandOptionType.Boolean,
+    })
+    showAll: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
     const ephemeral = !showInChat;
+
+    if (showAll === true) {
+      await safeDeferReply(interaction, {
+        flags: (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG,
+      });
+      const members = await Member.getAllMembersAvatarHistoryCounts();
+      if (!members.length) {
+        const container = new ContainerBuilder().addTextDisplayComponents(
+          new TextDisplayBuilder().setContent("No avatar history found for any members."),
+        );
+        await safeReply(interaction, {
+          components: [container],
+          flags: (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG,
+        });
+        return;
+      }
+
+      const lines = members.map((record) => {
+        const displayName = record.globalName ?? record.username ?? record.userId;
+        const suffix = record.count === 1 ? "avatar" : "avatars";
+        return `**${renderUsernameWithEmoji(record.userId, displayName)}**: ${record.count} ${suffix}`;
+      });
+
+      const container = new ContainerBuilder();
+      container.addTextDisplayComponents(
+        new TextDisplayBuilder().setContent("# Avatar History - Everyone"),
+      );
+      container.addTextDisplayComponents(
+        new TextDisplayBuilder().setContent(lines.join("\n")),
+      );
+
+      await safeReply(interaction, {
+        components: [container],
+        flags: (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG,
+      });
+      return;
+    }
+
     await safeDeferReply(interaction, { flags: ephemeralFlag(ephemeral) });
 
     const target = member ?? interaction.user;


### PR DESCRIPTION
## Summary
- Adds an optional `all:true` boolean parameter to `/avatar-history`
- When `all:true`, queries all server members with avatar history and displays their stored count using V2 components
- Renders with ContainerBuilder + TextDisplayBuilder matching the style of `/now-playing list all:true` (heading + one line per member)
- New `Member.getAllMembersAvatarHistoryCounts()` DB method groups avatar history by user and joins RPG_CLUB_USERS for display names, filtering out bots and departed members

## Test plan
- [ ] `/avatar-history all:true` shows a V2 component list of members sorted alphabetically with avatar counts
- [ ] `/avatar-history all:true` with no history in DB shows empty-state message
- [ ] `/avatar-history` (no all param) still works as before with paginated embeds
- [ ] `/avatar-history member:@user` still works as before

Generated with [Claude Code](https://claude.com/claude-code)