### PR TITLE
fix: simplify collection list to title rows, 20 per page

### DIFF
--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -6,21 +6,16 @@ import {
 } from "discord.js";
 import {
   ContainerBuilder,
-  SectionBuilder,
   TextDisplayBuilder,
-  ThumbnailBuilder,
 } from "@discordjs/builders";
 import UserGameCollection, {
   type CollectionOwnershipType,
 } from "../../classes/UserGameCollection.js";
-import Game from "../../classes/Game.js";
-import { igdbService } from "../../services/IGDB/IgdbService.js";
 import { flattenErrorMessages } from "../imports/import-scaffold.service.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
-import { formatTableDate } from "../profile.command.js";
 import { safeDeferUpdate } from "../../functions/InteractionUtils.js";
 
-const COLLECTION_LIST_PAGE_SIZE = 10;
+const COLLECTION_LIST_PAGE_SIZE = 20;
 const COLLECTION_LIST_NAV_PREFIX = "collection-list-nav-v2";
 const COLLECTION_LIST_FILTER_PREFIX = "collection-list-filter-v1";
 const COLLECTION_LIST_FILTER_PANEL_PREFIX = "clf1";
@@ -397,47 +392,6 @@ export function parseCollectionFiltersFromListMessage(message: any): {
   };
 }
 
-async function buildCollectionThumbnails(
-  entries: Array<{ gameId: number }>,
-): Promise<Map<number, string>> {
-  const thumbnailsByGameId = new Map<number, string>();
-  if (!entries.length) return thumbnailsByGameId;
-
-  const uniqueGameIds = [...new Set(entries.map((e) => e.gameId))];
-  console.log("[collection-list] thumbnails: getGameById start", { count: uniqueGameIds.length });
-  const games = await Promise.all(uniqueGameIds.map((id) => Game.getGameById(id)));
-  console.log("[collection-list] thumbnails: getGameById done");
-
-  const igdbIdsByGameId = new Map<number, number>();
-  for (let i = 0; i < uniqueGameIds.length; i++) {
-    const game = games[i];
-    if (game?.igdbId) igdbIdsByGameId.set(uniqueGameIds[i]!, game.igdbId);
-  }
-
-  if (!igdbIdsByGameId.size) return thumbnailsByGameId;
-
-  console.log("[collection-list] thumbnails: getCoversForGames start", { count: igdbIdsByGameId.size });
-  let imageIdsByIgdbId: Map<number, string>;
-  try {
-    imageIdsByIgdbId = await igdbService.getCoversForGames([...igdbIdsByGameId.values()]);
-    console.log("[collection-list] thumbnails: getCoversForGames done");
-  } catch (err) {
-    console.error("[collection-list] thumbnails: getCoversForGames failed", err);
-    return thumbnailsByGameId;
-  }
-
-  for (const [gameId, igdbId] of igdbIdsByGameId) {
-    const imageId = imageIdsByIgdbId.get(igdbId);
-    if (imageId) {
-      thumbnailsByGameId.set(
-        gameId,
-        `https://images.igdb.com/igdb/image/upload/t_cover_big/${imageId}.jpg`,
-      );
-    }
-  }
-  return thumbnailsByGameId;
-}
-
 function logCollectionListNavDebug(
   event: string,
   details: Record<string, unknown>,
@@ -537,70 +491,37 @@ async function buildCollectionListResponse(params: {
     params.platformId ? `platform-id=${params.platformId}` : null,
     params.ownershipType ? `ownership=${params.ownershipType}` : null,
   ].filter(Boolean).join(" | ");
-  console.log("[collection-list] step: buildThumbnails start", { pageEntryCount: pageEntries.length });
-  const thumbnailsByGameId = await buildCollectionThumbnails(pageEntries);
-  console.log("[collection-list] step: buildThumbnails done", { count: thumbnailsByGameId.size });
+
+  const listText = pageEntries
+    .map((entry) => {
+      const platform = entry.platformName ?? "Unknown";
+      return `**${safeV2TextContent(entry.title, 100)}** · ${platform} · ${entry.ownershipType}`;
+    })
+    .join("\n");
+
   const components: Array<ContainerBuilder | ActionRowBuilder<any>> = [];
 
-  const headerContainer = new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(safeV2TextContent(`## ${headerTitle}`, 250)),
+  components.push(
+    new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(safeV2TextContent(`## ${headerTitle}`, 250)),
+    ),
   );
-  components.push(headerContainer);
 
-  for (const entry of pageEntries) {
-    const platform = entry.platformName ?? "Unknown platform";
-    const noteLine = entry.note ? `\n> Note: ${entry.note}` : "";
-    const sectionText = safeV2TextContent(
-      `### ${entry.title}\n` +
-      `> Platform: ${platform}\n` +
-      `> Ownership: ${entry.ownershipType}\n` +
-      `> Added: ${formatTableDate(entry.createdAt)}${noteLine}`,
-      1000,
-    );
-    if (params.debugSource === "nav") {
-      logCollectionListNavDebug("entry_section_payload", {
-        entryId: entry.entryId,
-        gameId: entry.gameId,
-        titleLength: entry.title.length,
-        noteLength: entry.note?.length ?? 0,
-        platformLength: (entry.platformName ?? "Unknown platform").length,
-        sectionTextLength: sectionText.length,
-      });
-    }
-    const thumb = thumbnailsByGameId.get(entry.gameId);
-    if (!thumb) {
-      const entryContainer = new ContainerBuilder().addTextDisplayComponents(
-        new TextDisplayBuilder().setContent(safeV2TextContent(sectionText, 1000)),
-      );
-      components.push(entryContainer);
-      continue;
-    }
-
-    const section = new SectionBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(safeV2TextContent(sectionText, 1000)),
-    );
-    try {
-      section.setThumbnailAccessory(new ThumbnailBuilder().setURL(thumb));
-      section.toJSON();
-    } catch {
-      const entryContainer = new ContainerBuilder().addTextDisplayComponents(
-        new TextDisplayBuilder().setContent(safeV2TextContent(sectionText, 1000)),
-      );
-      components.push(entryContainer);
-      continue;
-    }
-    const entryContainer = new ContainerBuilder().addSectionComponents(section);
-    components.push(entryContainer);
-  }
+  components.push(
+    new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(safeV2TextContent(listText, 3500)),
+    ),
+  );
 
   const footerParts = [`Page ${safePage + 1}/${pageCount}`, `${total} total entries`];
   if (filtersText) {
     footerParts.push(`Filters: ${filtersText}`);
   }
