### PR TITLE
feat(avatar-history): scan subcommand and record avatar on member join

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -2399,6 +2399,25 @@ export default class Member {
     }
   }
 
+  static async insertAvatarHistoryRecord(
+    userId: string,
+    avatarHash: string,
+    avatarUrl: string,
+    avatarBlob: Buffer | null,
+  ): Promise<void> {
+    const connection = await getOraclePool().getConnection();
+    try {
+      await connection.execute(
+        `INSERT INTO RPG_CLUB_USER_AVATAR_HISTORY (USER_ID, AVATAR_HASH, AVATAR_URL, AVATAR_BLOB)
+         VALUES (:userId, :avatarHash, :avatarUrl, :avatarBlob)`,
+        { userId, avatarHash, avatarUrl, avatarBlob },
+        { autoCommit: true },
+      );
+    } finally {
+      await connection.close();
+    }
+  }
+
   static async getAllMembersAvatarHistoryCounts(): Promise<IMemberAvatarHistoryCount[]> {
     const connection = await getOraclePool().getConnection();
     try {

--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -26,6 +26,8 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { buildUserHeaderContainer } from "../functions/uiComponents.js";
+import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
+import { isAdmin } from "./admin/admin-auth.utils.js";
 
 const AVATAR_HISTORY_PAGE_SIZE = 10;
 
@@ -154,9 +156,63 @@ export class AvatarHistoryCommand {
       type: ApplicationCommandOptionType.Boolean,
     })
     showAll: boolean | undefined,
+    @SlashOption({
+      description: "Scan all cached members and record current avatars for new entries (admin only).",
+      name: "scan",
+      required: false,
+      type: ApplicationCommandOptionType.Boolean,
+    })
+    scan: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
     const ephemeral = !showInChat;
+
+    if (scan === true) {
+      await safeDeferReply(interaction, { flags: buildComponentsV2Flags(true) });
+      if (!(await isAdmin(interaction))) return;
+      if (!interaction.guild) {
+        await safeReply(interaction, {
+          components: [
+            new ContainerBuilder().addTextDisplayComponents(
+              new TextDisplayBuilder().setContent("This command can only be used in a server."),
+            ),
+          ],
+          flags: buildComponentsV2Flags(true),
+        });
+        return;
+      }
+      const guildMembers = interaction.guild.members.cache.filter((m) => !m.user.bot);
+      let recorded = 0;
+      let skipped = 0;
+      let failed = 0;
+      for (const guildMember of guildMembers.values()) {
+        try {
+          const wasRecorded = await recordCurrentAvatarIfNew(guildMember);
+          if (wasRecorded) recorded++;
+          else skipped++;
+        } catch {
+          failed++;
+        }
+      }
+      const lines = [
+        `Scanned **${guildMembers.size}** members.`,
+        `- **${recorded}** new avatar${recorded !== 1 ? "s" : ""} recorded`,
+        `- **${skipped}** already up to date or no avatar`,
+        ...(failed > 0 ? [`- **${failed}** failed`] : []),
+      ];
+      const scanContainer = new ContainerBuilder();
+      scanContainer.addTextDisplayComponents(
+        new TextDisplayBuilder().setContent("# Avatar History Scan"),
+      );
+      scanContainer.addTextDisplayComponents(
+        new TextDisplayBuilder().setContent(lines.join("\n")),
+      );
+      await safeReply(interaction, {
+        components: [scanContainer],
+        flags: buildComponentsV2Flags(true),
+      });
+      return;
+    }
 
     if (showAll === true) {
       await safeDeferReply(interaction, {

--- a/src/events/GuildMemberAdd.command.ts
+++ b/src/events/GuildMemberAdd.command.ts
@@ -3,6 +3,7 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
+import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
 
 function formatDiscordDateTime(date: Date): string {
   return `<t:${Math.floor(date.getTime() / 1000)}:F>`;
@@ -45,6 +46,14 @@ export class GuildMemberAdd {
 
         await (logChannel as any).send({ embeds: [embed] });
       }
+    }
+
+    if (!member.user.bot) {
+      recordCurrentAvatarIfNew(member).catch((err: any) => {
+        console.error(
+          `[GuildMemberAdd] Failed to record avatar for ${member.user.id}: ${err?.message ?? err}`,
+        );
+      });
     }
 
     // auto-role assignment on member join

--- a/src/utilities/AvatarLogUtils.ts
+++ b/src/utilities/AvatarLogUtils.ts
@@ -1,6 +1,6 @@
 import axios from "axios";
 import { AttachmentBuilder, EmbedBuilder } from "discord.js";
-import type { User } from "discord.js";
+import type { GuildMember, User } from "discord.js";
 import Member, { type IMemberRecord } from "../classes/Member.js";
 import { formatTimestampWithDay, resolveLogChannel } from "./DiscordLogUtils.js";
 
@@ -72,6 +72,22 @@ export async function updateAvatarRecordFromUrl(
   const avatarBlob = await downloadAvatarBuffer(avatarUrl);
   if (!avatarBlob) return false;
   await upsertAvatarRecord(user, avatarBlob);
+  return true;
+}
+
+export async function recordCurrentAvatarIfNew(member: GuildMember): Promise<boolean> {
+  if (member.user.bot) return false;
+  const avatarHash = member.avatar ?? member.user.avatar;
+  if (!avatarHash) return false;
+
+  const latest = await Member.getAvatarHistory(member.user.id, 1, 0);
+  if (latest.length && latest[0].avatarHash === avatarHash) return false;
+
+  const avatarUrl = member.displayAvatarURL({ extension: "png", size: 512, forceStatic: true });
+  const avatarBlob = await downloadAvatarBuffer(avatarUrl);
+  if (!avatarBlob) return false;
+
+  await Member.insertAvatarHistoryRecord(member.user.id, avatarHash, avatarUrl, avatarBlob);
   return true;
 }
 


### PR DESCRIPTION
## Summary

- **`Member.insertAvatarHistoryRecord`** -- new direct INSERT into `RPG_CLUB_USER_AVATAR_HISTORY` that stores hash, URL, and blob. Bypasses the trigger path so `AVATAR_HASH` is always populated, enabling reliable dedup.
- **`AvatarLogUtils.recordCurrentAvatarIfNew(member)`** -- shared helper that deduplicates by comparing the latest stored `AVATAR_HASH` before downloading. Returns `true` if a new entry was written, `false` if already up to date or no avatar hash present.
- **`GuildMemberAdd`** -- calls `recordCurrentAvatarIfNew` on every non-bot join (fire-and-forget with error logging, does not block the join flow).
- **`/avatar-history scan:true`** -- new admin-only option that iterates `guild.members.cache`, calls `recordCurrentAvatarIfNew` for each non-bot member, and reports a summary (recorded / skipped / failed counts).

## Dedup strategy

The new storage paths use `AVATAR_HASH` for dedup: skip if the latest history entry has the same hash as the member's current avatar. Entries written by the existing DB trigger (`TRG_RPG_CLUB_USERS_AVATAR_HIST`) have null hashes, so the first scan run will create hash-indexed entries for those members. Subsequent scan runs dedupe correctly against the hash-indexed entries.

## Test plan

- [ ] Run `/avatar-history scan:true` as admin -- confirm summary reports recorded/skipped counts
- [ ] Run `/avatar-history scan:true` again immediately -- confirm all members show as "already up to date"
- [ ] Have a non-bot user join the server -- confirm a history entry appears in `/avatar-history member:<user>`
- [ ] Have a user rejoin with the same avatar -- confirm no duplicate entry is created
- [ ] Attempt `/avatar-history scan:true` as non-admin -- confirm "Access denied" reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)