### PR TITLE
debug: log editReply result message ID to confirm Discord acceptance

### DIFF
--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -368,7 +368,9 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
         // eslint-disable-next-line local/no-plain-text-v1-reply
         return await interaction.editReply({ content: options });
       } else {
-        return await interaction.editReply(normalizedOptions as any);
+        const result = await interaction.editReply(normalizedOptions as any);
+        console.log("[safeReply] editReply success", { messageId: (result as any)?.id });
+        return result;
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -372,6 +372,12 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;
+      console.error("[safeReply] editReply ack error", {
+        code: err?.code,
+        status: err?.status,
+        message: err?.message,
+        rawError: JSON.stringify(err?.rawError),
+      });
     }
     return;
   }


### PR DESCRIPTION
## Summary

Follow-up to #532. `editReply` returns without any error or ack error, but Discord still shows "thinking." This PR logs the message ID from the `editReply` result to confirm whether Discord is actually accepting and processing the edit.

If `messageId` is `undefined` in the log, Discord is returning a response without a message ID, indicating the edit didn't actually commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)