### PR TITLE
fix: remove good/bad thumbnail buttons from /gamedb view

### DIFF
--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -43,9 +43,6 @@ type GameProfileResult = {
   files: AttachmentBuilder[];
   hasThread: boolean;
   featuredVideoUrl: string | null;
-  canMarkThumbnailBad: boolean;
-  isThumbnailBad: boolean;
-  isThumbnailApproved: boolean;
   isReleased: boolean;
 };
 
@@ -123,9 +120,6 @@ export function buildGameProfileActionRow(
   gameId: number,
   hasThread: boolean,
   featuredVideoUrl: string | null,
-  canMarkThumbnailBad: boolean,
-  isThumbnailBad: boolean,
-  isThumbnailApproved: boolean,
   isReleased: boolean,
   disableVideo = false,
 ): ActionRowBuilder<ButtonBuilder>[] {
@@ -160,24 +154,6 @@ export function buildGameProfileActionRow(
     primaryRow.addComponents(viewFeaturedVideo);
   }
   rows.push(primaryRow);
-  if (canMarkThumbnailBad && !isThumbnailBad && !isThumbnailApproved) {
-    const badThumbnail = new ButtonBuilder()
-      // eslint-disable-next-line local/custom-id-has-matching-handler
-      .setCustomId(`gamedb-action:bad-thumb:${gameId}`)
-      .setLabel("Bad Thumbnail")
-      .setStyle(ButtonStyle.Danger);
-
-    const goodThumbnail = new ButtonBuilder()
-      // eslint-disable-next-line local/custom-id-has-matching-handler
-      .setCustomId(`gamedb-action:good-thumb:${gameId}`)
-      .setLabel("Good Thumbnail")
-      .setStyle(ButtonStyle.Secondary);
-    const thumbRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      badThumbnail,
-      goodThumbnail,
-    );
-    rows.push(thumbRow);
-  }
   return rows;
 }
 
@@ -217,8 +193,6 @@ export async function buildGameProfile(
     const prefaceText = (interaction as GameProfileRenderContext | undefined)?.prefaceText?.trim();
 
     const files: AttachmentBuilder[] = [];
-    const isThumbnailBad = Boolean(game.thumbnailBad);
-    const isThumbnailApproved = Boolean(game.thumbnailApproved);
     const isReleased = isGameReleased(game, releases);
     const primaryArt = game.imageData;
     if (primaryArt) {
@@ -576,9 +550,6 @@ export async function buildGameProfile(
       files,
       hasThread: Boolean(threadId),
       featuredVideoUrl: game.featuredVideoUrl ?? null,
-      canMarkThumbnailBad: Boolean(game.imageData) && !isThumbnailApproved,
-      isThumbnailBad,
-      isThumbnailApproved,
       isReleased,
     };
   } catch (error: any) {
@@ -610,9 +581,6 @@ export async function showGameProfile(
         gameId,
         profile.hasThread,
         profile.featuredVideoUrl,
-        profile.canMarkThumbnailBad,
-        profile.isThumbnailBad,
-        profile.isThumbnailApproved,
         profile.isReleased,
       ),
     );
@@ -641,9 +609,6 @@ export async function showGameProfileFromNomination(
       gameId,
       profile.hasThread,
       profile.featuredVideoUrl,
-      profile.canMarkThumbnailBad,
-      profile.isThumbnailBad,
-      profile.isThumbnailApproved,
       profile.isReleased,
     ),
   ];
@@ -683,9 +648,6 @@ export async function buildGameProfileMessagePayload(
         gameId,
         profile.hasThread,
         profile.featuredVideoUrl,
-        profile.canMarkThumbnailBad,
-        profile.isThumbnailBad,
-        profile.isThumbnailApproved,
         profile.isReleased,
       ),
     );
@@ -708,9 +670,6 @@ export async function refreshGameProfileMessage(
     gameId,
     profile.hasThread,
     profile.featuredVideoUrl,
-    profile.canMarkThumbnailBad,
-    profile.isThumbnailBad,
-    profile.isThumbnailApproved,
     profile.isReleased,
   );
   const existingComponents = interaction.message?.components ?? [];
