### PR TITLE
fix: GameDB Search title, platform-only sort, show platforms for released games

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -1915,7 +1915,7 @@ export default class Game {
            FROM GAMEDB_GAMES g
            LEFT JOIN upcoming u ON u.GAME_ID = g.GAME_ID
           WHERE ${whereClause}
-          ORDER BY u.UPCOMING_DATE ASC NULLS LAST, g.TITLE ASC`,
+          ORDER BY ${filters.upcomingRelease ? "u.UPCOMING_DATE ASC NULLS LAST, " : ""}g.TITLE ASC`,
         binds,
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -127,7 +127,9 @@ function buildSearchResponse(
   const resultList = displayedResults.map((game) => {
     const title = String(game.title ?? "");
     const dateStr = formatUpcomingDate(game.upcomingReleaseDate);
-    const platforms: string[] = game.upcomingReleasePlatforms ?? [];
+    const platforms: string[] = game.upcomingReleasePlatforms?.length
+      ? game.upcomingReleasePlatforms
+      : (game.platforms ?? []).map((p: any) => p.abbreviation ?? p.name);
     const platformStr = platforms.length ? ` (${platforms.join(", ")})` : "";
     const datePart = dateStr ? `${dateStr} ` : "";
     return `• ${datePart}**${title}**${platformStr}`;
@@ -135,7 +137,7 @@ function buildSearchResponse(
 
   const title = searchTerm
     ? `Search Results for "${searchTerm}" (Page ${safePage + 1}/${totalPages})`
-    : `Upcoming Releases (Page ${safePage + 1}/${totalPages})`;
+    : `GameDB Search (Page ${safePage + 1}/${totalPages})`;
 
   const selectCustomId = buildSearchCustomId("select", ownerId, safePage, searchTerm, undefined, filters);
   const options = displayedResults.map((game) => {


### PR DESCRIPTION
## Summary
- Heading when no search term is provided now reads **GameDB Search** instead of **Upcoming Releases**
- Sort order only uses upcoming date as primary key when `upcomingRelease` filter is active; platform/year/title-only searches sort alphabetically
- Result rows now fall back to `game.platforms` for the platform list when a game has no upcoming release, so released games show their platforms too

## Test plan
- [ ] `/gamedb search platform:<PS5>` -- results should be alphabetical, each row should show platform(s)
- [ ] `/gamedb search upcoming_release:true` -- results should be ordered by upcoming date ASC, platforms shown for upcoming releases
- [ ] `/gamedb search upcoming_release:true platform:<PS5>` -- filtered to PS5 games with upcoming releases, ordered by date

🤖 Generated with [Claude Code](https://claude.com/claude-code)