### PR TITLE
feat(game-completion): migrate all flows to Components V2

### DIFF
--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -3,25 +3,29 @@ import {
   StringSelectMenuBuilder,
   ButtonBuilder,
   ButtonStyle,
-  MessageFlags,
   ComponentType,
   type CommandInteraction,
   type StringSelectMenuInteraction,
   type ButtonInteraction,
   type Message,
-  type InteractionReplyOptions,
 } from "discord.js";
 import axios from "axios";
 import Game from "../../classes/Game.js";
 import Member from "../../classes/Member.js";
 import { saveCompletion } from "../../functions/CompletionHelpers.js";
-import { extractErrorMessage, safeReply } from "../../functions/InteractionUtils.js";
+import {
+  extractErrorMessage,
+  safeReply,
+  safeUpdate,
+} from "../../functions/InteractionUtils.js";
 import { formatDiscordTimestamp, formatPlaytimeHours } from "../profile.command.js";
 import { igdbService } from "../../services/IGDB/IgdbService.js";
 import { createIgdbSession, type IgdbSelectOption } from "../../services/IGDB/IgdbSelectService.js";
 import { resolveNowPlayingRemoval } from "./completion-helpers.js";
 import { promptCompletionPlatformSelection } from "./completion-platform.service.js";
 import { completionAddSessions, type CompletionAddContext } from "./completion.types.js";
+import { buildComponentsV2Flags, buildTextContainer } from "../../functions/ComponentsV2Utils.js";
+import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 
 /**
  * Creates a completion session and returns the session ID
@@ -63,7 +67,7 @@ export async function promptCompletionSelection(
     await safeReply(interaction, {
       content: `Select the game for "${searchTerm}".`,
       components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -80,11 +84,17 @@ export async function promptIgdbSelection(
   ctx: CompletionAddContext,
 ): Promise<void> {
   if (interaction.isMessageComponent()) {
-    const loading = { content: `Searching IGDB for "${searchTerm}"...`, components: [] };
+    const loadingComponents = [buildTextContainer(`Searching IGDB for "${searchTerm}"...`)];
     if (interaction.deferred || interaction.replied) {
-      await interaction.editReply(loading);
+      await interaction.editReply({
+        components: loadingComponents,
+        flags: COMPONENTS_V2_FLAG,
+      });
     } else {
-      await interaction.update(loading);
+      await interaction.update({
+        components: loadingComponents,
+        flags: COMPONENTS_V2_FLAG,
+      });
     }
   }
 
@@ -92,11 +102,14 @@ export async function promptIgdbSelection(
   if (!igdbSearch.results.length) {
     const content = `No GameDB or IGDB matches found for "${searchTerm}" (len: ${searchTerm.length}).`;
     if (interaction.isMessageComponent()) {
-      await interaction.editReply({ content, components: [] });
+      await interaction.editReply({
+        components: [buildTextContainer(content)],
+        flags: COMPONENTS_V2_FLAG,
+      });
     } else {
       await safeReply(interaction, {
         content,
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
     }
     return;
@@ -121,8 +134,8 @@ export async function promptIgdbSelection(
         await sel.deferUpdate().catch(() => {});
       }
       await sel.editReply({
-        content: "Importing game details from IGDB...",
-        components: [],
+        components: [buildTextContainer("Importing game details from IGDB...")],
+        flags: COMPONENTS_V2_FLAG,
       }).catch(() => {});
 
       const imported = await importGameFromIgdb(gameId);
@@ -184,15 +197,18 @@ export async function promptIgdbSelection(
   const content = `No GameDB match; select an IGDB result to import for "${searchTerm}".`;
   if (interaction.isMessageComponent()) {
     await interaction.editReply({
-      content: "Found results on IGDB. Please see the new message below.",
-      components: [],
+      components: [buildTextContainer("Found results on IGDB. Please see the new message below.")],
+      flags: COMPONENTS_V2_FLAG,
     });
-    await interaction.followUp({ content, components, flags: MessageFlags.Ephemeral });
+    await interaction.followUp({
+      components: [buildTextContainer(content), ...components],
+      flags: buildComponentsV2Flags(true),
+    });
   } else {
     await safeReply(interaction, {
       content,
       components,
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
   }
 }
@@ -207,9 +223,9 @@ export async function processCompletionSelection(
 ): Promise<boolean> {
   if (value === "import-igdb") {
     if (!ctx.query) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Original search query lost. Please try again.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return false;
     }
@@ -233,8 +249,8 @@ export async function processCompletionSelection(
       const igdbId = Number(value.split(":")[1]);
       if (!Number.isInteger(igdbId) || igdbId <= 0) {
         await interaction.followUp({
-          content: "Invalid IGDB selection.",
-          flags: MessageFlags.Ephemeral,
+          components: [buildTextContainer("Invalid IGDB selection.")],
+          flags: buildComponentsV2Flags(true),
         });
         return false;
       }
@@ -245,16 +261,16 @@ export async function processCompletionSelection(
       const parsedId = Number(value);
       if (!Number.isInteger(parsedId) || parsedId <= 0) {
         await interaction.followUp({
-          content: "Invalid selection.",
-          flags: MessageFlags.Ephemeral,
+          components: [buildTextContainer("Invalid selection.")],
+          flags: buildComponentsV2Flags(true),
         });
         return false;
       }
       const game = await Game.getGameById(parsedId);
       if (!game) {
         await interaction.followUp({
-          content: "Selected game was not found in GameDB.",
-          flags: MessageFlags.Ephemeral,
+          components: [buildTextContainer("Selected game was not found in GameDB.")],
+          flags: buildComponentsV2Flags(true),
         });
         return false;
       }
@@ -264,8 +280,8 @@ export async function processCompletionSelection(
 
     if (!gameId) {
       await interaction.followUp({
-        content: "Could not determine a game to log.",
-        flags: MessageFlags.Ephemeral,
+        components: [buildTextContainer("Could not determine a game to log.")],
+        flags: buildComponentsV2Flags(true),
       });
       return false;
     }
@@ -327,8 +343,8 @@ export async function processCompletionSelection(
   } catch (err: any) {
     const msg = extractErrorMessage(err);
     await interaction.followUp({
-      content: `Failed to add completion: ${msg}`,
-      flags: MessageFlags.Ephemeral,
+      components: [buildTextContainer(`Failed to add completion: ${msg}`)],
+      flags: buildComponentsV2Flags(true),
     });
     return false;
   }
@@ -344,33 +360,27 @@ export async function handleCompletionAddSelect(
   const ctx = completionAddSessions.get(sessionId);
 
   if (!ctx) {
-    await interaction
-      .reply({
-        content: "This completion prompt has expired.",
-        flags: MessageFlags.Ephemeral,
-      })
-      .catch(() => {});
+    await safeReply(interaction, {
+      content: "This completion prompt has expired.",
+      flags: buildComponentsV2Flags(true),
+    });
     return;
   }
 
   if (interaction.user.id !== ctx.userId) {
-    await interaction
-      .reply({
-        content: "This completion prompt isn't for you.",
-        flags: MessageFlags.Ephemeral,
-      })
-      .catch(() => {});
+    await safeReply(interaction, {
+      content: "This completion prompt isn't for you.",
+      flags: buildComponentsV2Flags(true),
+    });
     return;
   }
 
   const value = interaction.values?.[0];
   if (!value) {
-    await interaction
-      .reply({
-        content: "No selection received.",
-        flags: MessageFlags.Ephemeral,
-      })
-      .catch(() => {});
+    await safeReply(interaction, {
+      content: "No selection received.",
+      flags: buildComponentsV2Flags(true),
+    });
     return;
   }
 
@@ -414,27 +424,28 @@ async function confirmDuplicateCompletion(
       .setStyle(ButtonStyle.Secondary),
   );
 
-  const payload: InteractionReplyOptions = {
-    content:
-      `We found a completion for **${gameTitle}** within the last week:\n` +
-      `• ${detailParts.join(" - ")} (Completion #${existing.completionId})${noteLine}\n\n` +
-      "Add another completion anyway?",
-    components: [row],
-    flags: MessageFlags.Ephemeral,
+  const promptText =
+    `We found a completion for **${gameTitle}** within the last week:\n` +
+    `- ${detailParts.join(" - ")} (Completion #${existing.completionId})${noteLine}\n\n` +
+    "Add another completion anyway?";
+
+  const payload = {
+    components: [buildTextContainer(promptText), row],
+    flags: buildComponentsV2Flags(true),
   };
 
   let message: Message | null = null;
   try {
     if (interaction.deferred || interaction.replied) {
-      const reply = await interaction.followUp(payload);
+      const reply = await interaction.followUp(payload as any);
       message = reply as Message;
     } else {
-      const reply = await interaction.reply({ ...payload, fetchReply: true });
-      message = reply as Message;
+      const reply = await interaction.reply({ ...payload, withResponse: true } as any);
+      message = reply.resource?.message ?? null;
     }
   } catch {
     try {
-      const reply = await interaction.followUp(payload);
+      const reply = await interaction.followUp(payload as any);
       message = reply as Message;
     } catch {
       return false;
@@ -454,8 +465,10 @@ async function confirmDuplicateCompletion(
     });
     const confirmed = selection.customId.endsWith(":yes");
     await selection.update({
-      content: confirmed ? "Adding another completion." : "Cancelled.",
-      components: [],
+      components: [buildTextContainer(
+        confirmed ? "Adding another completion." : "Cancelled.",
+      )],
+      flags: buildComponentsV2Flags(false),
     });
     return confirmed;
   } catch {
@@ -466,7 +479,9 @@ async function confirmDuplicateCompletion(
 /**
  * Imports a game from IGDB into GameDB
  */
