### PR TITLE
fix: catch errors in /collection list and timeout IGDB token fetch

### DIFF
--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -143,18 +143,25 @@ export class CollectionViewCommand {
       : undefined;
 
     const memberLabel = resolveMemberLabel(member, interaction.user);
-    const response = await buildCollectionListResponse({
-      viewerUserId: interaction.user.id,
-      targetUserId,
-      memberLabel,
-      title: titleFilter,
-      platform: platformFilter,
-      platformId: undefined,
-      platformLabel: platformFilter,
-      ownershipType,
-      page: 0,
-      isEphemeral,
-    });
+    let response: Awaited<ReturnType<typeof buildCollectionListResponse>>;
+    try {
+      response = await buildCollectionListResponse({
+        viewerUserId: interaction.user.id,
+        targetUserId,
+        memberLabel,
+        title: titleFilter,
+        platform: platformFilter,
+        platformId: undefined,
+        platformLabel: platformFilter,
+        ownershipType,
+        page: 0,
+        isEphemeral,
+      });
+    } catch (err) {
+      console.error("[collection list] Failed to build response:", err);
+      await safeReply(interaction, buildTextReply("Failed to load your collection. Please try again.", true));
+      return;
+    }
 
     if (response.content) {
       await safeReply(interaction, response.content);

--- a/src/services/IGDB/IgdbService.ts
+++ b/src/services/IGDB/IgdbService.ts
@@ -99,6 +99,8 @@ class IgdbService {
       const response = await axios.post<ITwitchAuthResponse>(
         `https://id.twitch.tv/oauth2/token?client_id=${this.clientId}` +
         `&client_secret=${this.clientSecret}&grant_type=client_credentials`,
+        null,
+        { timeout: 8000 },
       );
 
       this.accessToken = response.data.access_token;


### PR DESCRIPTION
## Summary

Two causes of silent hangs after the interaction was acknowledged:

1. **No error handling in the list command** -- any exception thrown after `safeDeferReply` produced zero user feedback; the deferred interaction just expired silently. Added a try-catch that sends an ephemeral error reply and logs the error.

2. **`getAccessToken()` had no timeout** -- the Twitch auth POST could hang indefinitely, stalling the thumbnail fetch even after the 8s timeout added to the IGDB API call in #527. Added an 8s timeout to the token fetch as well.

## Test plan

- [ ] Run \`/collection list\` normally -- confirm it still works
- [ ] Temporarily break IGDB credentials and run \`/collection list\` -- confirm an error message appears within ~8s instead of hanging until the interaction expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)