### PR TITLE
fix(lint): resolve all max-len ESLint violations

### DIFF
--- a/src/commands/admin/gotm-audit-handlers.ts
+++ b/src/commands/admin/gotm-audit-handlers.ts
@@ -1,6 +1,10 @@
 // Handlers for gotm-audit button/select/modal interactions
 
-import type { ButtonInteraction, StringSelectMenuInteraction, ModalSubmitInteraction } from "discord.js";
+import type {
+  ButtonInteraction,
+  StringSelectMenuInteraction,
+  ModalSubmitInteraction,
+} from "discord.js";
 import {
   MessageFlags,
   ModalBuilder,
@@ -32,7 +36,8 @@ import {
   buildGotmAuditPromptComponents,
 } from "./gotm-audit-ui.service.js";
 
-export async function handleGotmAuditSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+export async function handleGotmAuditSelect(
+  interaction: StringSelectMenuInteraction): Promise<void> {
   const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
   if (interaction.user.id !== ownerId) {
     await interaction
@@ -299,7 +304,9 @@ export async function handleGotmAuditAction(interaction: ButtonInteraction): Pro
   }
 }
 
-export async function handleGotmAuditManualModal(interaction: ModalSubmitInteraction): Promise<void> {
+export async function handleGotmAuditManualModal(
+  interaction: ModalSubmitInteraction,
+): Promise<void> {
   const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
   if (interaction.user.id !== ownerId) {
     await interaction
@@ -393,7 +400,9 @@ export async function handleGotmAuditManualModal(interaction: ModalSubmitInterac
   await processNextGotmAuditItem(interaction, session);
 }
 
-export async function handleGotmAuditQueryModal(interaction: ModalSubmitInteraction): Promise<void> {
+export async function handleGotmAuditQueryModal(
+  interaction: ModalSubmitInteraction,
+): Promise<void> {
   const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
   if (interaction.user.id !== ownerId) {
     await interaction

--- a/src/commands/admin/nomination-admin.service.ts
+++ b/src/commands/admin/nomination-admin.service.ts
@@ -117,7 +117,9 @@ export async function handleAdminNominationDeleteReasonModal(
     return;
   }
 
-  const nomination = await getNominationForUser(parsedState.kind, parsedState.round, parsedState.userId);
+  const nomination = await getNominationForUser(
+    parsedState.kind, parsedState.round, parsedState.userId,
+  );
   const sessionState = nomination
     ? buildDeletionReasonState(
       parsedState.kind,

--- a/src/commands/collection/collection-steam-import.command.ts
+++ b/src/commands/collection/collection-steam-import.command.ts
@@ -11,7 +11,15 @@ import {
   TextInputStyle,
   ActionRowBuilder,
 } from "discord.js";
-import { ButtonComponent, Discord, ModalComponent, Slash, SlashChoice, SlashGroup, SlashOption } from "discordx";
+import {
+  ButtonComponent,
+  Discord,
+  ModalComponent,
+  Slash,
+  SlashChoice,
+  SlashGroup,
+  SlashOption,
+} from "discordx";
 import Game from "../../classes/Game.js";
 import UserGameCollection from "../../classes/UserGameCollection.js";
 import {
@@ -151,7 +159,8 @@ export class CollectionSteamImportCommand {
     importId: number,
     ownerId: string,
   ): Promise<void> {
-    const shouldUseInteractionUpdate = (interaction.isButton() || interaction.isStringSelectMenu()) &&
+    const shouldUseInteractionUpdate =
+      (interaction.isButton() || interaction.isStringSelectMenu()) &&
       !interaction.deferred &&
       !interaction.replied;
     const shouldUseModalUpdate = interaction.isModalSubmit();

--- a/src/commands/help.command.ts
+++ b/src/commands/help.command.ts
@@ -845,7 +845,9 @@ const GAMEDB_HELP_TOPICS: GameDbHelpTopic[] = [
   },
 ];
 
-function buildRssHelpButtons(activeId?: RssHelpTopicId): ActionRowBuilder<StringSelectMenuBuilder>[] {
+function buildRssHelpButtons(
+  activeId?: RssHelpTopicId,
+): ActionRowBuilder<StringSelectMenuBuilder>[] {
   const select = new StringSelectMenuBuilder()
     .setCustomId(buildHelpCustomId("rss", { activeTopicId: activeId }))
     .setPlaceholder("/rss help")
@@ -984,7 +986,10 @@ export class BotHelp {
     }
 
     if (!topicId) {
-      const response = buildCategoryHelpResponse(category.id, parsed.state.activeTopicId as HelpTopicId | undefined);
+      const response = buildCategoryHelpResponse(
+        category.id,
+        parsed.state.activeTopicId as HelpTopicId | undefined,
+      );
       await safeUpdate(interaction, {
         ...response,
         content: "Please pick a command from the list.",
@@ -1050,7 +1055,9 @@ export class BotHelp {
     const topic = RSS_HELP_TOPICS.find((entry) => entry.id === topicId);
 
     if (!topic) {
-      const response = buildRssHelpResponse(parsed.state.activeTopicId as RssHelpTopicId | undefined);
+      const response = buildRssHelpResponse(
+        parsed.state.activeTopicId as RssHelpTopicId | undefined,
+      );
       await safeUpdate(interaction, {
         ...response,
         content: "Sorry, I don't recognize that RSS help topic. Showing the RSS help menu.",
@@ -1084,7 +1091,9 @@ export class BotHelp {
     const topic = PROFILE_HELP_TOPICS.find((entry) => entry.id === topicId);
 
     if (!topic) {
-      const response = buildProfileHelpResponse(parsed.state.activeTopicId as ProfileHelpTopicId | undefined);
+      const response = buildProfileHelpResponse(
+        parsed.state.activeTopicId as ProfileHelpTopicId | undefined,
+      );
       await safeUpdate(interaction, {
         ...response,
         content: "Sorry, I don't recognize that profile help topic. Showing the profile help menu.",
@@ -1118,7 +1127,9 @@ export class BotHelp {
     const topic = NOW_PLAYING_HELP_TOPICS.find((entry) => entry.id === topicId);
 
     if (!topic) {
-      const response = buildNowPlayingHelpResponse(parsed.state.activeTopicId as NowPlayingHelpTopicId | undefined);
+      const response = buildNowPlayingHelpResponse(
+        parsed.state.activeTopicId as NowPlayingHelpTopicId | undefined,
+      );
       await safeUpdate(interaction, {
         ...response,
         content: "Sorry, I don't recognize that now-playing help topic. Showing the help menu.",
@@ -1152,7 +1163,9 @@ export class BotHelp {
     const topic = GAMEDB_HELP_TOPICS.find((entry) => entry.id === topicId);
 
     if (!topic) {
-      const response = buildGamedbHelpResponse(parsed.state.activeTopicId as GameDbHelpTopicId | undefined);
+      const response = buildGamedbHelpResponse(
+        parsed.state.activeTopicId as GameDbHelpTopicId | undefined,
+      );
       await safeUpdate(interaction, {
         ...response,
         content: "Sorry, I don't recognize that gamedb help topic. Showing the gamedb help menu.",

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -22,7 +22,10 @@ import {
   buildComponentsV2Flags,
   buildNominationListPayload,
 } from "../functions/NominationListComponents.js";
-import { formatGameTitleWithYear, parseTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
+import {
+  formatGameTitleWithYear,
+  parseTitleWithYear,
+} from "../functions/GameTitleAutocompleteUtils.js";
 import {
   areNominationsClosed,
   getUpcomingNominationWindow,
@@ -33,7 +36,10 @@ import {
   safeReply,
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
-import { GOTM_NOMINATION_CHANNEL_ID, NR_GOTM_NOMINATION_CHANNEL_ID } from "../config/nominationChannels.js";
+import {
+  GOTM_NOMINATION_CHANNEL_ID,
+  NR_GOTM_NOMINATION_CHANNEL_ID,
+} from "../config/nominationChannels.js";
 import { showGameProfileFromNomination } from "./gamedb.command.js";
 
 const NOMINATE_REASON_MAX_LENGTH = 1500;
@@ -233,7 +239,9 @@ export class NominateCommand {
         return;
       }
 
-      const existing = await getNominationForUser(selectedKind, window.targetRound, interaction.user.id);
+      const existing = await getNominationForUser(
+        selectedKind, window.targetRound, interaction.user.id,
+      );
       const saved = await upsertNomination(
         selectedKind,
         window.targetRound,

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -229,11 +229,16 @@ export async function restoreJournalMessageContextsFromDb(): Promise<void> {
 }
 
 type NowPlayingMessageComponents = Array<
-  ContainerBuilder | MediaGalleryBuilder | ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>
+  | ContainerBuilder
+  | MediaGalleryBuilder
+  | ActionRowBuilder<ButtonBuilder>
+  | ActionRowBuilder<StringSelectMenuBuilder>
 >;
 
 type NowPlayingListComponents = ContainerBuilder[];
-type NowPlayingPayloadComponents = Array<ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder>>;
+type NowPlayingPayloadComponents = Array<
+  ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder>
+>;
 
 function buildComponentsV2Flags(isEphemeral: boolean): number {
   return (isEphemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
@@ -1190,7 +1195,8 @@ export class NowPlayingCommand {
 
     const typeRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(typeSelect);
     const removeRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(removeSelect);
-    const announceRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(announceSelect);
+    const announceRow = new ActionRowBuilder<StringSelectMenuBuilder>()
+      .addComponents(announceSelect);
     const noteRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(noteSelect);
     const helpButton = new ButtonBuilder()
       .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:completion-config:${session.userId}`)
@@ -1275,7 +1281,9 @@ export class NowPlayingCommand {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("Your Now Playing list is empty."),
       );
-      const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, [container]);
+      const pmComponents = await this.withPmNowPlayingList(
+        ownerId, interaction.guildId, [container],
+      );
       await safeUpdate(interaction, { components: pmComponents });
       return;
     }
@@ -2214,7 +2222,10 @@ export class NowPlayingCommand {
       new TextDisplayBuilder().setContent(titleWithCap),
     );
     const payload = {
-      components: [container, new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
+      components: [
+        container,
+        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+      ],
       flags: buildComponentsV2Flags(true),
     };
     if (mode === "update") {
@@ -2340,8 +2351,13 @@ export class NowPlayingCommand {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("Your Now Playing list is empty."),
       );
-      const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, [container]);
-      await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(isEphemeral) });
+      const pmComponents = await this.withPmNowPlayingList(
+        ownerId, interaction.guildId, [container],
+      );
+      await interaction.update({
+        components: pmComponents,
+        flags: buildComponentsV2Flags(isEphemeral),
+      });
       return;
     }
     const stateToken = buildNowPlayingSortStateToken(entries.length);
@@ -2351,7 +2367,10 @@ export class NowPlayingCommand {
       interaction.guildId,
       components,
     );
-    await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(isEphemeral) });
+    await interaction.update({
+      components: pmComponents,
+      flags: buildComponentsV2Flags(isEphemeral),
+    });
   }
 
   private parseNowPlayingCompletionDate(value: string): Date | null {
@@ -2610,7 +2629,10 @@ export class NowPlayingCommand {
       new TextDisplayBuilder().setContent(content),
     );
     const payload = {
-      components: [container, new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
+      components: [
+        container,
+        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+      ],
       flags: buildComponentsV2Flags(true),
     };
     const pmComponents = await this.withPmNowPlayingList(
@@ -2678,7 +2700,10 @@ export class NowPlayingCommand {
       encodeNowPlayingPlatformState(parsed),
     );
     const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, components);
-    await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(isEphemeral) });
+    await interaction.update({
+      components: pmComponents,
+      flags: buildComponentsV2Flags(isEphemeral),
+    });
   }
 
   @SelectMenuComponent({ id: /^nowplaying-edit-note-select:\d+$/ })
@@ -2818,7 +2843,10 @@ export class NowPlayingCommand {
         const container = new ContainerBuilder().addTextDisplayComponents(
           new TextDisplayBuilder().setContent("This sort form has expired. Open Sort again."),
         );
-        await interaction.update({ components: [container], flags: buildComponentsV2Flags(isEphemeral) });
+        await interaction.update({
+          components: [container],
+          flags: buildComponentsV2Flags(isEphemeral),
+        });
         return;
       }
 
@@ -2833,8 +2861,13 @@ export class NowPlayingCommand {
         ownerId,
         encodeNowPlayingSortState(parsed),
       );
-      const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, components);
-      await interaction.update({ components: pmComponents, flags: buildComponentsV2Flags(isEphemeral) });
+      const pmComponents = await this.withPmNowPlayingList(
+        ownerId, interaction.guildId, components,
+      );
+      await interaction.update({
+        components: pmComponents,
+        flags: buildComponentsV2Flags(isEphemeral),
+      });
     } catch {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("Could not update the sort form right now."),
@@ -2869,7 +2902,9 @@ export class NowPlayingCommand {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("This sort form has expired. Open Sort again."),
       );
-      const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, [container]);
+      const pmComponents = await this.withPmNowPlayingList(
+        ownerId, interaction.guildId, [container],
+      );
       await safeReply(interaction, { components: pmComponents, flags: responseFlags });
       return;
     }
@@ -2880,7 +2915,9 @@ export class NowPlayingCommand {
         stateToken,
         "Assign a title to every visible position before saving.",
       );
-      const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, components);
+      const pmComponents = await this.withPmNowPlayingList(
+        ownerId, interaction.guildId, components,
+      );
       await safeReply(interaction, { components: pmComponents, flags: responseFlags });
       return;
     }
@@ -2891,7 +2928,9 @@ export class NowPlayingCommand {
         stateToken,
         "Each title can only be used once. Remove duplicate assignments and try again.",
       );
-      const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, components);
+      const pmComponents = await this.withPmNowPlayingList(
+        ownerId, interaction.guildId, components,
+      );
       await safeReply(interaction, { components: pmComponents, flags: responseFlags });
       return;
     }
@@ -2909,7 +2948,9 @@ export class NowPlayingCommand {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("Could not update the sort order."),
       );
-      const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, [container]);
+      const pmComponents = await this.withPmNowPlayingList(
+        ownerId, interaction.guildId, [container],
+      );
       await safeReply(interaction, { components: pmComponents, flags: responseFlags });
       return;
     }
@@ -3231,7 +3272,9 @@ export class NowPlayingCommand {
     const [, ownerId, action] = interaction.customId.split(":");
     const showNotes = action === "show";
     const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
-    const contextKey = buildNowPlayingContextKey(interaction.message.channelId, interaction.message.id);
+    const contextKey = buildNowPlayingContextKey(
+      interaction.message.channelId, interaction.message.id,
+    );
     const trackedView = nowPlayingListContexts.get(contextKey)?.view ?? null;
     const singleUserMode = trackedView === "single" || trackedView === "everyone-selected";
     const ownerUser =
@@ -3360,7 +3403,9 @@ export class NowPlayingCommand {
     await safeReply(interaction, {
       components: payload.components,
       files: payload.files,
-      flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
+      flags: buildComponentsV2Flags(
+        interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false,
+      ),
       allowedMentions: payload.allowedMentions,
     });
     await this.trackJournalReply(interaction, ownerId, gameId);
@@ -3396,7 +3441,9 @@ export class NowPlayingCommand {
     await safeReply(interaction, {
       components: payload.components,
       files: payload.files,
-      flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
+      flags: buildComponentsV2Flags(
+        interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false,
+      ),
       allowedMentions: payload.allowedMentions,
     });
     await this.trackJournalReply(interaction, ownerId, gameId);
@@ -3436,7 +3483,9 @@ export class NowPlayingCommand {
     await safeReply(interaction, {
       components: payload.components,
       files: payload.files,
-      flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
+      flags: buildComponentsV2Flags(
+        interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false,
+      ),
       allowedMentions: payload.allowedMentions,
     });
     await this.trackJournalReply(interaction, ownerId, gameId);
@@ -3552,12 +3601,16 @@ export class NowPlayingCommand {
     );
     await safeUpdate(interaction, {
       components: [container, row, helpRow],
-      flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
+      flags: buildComponentsV2Flags(
+        interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false,
+      ),
     });
   }
 
   @SelectMenuComponent({ id: /^nowplaying-journal-delete-select:\d+:\d+:\d+$/ })
-  async handleNowPlayingJournalDeleteSelect(interaction: StringSelectMenuInteraction): Promise<void> {
+  async handleNowPlayingJournalDeleteSelect(
+    interaction: StringSelectMenuInteraction,
+  ): Promise<void> {
     const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, { content: "Only the owner can delete journal entries." });
@@ -3595,7 +3648,9 @@ export class NowPlayingCommand {
     );
     await safeUpdate(interaction, {
       components: [container, row],
-      flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
+      flags: buildComponentsV2Flags(
+        interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false,
+      ),
     });
   }
 
@@ -3616,7 +3671,9 @@ export class NowPlayingCommand {
     const row = await this.buildManageJournalButtonRow(ownerId, Number(gameIdRaw), Number(pageRaw));
     await safeUpdate(interaction, {
       components: [row],
-      flags: buildComponentsV2Flags(interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false),
+      flags: buildComponentsV2Flags(
+        interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false,
+      ),
     });
     if (action === "yes") {
       await refreshJournalMessages(
@@ -3984,7 +4041,9 @@ export class NowPlayingCommand {
         stateToken,
         "Assign a platform for every visible game before saving.",
       );
-      const pmComponents = await this.withPmNowPlayingList(ownerId, interaction.guildId, components);
+      const pmComponents = await this.withPmNowPlayingList(
+        ownerId, interaction.guildId, components,
+      );
       await safeReply(interaction, { components: pmComponents, flags: responseFlags });
       return;
     }
@@ -4375,7 +4434,10 @@ export class NowPlayingCommand {
   private buildComponentPayload(
     components: Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>>,
     files?: AttachmentBuilder[],
-  ): { components: Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>>; files?: AttachmentBuilder[] } {
+  ): {
+    components: Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>>;
+    files?: AttachmentBuilder[];
+  } {
     if (files && files.length) {
       return { components, files };
     }
@@ -4435,7 +4497,9 @@ export class NowPlayingCommand {
     showPrivateOnlyJournalButtons: boolean = false,
     singleUserMode: boolean = false,
   ): Promise<{ components: NowPlayingPayloadComponents; files: AttachmentBuilder[] }> {
-    const { files, covers } = await this.buildNowPlayingAttachments(entries, NOW_PLAYING_COMPOSITE_MAX);
+    const { files, covers } = await this.buildNowPlayingAttachments(
+      entries, NOW_PLAYING_COMPOSITE_MAX,
+    );
     const hasDisplayableNotes = this.hasDisplayableNowPlayingNotes(entries);
     const listComponents = this.buildNowPlayingEntryComponents(
       entries,
@@ -4459,7 +4523,8 @@ export class NowPlayingCommand {
       headerCustomId,
     );
     const journalSelectRow = this.buildJournalSelectRow(entries, target.id);
-    const trailingComponents: NowPlayingPayloadComponents = journalSelectRow ? [journalSelectRow] : [];
+    const trailingComponents: NowPlayingPayloadComponents =
+      journalSelectRow ? [journalSelectRow] : [];
     return { components: [headerContainer, ...listComponents, ...trailingComponents], files };
   }
 
@@ -4939,7 +5004,8 @@ export class NowPlayingCommand {
         continue;
       }
       const selectedIndex = parsedState[slotIndex];
-      const currentPlatformName = selectedIndex >= 0 ? (options[selectedIndex]?.label ?? null) : null;
+      const currentPlatformName =
+        selectedIndex >= 0 ? (options[selectedIndex]?.label ?? null) : null;
       const placeholder = currentPlatformName
         ? `${entry.title.slice(0, 50)} - ${currentPlatformName}`.slice(0, 100)
         : entry.title.slice(0, 100);
@@ -4957,7 +5023,9 @@ export class NowPlayingCommand {
         })));
       rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
     }
-    const components: Array<ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>> = [
+    const components: Array<
+      ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>
+    > = [
       container,
       ...rows,
     ];
@@ -5351,7 +5419,9 @@ export class NowPlayingCommand {
 
     if (!latestKey || !latestContext) return;
 
-    const channel = await interaction.client.channels.fetch(latestContext.channelId).catch(() => null);
+    const channel = await interaction.client.channels
+      .fetch(latestContext.channelId)
+      .catch(() => null);
     if (!channel?.isTextBased()) {
       nowPlayingJournalContexts.delete(latestKey);
       await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -582,7 +582,9 @@ export class ProfileCommand {
 
     userId = userId ? sanitizeUserInput(userId, { preserveNewlines: false }) : undefined;
     username = username ? sanitizeUserInput(username, { preserveNewlines: false }) : undefined;
-    globalName = globalName ? sanitizeUserInput(globalName, { preserveNewlines: false }) : undefined;
+    globalName = globalName
+      ? sanitizeUserInput(globalName, { preserveNewlines: false })
+      : undefined;
     completionator = completionator
       ? sanitizeUserInput(completionator, { preserveNewlines: false })
       : undefined;
@@ -590,7 +592,9 @@ export class ProfileCommand {
     psn = psn ? sanitizeUserInput(psn, { preserveNewlines: false }) : undefined;
     xbl = xbl ? sanitizeUserInput(xbl, { preserveNewlines: false }) : undefined;
     nsw = nsw ? sanitizeUserInput(nsw, { preserveNewlines: false }) : undefined;
-    joinedAfter = joinedAfter ? sanitizeUserInput(joinedAfter, { preserveNewlines: false }) : undefined;
+    joinedAfter = joinedAfter
+      ? sanitizeUserInput(joinedAfter, { preserveNewlines: false })
+      : undefined;
     joinedBefore = joinedBefore
       ? sanitizeUserInput(joinedBefore, { preserveNewlines: false })
       : undefined;

--- a/src/commands/round-history.command.ts
+++ b/src/commands/round-history.command.ts
@@ -27,11 +27,22 @@ import type { IGotmEntry } from "../classes/Gotm.js";
 import Gotm from "../classes/Gotm.js";
 import type { INrGotmEntry } from "../classes/NrGotm.js";
 import NrGotm from "../classes/NrGotm.js";
-import { buildGotmCardsFromEntries, buildGotmSearchMessages } from "../functions/GotmSearchComponents.js";
-import { safeDeferReply, safeDeferUpdate, safeReply, sanitizeUserInput } from "../functions/InteractionUtils.js";
+import {
+  buildGotmCardsFromEntries,
+  buildGotmSearchMessages,
+} from "../functions/GotmSearchComponents.js";
+import {
+  safeDeferReply,
+  safeDeferUpdate,
+  safeReply,
+  sanitizeUserInput,
+} from "../functions/InteractionUtils.js";
 import { buildComponentsV2Flags } from "../functions/ComponentsV2Utils.js";
 import { decodeBase64Url, encodeBase64Url } from "../functions/CustomIdUtils.js";
-import { buildRawModalCustomId, parseRawModalCustomId } from "../services/raw-modal/RawModalCustomId.js";
+import {
+  buildRawModalCustomId,
+  parseRawModalCustomId,
+} from "../services/raw-modal/RawModalCustomId.js";
 
 const ROUND_HISTORY_MODAL_TITLE = "Round History";
 const ROUND_HISTORY_HELP_ID = "round-history-help";
@@ -302,7 +313,9 @@ function parseRoundHistoryPageCustomId(customId: string): IRoundHistoryFilterSta
   const sortToken = parts[4];
   const page = Number(parts[5]);
   const query = decodeQueryToken(parts[6] ?? "");
-  if (!ownerUserId || !Number.isInteger(year) || !Number.isInteger(page) || page < 0 || query === null) {
+  if (
+    !ownerUserId || !Number.isInteger(year) || !Number.isInteger(page) || page < 0 || query === null
+  ) {
     return null;
   }
 

--- a/src/commands/suggestion.command.ts
+++ b/src/commands/suggestion.command.ts
@@ -384,7 +384,11 @@ function buildSuggestionReviewContainer(
 
 async function getCurrentSuggestionForReview(
   session: SuggestionReviewSession,
-): Promise<{ suggestion: Awaited<ReturnType<typeof getSuggestionById>>; index: number; total: number }> {
+): Promise<{
+  suggestion: Awaited<ReturnType<typeof getSuggestionById>>;
+  index: number;
+  total: number;
+}> {
   while (session.index < session.suggestionIds.length) {
     const suggestionId = session.suggestionIds[session.index];
     const suggestion = await getSuggestionById(suggestionId);

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -695,7 +695,9 @@ export class SuperAdmin {
     }
   }
 
-  private async importGameFromIgdbForCompletion(igdbId: number): Promise<{ gameId: number; title: string }> {
+  private async importGameFromIgdbForCompletion(
+    igdbId: number,
+  ): Promise<{ gameId: number; title: string }> {
     const existing = await Game.getGameByIgdbId(igdbId);
     if (existing) {
       return { gameId: existing.id, title: existing.title };

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -660,7 +660,9 @@ function buildTodoCommentButtonId(payloadToken: string, page: number, issueNumbe
   return [TODO_COMMENT_BUTTON_PREFIX, payloadToken, page, issueNumber].join(":");
 }
 
-function buildTodoEditViewButtonId(payloadToken: string, page: number, issueNumber: number): string {
+function buildTodoEditViewButtonId(
+  payloadToken: string, page: number, issueNumber: number,
+): string {
   return [TODO_EDIT_VIEW_BUTTON_PREFIX, payloadToken, page, issueNumber].join(":");
 }
 
@@ -885,7 +887,13 @@ function parseTodoIssueActionId(
 function parseTodoIssueModalId(
   id: string,
   prefix: string,
-): { payloadToken: string; page: number; issueNumber: number; channelId: string; messageId: string } | null {
+): {
+  payloadToken: string;
+  page: number;
+  issueNumber: number;
+  channelId: string;
+  messageId: string;
+} | null {
   const parts = id.split(":");
   if (parts.length !== 6 || parts[0] !== prefix) {
     return null;
@@ -927,7 +935,13 @@ function parseTodoLabelEditId(
 function parseTodoLabelEditSelectId(
   id: string,
   prefix: string,
-): { payloadToken: string; page: number; issueNumber: number; channelId: string; messageId: string } | null {
+): {
+  payloadToken: string;
+  page: number;
+  issueNumber: number;
+  channelId: string;
+  messageId: string;
+} | null {
   return parseTodoIssueModalId(id, prefix);
 }
 

--- a/src/events/MessageLog.command.ts
+++ b/src/events/MessageLog.command.ts
@@ -76,9 +76,13 @@ export class MessageLog {
     [oldMessage, newMessage]: ArgsOf<"messageUpdate">,
     client: Client,
   ): Promise<void> {
-    const resolvedNew = newMessage.partial ? await newMessage.fetch().catch(() => null) : newMessage;
+    const resolvedNew = newMessage.partial
+      ? await newMessage.fetch().catch(() => null)
+      : newMessage;
     if (!resolvedNew || !resolvedNew.author || resolvedNew.author.bot) return;
-    const resolvedOld = oldMessage.partial ? await oldMessage.fetch().catch(() => null) : oldMessage;
+    const resolvedOld = oldMessage.partial
+      ? await oldMessage.fetch().catch(() => null)
+      : oldMessage;
     if (!resolvedOld) return;
 
     const beforeText = resolvedOld.cleanContent ?? resolvedOld.content ?? "";

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -197,7 +197,9 @@ export class MessageReactionAdd {
 
       const row = buildCompletionTypeRow(sessionId);
       const titleRow = buildCompletionTitleRow(sessionId);
-      const targetChannel = await _client.channels.fetch(COMPLETION_REACTION_DEV_CHANNEL_ID).catch(() => null);
+      const targetChannel = await _client.channels
+        .fetch(COMPLETION_REACTION_DEV_CHANNEL_ID)
+        .catch(() => null);
       if (!targetChannel || !("send" in targetChannel)) {
         await user.send({
           content: "Bot dev channel not found. Cannot start completion flow.",

--- a/src/functions/GotmSearchComponents.ts
+++ b/src/functions/GotmSearchComponents.ts
@@ -106,7 +106,9 @@ export async function buildGotmSearchMessages(
     messageStartIndex < chunks.length;
     messageStartIndex += maxContainersPerMessage
   ) {
-    const messageChunks = chunks.slice(messageStartIndex, messageStartIndex + maxContainersPerMessage);
+    const messageChunks = chunks.slice(
+      messageStartIndex, messageStartIndex + maxContainersPerMessage,
+    );
     const components: ContainerBuilder[] = [];
     const files: AttachmentBuilder[] = [];
 

--- a/src/functions/NominationAdminHelpers.ts
+++ b/src/functions/NominationAdminHelpers.ts
@@ -41,7 +41,10 @@ type PendingDeleteSelectionState = {
 export async function buildNominationDeleteView(
   kind: NominationKind,
   commandLabel: string,
-): Promise<{ payload: NominationListPayload; controls: ActionRowBuilder<StringSelectMenuBuilder>[] } | null> {
+): Promise<{
+  payload: NominationListPayload;
+  controls: ActionRowBuilder<StringSelectMenuBuilder>[];
+} | null> {
   const window = await getUpcomingNominationWindow();
   const nominations = await listNominationsForRound(kind, window.targetRound);
   if (!nominations.length) return null;
@@ -83,7 +86,9 @@ export function buildDeletionSelectCustomId(kind: NominationKind, round: number)
   return `${ADMIN_NOMINATION_DELETE_SELECT_PREFIX}:${kind}:${round}`;
 }
 
-export function buildDeletionReasonModalCustomId(kind: NominationKind, round: number, userId: string): string {
+export function buildDeletionReasonModalCustomId(
+  kind: NominationKind, round: number, userId: string,
+): string {
   return buildDeletionReasonStateId(kind, round, userId);
 }
 

--- a/src/services/GamedbAuditService.ts
+++ b/src/services/GamedbAuditService.ts
@@ -302,7 +302,9 @@ export async function runAutoAcceptImagesAudit(
     await message.edit({ embeds: [currentEmbed] }).catch(() => {});
   };
 
-  const { updated, skipped, failed, logs } = await performAutoAcceptImages(updateEmbed, undefined, titleWords);
+  const { updated, skipped, failed, logs } = await performAutoAcceptImages(
+    updateEmbed, undefined, titleWords,
+  );
   if (!logs.length) {
     currentEmbed
       .setDescription("No games found with missing images and valid IGDB IDs.")

--- a/src/services/IGDB/IgdbSelectService.ts
+++ b/src/services/IGDB/IgdbSelectService.ts
@@ -174,7 +174,9 @@ export async function handleIgdbSelectInteraction(
     const message = session.emptyMessage ??
       "No IGDB matches found. Try Search a different title.";
     if (interaction.deferred || interaction.replied) {
-      await interaction.followUp({ content: message, flags: MessageFlags.Ephemeral }).catch(() => {});
+      await interaction
+        .followUp({ content: message, flags: MessageFlags.Ephemeral })
+        .catch(() => {});
     } else {
       await interaction.reply({ content: message, flags: MessageFlags.Ephemeral }).catch(() => {});
     }
@@ -247,7 +249,9 @@ export async function handleIgdbFirstMatchInteraction(
     const message = session.emptyMessage ??
       "No IGDB matches found. Try Search a different title.";
     if (interaction.deferred || interaction.replied) {
-      await interaction.followUp({ content: message, flags: MessageFlags.Ephemeral }).catch(() => {});
+      await interaction
+        .followUp({ content: message, flags: MessageFlags.Ephemeral })
+        .catch(() => {});
     } else {
       await interaction.reply({ content: message, flags: MessageFlags.Ephemeral }).catch(() => {});
     }

--- a/src/services/RssFeedService.ts
+++ b/src/services/RssFeedService.ts
@@ -24,7 +24,9 @@ function hashId(parts: (string | null | undefined)[]): string {
   return crypto.createHash("sha256").update(joined).digest("hex");
 }
 
-function matchesKeywords(include: string[], exclude: string[], title: string, content: string): boolean {
+function matchesKeywords(
+  include: string[], exclude: string[], title: string, content: string,
+): boolean {
   const haystack = `${title} ${content}`.toLowerCase();
 
   if (exclude.length && exclude.some((kw) => haystack.includes(kw))) {


### PR DESCRIPTION
## Summary

- Fixed all 61 `max-len` ESLint violations across 18 files
- All lines now stay at or under the 100-character limit
- Zero type-check errors introduced

## Approach

Wrapped long lines using standard TypeScript formatting conventions:
- Multi-line function signatures for overlong parameter/return-type lines
- Split call arguments across lines when a single call exceeded the limit
- Broke inline ternaries and chained method calls onto multiple lines
- Expanded inline object literals (`interaction.update({...})`) to multi-line form
- Reformatted long union type aliases to use leading-pipe style

## Files changed (18)

`src/commands/admin/gotm-audit-handlers.ts`, `nomination-admin.service.ts`, `collection-steam-import.command.ts`, `help.command.ts`, `nominate.command.ts`, `now-playing.command.ts` (32 violations), `profile.command.ts`, `round-history.command.ts`, `suggestion.command.ts`, `superadmin.command.ts`, `todo.command.ts`, `events/MessageLog.command.ts`, `events/MessageReactionAdd.command.ts`, `functions/GotmSearchComponents.ts`, `functions/NominationAdminHelpers.ts`, `services/GamedbAuditService.ts`, `services/IGDB/IgdbSelectService.ts`, `services/RssFeedService.ts`

## Test plan

- [x] `npx eslint src` - 0 max-len errors remaining
- [x] `tsc --noEmit` - no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)