### PR TITLE
fix: /collection list never replies after IS_COMPONENTS_V2 defer

### DIFF
--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -165,7 +165,10 @@ export class CollectionViewCommand {
       ]);
     } catch (err) {
       console.error("[collection list] Failed to build response:", err);
-      await safeReply(interaction, buildTextReply("Failed to load your collection. Please try again.", true));
+      await safeReply(
+        interaction,
+        buildTextReply("Failed to load your collection. Please try again.", isEphemeral),
+      );
       return;
     }
 
@@ -175,7 +178,7 @@ export class CollectionViewCommand {
     });
     try {
       if (response.content) {
-        await safeReply(interaction, response.content);
+        await safeReply(interaction, buildTextReply(response.content, isEphemeral));
         return;
       }
       await safeReply(interaction, {
@@ -184,6 +187,11 @@ export class CollectionViewCommand {
       });
     } catch (err) {
       console.error("[collection list] safeReply failed:", err);
+      try {
+        await interaction.editReply({ content: "Failed to display collection. Please try again." });
+      } catch (fallbackErr) {
+        console.error("[collection list] fallback editReply also failed:", fallbackErr);
+      }
     }
     console.log("[collection list] step: reply sent");
   }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -368,7 +368,9 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
         // eslint-disable-next-line local/no-plain-text-v1-reply
         return await interaction.editReply({ content: options });
       } else {
-        return await interaction.editReply(normalizedOptions as any);
+        const result = await interaction.editReply(normalizedOptions as any);
+        console.log("[safeReply] editReply success", { messageId: (result as any)?.id });
+        return result;
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -372,6 +372,12 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;
+      console.error("[safeReply] editReply ack error", {
+        code: err?.code,
+        status: err?.status,
+        message: err?.message,
+        rawError: JSON.stringify(err?.rawError),
+      });
     }
     return;
   }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -374,12 +374,26 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;
+      const ackCode = err?.code ?? err?.rawError?.code;
       console.error("[safeReply] editReply ack error", {
         code: err?.code,
         status: err?.status,
         message: err?.message,
         rawError: JSON.stringify(err?.rawError),
       });
+      // 40060 = already replied; a followUp can still deliver the content
+      if (ackCode === 40060) {
+        try {
+          if (typeof options === "string") {
+            // eslint-disable-next-line local/no-plain-text-v1-reply
+            return await interaction.followUp({ content: options });
+          } else {
+            return await interaction.followUp(normalizedOptions as any);
+          }
+        } catch {
+          // followUp also failed; nothing more to do
+        }
+      }
     }
     return;
   }


### PR DESCRIPTION
## Summary

Three bugs caused `/collection list` to stay stuck in "thinking..." forever after the IS_COMPONENTS_V2 refactor:

- **Empty collection path** (`collection-view.command.ts`): `safeReply(interaction, plainString)` was called after deferring with the IS_COMPONENTS_V2 flag. This sent `editReply({ content: "..." })` with no IS_COMPONENTS_V2 flag -- inconsistent with the defer, which Discord rejects. Fixed by using `buildTextReply` so the response matches the deferred format.

- **No fallback reply on safeReply failure** (`collection-view.command.ts`): The outer `catch` block logged the error but sent no reply, leaving the interaction permanently stuck. Added a plain-text `editReply` fallback so the user sees an error message instead.

- **Hardcoded `isEphemeral=true`** on the build-failure reply path: now correctly uses the `isEphemeral` value derived from the `showinchat` option.

- **`safeReply` 40060 recovery** (`InteractionUtils.ts`): when `editReply` fails with error 40060 (already acknowledged) after a successful defer, attempt a `followUp` to deliver the content rather than silently returning void.

## Test plan

- [ ] `/collection list` with entries returns the collection components (not stuck in thinking...)
- [ ] `/collection list` with no matching entries returns the "No collection entries matched" text container
- [ ] `/collection list showinchat:true` respects public visibility on both success and error paths
- [ ] Force an error condition (e.g., DB offline) and verify the user sees an error message rather than infinite thinking

🤖 Generated with [Claude Code](https://claude.com/claude-code)