### PR TITLE
fix: rename 'All Games' to 'Upcoming Releases' and wrap platforms in parens

### DIFF
--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -128,14 +128,14 @@ function buildSearchResponse(
     const title = String(game.title ?? "");
     const dateStr = formatUpcomingDate(game.upcomingReleaseDate);
     const platforms: string[] = game.upcomingReleasePlatforms ?? [];
-    const platformStr = platforms.length ? ` ${platforms.join(", ")}` : "";
+    const platformStr = platforms.length ? ` (${platforms.join(", ")})` : "";
     const datePart = dateStr ? `${dateStr} ` : "";
     return `• ${datePart}**${title}**${platformStr}`;
   }).join("\n");
 
   const title = searchTerm
     ? `Search Results for "${searchTerm}" (Page ${safePage + 1}/${totalPages})`
-    : `All Games (Page ${safePage + 1}/${totalPages})`;
+    : `Upcoming Releases (Page ${safePage + 1}/${totalPages})`;
 
   const selectCustomId = buildSearchCustomId("select", ownerId, safePage, searchTerm, undefined, filters);
   const options = displayedResults.map((game) => {


### PR DESCRIPTION
## Summary
- Heading when no search term is provided now reads **Upcoming Releases** instead of **All Games**
- Platform names in result rows are now wrapped in parentheses: `(PS5, PC)` instead of `PS5, PC`

## Test plan
- [ ] Run `/gamedb search upcoming_release:true` and confirm the header reads "Upcoming Releases (Page 1/N)"
- [ ] Confirm each result row renders platforms as `\`MM/DD/YYYY\` **Title** (Platform1, Platform2)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)