### PR TITLE
fix: suppress skip output in gamedb audit sweep mode

### DIFF
--- a/src/services/GamedbAuditService.ts
+++ b/src/services/GamedbAuditService.ts
@@ -358,7 +358,6 @@ async function performAutoAcceptAll(
       stats.videos.skipped++;
       stats.descriptions.skipped++;
       stats.releases.skipped++;
-      await addLog(`⏭️ Skipped **${game.title}** (Missing IGDB ID)`, processed);
       continue;
     }
 
@@ -384,7 +383,6 @@ async function performAutoAcceptAll(
       stats.videos.skipped++;
       stats.descriptions.skipped++;
       stats.releases.skipped++;
-      await addLog(`⏭️ Skipped **${game.title}** (No IGDB data found)`, processed);
       if (shouldStop?.()) break;
       await new Promise((resolve) => setTimeout(resolve, 1000));
       continue;
@@ -466,11 +464,12 @@ async function performAutoAcceptAll(
       failures.push(`releases: ${err?.message ?? String(err)}`);
     }
 
-    const parts: string[] = [];
-    if (updates.length) parts.push(`✅ Updated: ${updates.join(", ")}`);
-    if (skips.length) parts.push(`⏭️ No data: ${skips.join(", ")}`);
-    if (failures.length) parts.push(`❌ Failed: ${failures.join("; ")}`);
-    await addLog(`**${game.title}**: ${parts.join(" | ")}`, processed);
+    if (updates.length || failures.length) {
+      const parts: string[] = [];
+      if (updates.length) parts.push(`✅ Updated: ${updates.join(", ")}`);
+      if (failures.length) parts.push(`❌ Failed: ${failures.join("; ")}`);
+      await addLog(`**${game.title}**: ${parts.join(" | ")}`, processed);
+    }
 
     if (shouldStop?.()) break;
     await new Promise((resolve) => setTimeout(resolve, 1000));


### PR DESCRIPTION
## Summary
- In `auto_accept_all` sweep, games that are fully skipped (no IGDB ID, no IGDB data found, or all IGDB fields were empty for missing slots) now produce no log output
- Only games that had at least one field updated or one failure are logged
- Per-type skip counts in the completion summary are still tracked and displayed

## Test plan
- [ ] Run `/gamedb audit auto_accept_all:True` and confirm only updated/failed games appear in the running log
- [ ] Confirm the sweep summary still shows correct skip counts at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)