### PR TITLE
debug: log ack errors in safeReply editReply instead of swallowing

### DIFF
--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -372,6 +372,12 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;
+      console.error("[safeReply] editReply ack error", {
+        code: err?.code,
+        status: err?.status,
+        message: err?.message,
+        rawError: JSON.stringify(err?.rawError),
+      });
     }
     return;
   }


### PR DESCRIPTION
## Summary

When `editReply` fails with a 40060 (already acknowledged) or 10062 (unknown interaction) error, `safeReply` was silently dropping it. This made the interaction appear to succeed in our logs while Discord kept showing "thinking."

Now logs the full error (code, status, message, rawError) so we can see what Discord is actually rejecting.

## Expected output if this is the cause

```
[safeReply] editReply ack error { code: XXXXX, status: 400, message: "...", rawError: "..." }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)