### PR TITLE
fix: add missing SlashGroup declaration for /collection commands

### DIFF
--- a/src/commands/collection/collection-crud.command.ts
+++ b/src/commands/collection/collection-crud.command.ts
@@ -41,6 +41,7 @@ import { resolveCollectionGameForAdd } from "./collection-game-resolve.utils.js"
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 
 @Discord()
+@SlashGroup({ description: "Manage your game collection", name: "collection" })
 @SlashGroup("collection")
 export class CollectionCrudCommand {
   @Slash({ name: "add", description: "Add a game you own to your collection" })


### PR DESCRIPTION
## Summary
- `/collection` commands were not appearing in Discord because no file declared the slash command group
- discordx requires at least one class per group to use `@SlashGroup({ name, description })` (the declaration form) -- all four collection command files only had `@SlashGroup("collection")` (the apply form)
- Added `@SlashGroup({ description: "Manage your game collection", name: "collection" })` to `CollectionCrudCommand`, matching the pattern used by `gamedb-add.command.ts` for the split `gamedb` group

## Test plan
- [ ] Deploy bot and confirm `/collection` slash command group appears in Discord
- [ ] Verify all subcommands (add, edit, remove, list, overview, import-steam, import-csv, etc.) are present under `/collection`

🤖 Generated with [Claude Code](https://claude.com/claude-code)