-  const footerContainer = new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(safeV2TextContent(`-# ${footerParts.join(" | ")}`, 1000)),
+  components.push(
+    new ContainerBuilder().addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(safeV2TextContent(`-# ${footerParts.join(" | ")}`, 1000)),
+    ),
   );
-  components.push(footerContainer);
 
   const row = new ActionRowBuilder<ButtonBuilder>();
   if (pageCount > 1) {

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -165,7 +165,10 @@ export class CollectionViewCommand {
       ]);
     } catch (err) {
       console.error("[collection list] Failed to build response:", err);
-      await safeReply(interaction, buildTextReply("Failed to load your collection. Please try again.", true));
+      await safeReply(
+        interaction,
+        buildTextReply("Failed to load your collection. Please try again.", isEphemeral),
+      );
       return;
     }
 
@@ -175,7 +178,7 @@ export class CollectionViewCommand {
     });
     try {
       if (response.content) {
-        await safeReply(interaction, response.content);
+        await safeReply(interaction, buildTextReply(response.content, isEphemeral));
         return;
       }
       await safeReply(interaction, {
@@ -184,6 +187,11 @@ export class CollectionViewCommand {
       });
     } catch (err) {
       console.error("[collection list] safeReply failed:", err);
+      try {
+        await interaction.editReply({ content: "Failed to display collection. Please try again." });
+      } catch (fallbackErr) {
+        console.error("[collection list] fallback editReply also failed:", fallbackErr);
+      }
     }
     console.log("[collection list] step: reply sent");
   }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -368,7 +368,9 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
         // eslint-disable-next-line local/no-plain-text-v1-reply
         return await interaction.editReply({ content: options });
       } else {
-        return await interaction.editReply(normalizedOptions as any);
+        const result = await interaction.editReply(normalizedOptions as any);
+        console.log("[safeReply] editReply success", { messageId: (result as any)?.id });
+        return result;
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -372,6 +372,12 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;
+      console.error("[safeReply] editReply ack error", {
+        code: err?.code,
+        status: err?.status,
+        message: err?.message,
+        rawError: JSON.stringify(err?.rawError),
+      });
     }
     return;
   }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -374,12 +374,26 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
       }
     } catch (err: any) {
       if (!isAckError(err)) throw err;
+      const ackCode = err?.code ?? err?.rawError?.code;
       console.error("[safeReply] editReply ack error", {
         code: err?.code,
         status: err?.status,
         message: err?.message,
         rawError: JSON.stringify(err?.rawError),
       });
+      // 40060 = already replied; a followUp can still deliver the content
+      if (ackCode === 40060) {
+        try {
+          if (typeof options === "string") {
+            // eslint-disable-next-line local/no-plain-text-v1-reply
+            return await interaction.followUp({ content: options });
+          } else {
+            return await interaction.followUp(normalizedOptions as any);
+          }
+        } catch {
+          // followUp also failed; nothing more to do
+        }
+      }
     }
     return;
   }


### PR DESCRIPTION
## Summary

- The 10-entry-per-page layout with thumbnails pushed the IS_COMPONENTS_V2 component count to 48 total (Discord's limit is 40), causing every `editReply` to be rejected with a 50035 error and leaving the interaction stuck.
- Removed thumbnail fetching entirely (`buildCollectionThumbnails`, IGDB/Game imports).
- Removed the per-entry `Container+Section` nesting; all 20 titles now render in a single `TextDisplay` inside one `ContainerBuilder`.
- Increased page size from 10 to 20.
- New layout: 4 top-level components, 10 total -- well under Discord's limits.

Entry format: `**Title** · Platform · OwnershipType`

## Test plan

- [ ] `/collection list` returns the title list (no longer stuck in thinking...)
- [ ] Navigation buttons (Prev/Next) page through results correctly
- [ ] Filter button opens the filter panel
- [ ] `/collection list title:xyz` filters by title
- [ ] Empty collection shows the "No collection entries" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)