### PR TITLE
debug: add component-build and safeReply step logs to collection list

### DIFF
--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -659,6 +659,7 @@ async function buildCollectionListResponse(params: {
     });
   }
 
+  console.log("[collection-list] step: components built", { count: components.length });
   // eslint-disable-next-line local/dynamic-components-require-chunking
   return { components };
 }

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -169,14 +169,23 @@ export class CollectionViewCommand {
       return;
     }
 
-    if (response.content) {
-      await safeReply(interaction, response.content);
-      return;
-    }
-    await safeReply(interaction, {
-      components: response.components,
-      flags: buildComponentsV2Flags(isEphemeral),
+    console.log("[collection list] step: sending reply", {
+      hasContent: Boolean(response.content),
+      componentCount: response.components?.length,
     });
+    try {
+      if (response.content) {
+        await safeReply(interaction, response.content);
+        return;
+      }
+      await safeReply(interaction, {
+        components: response.components,
+        flags: buildComponentsV2Flags(isEphemeral),
+      });
+    } catch (err) {
+      console.error("[collection list] safeReply failed:", err);
+    }
+    console.log("[collection list] step: reply sent");
   }
 
   @Slash({ name: "overview", description: "Show a summary of your collection by platform" })


### PR DESCRIPTION
## Summary

Follow-up to #530. All async steps (`searchEntries`, `getGameById`, `getCoversForGames`) complete successfully. The hang must be in either:

- The synchronous component building loop (ContainerBuilder/SectionBuilder)
- The `editReply` Discord API call inside `safeReply`

Adds logs at both points:
- `components built` -- confirms sync component building finished
- `sending reply` -- confirms we reached the Discord API call
- `reply sent` -- confirms `editReply` returned
- `safeReply failed` -- captures any error from `editReply`

## Expected log output

If hang is in component building:
```
[collection-list] step: buildThumbnails done ...
(silence -- no "components built" log)
```

If hang is in Discord API call:
```
[collection list] step: sending reply ...
(silence -- no "reply sent" log)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)