### PR TITLE
feat: add unreleased, platform, and year filters to /gamedb search

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -1770,7 +1770,10 @@ export default class Game {
     }
   }
 
-  static async searchGames(query: string): Promise<IGameWithPlatforms[]> {
+  static async searchGames(
+    query: string,
+    filters: { unreleased?: boolean; platformId?: number; year?: number } = {},
+  ): Promise<IGameWithPlatforms[]> {
     const pool = getOraclePool();
     const connection = await pool.getConnection();
     try {
@@ -1834,7 +1837,7 @@ export default class Game {
 
       const termEntries = Array.from(termSet.entries());
       const clauses: string[] = [];
-      const binds: Record<string, string> = {};
+      const binds: Record<string, string | number> = {};
       const titleFoldExpr =
         "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(TITLE), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')";
       const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '')`;
@@ -1848,7 +1851,28 @@ export default class Game {
         );
       });
 
-      const whereClause = clauses.length ? clauses.join(" OR ") : "1=0";
+      const filterClauses: string[] = [];
+      if (filters.unreleased) {
+        filterClauses.push(
+          "INITIAL_RELEASE_DATE IS NOT NULL AND INITIAL_RELEASE_DATE > SYSDATE",
+        );
+      }
+      if (filters.platformId) {
+        filterClauses.push(
+          "GAME_ID IN (SELECT GAME_ID FROM GAMEDB_GAME_PLATFORMS WHERE PLATFORM_ID = :filterPlatformId)",
+        );
+        binds["filterPlatformId"] = filters.platformId;
+      }
+      if (filters.year) {
+        filterClauses.push("EXTRACT(YEAR FROM INITIAL_RELEASE_DATE) = :filterYear");
+        binds["filterYear"] = filters.year;
+      }
+
+      const titleWhereClause = clauses.length ? clauses.join(" OR ") : "1=0";
+      const filterWhere = filterClauses.length
+        ? ` AND (${filterClauses.join(" AND ")})`
+        : "";
+
       const result = await connection.execute<{
         GAME_ID: number;
         TITLE: string;
@@ -1866,7 +1890,7 @@ export default class Game {
         `SELECT GAME_ID, TITLE, DESCRIPTION, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL, FEATURED_VIDEO_URL,
                 INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
            FROM GAMEDB_GAMES
-          WHERE ${whereClause}
+          WHERE (${titleWhereClause})${filterWhere}
           ORDER BY TITLE ASC`,
         binds,
         {

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -1,6 +1,7 @@
 import {
   ActionRowBuilder,
   ApplicationCommandOptionType,
+  AutocompleteInteraction,
   ButtonBuilder,
   ButtonStyle,
   CommandInteraction,
@@ -31,11 +32,14 @@ import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2U
 import { shouldRenderPrevNextButtons } from "../../functions/PaginationUtils.js";
 import Game from "../../classes/Game.js";
 import {
+  autocompleteSearchPlatform,
   buildComponentsV2Flags,
   buildSearchCustomId,
   buildSearchRecoveryComponents,
+  decodeISearchFilters,
   decodeSearchQuery,
   GAME_SEARCH_PAGE_SIZE,
+  type ISearchFilters,
 } from "./gamedb-utils.js";
 import {
   buildGameProfile,
@@ -45,24 +49,42 @@ import {
 } from "./gamedb-profile.service.js";
 import { handleNoResults } from "./gamedb-add.command.js";
 
+async function buildFilterSummary(filters: ISearchFilters): Promise<string> {
+  const parts: string[] = [];
+  if (filters.unreleased) parts.push("Unreleased only");
+  if (filters.platformId) {
+    const platform = await Game.getPlatformById(filters.platformId);
+    parts.push(`Platform: ${platform?.name ?? `ID ${filters.platformId}`}`);
+  }
+  if (filters.year) parts.push(`Year: ${filters.year}`);
+  return parts.join(" | ");
+}
+
 export async function runSearchFlow(
   interaction: CommandInteraction,
   searchTerm: string,
   rawQuery?: string,
+  filters?: ISearchFilters,
 ): Promise<void> {
-  const results = await Game.searchGames(searchTerm);
+  const activeFilters = filters ?? {};
+  const results = await Game.searchGames(searchTerm, activeFilters);
 
   if (results.length === 0) {
     await handleNoResults(interaction, searchTerm || rawQuery || "Unknown");
     return;
   }
 
-  if (results.length === 1) {
+  if (results.length === 1 && !Object.keys(activeFilters).length) {
     await showGameProfile(interaction, results[0].id);
     return;
   }
 
-  const response = buildSearchResponse(searchTerm, results, interaction.user.id, 0, true);
+  const filterSummary = Object.keys(activeFilters).length
+    ? await buildFilterSummary(activeFilters)
+    : "";
+  const response = buildSearchResponse(
+    searchTerm, results, interaction.user.id, 0, true, activeFilters, filterSummary,
+  );
 
   await safeReply(interaction, response);
 }
@@ -73,6 +95,8 @@ function buildSearchResponse(
   ownerId: string,
   page: number,
   includeList: boolean,
+  filters?: ISearchFilters,
+  filterSummary?: string,
 ): { components: Array<ContainerBuilder | ActionRowBuilder<any>>; flags: number } {
   const totalPages = Math.max(
     1,
@@ -106,7 +130,7 @@ function buildSearchResponse(
     ? `Search Results for "${searchTerm}" (Page ${safePage + 1}/${totalPages})`
     : `All Games (Page ${safePage + 1}/${totalPages})`;
 
-  const selectCustomId = buildSearchCustomId("select", ownerId, safePage, searchTerm);
+  const selectCustomId = buildSearchCustomId("select", ownerId, safePage, searchTerm, undefined, filters);
   const options = displayedResults.map((game) => {
     const gameTitle = String(game.title ?? "");
     const isDuplicate = (titleCounts.get(gameTitle) ?? 0) > 1;
@@ -129,7 +153,7 @@ function buildSearchResponse(
   });
 
   const selectMenu = new StringSelectMenuBuilder()
-     
+
     .setCustomId(selectCustomId)
     .setPlaceholder("Select a game to view details")
     .addOptions(options);
@@ -140,15 +164,15 @@ function buildSearchResponse(
   const nextDisabled = safePage >= totalPages - 1;
 
   const prevButton = new ButtonBuilder()
-     
-    .setCustomId(buildSearchCustomId("page", ownerId, safePage, searchTerm, "prev"))
+
+    .setCustomId(buildSearchCustomId("page", ownerId, safePage, searchTerm, "prev", filters))
     .setLabel("Previous Page")
     .setStyle(ButtonStyle.Secondary)
     .setDisabled(prevDisabled);
 
   const nextButton = new ButtonBuilder()
-     
-    .setCustomId(buildSearchCustomId("page", ownerId, safePage, searchTerm, "next"))
+
+    .setCustomId(buildSearchCustomId("page", ownerId, safePage, searchTerm, "next", filters))
     .setLabel("Next Page")
     .setStyle(ButtonStyle.Secondary)
     .setDisabled(nextDisabled);
@@ -156,9 +180,10 @@ function buildSearchResponse(
   const buttonRow = new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton);
   const components: Array<ContainerBuilder | ActionRowBuilder<any>> = [];
   if (includeList) {
+    const filterNote = filterSummary ? `\n*Filters: ${filterSummary}*` : "";
     const listText = resultList || "No results.";
     const content = trimTextDisplayContent(
-      `## ${title}\n\n${listText}\n\n*${results.length} results total*`,
+      `## ${title}\n\n${listText}\n\n*${results.length} results total*${filterNote}`,
     );
     const container = new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent(safeV2TextContent(content, 3500)),
@@ -168,7 +193,7 @@ function buildSearchResponse(
   components.push(selectRow);
 
   if (shouldRenderPrevNextButtons(prevDisabled, nextDisabled)) {
-     
+
     components.push(buttonRow);
   }
 
@@ -191,20 +216,51 @@ export class GameDbSearchCommand {
       type: ApplicationCommandOptionType.String,
     })
     query: string,
+    @SlashOption({
+      description: "Filter to games with a future release date (must have release info).",
+      name: "unreleased",
+      required: false,
+      type: ApplicationCommandOptionType.Boolean,
+    })
+    unreleased: boolean | null,
+    @SlashOption({
+      description: "Filter to a specific platform.",
+      name: "platform",
+      required: false,
+      type: ApplicationCommandOptionType.String,
+      autocomplete: async (interaction: AutocompleteInteraction) => {
+        await autocompleteSearchPlatform(interaction);
+      },
+    })
+    platformValue: string | null,
+    @SlashOption({
+      description: "Filter to a specific release year (uses first release date).",
+      name: "year",
+      required: false,
+      type: ApplicationCommandOptionType.Integer,
+    })
+    year: number | null,
     interaction: CommandInteraction,
   ): Promise<void> {
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(false) });
 
     try {
       const searchTerm = sanitizeUserInput(query, { preserveNewlines: false });
-      await runSearchFlow(interaction, searchTerm, query);
+      const filters: ISearchFilters = {};
+      if (unreleased === true) filters.unreleased = true;
+      const platformId = platformValue ? Number(platformValue) : null;
+      if (platformId && Number.isInteger(platformId) && platformId > 0) {
+        filters.platformId = platformId;
+      }
+      if (year && Number.isInteger(year) && year > 0) filters.year = year;
+      await runSearchFlow(interaction, searchTerm, query, filters);
     } catch (error: any) {
       await safeReply(interaction, buildTextReply(
         `Failed to search games. Error: ${error.message}`, true,
       ));
     }
   }
