### PR TITLE
fix: use release date and platforms as select option description

### DIFF
--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -154,10 +154,24 @@ function buildSearchResponse(
       const yearText = year ? ` (${year})` : " (Unknown Year)";
       label = `${gameTitle}${yearText}`;
     }
+    const upcomingDate = game.upcomingReleaseDate as Date | null | undefined;
+    const dateLabel = upcomingDate
+      ? (() => {
+        const d = upcomingDate instanceof Date ? upcomingDate : new Date(upcomingDate);
+        const mm = String(d.getUTCMonth() + 1).padStart(2, "0");
+        const dd = String(d.getUTCDate()).padStart(2, "0");
+        const yyyy = d.getUTCFullYear();
+        return `${mm}/${dd}/${yyyy}`;
+      })()
+      : null;
+    const releasePlatforms: string[] = game.upcomingReleasePlatforms
+      ?? (game.platforms ?? []).map((p: any) => p.abbreviation ?? p.name);
+    const platformLabel = releasePlatforms.length ? ` (${releasePlatforms.join(", ")})` : "";
+    const description = dateLabel ? `${dateLabel}${platformLabel}` : undefined;
     return {
       label: label.substring(0, 100),
       value: String(game.id),
-      description: "View this game",
+      ...(description ? { description: description.substring(0, 100) } : {}),
     };
   });
 


### PR DESCRIPTION
## Summary

Replaces the static `"View this game"` description on each select menu option with the upcoming release date and associated platforms, e.g. `06/15/2026 (PS5, PC)`. If a game has no upcoming release date the description is omitted entirely (Discord allows optional descriptions).

Uses `upcomingReleasePlatforms` when available (populated by #521), with a fallback to `game.platforms` for compatibility before that PR merges.

## Test plan

- [ ] Select options for games with an upcoming release show `MM/DD/YYYY (Platform1, Platform2)`
- [ ] Select options for already-released games with no upcoming date show no description
- [ ] Description is truncated to 100 chars if somehow over the limit

🤖 Generated with [Claude Code](https://claude.com/claude-code)