### PR TITLE
feat: upcoming release date in search results, rename unreleased filter

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -50,6 +50,10 @@ export interface IGameWithPlatforms extends IGame {
   platforms: IPlatformDef[];
 }
 
+export interface IGameSearchResult extends IGameWithPlatforms {
+  upcomingReleaseDate: Date | null;
+}
+
 export interface IGameAutocompleteResult {
   id: number;
   title: string;
@@ -1772,13 +1776,13 @@ export default class Game {
 
   static async searchGames(
     query: string,
-    filters: { unreleased?: boolean; platformId?: number; year?: number } = {},
-  ): Promise<IGameWithPlatforms[]> {
+    filters: { upcomingRelease?: boolean; platformId?: number; year?: number } = {},
+  ): Promise<IGameSearchResult[]> {
     const pool = getOraclePool();
     const connection = await pool.getConnection();
     try {
       const baseQuery = query.trim();
-      const hasFilters = filters.unreleased || filters.platformId || filters.year;
+      const hasFilters = filters.upcomingRelease || filters.platformId || filters.year;
       if (!baseQuery && !hasFilters) {
         return [];
       }
@@ -1855,9 +1859,9 @@ export default class Game {
       }
 
       const filterClauses: string[] = [];
-      if (filters.unreleased) {
+      if (filters.upcomingRelease) {
         filterClauses.push(
-          "INITIAL_RELEASE_DATE IS NOT NULL AND INITIAL_RELEASE_DATE > SYSDATE",
+          "GAME_ID IN (SELECT DISTINCT GAME_ID FROM GAMEDB_RELEASES WHERE RELEASE_DATE > SYSDATE)",
         );
       }
       if (filters.platformId) {
@@ -1890,12 +1894,15 @@ export default class Game {
         INITIAL_RELEASE_DATE: Date | null;
         CREATED_AT: Date;
         UPDATED_AT: Date;
+        UPCOMING_RELEASE_DATE: Date | null;
       }>(
-        `SELECT GAME_ID, TITLE, DESCRIPTION, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL, FEATURED_VIDEO_URL,
-                INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
-           FROM GAMEDB_GAMES
+        `SELECT g.GAME_ID, g.TITLE, g.DESCRIPTION, g.IGDB_ID, g.SLUG, g.TOTAL_RATING,
+                g.IGDB_URL, g.FEATURED_VIDEO_URL, g.INITIAL_RELEASE_DATE, g.CREATED_AT, g.UPDATED_AT,
+                (SELECT MIN(r.RELEASE_DATE) FROM GAMEDB_RELEASES r
+                  WHERE r.GAME_ID = g.GAME_ID AND r.RELEASE_DATE > SYSDATE) AS UPCOMING_RELEASE_DATE
+           FROM GAMEDB_GAMES g
           WHERE ${whereClause}
-          ORDER BY TITLE ASC`,
+          ORDER BY UPCOMING_RELEASE_DATE ASC NULLS LAST, TITLE ASC`,
         binds,
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
@@ -1903,30 +1910,43 @@ export default class Game {
         },
       );
 
-      // Map rows, but exclude imageData to keep search results lightweight
-      const games: IGame[] = (result.rows ?? []).map(row => ({
-        id: Number(row.GAME_ID),
-        title: String(row.TITLE),
-        description: row.DESCRIPTION ? String(row.DESCRIPTION) : null,
-        imageData: null,
-        thumbnailBad: false,
-        thumbnailApproved: false,
-        igdbId: row.IGDB_ID ? Number(row.IGDB_ID) : null,
-        slug: row.SLUG ? String(row.SLUG) : null,
-        totalRating: row.TOTAL_RATING ? Number(row.TOTAL_RATING) : null,
-        igdbUrl: row.IGDB_URL ? String(row.IGDB_URL) : null,
-        featuredVideoUrl: row.FEATURED_VIDEO_URL ? String(row.FEATURED_VIDEO_URL) : null,
-        initialReleaseDate: row.INITIAL_RELEASE_DATE instanceof Date
-          ? row.INITIAL_RELEASE_DATE
-          : row.INITIAL_RELEASE_DATE
-            ? new Date(row.INITIAL_RELEASE_DATE)
-            : null,
-        createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT),
-        updatedAt: row.UPDATED_AT instanceof Date ? row.UPDATED_AT : new Date(row.UPDATED_AT),
-        coverUrl: null,
-      }));
+      const upcomingDates = new Map<number, Date | null>();
+      const games: IGame[] = (result.rows ?? []).map(row => {
+        const id = Number(row.GAME_ID);
+        const upcomingDate = row.UPCOMING_RELEASE_DATE instanceof Date
+          ? row.UPCOMING_RELEASE_DATE
+          : row.UPCOMING_RELEASE_DATE
+            ? new Date(row.UPCOMING_RELEASE_DATE)
+            : null;
+        upcomingDates.set(id, upcomingDate);
+        return {
+          id,
+          title: String(row.TITLE),
+          description: row.DESCRIPTION ? String(row.DESCRIPTION) : null,
+          imageData: null,
+          thumbnailBad: false,
+          thumbnailApproved: false,
+          igdbId: row.IGDB_ID ? Number(row.IGDB_ID) : null,
+          slug: row.SLUG ? String(row.SLUG) : null,
+          totalRating: row.TOTAL_RATING ? Number(row.TOTAL_RATING) : null,
+          igdbUrl: row.IGDB_URL ? String(row.IGDB_URL) : null,
+          featuredVideoUrl: row.FEATURED_VIDEO_URL ? String(row.FEATURED_VIDEO_URL) : null,
+          initialReleaseDate: row.INITIAL_RELEASE_DATE instanceof Date
+            ? row.INITIAL_RELEASE_DATE
+            : row.INITIAL_RELEASE_DATE
+              ? new Date(row.INITIAL_RELEASE_DATE)
+              : null,
+          createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT),
+          updatedAt: row.UPDATED_AT instanceof Date ? row.UPDATED_AT : new Date(row.UPDATED_AT),
+          coverUrl: null,
+        };
+      });
 
-      return await Game.attachPlatformsToGames(games);
+      const withPlatforms = await Game.attachPlatformsToGames(games);
+      return withPlatforms.map(g => ({
+        ...g,
+        upcomingReleaseDate: upcomingDates.get(g.id) ?? null,
+      }));
     } finally {
       await connection.close();
     }

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -49,9 +49,19 @@ import {
 } from "./gamedb-profile.service.js";
 import { handleNoResults } from "./gamedb-add.command.js";
 
+function formatUpcomingDate(date: Date | null | undefined): string {
+  if (!date) return "";
+  const d = date instanceof Date ? date : new Date(date);
+  if (Number.isNaN(d.getTime())) return "";
+  const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(d.getUTCDate()).padStart(2, "0");
+  const yyyy = d.getUTCFullYear();
+  return `\`${mm}/${dd}/${yyyy}\``;
+}
+
 async function buildFilterSummary(filters: ISearchFilters): Promise<string> {
   const parts: string[] = [];
-  if (filters.unreleased) parts.push("Unreleased only");
+  if (filters.upcomingRelease) parts.push("Upcoming release");
   if (filters.platformId) {
     const platform = await Game.getPlatformById(filters.platformId);
     parts.push(`Platform: ${platform?.name ?? `ID ${filters.platformId}`}`);
@@ -116,18 +126,13 @@ function buildSearchResponse(
   });
   const resultList = displayedResults.map((game) => {
     const title = String(game.title ?? "");
-    const isDuplicate = (titleCounts.get(title) ?? 0) > 1;
-    if (!isDuplicate) {
-      return `• **${title}**`;
-    }
-    const releaseDate = game.initialReleaseDate as Date | null | undefined;
-    const year = releaseDate instanceof Date
-      ? releaseDate.getFullYear()
-      : releaseDate
-        ? new Date(releaseDate).getFullYear()
-        : null;
-    const yearText = year ? ` (${year})` : " (Unknown Year)";
-    return `• **${title}**${yearText}`;
+    const dateStr = formatUpcomingDate(game.upcomingReleaseDate);
+    const platforms: string[] = (game.platforms ?? []).map(
+      (p: any) => p.abbreviation ?? p.name,
+    );
+    const platformStr = platforms.length ? ` ${platforms.join(", ")}` : "";
+    const datePart = dateStr ? `${dateStr} ` : "";
+    return `• ${datePart}**${title}**${platformStr}`;
   }).join("\n");
 
   const title = searchTerm
@@ -221,12 +226,12 @@ export class GameDbSearchCommand {
     })
     query: string | null,
     @SlashOption({
-      description: "Filter to games with a future release date (must have release info).",
-      name: "unreleased",
+      description: "Filter to games with any upcoming release (including games already out on other platforms).",
+      name: "upcoming_release",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    unreleased: boolean | null,
+    upcomingRelease: boolean | null,
     @SlashOption({
       description: "Filter to a specific platform.",
       name: "platform",
@@ -251,16 +256,16 @@ export class GameDbSearchCommand {
     try {
       const searchTerm = query ? sanitizeUserInput(query, { preserveNewlines: false }) : "";
       const filters: ISearchFilters = {};
-      if (unreleased === true) filters.unreleased = true;
+      if (upcomingRelease === true) filters.upcomingRelease = true;
       const platformId = platformValue ? Number(platformValue) : null;
       if (platformId && Number.isInteger(platformId) && platformId > 0) {
         filters.platformId = platformId;
       }
       if (year && Number.isInteger(year) && year > 0) filters.year = year;
-      const hasFilters = filters.unreleased || filters.platformId || filters.year;
+      const hasFilters = filters.upcomingRelease || filters.platformId || filters.year;
       if (!searchTerm && !hasFilters) {
         await safeReply(interaction, buildTextReply(
-          "Please provide a title or at least one filter (unreleased, platform, or year).", true,
+          "Please provide a title or at least one filter (upcoming_release, platform, or year).", true,
         ));
         return;
       }
@@ -289,7 +294,7 @@ export class GameDbSearchCommand {
       { preserveNewlines: false },
     );
     const filters = decodeISearchFilters(encodedQuery);
-    const hasFilters = filters.unreleased || filters.platformId || filters.year;
+    const hasFilters = filters.upcomingRelease || filters.platformId || filters.year;
     if (!searchTerm && !hasFilters) {
       const recoveryComponents = buildSearchRecoveryComponents(ownerId, encodedQuery);
       const textParts = buildTextReply(
@@ -363,7 +368,7 @@ export class GameDbSearchCommand {
       { preserveNewlines: false },
     );
     const filters = decodeISearchFilters(encodedQuery);
-    const hasFilters = filters.unreleased || filters.platformId || filters.year;
+    const hasFilters = filters.upcomingRelease || filters.platformId || filters.year;
     if (!searchTerm && !hasFilters) {
       const recoveryComponents = buildSearchRecoveryComponents(ownerId, encodedQuery);
       const textParts = buildTextReply(
@@ -423,7 +428,7 @@ export class GameDbSearchCommand {
       { preserveNewlines: false },
     );
     const filters = decodeISearchFilters(encodedQuery);
-    const hasFilters = filters.unreleased || filters.platformId || filters.year;
+    const hasFilters = filters.upcomingRelease || filters.platformId || filters.year;
     if (!searchTerm && !hasFilters) {
       await safeReply(interaction, buildTextReply(
         "Unable to refresh: search details were not found.", true,

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -14,14 +14,14 @@ import { decodeBase64Url, encodeBase64Url } from "../../functions/CustomIdUtils.
 import Game from "../../classes/Game.js";
 
 export interface ISearchFilters {
-  unreleased?: boolean;
+  upcomingRelease?: boolean;
   platformId?: number;
   year?: number;
 }
 
 function compactFilters(filters: ISearchFilters): string {
   let result = "";
-  if (filters.unreleased) result += "u";
+  if (filters.upcomingRelease) result += "u";
   if (filters.platformId) result += `p${filters.platformId}`;
   if (filters.year) result += `y${filters.year}`;
   return result;
@@ -29,7 +29,7 @@ function compactFilters(filters: ISearchFilters): string {
 
 function parseCompactFilters(filterStr: string): ISearchFilters {
   const filters: ISearchFilters = {};
-  if (filterStr.includes("u")) filters.unreleased = true;
+  if (filterStr.includes("u")) filters.upcomingRelease = true;
   const platformMatch = filterStr.match(/p(\d+)/);
   if (platformMatch) filters.platformId = Number(platformMatch[1]);
   const yearMatch = filterStr.match(/y(\d{4})/);


### PR DESCRIPTION
## Summary

- Renames `unreleased` filter to `upcomingRelease` (Discord option name: `upcoming_release`)
- Updated filter logic: matches any game with a future date in `GAMEDB_RELEASES` -- games already released on other platforms but with an upcoming release on another are now included
- `searchGames` now includes a correlated subquery for `UPCOMING_RELEASE_DATE` (min future release date per game) and sorts by it ASC NULLS LAST, then title
- Search result rows now display: `` `MM/DD/YYYY` **Title** Platform1, Platform2 ``
- Adds `IGameSearchResult` interface extending `IGameWithPlatforms` with `upcomingReleaseDate: Date | null`

## Test plan

- [ ] `/gamedb search upcoming_release:true` -- lists games with any upcoming platform release, sorted by date
- [ ] A game released on PS5 but with a future PC release should appear in the upcoming list
- [ ] Result rows show `` `MM/DD/YYYY` `` before the title when an upcoming date exists; no date shown when none
- [ ] Platform abbreviations appear after the title (e.g. `PS5, PC`)
- [ ] Pagination and game selection still work correctly
- [ ] Games with no upcoming release sort to the bottom (NULLS LAST)

🤖 Generated with [Claude Code](https://claude.com/claude-code)