### PR TITLE
debug: add step logs and 20s timeout to /collection list hang

### DIFF
--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -404,7 +404,9 @@ async function buildCollectionThumbnails(
   if (!entries.length) return thumbnailsByGameId;
 
   const uniqueGameIds = [...new Set(entries.map((e) => e.gameId))];
+  console.log("[collection-list] thumbnails: getGameById start", { count: uniqueGameIds.length });
   const games = await Promise.all(uniqueGameIds.map((id) => Game.getGameById(id)));
+  console.log("[collection-list] thumbnails: getGameById done");
 
   const igdbIdsByGameId = new Map<number, number>();
   for (let i = 0; i < uniqueGameIds.length; i++) {
@@ -414,10 +416,13 @@ async function buildCollectionThumbnails(
 
   if (!igdbIdsByGameId.size) return thumbnailsByGameId;
 
+  console.log("[collection-list] thumbnails: getCoversForGames start", { count: igdbIdsByGameId.size });
   let imageIdsByIgdbId: Map<number, string>;
   try {
     imageIdsByIgdbId = await igdbService.getCoversForGames([...igdbIdsByGameId.values()]);
-  } catch {
+    console.log("[collection-list] thumbnails: getCoversForGames done");
+  } catch (err) {
+    console.error("[collection-list] thumbnails: getCoversForGames failed", err);
     return thumbnailsByGameId;
   }
 
@@ -482,6 +487,7 @@ async function buildCollectionListResponse(params: {
   components: Array<ContainerBuilder | ActionRowBuilder<any>>;
   content?: string;
 }> {
+  console.log("[collection-list] step: searchEntries start", { targetUserId: params.targetUserId });
   const entries = await UserGameCollection.searchEntries({
     targetUserId: params.targetUserId,
     title: params.title,
@@ -489,6 +495,7 @@ async function buildCollectionListResponse(params: {
     platformId: params.platformId,
     ownershipType: params.ownershipType,
   });
+  console.log("[collection-list] step: searchEntries done", { count: entries.length });
 
   const total = entries.length;
   if (!total) {
@@ -530,7 +537,9 @@ async function buildCollectionListResponse(params: {
     params.platformId ? `platform-id=${params.platformId}` : null,
     params.ownershipType ? `ownership=${params.ownershipType}` : null,
   ].filter(Boolean).join(" | ");
+  console.log("[collection-list] step: buildThumbnails start", { pageEntryCount: pageEntries.length });
   const thumbnailsByGameId = await buildCollectionThumbnails(pageEntries);
+  console.log("[collection-list] step: buildThumbnails done", { count: thumbnailsByGameId.size });
   const components: Array<ContainerBuilder | ActionRowBuilder<any>> = [];
 
   const headerContainer = new ContainerBuilder().addTextDisplayComponents(

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -145,18 +145,24 @@ export class CollectionViewCommand {
     const memberLabel = resolveMemberLabel(member, interaction.user);
     let response: Awaited<ReturnType<typeof buildCollectionListResponse>>;
     try {
-      response = await buildCollectionListResponse({
-        viewerUserId: interaction.user.id,
-        targetUserId,
-        memberLabel,
-        title: titleFilter,
-        platform: platformFilter,
-        platformId: undefined,
-        platformLabel: platformFilter,
-        ownershipType,
-        page: 0,
-        isEphemeral,
-      });
+      const timeoutMs = 20_000;
+      response = await Promise.race([
+        buildCollectionListResponse({
+          viewerUserId: interaction.user.id,
+          targetUserId,
+          memberLabel,
+          title: titleFilter,
+          platform: platformFilter,
+          platformId: undefined,
+          platformLabel: platformFilter,
+          ownershipType,
+          page: 0,
+          isEphemeral,
+        }),
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error(`collection list timed out after ${timeoutMs}ms`)), timeoutMs),
+        ),
+      ]);
     } catch (err) {
       console.error("[collection list] Failed to build response:", err);
       await safeReply(interaction, buildTextReply("Failed to load your collection. Please try again.", true));

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -143,18 +143,25 @@ export class CollectionViewCommand {
       : undefined;
 
     const memberLabel = resolveMemberLabel(member, interaction.user);
-    const response = await buildCollectionListResponse({
-      viewerUserId: interaction.user.id,
-      targetUserId,
-      memberLabel,
-      title: titleFilter,
-      platform: platformFilter,
-      platformId: undefined,
-      platformLabel: platformFilter,
-      ownershipType,
-      page: 0,
-      isEphemeral,
-    });
+    let response: Awaited<ReturnType<typeof buildCollectionListResponse>>;
+    try {
+      response = await buildCollectionListResponse({
+        viewerUserId: interaction.user.id,
+        targetUserId,
+        memberLabel,
+        title: titleFilter,
+        platform: platformFilter,
+        platformId: undefined,
+        platformLabel: platformFilter,
+        ownershipType,
+        page: 0,
+        isEphemeral,
+      });
+    } catch (err) {
+      console.error("[collection list] Failed to build response:", err);
+      await safeReply(interaction, buildTextReply("Failed to load your collection. Please try again.", true));
+      return;
+    }
 
     if (response.content) {
       await safeReply(interaction, response.content);

--- a/src/services/IGDB/IgdbService.ts
+++ b/src/services/IGDB/IgdbService.ts
@@ -99,6 +99,8 @@ class IgdbService {
       const response = await axios.post<ITwitchAuthResponse>(
         `https://id.twitch.tv/oauth2/token?client_id=${this.clientId}` +
         `&client_secret=${this.clientSecret}&grant_type=client_credentials`,
+        null,
+        { timeout: 8000 },
       );
 
       this.accessToken = response.data.access_token;


### PR DESCRIPTION
## Summary

The \`/collection list\` command hangs silently after the ack. Previous fixes (batched IGDB calls, error handling, token timeout) haven't resolved it because the hang is a frozen \`await\` — no exception thrown, no log output.

This PR adds:
- **Step logs** at each key stage: \`searchEntries\`, \`getGameById\` (parallel), \`getCoversForGames\` — the bot console will now show exactly which step stops progressing
- **20s hard timeout** via \`Promise.race\` around the whole response build — the user gets "Failed to load your collection" instead of a forever-hanging interaction, and the timeout error appears in the log

## Next steps

Once merged and deployed, run \`/collection list\` and check the bot console. The last printed step before it times out identifies the root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)