### PR TITLE
fix: handle filter-only searches in page/select/refresh handlers

### DIFF
--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -288,7 +288,9 @@ export class GameDbSearchCommand {
       decodeSearchQuery(encodedQuery),
       { preserveNewlines: false },
     );
-    if (!searchTerm) {
+    const filters = decodeISearchFilters(encodedQuery);
+    const hasFilters = filters.unreleased || filters.platformId || filters.year;
+    if (!searchTerm && !hasFilters) {
       const recoveryComponents = buildSearchRecoveryComponents(ownerId, encodedQuery);
       const textParts = buildTextReply(
         "This search request expired. Refresh to run it again.", true,
@@ -296,12 +298,10 @@ export class GameDbSearchCommand {
       await safeReply(interaction, {
         components: [...textParts.components, ...recoveryComponents],
         flags: textParts.flags,
-        __forceFollowUp: true,
       });
       return;
     }
 
-    const filters = decodeISearchFilters(encodedQuery);
     const results = await Game.searchGames(searchTerm, filters);
 
     const gameId = Number(interaction.values?.[0]);
@@ -362,7 +362,9 @@ export class GameDbSearchCommand {
       decodeSearchQuery(encodedQuery),
       { preserveNewlines: false },
     );
-    if (!searchTerm) {
+    const filters = decodeISearchFilters(encodedQuery);
+    const hasFilters = filters.unreleased || filters.platformId || filters.year;
+    if (!searchTerm && !hasFilters) {
       const recoveryComponents = buildSearchRecoveryComponents(ownerId, encodedQuery);
       const textParts = buildTextReply(
         "This search request expired. Refresh to run it again.", true,
@@ -370,12 +372,10 @@ export class GameDbSearchCommand {
       await safeReply(interaction, {
         components: [...textParts.components, ...recoveryComponents],
         flags: textParts.flags,
-        __forceFollowUp: true,
       });
       return;
     }
 
-    const filters = decodeISearchFilters(encodedQuery);
     const results = await Game.searchGames(searchTerm, filters);
     const totalPages = Math.max(
       1,
@@ -422,21 +422,21 @@ export class GameDbSearchCommand {
       decodeSearchQuery(encodedQuery),
       { preserveNewlines: false },
     );
-    if (!searchTerm) {
-      await safeReply(interaction, {
-        ...buildTextReply("Unable to refresh: search details were not found.", true),
-        __forceFollowUp: true,
-      });
+    const filters = decodeISearchFilters(encodedQuery);
+    const hasFilters = filters.unreleased || filters.platformId || filters.year;
+    if (!searchTerm && !hasFilters) {
+      await safeReply(interaction, buildTextReply(
+        "Unable to refresh: search details were not found.", true,
+      ));
       return;
     }
 
-    const filters = decodeISearchFilters(encodedQuery);
     const results = await Game.searchGames(searchTerm, filters);
     if (results.length === 0) {
-      await safeReply(interaction, {
-        ...buildTextReply(`No results found for "${searchTerm}".`, true),
-        __forceFollowUp: true,
-      });
+      const msg = searchTerm
+        ? `No results found for "${searchTerm}".`
+        : "No games found matching your filters.";
+      await safeReply(interaction, buildTextReply(msg, true));
       return;
     }
 


### PR DESCRIPTION
## Root cause

When a user ran a filter-only search (no title), `decodeSearchQuery` returned `""` because the encoded payload has no text before the null-byte separator. All three component handlers checked `if (!searchTerm)` and entered an "expired search" branch that called `safeReply` with `__forceFollowUp: true` on an **unacknowledged** button interaction. Discord rejected the `followUp()` call with error 10062 ("Unknown interaction"), which `isAckError` swallowed silently — leaving the interaction permanently unacknowledged and showing the user "Interaction failed".

## Fix

- Decode filters **before** the expiry check in all three handlers (`handleSearchSelect`, `handleSearchPage`, `handleSearchRefresh`)
- Change expiry condition from `!searchTerm` to `!searchTerm && !hasFilters`
- Remove `__forceFollowUp` from early-exit branches that run before the interaction is acknowledged (those branches should do a direct `reply`, not `followUp`)
- Improve the no-results message in `handleSearchRefresh` to say "No games found matching your filters." when no title was given

## Test plan

- [ ] `/gamedb search platform:<PS5>` then click Next Page — should paginate correctly
- [ ] `/gamedb search unreleased:true` then click Next Page — should paginate correctly
- [ ] `/gamedb search title:Mario` then click Next Page — existing behavior unchanged
- [ ] Old interactions (pre-fix) — selecting from an expired result shows the "expired" message instead of silently failing

🤖 Generated with [Claude Code](https://claude.com/claude-code)