### PR TITLE
fix(eslint): add fixable meta and fixer callbacks to three local rules

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1280,6 +1280,7 @@ export default {
     "no-deprecated-interaction-options": {
       meta: {
         type: "problem",
+        fixable: "code",
         docs: {
           description:
             "Disallow deprecated interaction response options and fetchReply usage.",
@@ -1587,6 +1588,7 @@ export default {
     "require-relative-import-js-extension": {
       meta: {
         type: "problem",
+        fixable: "code",
         docs: {
           description:
             "Require relative import and export paths to include .js or other allowed extensions.",
@@ -1603,7 +1605,13 @@ export default {
           const value = sourceNode.value;
           if (!isRelativeImportPath(value)) return;
           if (hasAllowedRelativeImportExtension(value)) return;
-          context.report({ node: sourceNode, messageId: "missingExtension" });
+          context.report({
+            node: sourceNode,
+            messageId: "missingExtension",
+            fix(fixer) {
+              return fixer.replaceText(sourceNode, JSON.stringify(`${value}.js`));
+            },
+          });
         };
 
         return {
@@ -1780,6 +1788,7 @@ export default {
     "no-emdash": {
       meta: {
         type: "problem",
+        fixable: "code",
         docs: {
           description: "Disallow em dash characters.",
         },
@@ -1804,12 +1813,29 @@ export default {
             }
           },
           Literal(node) {
-            if (typeof node.value === "string") {
-              reportIfEmdash(node, node.value);
+            if (typeof node.value === "string" && node.value.includes("—")) {
+              context.report({
+                node,
+                messageId: "emdash",
+                fix(fixer) {
+                  const src = sourceCode.getText(node);
+                  return fixer.replaceText(node, src.replace(/—/g, " - "));
+                },
+              });
             }
           },
           TemplateElement(node) {
-            reportIfEmdash(node, node.value?.cooked ?? node.value?.raw);
+            const text = node.value?.cooked ?? node.value?.raw;
+            if (typeof text === "string" && text.includes("—")) {
+              context.report({
+                node,
+                messageId: "emdash",
+                fix(fixer) {
+                  const src = sourceCode.getText(node);
+                  return fixer.replaceText(node, src.replace(/—/g, " - "));
+                },
+              });
+            }
           },
         };
       },


### PR DESCRIPTION
## Summary

- **`no-deprecated-interaction-options`**: had `fix` logic already written but was missing `meta.fixable = "code"`, causing ESLint to silently discard the fix. Now `ephemeral: true` auto-fixes to `flags: MessageFlags.Ephemeral` and `ephemeral: false` is removed.
- **`require-relative-import-js-extension`**: adds a fixer that appends `.js` to the relative import path string literal.
- **`no-emdash`**: adds fixers for `Literal` and `TemplateElement` nodes that replace `—` with ` - ` via source-level text replacement. Comments are detected but not auto-fixed (require manual correction).

## Test plan
- [ ] Run `eslint --fix` on a file with `ephemeral: true` in a reply call and verify it becomes `flags: MessageFlags.Ephemeral`
- [ ] Run `eslint --fix` on a file with a relative import missing `.js` and verify the extension is appended
- [ ] Run `eslint --fix` on a file with an em dash in a string literal and verify it becomes ` - `

Generated with [Claude Code](https://claude.com/claude-code)