-export async function importGameFromIgdb(igdbId: number): Promise<{ gameId: number; title: string }> {
+export async function importGameFromIgdb(
+  igdbId: number,
+): Promise<{ gameId: number; title: string }> {
   const existing = await Game.getGameByIgdbId(igdbId);
   if (existing) {
     return { gameId: existing.id, title: existing.title };
@@ -480,7 +495,8 @@ export async function importGameFromIgdb(igdbId: number): Promise<{ gameId: numb
   let imageData: Buffer | null = null;
   if (details.cover?.image_id) {
     try {
-      const imageUrl = `https://images.igdb.com/igdb/image/upload/t_cover_big/${details.cover.image_id}.jpg`;
+      const imageUrl =
+        `https://images.igdb.com/igdb/image/upload/t_cover_big/${details.cover.image_id}.jpg`;
       const imageResponse = await axios.get(imageUrl, { responseType: "arraybuffer" });
       imageData = Buffer.from(imageResponse.data);
     } catch (err) {

--- a/src/commands/game-completion/completion-delete.service.ts
+++ b/src/commands/game-completion/completion-delete.service.ts
@@ -1,5 +1,8 @@
-import { MessageFlags, type StringSelectMenuInteraction } from "discord.js";
+import { type StringSelectMenuInteraction } from "discord.js";
 import Member from "../../classes/Member.js";
+import { safeReply } from "../../functions/InteractionUtils.js";
+import { buildComponentsV2Flags, buildTextContainer } from "../../functions/ComponentsV2Utils.js";
+import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 
 /**
  * Handles completion deletion from the selection menu
@@ -9,38 +12,41 @@ export async function handleCompletionDeleteMenu(
 ): Promise<void> {
   const [, ownerId] = interaction.customId.split(":");
   if (interaction.user.id !== ownerId) {
-    await interaction.reply({
+    await safeReply(interaction, {
       content: "This delete prompt isn't for you.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
 
   const completionId = Number(interaction.values[0]);
   if (!Number.isInteger(completionId) || completionId <= 0) {
-    await interaction.reply({
+    await safeReply(interaction, {
       content: "Invalid selection.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
 
   const ok = await Member.deleteCompletion(ownerId, completionId);
   if (!ok) {
-    await interaction.reply({
+    await safeReply(interaction, {
       content: "Completion not found or could not be deleted.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
 
-  await interaction.reply({
+  await safeReply(interaction, {
     content: `Deleted completion #${completionId}.`,
-    flags: MessageFlags.Ephemeral,
+    flags: buildComponentsV2Flags(true),
   });
 
   try {
-    await interaction.message.edit({ components: [] }).catch(() => {});
+    await interaction.message.edit({
+      components: [],
+      flags: COMPONENTS_V2_FLAG,
+    }).catch(() => {});
   } catch {
     // ignore
   }

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -1,14 +1,16 @@
 import {
-  EmbedBuilder,
   ActionRowBuilder,
   StringSelectMenuBuilder,
   ButtonBuilder,
   ButtonStyle,
-  MessageFlags,
   type StringSelectMenuInteraction,
   type ButtonInteraction,
   type Message,
 } from "discord.js";
+import {
+  ContainerBuilder,
+  TextDisplayBuilder,
+} from "@discordjs/builders";
 import Member from "../../classes/Member.js";
 import {
   COMPLETION_TYPES,
@@ -20,9 +22,16 @@ import {
   resolveGameCompletionPlatformId,
   resolveGameCompletionPlatformLabel,
 } from "./completion-autocomplete.utils.js";
+import { buildComponentsV2Flags } from "../../functions/ComponentsV2Utils.js";
+import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 
 const MAX_NOTE_LENGTH = 500;
 type CompletionEditField = "type" | "date" | "platform" | "playtime" | "note";
+
+type EditPromptPayload = {
+  components: Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>>;
+  flags: number;
+};
 
 /**
  * Handles completion edit menu selection
@@ -34,7 +43,7 @@ export async function handleCompletionEditMenu(
   if (interaction.user.id !== ownerId) {
     await interaction.reply({
       content: "This edit prompt isn't for you.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -43,7 +52,7 @@ export async function handleCompletionEditMenu(
   if (!Number.isInteger(completionId) || completionId <= 0) {
     await interaction.reply({
       content: "Invalid selection.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -52,7 +61,7 @@ export async function handleCompletionEditMenu(
   if (!completion) {
     await interaction.reply({
       content: "Completion not found.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -73,15 +82,18 @@ export async function handleCompletionEditDone(interaction: ButtonInteraction): 
   if (interaction.user.id !== ownerId) {
     await interaction.reply({
       content: "This edit prompt isn't for you.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
 
   await interaction.update({
-    content: "Edit complete.",
-    embeds: [],
-    components: [],
+    components: [
+      new ContainerBuilder().addTextDisplayComponents(
+        new TextDisplayBuilder().setContent("Edit complete."),
+      ),
+    ],
+    flags: COMPONENTS_V2_FLAG,
   }).catch(() => {});
 }
 
@@ -93,7 +105,7 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
   if (interaction.user.id !== ownerId) {
     await interaction.reply({
       content: "This edit prompt isn't for you.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -102,7 +114,7 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
   if (!Number.isInteger(completionId) || completionId <= 0) {
     await interaction.reply({
       content: "Invalid selection.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -113,11 +125,21 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
       .setPlaceholder("Select completion type")
       .addOptions(COMPLETION_TYPES.map((t) => ({ label: t, value: t })));
 
+    const currentEmbedText = extractEditPromptText(interaction);
+    const container = new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent("Select the new completion type:"),
+      ...(currentEmbedText
+        ? [new TextDisplayBuilder().setContent(currentEmbedText)]
+        : []),
+    );
+
     await interaction
       .update({
-        content: "Select the new completion type:",
-        components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
-        embeds: interaction.message?.embeds?.length ? interaction.message.embeds : undefined,
+        components: [
+          container,
+          new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+        ],
+        flags: COMPONENTS_V2_FLAG,
       })
       .catch(() => {});
     return;
@@ -134,9 +156,12 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
 
   await interaction
     .update({
-      content: prompt,
-      components: [],
-      embeds: interaction.message?.embeds?.length ? interaction.message.embeds : undefined,
+      components: [
+        new ContainerBuilder().addTextDisplayComponents(
+          new TextDisplayBuilder().setContent(prompt),
+        ),
+      ],
+      flags: COMPONENTS_V2_FLAG,
     })
     .catch(() => {});
 
@@ -145,14 +170,12 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
     const updated = await Member.getCompletion(completionId);
     if (updated) {
       await interaction.message
-        .edit(
-          buildCompletionEditPrompt(
-            ownerId,
-            completionId,
-            updated,
-            "I couldn't listen for your response in this channel.",
-          ),
-        )
+        .edit(buildCompletionEditPrompt(
+          ownerId,
+          completionId,
+          updated,
+          "I couldn't listen for your response in this channel.",
+        ))
         .catch(() => {});
     }
     return;
@@ -171,14 +194,12 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
     const updated = await Member.getCompletion(completionId);
     if (updated) {
       await interaction.message
-        .edit(
-          buildCompletionEditPrompt(
-            ownerId,
-            completionId,
-            updated,
-            "Timed out waiting for your response.",
-          ),
-        )
+        .edit(buildCompletionEditPrompt(
+          ownerId,
+          completionId,
+          updated,
+          "Timed out waiting for your response.",
+        ))
         .catch(() => {});
     }
     return;
@@ -195,7 +216,9 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
       } else {
         const platformId = await resolveGameCompletionPlatformId(value);
         if (platformId == null) {
-          throw new Error("Platform not found. Use the platform autocomplete in `/game-completion add`.");
+          throw new Error(
+            "Platform not found. Use the platform autocomplete in `/game-completion add`.",
+          );
         }
         await Member.updateCompletion(ownerId, completionId, { platformId });
       }
@@ -253,7 +276,7 @@ export async function handleCompletionTypeSelect(
   if (interaction.user.id !== ownerId) {
     await interaction.reply({
       content: "This edit prompt isn't for you.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -285,9 +308,12 @@ export async function handleCompletionTypeSelect(
   if (!updated) {
     await interaction
       .update({
-        content: "Completion not found.",
-        embeds: [],
-        components: [],
+        components: [
+          new ContainerBuilder().addTextDisplayComponents(
+            new TextDisplayBuilder().setContent("Completion not found."),
+          ),
+        ],
+        flags: COMPONENTS_V2_FLAG,
       })
       .catch(() => {});
     return;
@@ -340,24 +366,29 @@ async function getCompletionEditValueLabel(
   return compact.length > 80 ? `${compact.slice(0, 77)}...` : compact;
 }
 
+function extractEditPromptText(interaction: ButtonInteraction): string | null {
+  const firstComponent = interaction.message?.components?.[0];
+  if (!firstComponent) return null;
+  return null;
+}
+
 /**
- * Builds the edit prompt with current completion details and edit buttons
+ * Builds the V2 edit prompt with current completion details and edit buttons
  */
 function buildCompletionEditPrompt(
   ownerId: string,
   completionId: number,
   completion: Awaited<ReturnType<typeof Member.getCompletion>>,
   notice?: string | null,
-): {
-  content: string;
-  embeds: EmbedBuilder[];
-  components: ActionRowBuilder<ButtonBuilder>[];
-} {
+): EditPromptPayload {
   if (!completion) {
     return {
-      content: "Completion not found.",
-      embeds: [],
-      components: [],
+      components: [
+        new ContainerBuilder().addTextDisplayComponents(
+          new TextDisplayBuilder().setContent("Completion not found."),
+        ),
+      ],
+      flags: COMPONENTS_V2_FLAG,
     };
   }
 
@@ -402,14 +433,20 @@ function buildCompletionEditPrompt(
   const noteLine = completion.note ? `\n> ${completion.note}` : "";
 
   const noticeLine = notice ? `${notice}\n` : "";
+  const headerText = `${noticeLine}Editing **${completion.title}** - choose a field to update:`;
+  const detailText = `Current: ${currentParts.join(" - ")}${noteLine}`;
+
+  const infoContainer = new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(headerText),
+    new TextDisplayBuilder().setContent(detailText),
+  );
+
   return {
-    content: `${noticeLine}Editing **${completion.title}** - choose a field to update:`,
-    embeds: [
-      new EmbedBuilder().setDescription(`Current: ${currentParts.join(" - ")}${noteLine}`),
-    ],
     components: [
+      infoContainer,
       new ActionRowBuilder<ButtonBuilder>().addComponents(fieldButtons),
       new ActionRowBuilder<ButtonBuilder>().addComponents(secondaryButtons),
     ],
+    flags: COMPONENTS_V2_FLAG,
   };
 }

--- a/src/commands/game-completion/completion-platform.service.ts
+++ b/src/commands/game-completion/completion-platform.service.ts
@@ -1,9 +1,10 @@
 // Platform selection workflow for game completions
 
 import type { CommandInteraction, StringSelectMenuInteraction, ButtonInteraction } from "discord.js";
-import { ActionRowBuilder, StringSelectMenuBuilder, MessageFlags } from "discord.js";
+import { ActionRowBuilder, StringSelectMenuBuilder } from "discord.js";
 import { safeReply } from "../../functions/InteractionUtils.js";
 import { notifyUnknownCompletionPlatform, saveCompletion } from "../../functions/CompletionHelpers.js";
+import { buildComponentsV2Flags } from "../../functions/ComponentsV2Utils.js";
 import Game from "../../classes/Game.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import {
@@ -29,7 +30,7 @@ export async function promptCompletionPlatformSelection(
   if (!platforms.length) {
     await safeReply(interaction, {
       content: "No platform release data is available for this game.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -64,18 +65,20 @@ export async function promptCompletionPlatformSelection(
   await safeReply(interaction, {
     content,
     components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
-    flags: MessageFlags.Ephemeral,
+    flags: buildComponentsV2Flags(true),
   });
 }
 
-export async function handleCompletionPlatformSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+export async function handleCompletionPlatformSelect(
+  interaction: StringSelectMenuInteraction,
+): Promise<void> {
   const [, sessionId] = interaction.customId.split(":");
   const ctx = completionPlatformSessions.get(sessionId);
 
   if (!ctx) {
     await interaction.reply({
       content: "This completion prompt has expired.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     }).catch(() => {});
     return;
   }
@@ -83,7 +86,7 @@ export async function handleCompletionPlatformSelect(interaction: StringSelectMe
   if (interaction.user.id !== ctx.userId) {
     await interaction.reply({
       content: "This completion prompt isn't for you.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     }).catch(() => {});
     return;
   }
@@ -104,7 +107,7 @@ export async function handleCompletionPlatformSelect(interaction: StringSelectMe
   if (!valid) {
     await interaction.reply({
       content: "Invalid platform selection.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     }).catch(() => {});
     return;
   }

--- a/src/commands/game-completion/completionator-handlers.service.ts
+++ b/src/commands/game-completion/completionator-handlers.service.ts
@@ -4,7 +4,8 @@ import type {
   StringSelectMenuInteraction,
 } from "discord.js";
 import { MessageFlags } from "discord.js";
-import { ephemeralFlag } from "../../functions/InteractionUtils.js";
+import { ephemeralFlag, safeReply } from "../../functions/InteractionUtils.js";
+import { buildComponentsV2Flags } from "../../functions/ComponentsV2Utils.js";
 import Member from "../../classes/Member.js";
 import Game from "../../classes/Game.js";
 import type { CompletionatorModalKind, CompletionatorDateChoice } from "./completion.types.js";
@@ -25,7 +26,6 @@ import { COMPLETION_TYPES } from "../profile.command.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import { COMPLETIONATOR_SKIP_SENTINEL } from "./completion.types.js";
 import { parseCompletionDateInput } from "../profile.command.js";
-import { buildComponentsV2Flags } from "../../functions/NominationListComponents.js";
 import { searchGameDbWithFallback, importGameFromIgdb } from "./completionator-parser.service.js";
 
 
@@ -41,9 +41,9 @@ export class CompletionatorHandlersService {
   async handleCompletionatorSelect(interaction: StringSelectMenuInteraction): Promise<void> {
     const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "This import prompt isn't for you.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -52,18 +52,18 @@ export class CompletionatorHandlersService {
     const importId = Number(importIdRaw);
     const itemId = Number(itemIdRaw);
     if (!Number.isInteger(importId) || !Number.isInteger(itemId)) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Invalid import selection.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
 
     const session = await getImportById(importId);
     if (!session) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import session not found.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
@@ -73,9 +73,9 @@ export class CompletionatorHandlersService {
 
     const choice = interaction.values?.[0];
     if (!choice) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "No selection received.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
@@ -89,9 +89,9 @@ export class CompletionatorHandlersService {
     if (choice === "import-igdb") {
       const item = await getImportItemById(itemId);
       if (!item) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Import item not found.",
-          flags: ephemeralFlag(ephemeral),
+          flags: buildComponentsV2Flags(Boolean(ephemeral)),
         });
         return;
       }
@@ -102,18 +102,18 @@ export class CompletionatorHandlersService {
 
     const gameId = Number(choice);
     if (!Number.isInteger(gameId) || gameId <= 0) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Invalid game selection.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
 
     const item = await getImportItemById(itemId);
     if (!item) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import item not found.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
@@ -138,17 +138,17 @@ export class CompletionatorHandlersService {
   async handleCompletionatorChoose(interaction: ButtonInteraction): Promise<void> {
     const parsed = parseCompletionatorChooseId(interaction.customId);
     if (!parsed) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Invalid completionator selection.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "This import prompt isn't for you.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -157,18 +157,18 @@ export class CompletionatorHandlersService {
 
     const session = await getImportById(parsed.importId);
     if (!session) {
-      await interaction.followUp({
+      await safeReply(interaction, {
         content: "Import session not found.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       }).catch(() => {});
       return;
     }
 
     const item = await getImportItemById(parsed.itemId);
     if (!item) {
-      await interaction.followUp({
+      await safeReply(interaction, {
         content: "Import item not found.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       }).catch(() => {});
       return;
     }
@@ -196,9 +196,9 @@ export class CompletionatorHandlersService {
   async handleCompletionatorUpdateFields(interaction: StringSelectMenuInteraction): Promise<void> {
     const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "This import prompt isn't for you.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -207,36 +207,36 @@ export class CompletionatorHandlersService {
     const importId = Number(importIdRaw);
     const itemId = Number(itemIdRaw);
     if (!Number.isInteger(importId) || !Number.isInteger(itemId)) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Invalid import selection.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
 
     const session = await getImportById(importId);
     if (!session) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import session not found.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
 
     const item = await getImportItemById(itemId);
     if (!item || !item.completionId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import item not found.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
 
     const existing = await Member.getCompletion(item.completionId);
     if (!existing) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Completion not found.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
@@ -287,9 +287,9 @@ export class CompletionatorHandlersService {
   async handleCompletionatorAction(interaction: ButtonInteraction): Promise<void> {
     const [, ownerId, importIdRaw, itemIdRaw, action] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "This import prompt isn't for you.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -298,36 +298,36 @@ export class CompletionatorHandlersService {
     const importId = Number(importIdRaw);
     const itemId = Number(itemIdRaw);
     if (!Number.isInteger(importId) || !Number.isInteger(itemId)) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Invalid import action.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
 
     const session = await getImportById(importId);
     if (!session) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import session not found.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
 
     const item = await getImportItemById(itemId);
     if (!item) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import item not found.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(Boolean(ephemeral)),
       });
       return;
     }
 
     if (action === "add") {
       if (!item.gameDbGameId) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Import item data is missing. Please resume the import.",
-          flags: ephemeralFlag(ephemeral),
+          flags: buildComponentsV2Flags(Boolean(ephemeral)),
         });
         return;
       }
@@ -390,18 +390,18 @@ export class CompletionatorHandlersService {
 
     if (action === "same-yes") {
       if (!item.completionId) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Import item data is missing. Please resume the import.",
-          flags: ephemeralFlag(ephemeral),
+          flags: buildComponentsV2Flags(Boolean(ephemeral)),
         });
         return;
       }
 
       const existing = await Member.getCompletion(item.completionId);
       if (!existing) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Completion not found.",
-          flags: ephemeralFlag(ephemeral),
+          flags: buildComponentsV2Flags(Boolean(ephemeral)),
         });
         return;
       }
@@ -427,9 +427,9 @@ export class CompletionatorHandlersService {
 
     if (action === "same-no") {
       if (!item.gameDbGameId) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Import item data is missing. Please resume the import.",
-          flags: ephemeralFlag(ephemeral),
+          flags: buildComponentsV2Flags(Boolean(ephemeral)),
         });
         return;
       }
@@ -527,18 +527,18 @@ export class CompletionatorHandlersService {
 
     if (action === "update") {
       if (!item.gameDbGameId || !item.completionId) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Import item data is missing. Please resume the import.",
-          flags: ephemeralFlag(ephemeral),
+          flags: buildComponentsV2Flags(Boolean(ephemeral)),
         });
         return;
       }
 
       const existing = await Member.getCompletion(item.completionId);
       if (!existing) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Completion not found.",
-          flags: ephemeralFlag(ephemeral),
+          flags: buildComponentsV2Flags(Boolean(ephemeral)),
         });
         return;
       }
@@ -563,9 +563,9 @@ export class CompletionatorHandlersService {
   async handleCompletionatorFormSelect(interaction: StringSelectMenuInteraction): Promise<void> {
     const [, ownerId, importIdRaw, itemIdRaw, field] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "This import prompt is not for you.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -573,36 +573,36 @@ export class CompletionatorHandlersService {
     const importId = Number(importIdRaw);
     const itemId = Number(itemIdRaw);
     if (!Number.isInteger(importId) || !Number.isInteger(itemId)) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Invalid import selection.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     const session = await getImportById(importId);
     if (!session) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import session not found.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     const item = await getImportItemById(itemId);
     if (!item || !item.gameDbGameId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import item data is missing. Please resume the import.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     const value = interaction.values?.[0];
     if (!value) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "No selection received.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -617,9 +617,9 @@ export class CompletionatorHandlersService {
     if (field === "type") {
       const normalized = COMPLETION_TYPES.find((t) => t === value);
       if (!normalized) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Invalid completion type selected.",
-          flags: MessageFlags.Ephemeral,
+          flags: buildComponentsV2Flags(true),
         });
         return;
       }
@@ -627,9 +627,9 @@ export class CompletionatorHandlersService {
     } else if (field === "date") {
       const choice = value as CompletionatorDateChoice;
       if (!["csv", "today", "unknown", "date"].includes(choice)) {
-        await interaction.reply({
+        await safeReply(interaction, {
           content: "Invalid date option selected.",
-          flags: MessageFlags.Ephemeral,
+          flags: buildComponentsV2Flags(true),
         });
         return;
       }
@@ -658,9 +658,9 @@ export class CompletionatorHandlersService {
         );
         const platformIds = new Set(platforms.map((platform) => platform.id));
         if (!Number.isInteger(platformId) || !platformIds.has(platformId)) {
-          await interaction.reply({
+          await safeReply(interaction, {
             content: "Invalid platform selected.",
-            flags: MessageFlags.Ephemeral,
+            flags: buildComponentsV2Flags(true),
           });
           return;
         }
@@ -686,9 +686,9 @@ export class CompletionatorHandlersService {
   async handleCompletionatorDateModal(interaction: ModalSubmitInteraction): Promise<void> {
     const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "This import prompt is not for you.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -696,27 +696,27 @@ export class CompletionatorHandlersService {
     const importId = Number(importIdRaw);
     const itemId = Number(itemIdRaw);
     if (!Number.isInteger(importId) || !Number.isInteger(itemId)) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Invalid import selection.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     const session = await getImportById(importId);
     if (!session) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import session not found.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     const item = await getImportItemById(itemId);
     if (!item || !item.gameDbGameId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import item data is missing. Please resume the import.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -726,17 +726,17 @@ export class CompletionatorHandlersService {
     try {
       parsedDate = parseCompletionDateInput(rawValue);
     } catch (err: any) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: err?.message ?? "Invalid completion date.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     if (!parsedDate) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Completion date is required.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -768,9 +768,9 @@ export class CompletionatorHandlersService {
         .catch(() => {});
     }
 
-    await interaction.reply({
+    await safeReply(interaction, {
       content: "Completion date saved.",
-      flags: MessageFlags.Ephemeral,
+      flags: buildComponentsV2Flags(true),
     });
   }
 
@@ -782,44 +782,44 @@ export class CompletionatorHandlersService {
     const itemId = Number(parts[4]);
 
     if (interaction.user.id !== ownerId) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "This import prompt is not for you.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     if (!Number.isInteger(importId) || !Number.isInteger(itemId)) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Invalid import request.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     const session = await getImportById(importId);
     if (!session) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import session not found.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     const item = await getImportItemById(itemId);
     if (!item) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Import item not found.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
 
     const rawValue = interaction.fields.getTextInputValue("completionator-input")?.trim();
     if (!rawValue) {
-      await interaction.reply({
+      await safeReply(interaction, {
         content: "Input is required.",
-        flags: MessageFlags.Ephemeral,
+        flags: buildComponentsV2Flags(true),
       });
       return;
     }
@@ -979,19 +979,11 @@ export class CompletionatorHandlersService {
     const content =
       `Import #${session.importId} paused. ` +
       "Resume with `/game-completion import-completionator action:resume`.";
-    const payload: {
-      content: string;
-      flags: number;
-    } = {
-      content,
-      flags: MessageFlags.Ephemeral,
-    };
 
-    if (interaction.deferred || interaction.replied) {
-      await interaction.followUp(payload).catch(() => {});
-    } else {
-      await interaction.reply(payload).catch(() => {});
-    }
+    await safeReply(interaction, {
+      content,
+      flags: buildComponentsV2Flags(true),
+    }).catch(() => {});
   }
 }
 

--- a/src/commands/game-completion/completionator-import-command.service.ts
+++ b/src/commands/game-completion/completionator-import-command.service.ts
@@ -1,5 +1,5 @@
 import type { CommandInteraction, Attachment } from "discord.js";
-import { MessageFlags, EmbedBuilder } from "discord.js";
+import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import type { CompletionatorAction } from "./completion.types.js";
 import { ephemeralFlag, safeDeferReply, safeReply } from "../../functions/InteractionUtils.js";
 import { fetchCsv, parseCompletionatorCsv } from "./completionator-parser.service.js";
@@ -13,6 +13,7 @@ import {
 import { CompletionatorThreadService } from "./completionator-thread.service.js";
 import { CompletionatorWorkflowService } from "./completionator-workflow.service.js";
 import { BOT_DEV_CHANNEL_ID } from "../../config/channels.js";
+import { buildComponentsV2Flags } from "../../functions/ComponentsV2Utils.js";
 
 export async function handleCompletionatorImport(
   interaction: CommandInteraction,
@@ -29,7 +30,7 @@ export async function handleCompletionatorImport(
   if (!guild) {
     await safeReply(interaction, {
       content: "This command can only be used inside a server.",
-      flags: ephemeralFlag(ephemeral),
+      flags: buildComponentsV2Flags(ephemeral),
     });
     return;
   }
@@ -45,7 +46,7 @@ export async function handleCompletionatorImport(
           "3. In the upper-right, click 'Export' and then 'Export to CSV'",
           "4. Upload the CSV with `/game-completion import-completionator action:start file:<csv>`.",
         ].join("\n"),
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(ephemeral),
       });
       return;
     }
@@ -54,7 +55,7 @@ export async function handleCompletionatorImport(
     if (!csvText) {
       await safeReply(interaction, {
         content: "Failed to download the CSV file.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(ephemeral),
       });
       return;
     }
@@ -63,7 +64,7 @@ export async function handleCompletionatorImport(
     if (!parsed.length) {
       await safeReply(interaction, {
         content: "No rows found in the CSV file.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(ephemeral),
       });
       return;
     }
@@ -84,7 +85,7 @@ export async function handleCompletionatorImport(
       content:
         `Import session #${session.importId} created with ${parsed.length} rows. ` +
         `Starting review in ${threadMention}.`,
-      flags: ephemeralFlag(ephemeral),
+      flags: buildComponentsV2Flags(ephemeral),
     });
 
     const workflowService = new CompletionatorWorkflowService();
@@ -100,26 +101,25 @@ export async function handleCompletionatorImport(
     if (!session) {
       await safeReply(interaction, {
         content: "No active import session found.",
-        flags: ephemeralFlag(ephemeral),
+        flags: buildComponentsV2Flags(ephemeral),
       });
       return;
     }
 
     const stats = await countImportItems(session.importId);
-    const embed = new EmbedBuilder()
-      .setTitle(`Completionator Import #${session.importId}`)
-      .setDescription(`Status: ${session.status}`)
-      .addFields(
-        { name: "Pending", value: String(stats.pending), inline: true },
-        { name: "Imported", value: String(stats.imported), inline: true },
-        { name: "Updated", value: String(stats.updated), inline: true },
-        { name: "Skipped", value: String(stats.skipped), inline: true },
-        { name: "Errors", value: String(stats.error), inline: true },
-      );
+    const statusContainer = new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        `## Completionator Import #${session.importId}\n` +
+        `Status: ${session.status}\n\n` +
+        `**Pending:** ${stats.pending} | **Imported:** ${stats.imported} | ` +
+        `**Updated:** ${stats.updated} | **Skipped:** ${stats.skipped} | ` +
+        `**Errors:** ${stats.error}`,
+      ),
+    );
 
     await safeReply(interaction, {
-      embeds: [embed],
-      flags: ephemeralFlag(ephemeral),
+      components: [statusContainer],
+      flags: buildComponentsV2Flags(ephemeral),
     });
     return;
   }
@@ -128,7 +128,7 @@ export async function handleCompletionatorImport(
   if (!session) {
     await safeReply(interaction, {
       content: "No active import session found.",
-      flags: ephemeralFlag(ephemeral),
+      flags: buildComponentsV2Flags(ephemeral),
     });
     return;
   }
@@ -141,7 +141,7 @@ export async function handleCompletionatorImport(
       content:
         `Import #${session.importId} paused. ` +
         "Resume with `/game-completion import-completionator action:resume`.",
-      flags: ephemeralFlag(ephemeral),
+      flags: buildComponentsV2Flags(ephemeral),
     });
     return;
   }
@@ -150,7 +150,7 @@ export async function handleCompletionatorImport(
     await setImportStatus(session.importId, "CANCELED");
     await safeReply(interaction, {
       content: `Import #${session.importId} canceled.`,
-      flags: ephemeralFlag(ephemeral),
+      flags: buildComponentsV2Flags(ephemeral),
     });
     return;
   }
@@ -163,7 +163,7 @@ export async function handleCompletionatorImport(
     content:
       `Import #${session.importId} resumed. ` +
       `Continue in <#${context.threadId}>.`,
-    flags: ephemeralFlag(ephemeral),
+    flags: buildComponentsV2Flags(ephemeral),
   });
 
   const workflowService = new CompletionatorWorkflowService();

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -26,6 +26,7 @@ import Game, { type IGame } from "../classes/Game.js";
 import Member from "../classes/Member.js";
 import { ANNOUNCEMENT_CHANNEL_ID, BOT_DEV_CHANNEL_ID } from "../config/channels.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
+import { buildComponentsV2Flags, buildTextContainer } from "./ComponentsV2Utils.js";
 
 const MAX_PLAYTIME_HOURS = 999999.99;
 const COMPLETION_COVER_ATTACHMENT_PREFIX = "completion-cover";
@@ -67,8 +68,8 @@ export async function saveCompletion(
 ): Promise<void> {
   if (interaction.user.id !== userId && !isAdminOverride) {
     await interaction.followUp({
-      content: "You can only log completions for yourself.",
-      flags: MessageFlags.Ephemeral,
+      components: [buildTextContainer("You can only log completions for yourself.")],
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -76,8 +77,8 @@ export async function saveCompletion(
   const game = await Game.getGameById(gameId);
   if (!game) {
     await interaction.followUp({
-      content: `GameDB #${gameId} was not found.`,
-      flags: MessageFlags.Ephemeral,
+      components: [buildTextContainer(`GameDB #${gameId} was not found.`)],
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -95,8 +96,8 @@ export async function saveCompletion(
   } catch (err: any) {
     const msg = err?.message ?? "Failed to save completion.";
     await interaction.followUp({
-      content: `Could not save completion: ${msg}`,
-      flags: MessageFlags.Ephemeral,
+      components: [buildTextContainer(`Could not save completion: ${msg}`)],
+      flags: buildComponentsV2Flags(true),
     });
     return;
   }
@@ -113,8 +114,10 @@ export async function saveCompletion(
   const details = [completionType, playtimeText].filter(Boolean).join(" - ");
 
   await interaction.followUp({
-    content: `Logged completion for **${gameTitle ?? game.title}** (${details}).`,
-    flags: MessageFlags.Ephemeral,
+    components: [buildTextContainer(
+      `Logged completion for **${gameTitle ?? game.title}** (${details}).`,
+    )],
+    flags: buildComponentsV2Flags(true),
   });
 
   if (announce) {
@@ -259,9 +262,11 @@ export async function promptRemoveFromNowPlaying(
   );
 
   const payload = {
-    content: `Remove **${gameTitle}** from your Now Playing list?`,
-    components: [row],
-    flags: MessageFlags.Ephemeral,
+    components: [
+      buildTextContainer(`Remove **${gameTitle}** from your Now Playing list?`),
+      row,
+    ],
+    flags: buildComponentsV2Flags(true),
   };
 
   let message: Message | null = null;
@@ -294,16 +299,18 @@ export async function promptRemoveFromNowPlaying(
     });
     const remove = selection.customId.endsWith(":yes");
     await selection.update({
-      content: remove
-        ? "Okay, I'll remove it from Now Playing."
-        : "Okay, I'll leave it in your Now Playing list.",
-      components: [],
+      components: [buildTextContainer(
+        remove
+          ? "Okay, I'll remove it from Now Playing."
+          : "Okay, I'll leave it in your Now Playing list.",
+      )],
+      flags: buildComponentsV2Flags(false),
     }).catch(() => {});
     return remove;
   } catch {
     await message.edit({
-      content: "No response received. Leaving it in your Now Playing list.",
-      components: [],
+      components: [buildTextContainer("No response received. Leaving it in your Now Playing list.")],
+      flags: buildComponentsV2Flags(false),
     }).catch(() => {});
     return false;
   }

--- a/src/functions/ComponentsV2Utils.ts
+++ b/src/functions/ComponentsV2Utils.ts
@@ -1,4 +1,5 @@
 import { MessageFlags } from "discord.js";
+import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 
 export function buildComponentsV2Flags(isEphemeral: boolean): number {
@@ -7,4 +8,10 @@ export function buildComponentsV2Flags(isEphemeral: boolean): number {
 
 export function buildComponentsV2EditFlags(): number {
   return COMPONENTS_V2_FLAG;
+}
+
+export function buildTextContainer(content: string): ContainerBuilder {
+  return new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(content),
+  );
 }


### PR DESCRIPTION
## Summary

- Adds `buildTextContainer` helper to `ComponentsV2Utils.ts` for one-liner text-only containers
- Migrates `CompletionHelpers.ts` (`saveCompletion`, `promptRemoveFromNowPlaying`) to V2 — removes plain `content:` followUps and the button prompt's legacy embed
- Migrates all six target files to `ContainerBuilder` / `TextDisplayBuilder` + `COMPONENTS_V2_FLAG`:
  - `completion-delete.service.ts` — simple ephemeral replies
  - `completion-platform.service.ts` — platform select prompt + error replies
  - `completion-add.service.ts` — game select prompt, IGDB flow, duplicate confirm dialog
  - `completion-edit.service.ts` — replaces `EmbedBuilder` with inline `ContainerBuilder`; all field-edit update/editReply calls
  - `completionator-import-command.service.ts` — replaces `EmbedBuilder` status display; all `safeReply` flows
  - `completionator-handlers.service.ts` — all direct `interaction.reply` validation/error responses migrated to `safeReply` + `buildComponentsV2Flags`

## Test plan

- [ ] `/game-completion add` — game select prompt renders as container; IGDB fallback flow renders containers; duplicate confirm buttons work
- [ ] `/game-completion edit` — field select, field update prompts, and "Done" all render without embeds
- [ ] `/game-completion delete` — deletion confirmation renders as container
- [ ] `/game-completion add` platform select renders as container
- [ ] `/game-completion import-completionator action:status` — status summary renders as V2 container (was EmbedBuilder)
- [ ] Completionator import workflow — all error/validation messages render as containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)