### PR TITLE
feat: hide dates and sort by title when upcoming_release filter is not set

### DIFF
--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -124,9 +124,10 @@ function buildSearchResponse(
     const title = String(game.title ?? "");
     titleCounts.set(title, (titleCounts.get(title) ?? 0) + 1);
   });
+  const showDates = filters?.upcomingRelease === true;
   const resultList = displayedResults.map((game) => {
     const title = String(game.title ?? "");
-    const dateStr = formatUpcomingDate(game.upcomingReleaseDate);
+    const dateStr = showDates ? formatUpcomingDate(game.upcomingReleaseDate) : "";
     const platforms: string[] = game.upcomingReleasePlatforms?.length
       ? game.upcomingReleasePlatforms
       : (game.platforms ?? []).map((p: any) => p.abbreviation ?? p.name);
@@ -154,7 +155,7 @@ function buildSearchResponse(
       const yearText = year ? ` (${year})` : " (Unknown Year)";
       label = `${gameTitle}${yearText}`;
     }
-    const upcomingDate = game.upcomingReleaseDate as Date | null | undefined;
+    const upcomingDate = showDates ? (game.upcomingReleaseDate as Date | null | undefined) : null;
     const dateLabel = upcomingDate
       ? (() => {
         const d = upcomingDate instanceof Date ? upcomingDate : new Date(upcomingDate);


### PR DESCRIPTION
## Summary
- In GameDB search results, dates are now only shown when the `upcoming_release` filter is `true`
- When `upcoming_release` is not set, results are sorted by title ascending (was already the SQL default; dates no longer appear in the list or select menu descriptions)

## Test plan
- [ ] Run `/gamedb search title:some game` (no `upcoming_release` flag) -- verify no dates appear in the result list or dropdown descriptions, results sorted by title
- [ ] Run `/gamedb search upcoming_release:true` -- verify dates still appear as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)