@@ -741,9 +700,6 @@ export async function updateGameProfileMessageById(
     gameId,
     profile.hasThread,
     profile.featuredVideoUrl,
-    profile.canMarkThumbnailBad,
-    profile.isThumbnailBad,
-    profile.isThumbnailApproved,
     profile.isReleased,
   );
   const searchRows = getSearchRowsFromComponents(message.components ?? []);

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -262,9 +262,6 @@ export class GameDbSearchCommand {
       gameId,
       profile.hasThread,
       profile.featuredVideoUrl,
-      profile.canMarkThumbnailBad,
-      profile.isThumbnailBad,
-      profile.isThumbnailApproved,
       profile.isReleased,
     );
 

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -31,7 +31,6 @@ import {
   buildComponentsV2Flags,
   getSearchRowsFromComponents,
   isHltbImportEligible,
-  requireModeratorOrAdminOrOwner,
 } from "./gamedb-utils.js";
 import {
   buildGameProfile,
@@ -95,7 +94,7 @@ export class GameDbViewCommand {
   }
 
   @ButtonComponent({
-    id: /^gamedb-action:(nowplaying|completion|thread|video|hltb-import|bad-thumb|good-thumb):\d+$/,
+    id: /^gamedb-action:(nowplaying|completion|thread|video|hltb-import):\d+$/,
   })
   async handleGameDbAction(interaction: ButtonInteraction): Promise<void> {
     const [, action, gameIdRaw] = interaction.customId.split(":");
@@ -129,9 +128,6 @@ export class GameDbViewCommand {
           gameId,
           profile.hasThread,
           profile.featuredVideoUrl,
-          profile.canMarkThumbnailBad,
-          profile.isThumbnailBad,
-          profile.isThumbnailApproved,
           profile.isReleased,
           true,
         );
@@ -154,59 +150,6 @@ export class GameDbViewCommand {
       }
       await safeReply(interaction, {
         ...buildTextReply(`Warning: videos may contain spoilers. ${videoUrl}`, false),
-        __forceFollowUp: true,
-      });
-      return;
-    }
-
-    if (action === "bad-thumb" || action === "good-thumb") {
-      const hasAccess = await requireModeratorOrAdminOrOwner(interaction);
-      if (!hasAccess) {
-        return;
-      }
-    }
-
-    if (action === "bad-thumb") {
-      if (!game.imageData) {
-        await safeReply(interaction, buildTextReply(
-          "No cover image is available for this game.", true,
-        ));
-        return;
-      }
-      if (game.thumbnailBad) {
-        await safeReply(interaction, buildTextReply("This thumbnail is already marked as bad.", true));
-        return;
-      }
-      await safeDeferUpdate(interaction);
-      await Game.updateGameThumbnailBad(gameId, true);
-      await Game.updateGameThumbnailApproved(gameId, false);
-      await refreshGameProfileMessage(interaction, gameId);
-      await safeReply(interaction, {
-        ...buildTextReply("Thumbnail flagged. GameDB view will use cover art from now on.", true),
-        __forceFollowUp: true,
-      });
-      return;
-    }
-
-    if (action === "good-thumb") {
-      if (!game.imageData) {
-        await safeReply(interaction, buildTextReply(
-          "No cover image is available for this game.", true,
-        ));
-        return;
-      }
-      if (game.thumbnailApproved) {
-        await safeReply(interaction, buildTextReply(
-          "This thumbnail is already marked as approved.", true,
-        ));
-        return;
-      }
-      await safeDeferUpdate(interaction);
-      await Game.updateGameThumbnailBad(gameId, false);
-      await Game.updateGameThumbnailApproved(gameId, true);
-      await refreshGameProfileMessage(interaction, gameId);
-      await safeReply(interaction, {
-        ...buildTextReply("Thumbnail marked as good. GameDB view will keep using artwork.", true),
         __forceFollowUp: true,
       });
       return;


### PR DESCRIPTION
## Summary
- Removes the Bad Thumbnail and Good Thumbnail buttons from the `/gamedb view` action row
- Removes the `bad-thumb` and `good-thumb` button handlers and their access check from `GameDbViewCommand`
- Removes `canMarkThumbnailBad`, `isThumbnailBad`, and `isThumbnailApproved` from `GameProfileResult` and all related plumbing in `buildGameProfileActionRow` and `buildGameProfile`

## Test plan
- [ ] Run `/gamedb view <game>` and confirm no thumbnail buttons appear in the response
- [ ] Confirm other action buttons (Now Playing, Add Completion, Create Thread, View Featured Video) still appear normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)