### PR TITLE
fix(vscode): add ESLint settings so lint errors appear in Problems panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 # files
-.vscode
 .env
 .env.local
 package-lock.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,5 @@
 {
   "eslint.useFlatConfig": true,
-  "eslint.options": {
-    "flags": ["unstable_ts_config"]
-  },
   "eslint.validate": [
     "javascript",
     "typescript"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "eslint.useFlatConfig": true,
+  "eslint.options": {
+    "flags": ["unstable_ts_config"]
+  },
+  "eslint.validate": [
+    "javascript",
+    "typescript"
+  ]
+}


### PR DESCRIPTION
## Summary

- Removes `.vscode` from `.gitignore` so workspace settings can be shared
- Adds `.vscode/settings.json` with `eslint.useFlatConfig: true`, the `unstable_ts_config` flag (needed for `eslint.config.ts` to load via `jiti`), and explicit TypeScript/JavaScript validation

## Test plan

- [ ] Open a file with known lint errors (e.g. `src/utilities/DiscordConsoleLogger.ts`) and confirm squiggles appear in the editor and entries show in the Problems panel
- [ ] Confirm `npx eslint .` still runs cleanly from the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
