### PR TITLE
feat: make title optional in /gamedb search

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -1778,78 +1778,81 @@ export default class Game {
     const connection = await pool.getConnection();
     try {
       const baseQuery = query.trim();
-      if (!baseQuery) {
+      const hasFilters = filters.unreleased || filters.platformId || filters.year;
+      if (!baseQuery && !hasFilters) {
         return [];
       }
 
-      const queryVariants = new Set<string>();
-      queryVariants.add(baseQuery);
-      const spacedQuery = baseQuery
-        .replace(/([a-zA-Z])(\d)/g, "$1 $2")
-        .replace(/(\d)([a-zA-Z])/g, "$1 $2");
-      queryVariants.add(spacedQuery);
-
-      const tokens = spacedQuery.split(/\s+/).filter(Boolean);
-      const tokenOptions: string[][] = [];
-      for (const token of tokens) {
-        const options = new Set<string>();
-        options.add(token);
-        const tokenSynonyms = await GameSearchSynonym.getTermsForQuery(token, connection);
-        tokenSynonyms.forEach((synonym) => {
-          if (synonym.trim()) {
-            options.add(synonym.trim());
-          }
-        });
-        tokenOptions.push(Array.from(options));
-      }
-
-      if (tokenOptions.length) {
-        let variants: string[] = [""];
-        const MAX_VARIANTS = 50;
-        for (const options of tokenOptions) {
-          const nextVariants: string[] = [];
-          for (const prefix of variants) {
-            for (const option of options) {
-              const next = prefix ? `${prefix} ${option}` : option;
-              nextVariants.push(next);
-              if (nextVariants.length >= MAX_VARIANTS) break;
-            }
-            if (nextVariants.length >= MAX_VARIANTS) break;
-          }
-          variants = nextVariants;
-          if (variants.length >= MAX_VARIANTS) break;
-        }
-        variants.forEach((variant) => queryVariants.add(variant));
-      }
-
-      const termSet = new Map<string, string>();
-      Array.from(queryVariants).forEach((term) => {
-        const folded = foldAccentE(term).toLowerCase();
-        const norm = folded.replace(/[^a-z0-9]/g, "");
-        if (norm) {
-          termSet.set(norm, folded);
-        }
-      });
-
-      if (!termSet.size) {
-        return [];
-      }
-
-      const termEntries = Array.from(termSet.entries());
       const clauses: string[] = [];
       const binds: Record<string, string | number> = {};
-      const titleFoldExpr =
-        "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(TITLE), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')";
-      const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '')`;
-      termEntries.forEach(([norm, term], index) => {
-        const rawKey = `searchQuery${index}`;
-        const normKey = `normalizedQuery${index}`;
-        binds[rawKey] = `%${term}%`;
-        binds[normKey] = `%${norm}%`;
-        clauses.push(
-          `(${titleFoldExpr} LIKE :${rawKey} OR ${titleNormExpr} LIKE :${normKey})`,
-        );
-      });
+
+      if (baseQuery) {
+        const queryVariants = new Set<string>();
+        queryVariants.add(baseQuery);
+        const spacedQuery = baseQuery
+          .replace(/([a-zA-Z])(\d)/g, "$1 $2")
+          .replace(/(\d)([a-zA-Z])/g, "$1 $2");
+        queryVariants.add(spacedQuery);
+
+        const tokens = spacedQuery.split(/\s+/).filter(Boolean);
+        const tokenOptions: string[][] = [];
+        for (const token of tokens) {
+          const options = new Set<string>();
+          options.add(token);
+          const tokenSynonyms = await GameSearchSynonym.getTermsForQuery(token, connection);
+          tokenSynonyms.forEach((synonym) => {
+            if (synonym.trim()) {
+              options.add(synonym.trim());
+            }
+          });
+          tokenOptions.push(Array.from(options));
+        }
+
+        if (tokenOptions.length) {
+          let variants: string[] = [""];
+          const MAX_VARIANTS = 50;
+          for (const options of tokenOptions) {
+            const nextVariants: string[] = [];
+            for (const prefix of variants) {
+              for (const option of options) {
+                const next = prefix ? `${prefix} ${option}` : option;
+                nextVariants.push(next);
+                if (nextVariants.length >= MAX_VARIANTS) break;
+              }
+              if (nextVariants.length >= MAX_VARIANTS) break;
+            }
+            variants = nextVariants;
+            if (variants.length >= MAX_VARIANTS) break;
+          }
+          variants.forEach((variant) => queryVariants.add(variant));
+        }
+
+        const termSet = new Map<string, string>();
+        Array.from(queryVariants).forEach((term) => {
+          const folded = foldAccentE(term).toLowerCase();
+          const norm = folded.replace(/[^a-z0-9]/g, "");
+          if (norm) {
+            termSet.set(norm, folded);
+          }
+        });
+
+        if (!termSet.size) {
+          return [];
+        }
+
+        const titleFoldExpr =
+          "REPLACE(REPLACE(REPLACE(REPLACE(LOWER(TITLE), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')";
+        const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '')`;
+        Array.from(termSet.entries()).forEach(([norm, term], index) => {
+          const rawKey = `searchQuery${index}`;
+          const normKey = `normalizedQuery${index}`;
+          binds[rawKey] = `%${term}%`;
+          binds[normKey] = `%${norm}%`;
+          clauses.push(
+            `(${titleFoldExpr} LIKE :${rawKey} OR ${titleNormExpr} LIKE :${normKey})`,
+          );
+        });
+      }
 
       const filterClauses: string[] = [];
       if (filters.unreleased) {
@@ -1868,10 +1871,11 @@ export default class Game {
         binds["filterYear"] = filters.year;
       }
 
-      const titleWhereClause = clauses.length ? clauses.join(" OR ") : "1=0";
-      const filterWhere = filterClauses.length
-        ? ` AND (${filterClauses.join(" AND ")})`
-        : "";
+      const titlePart = clauses.length ? `(${clauses.join(" OR ")})` : "";
+      const filterPart = filterClauses.length ? `(${filterClauses.join(" AND ")})` : "";
+      const whereClause = titlePart && filterPart
+        ? `${titlePart} AND ${filterPart}`
+        : titlePart || filterPart || "1=0";
 
       const result = await connection.execute<{
         GAME_ID: number;
@@ -1890,7 +1894,7 @@ export default class Game {
         `SELECT GAME_ID, TITLE, DESCRIPTION, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL, FEATURED_VIDEO_URL,
                 INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
            FROM GAMEDB_GAMES
-          WHERE (${titleWhereClause})${filterWhere}
+          WHERE ${whereClause}
           ORDER BY TITLE ASC`,
         binds,
         {

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -70,11 +70,15 @@ export async function runSearchFlow(
   const results = await Game.searchGames(searchTerm, activeFilters);
 
   if (results.length === 0) {
-    await handleNoResults(interaction, searchTerm || rawQuery || "Unknown");
+    if (!searchTerm) {
+      await safeReply(interaction, buildTextReply("No games found matching your filters.", true));
+    } else {
+      await handleNoResults(interaction, searchTerm || rawQuery || "Unknown");
+    }
     return;
   }
 
-  if (results.length === 1 && !Object.keys(activeFilters).length) {
+  if (results.length === 1 && searchTerm && !Object.keys(activeFilters).length) {
     await showGameProfile(interaction, results[0].id);
     return;
   }
@@ -210,12 +214,12 @@ export class GameDbSearchCommand {
   @Slash({ description: "Search for a game", name: "search" })
   async search(
     @SlashOption({
-      description: "Search query (game title).",
+      description: "Search query (game title). Optional if other filters are provided.",
       name: "title",
-      required: true,
+      required: false,
       type: ApplicationCommandOptionType.String,
     })
-    query: string,
+    query: string | null,
     @SlashOption({
       description: "Filter to games with a future release date (must have release info).",
       name: "unreleased",
@@ -245,7 +249,7 @@ export class GameDbSearchCommand {
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(false) });
 
     try {
-      const searchTerm = sanitizeUserInput(query, { preserveNewlines: false });
+      const searchTerm = query ? sanitizeUserInput(query, { preserveNewlines: false }) : "";
       const filters: ISearchFilters = {};
       if (unreleased === true) filters.unreleased = true;
       const platformId = platformValue ? Number(platformValue) : null;
@@ -253,7 +257,14 @@ export class GameDbSearchCommand {
         filters.platformId = platformId;
       }
       if (year && Number.isInteger(year) && year > 0) filters.year = year;
-      await runSearchFlow(interaction, searchTerm, query, filters);
+      const hasFilters = filters.unreleased || filters.platformId || filters.year;
+      if (!searchTerm && !hasFilters) {
+        await safeReply(interaction, buildTextReply(
+          "Please provide a title or at least one filter (unreleased, platform, or year).", true,
+        ));
+        return;
+      }
+      await runSearchFlow(interaction, searchTerm, query ?? undefined, filters);
     } catch (error: any) {
       await safeReply(interaction, buildTextReply(
         `Failed to search games. Error: ${error.message}`, true,


### PR DESCRIPTION
## Summary

- `title` is now an optional parameter on `/gamedb search`
- When title is omitted, `searchGames` skips the title WHERE clause entirely and returns all games matching the active filters
- When neither title nor any filter is provided, the bot replies with a usage hint instead of querying
- With an empty title and filters returning no results, shows "No games found matching your filters." instead of the IGDB import prompt
- Single-result shortcut to game profile is preserved when a title is given with no filters, but intentionally skipped when browsing by filters only

## Test plan

- [ ] `/gamedb search unreleased:true` - lists upcoming games, no title needed
- [ ] `/gamedb search platform:<PS5>` - all PS5 games paginated
- [ ] `/gamedb search year:2024` - all 2024 releases
- [ ] `/gamedb search platform:<PS5> year:2024` - combined filters, no title
- [ ] `/gamedb search` (no args) - responds with usage hint
- [ ] `/gamedb search title:Zelda` - existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)