-   
+
   @SelectMenuComponent({ id: /^gamedb-search-select:\d+:\d+:[A-Za-z0-9_-]*$/ })
   async handleSearchSelect(interaction: StringSelectMenuInteraction): Promise<void> {
     const parts = interaction.customId.split(":");
@@ -234,7 +290,8 @@ export class GameDbSearchCommand {
       return;
     }
 
-    const results = await Game.searchGames(searchTerm);
+    const filters = decodeISearchFilters(encodedQuery);
+    const results = await Game.searchGames(searchTerm, filters);
 
     const gameId = Number(interaction.values?.[0]);
     if (!Number.isFinite(gameId)) {
@@ -257,7 +314,7 @@ export class GameDbSearchCommand {
       return;
     }
 
-    const response = buildSearchResponse(searchTerm, results, ownerId, page, false);
+    const response = buildSearchResponse(searchTerm, results, ownerId, page, false, filters);
     const actionRows = buildGameProfileActionRow(
       gameId,
       profile.hasThread,
@@ -276,7 +333,7 @@ export class GameDbSearchCommand {
       // ignore update failures
     }
   }
-   
+
   @ButtonComponent({ id: /^gamedb-search-page:\d+:\d+:[A-Za-z0-9_-]*:(next|prev)$/ })
   async handleSearchPage(interaction: ButtonInteraction): Promise<void> {
     const parts = interaction.customId.split(":");
@@ -307,7 +364,8 @@ export class GameDbSearchCommand {
       return;
     }
 
-    const results = await Game.searchGames(searchTerm);
+    const filters = decodeISearchFilters(encodedQuery);
+    const results = await Game.searchGames(searchTerm, filters);
     const totalPages = Math.max(
       1,
       Math.ceil(results.length / GAME_SEARCH_PAGE_SIZE),
@@ -321,7 +379,12 @@ export class GameDbSearchCommand {
       // ignore
     }
 
-    const response = buildSearchResponse(searchTerm, results, ownerId, newPage, true);
+    const filterSummary = Object.keys(filters).length
+      ? await buildFilterSummary(filters)
+      : "";
+    const response = buildSearchResponse(
+      searchTerm, results, ownerId, newPage, true, filters, filterSummary,
+    );
 
     try {
       await safeReply(interaction, response);
@@ -329,7 +392,7 @@ export class GameDbSearchCommand {
       // ignore
     }
   }
-   
+
   @ButtonComponent({ id: /^gamedb-search-refresh:\d+:[A-Za-z0-9_-]*$/ })
   async handleSearchRefresh(interaction: ButtonInteraction): Promise<void> {
     const parts = interaction.customId.split(":");
@@ -356,7 +419,8 @@ export class GameDbSearchCommand {
       return;
     }
 
-    const results = await Game.searchGames(searchTerm);
+    const filters = decodeISearchFilters(encodedQuery);
+    const results = await Game.searchGames(searchTerm, filters);
     if (results.length === 0) {
       await safeReply(interaction, {
         ...buildTextReply(`No results found for "${searchTerm}".`, true),
@@ -365,7 +429,12 @@ export class GameDbSearchCommand {
       return;
     }
 
-    const response = buildSearchResponse(searchTerm, results, ownerId, 0, true);
+    const filterSummary = Object.keys(filters).length
+      ? await buildFilterSummary(filters)
+      : "";
+    const response = buildSearchResponse(
+      searchTerm, results, ownerId, 0, true, filters, filterSummary,
+    );
     await safeUpdate(interaction, response);
   }
 }

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -10,8 +10,32 @@ import {
 import { AnyRepliable, safeReply, sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
-import { decodeBase64Url, encodeWithMaxLength } from "../../functions/CustomIdUtils.js";
+import { decodeBase64Url, encodeBase64Url } from "../../functions/CustomIdUtils.js";
 import Game from "../../classes/Game.js";
+
+export interface ISearchFilters {
+  unreleased?: boolean;
+  platformId?: number;
+  year?: number;
+}
+
+function compactFilters(filters: ISearchFilters): string {
+  let result = "";
+  if (filters.unreleased) result += "u";
+  if (filters.platformId) result += `p${filters.platformId}`;
+  if (filters.year) result += `y${filters.year}`;
+  return result;
+}
+
+function parseCompactFilters(filterStr: string): ISearchFilters {
+  const filters: ISearchFilters = {};
+  if (filterStr.includes("u")) filters.unreleased = true;
+  const platformMatch = filterStr.match(/p(\d+)/);
+  if (platformMatch) filters.platformId = Number(platformMatch[1]);
+  const yearMatch = filterStr.match(/y(\d{4})/);
+  if (yearMatch) filters.year = Number(yearMatch[1]);
+  return filters;
+}
 
 export const GAME_SEARCH_PAGE_SIZE = 10;
 export const MAX_COMPONENT_CUSTOM_ID_LENGTH = 100;
@@ -27,11 +51,35 @@ export type PromptChoiceOption = {
 };
 
 export function decodeSearchQuery(encoded: string): string {
-  return decodeBase64Url(encoded);
+  const decoded = decodeBase64Url(encoded);
+  const nullIdx = decoded.indexOf("\0");
+  return nullIdx >= 0 ? decoded.slice(0, nullIdx) : decoded;
 }
 
-export function encodeSearchQuery(query: string, maxLength: number): string {
-  return encodeWithMaxLength(query.trim(), maxLength);
+export function decodeISearchFilters(encoded: string): ISearchFilters {
+  const decoded = decodeBase64Url(encoded);
+  const nullIdx = decoded.indexOf("\0");
+  if (nullIdx < 0) return {};
+  return parseCompactFilters(decoded.slice(nullIdx + 1));
+}
+
+export function encodeSearchQuery(
+  query: string,
+  maxLength: number,
+  filters?: ISearchFilters,
+): string {
+  const filterStr = filters ? compactFilters(filters) : "";
+  const suffix = filterStr ? `\0${filterStr}` : "";
+  if (!query && !suffix) return "";
+  if (maxLength <= 0) return "";
+  let trimmed = query.trim();
+  while (trimmed.length >= 0) {
+    const encoded = encodeBase64Url(trimmed + suffix);
+    if (encoded.length <= maxLength) return encoded;
+    if (trimmed.length === 0) return "";
+    trimmed = trimmed.slice(0, -1);
+  }
+  return "";
 }
 
 export function buildIgdbSearchLink(title: string): string {
@@ -100,11 +148,12 @@ export function buildSearchCustomId(
   page: number,
   query: string,
   direction?: "next" | "prev",
+  filters?: ISearchFilters,
 ): string {
   const base = `gamedb-search-${type}:${ownerId}:${page}:`;
   const maxQueryLength =
     MAX_COMPONENT_CUSTOM_ID_LENGTH - base.length - (direction ? `:${direction}`.length : 0);
-  const encodedQuery = encodeSearchQuery(query, Math.max(maxQueryLength, 0));
+  const encodedQuery = encodeSearchQuery(query, Math.max(maxQueryLength, 0), filters);
   return direction
     ? `${base}${encodedQuery}:${direction}`
     : `${base}${encodedQuery}`;
@@ -174,6 +223,27 @@ export function buildKeepTypingOption(query: string): { name: string; value: str
     name: label.slice(0, 100),
     value: query,
   };
+}
+
+export async function autocompleteSearchPlatform(
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  const rawQuery = focused?.value ? String(focused.value) : "";
+  const platforms = await Game.getAllPlatforms();
+  const query = rawQuery.toLowerCase().trim();
+  const filtered = query
+    ? platforms.filter((p) =>
+      p.name.toLowerCase().includes(query)
+        || (p.abbreviation ?? "").toLowerCase().includes(query)
+        || p.code.toLowerCase().includes(query),
+    )
+    : platforms;
+  const options = filtered.slice(0, 25).map((p) => ({
+    name: (p.abbreviation ? `${p.name} (${p.abbreviation})` : p.name).slice(0, 100),
+    value: String(p.id),
+  }));
+  await interaction.respond(options);
 }
 
 export async function autocompleteGameDbViewTitle(


### PR DESCRIPTION
## Summary

- Adds `unreleased` boolean option: filters to games with a future `INITIAL_RELEASE_DATE` (skips records with no release info)
- Adds `platform` autocomplete option: filters results to a specific platform using `GAMEDB_GAME_PLATFORMS`
- Adds `year` integer option: filters by first release year using `EXTRACT(YEAR FROM INITIAL_RELEASE_DATE)`
- Filter state is encoded into component custom IDs (null-byte embedded in base64url payload) so pagination and game selection continue applying the same filters
- Active filters are shown in the result list footer (e.g. *Filters: Unreleased only | Platform: PlayStation 5 | Year: 2023*)

## Test plan

- [ ] `/gamedb search title:Final Fantasy unreleased:true` - should return only unreleased FF entries
- [ ] `/gamedb search title:Zelda platform:<autocomplete>` - platform autocomplete populates, results filtered
- [ ] `/gamedb search title:Mario year:2023` - only 2023 releases returned
- [ ] Pagination (next/previous) preserves filters across pages
- [ ] Selecting a game from filtered results shows game profile correctly
- [ ] Refresh button re-runs search with same filters
- [ ] No filters applied = existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)