### PR TITLE
feat: migrate all Oracle SQL to centralized SqlManager helpers

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,6 +1,7 @@
 {
   "permissions": {
     "allow": [
+      "Bash(gh issue edit *)",
       "Bash(npx tsc *)",
       "Bash(Remove-Item \"c:\\\\code\\\\RPGClubBotTs\\\\set-github-key.mjs\", \"c:\\\\code\\\\RPGClubBotTs\\\\test-github-auth.mjs\")",
       "Bash(grep -E '^pg$')",

--- a/src/classes/AdminWizardSession.ts
+++ b/src/classes/AdminWizardSession.ts
@@ -1,5 +1,4 @@
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 
 export const ADMIN_WIZARD_COMMANDS = ["nextround-setup"] as const;
 export type AdminWizardCommand = (typeof ADMIN_WIZARD_COMMANDS)[number];
@@ -101,7 +100,9 @@ function parseNextRoundWizardState(raw: string): INextRoundWizardState {
 
   const roundNumber = parsed?.roundNumber == null ? null : Number(parsed.roundNumber);
   const normalizedRoundNumber =
-    roundNumber !== null && Number.isInteger(roundNumber) && roundNumber > 0 ? roundNumber : null;
+    roundNumber !== null && Number.isInteger(roundNumber) && roundNumber > 0
+      ? roundNumber
+      : null;
 
   const monthYear =
     typeof parsed?.monthYear === "string" && parsed.monthYear.trim()
@@ -116,7 +117,8 @@ function parseNextRoundWizardState(raw: string): INextRoundWizardState {
   const parsedUpdated = parsed?.stateLastUpdatedAt
     ? new Date(parsed.stateLastUpdatedAt)
     : new Date();
-  const stateLastUpdatedAt = Number.isNaN(parsedUpdated.getTime()) ? new Date() : parsedUpdated;
+  const stateLastUpdatedAt =
+    Number.isNaN(parsedUpdated.getTime()) ? new Date() : parsedUpdated;
 
   return {
     step,
@@ -127,7 +129,8 @@ function parseNextRoundWizardState(raw: string): INextRoundWizardState {
     selectedGotmOrder: sanitizeNumberArray(parsed?.selectedGotmOrder),
     selectedNrGotmOrder: sanitizeNumberArray(parsed?.selectedNrGotmOrder),
     gotmPickCount:
-      Number.isInteger(Number(parsed?.gotmPickCount)) && Number(parsed?.gotmPickCount) > 0
+      Number.isInteger(Number(parsed?.gotmPickCount)) &&
+      Number(parsed?.gotmPickCount) > 0
         ? Number(parsed?.gotmPickCount)
         : null,
     nrPickCount:
@@ -162,7 +165,9 @@ function mapAdminWizardSessionRow(row: AdminWizardSessionRow): IAdminWizardSessi
   };
 }
 
-export function createDefaultNextRoundWizardState(testMode: boolean): INextRoundWizardState {
+export function createDefaultNextRoundWizardState(
+  testMode: boolean,
+): INextRoundWizardState {
   return {
     step: "start",
     roundNumber: null,
@@ -184,39 +189,28 @@ export async function getActiveAdminWizardSession(
   ownerUserId: string,
   channelId: string,
 ): Promise<IAdminWizardSession | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<AdminWizardSessionRow>(
-      `SELECT SESSION_ID,
-              COMMAND_KEY,
-              OWNER_USER_ID,
-              CHANNEL_ID,
-              GUILD_ID,
-              STATUS,
-              STATE_JSON,
-              LAST_UPDATED_AT,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_ADMIN_WIZARD_SESSIONS
-        WHERE COMMAND_KEY = :commandKey
-          AND OWNER_USER_ID = :ownerUserId
-          AND CHANNEL_ID = :channelId
-          AND STATUS = 'ACTIVE'
-        ORDER BY LAST_UPDATED_AT DESC
-        FETCH FIRST 1 ROWS ONLY`,
-      {
-        commandKey,
-        ownerUserId,
-        channelId,
-      },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-
-    const row = result.rows?.[0];
-    return row ? mapAdminWizardSessionRow(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `SELECT SESSION_ID,
+            COMMAND_KEY,
+            OWNER_USER_ID,
+            CHANNEL_ID,
+            GUILD_ID,
+            STATUS,
+            STATE_JSON,
+            LAST_UPDATED_AT,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_ADMIN_WIZARD_SESSIONS
+      WHERE COMMAND_KEY = :commandKey
+        AND OWNER_USER_ID = :ownerUserId
+        AND CHANNEL_ID = :channelId
+        AND STATUS = 'ACTIVE'
+      ORDER BY LAST_UPDATED_AT DESC
+      FETCH FIRST 1 ROWS ONLY`,
+    { commandKey, ownerUserId, channelId },
+    mapAdminWizardSessionRow,
+  );
+  return rows[0] ?? null;
 }
 
 export async function saveAdminWizardSession(params: {
@@ -226,80 +220,73 @@ export async function saveAdminWizardSession(params: {
   guildId?: string | null;
   state: INextRoundWizardState;
 }): Promise<IAdminWizardSession> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const normalizedState: INextRoundWizardState = {
-      ...params.state,
-      stateLastUpdatedAt: new Date(),
-    };
-    const stateJson = serializeNextRoundWizardState(normalizedState);
-    const now = new Date();
+  const normalizedState: INextRoundWizardState = {
+    ...params.state,
+    stateLastUpdatedAt: new Date(),
+  };
+  const stateJson = serializeNextRoundWizardState(normalizedState);
+  const now = new Date();
+  const uniqueSessionId = [
+    "wiz",
+    params.commandKey,
+    params.ownerUserId,
+    params.channelId,
+    Date.now().toString(),
+    Math.floor(Math.random() * 1_000_000).toString(),
+  ].join("-");
 
-    const uniqueSessionId = [
-      "wiz",
-      params.commandKey,
-      params.ownerUserId,
-      params.channelId,
-      Date.now().toString(),
-      Math.floor(Math.random() * 1_000_000).toString(),
-    ].join("-");
+  await oraMutate(
+    `MERGE INTO RPG_CLUB_ADMIN_WIZARD_SESSIONS t
+      USING (
+        SELECT :commandKey AS COMMAND_KEY,
+               :ownerUserId AS OWNER_USER_ID,
+               :channelId AS CHANNEL_ID,
+               :guildId AS GUILD_ID,
+               :stateJson AS STATE_JSON,
+               :lastUpdatedAt AS LAST_UPDATED_AT
+          FROM dual
+      ) src
+         ON (t.COMMAND_KEY = src.COMMAND_KEY
+             AND t.OWNER_USER_ID = src.OWNER_USER_ID
+             AND t.CHANNEL_ID = src.CHANNEL_ID
+             AND t.STATUS = 'ACTIVE')
+    WHEN MATCHED THEN
+      UPDATE SET t.STATE_JSON = src.STATE_JSON,
+                 t.GUILD_ID = src.GUILD_ID,
+                 t.LAST_UPDATED_AT = src.LAST_UPDATED_AT
+    WHEN NOT MATCHED THEN
+      INSERT (SESSION_ID, COMMAND_KEY, OWNER_USER_ID, CHANNEL_ID, GUILD_ID, STATUS,
+              STATE_JSON, LAST_UPDATED_AT)
+      VALUES (
+        :sessionId,
+        src.COMMAND_KEY,
+        src.OWNER_USER_ID,
+        src.CHANNEL_ID,
+        src.GUILD_ID,
+        'ACTIVE',
+        src.STATE_JSON,
+        src.LAST_UPDATED_AT
+      )`,
+    {
+      commandKey: params.commandKey,
+      ownerUserId: params.ownerUserId,
+      channelId: params.channelId,
+      guildId: params.guildId ?? null,
+      stateJson,
+      lastUpdatedAt: now,
+      sessionId: uniqueSessionId,
+    },
+  );
 
-    await connection.execute(
-      `MERGE INTO RPG_CLUB_ADMIN_WIZARD_SESSIONS t
-        USING (
-          SELECT :commandKey AS COMMAND_KEY,
-                 :ownerUserId AS OWNER_USER_ID,
-                 :channelId AS CHANNEL_ID,
-                 :guildId AS GUILD_ID,
-                 :stateJson AS STATE_JSON,
-                 :lastUpdatedAt AS LAST_UPDATED_AT
-            FROM dual
-        ) src
-           ON (t.COMMAND_KEY = src.COMMAND_KEY
-               AND t.OWNER_USER_ID = src.OWNER_USER_ID
-               AND t.CHANNEL_ID = src.CHANNEL_ID
-               AND t.STATUS = 'ACTIVE')
-      WHEN MATCHED THEN
-        UPDATE SET t.STATE_JSON = src.STATE_JSON,
-                   t.GUILD_ID = src.GUILD_ID,
-                   t.LAST_UPDATED_AT = src.LAST_UPDATED_AT
-      WHEN NOT MATCHED THEN
-        INSERT (SESSION_ID, COMMAND_KEY, OWNER_USER_ID, CHANNEL_ID, GUILD_ID, STATUS, STATE_JSON,
-                LAST_UPDATED_AT)
-        VALUES (
-          :sessionId,
-          src.COMMAND_KEY,
-          src.OWNER_USER_ID,
-          src.CHANNEL_ID,
-          src.GUILD_ID,
-          'ACTIVE',
-          src.STATE_JSON,
-          src.LAST_UPDATED_AT
-        )`,
-      {
-        commandKey: params.commandKey,
-        ownerUserId: params.ownerUserId,
-        channelId: params.channelId,
-        guildId: params.guildId ?? null,
-        stateJson,
-        lastUpdatedAt: now,
-        sessionId: uniqueSessionId,
-      },
-      { autoCommit: true },
-    );
-
-    const saved = await getActiveAdminWizardSession(
-      params.commandKey,
-      params.ownerUserId,
-      params.channelId,
-    );
-    if (!saved) {
-      throw new Error("Failed to save admin wizard session.");
-    }
-    return saved;
-  } finally {
-    await connection.close();
+  const saved = await getActiveAdminWizardSession(
+    params.commandKey,
+    params.ownerUserId,
+    params.channelId,
+  );
+  if (!saved) {
+    throw new Error("Failed to save admin wizard session.");
   }
+  return saved;
 }
 
 export async function closeActiveAdminWizardSession(params: {
@@ -308,11 +295,10 @@ export async function closeActiveAdminWizardSession(params: {
   channelId: string;
   status: Exclude<AdminWizardSessionStatus, "active">;
 }): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    // The unique index includes STATUS, so ensure we do not collide when promoting
-    // ACTIVE -> CANCELLED/COMPLETED if a prior historical row already exists.
-    await connection.execute(
+  return oraWithConnection(async (conn) => {
+    // Remove any prior historical row to avoid unique index collision when
+    // promoting ACTIVE -> CANCELLED/COMPLETED.
+    await conn.execute(
       `DELETE FROM RPG_CLUB_ADMIN_WIZARD_SESSIONS
         WHERE COMMAND_KEY = :commandKey
           AND OWNER_USER_ID = :ownerUserId
@@ -327,7 +313,7 @@ export async function closeActiveAdminWizardSession(params: {
       { autoCommit: true },
     );
 
-    const result = await connection.execute(
+    const result = await conn.execute(
       `UPDATE RPG_CLUB_ADMIN_WIZARD_SESSIONS
           SET STATUS = :status,
               LAST_UPDATED_AT = :lastUpdatedAt
@@ -345,7 +331,5 @@ export async function closeActiveAdminWizardSession(params: {
       { autoCommit: true },
     );
     return Number(result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+  });
 }

--- a/src/classes/BotVotingInfo.ts
+++ b/src/classes/BotVotingInfo.ts
@@ -1,5 +1,4 @@
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 
 export interface IBotVotingInfoEntry {
   roundNumber: number;
@@ -9,13 +8,15 @@ export interface IBotVotingInfoEntry {
   oneDayReminderSent: boolean;
 }
 
-function mapRowToEntry(row: {
+type VotingRow = {
   ROUND_NUMBER: number;
   NOMINATION_LIST_ID: number | null;
   NEXT_VOTE_AT: Date | string;
   FIVE_DAY_REMINDER_SENT: number | null;
   ONE_DAY_REMINDER_SENT: number | null;
-}): IBotVotingInfoEntry {
+};
+
+function mapRowToEntry(row: VotingRow): IBotVotingInfoEntry {
   const roundNumber = Number(row.ROUND_NUMBER);
   const nominationListId =
     row.NOMINATION_LIST_ID === null || row.NOMINATION_LIST_ID === undefined
@@ -23,8 +24,7 @@ function mapRowToEntry(row: {
       : Number(row.NOMINATION_LIST_ID);
 
   const rawDate = row.NEXT_VOTE_AT;
-  const nextVoteAt =
-    rawDate instanceof Date ? rawDate : new Date(rawDate as string);
+  const nextVoteAt = rawDate instanceof Date ? rawDate : new Date(rawDate as string);
 
   const fiveDayReminderSent = Boolean(row.FIVE_DAY_REMINDER_SENT ?? 0);
   const oneDayReminderSent = Boolean(row.ONE_DAY_REMINDER_SENT ?? 0);
@@ -36,13 +36,7 @@ function mapRowToEntry(row: {
     throw new Error("Invalid NEXT_VOTE_AT value in BOT_VOTING_INFO row.");
   }
 
-  return {
-    roundNumber,
-    nominationListId,
-    nextVoteAt,
-    fiveDayReminderSent,
-    oneDayReminderSent,
-  };
+  return { roundNumber, nominationListId, nextVoteAt, fiveDayReminderSent, oneDayReminderSent };
 }
 
 function normalizeRoundNumber(roundNumber: number): number {
@@ -67,135 +61,48 @@ function normalizeDate(value: Date | string): Date {
   return d;
 }
 
-export default class BotVotingInfo {
-  static async getAll(): Promise<IBotVotingInfoEntry[]> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute<{
-        ROUND_NUMBER: number;
-        NOMINATION_LIST_ID: number | null;
-        NEXT_VOTE_AT: Date;
-        FIVE_DAY_REMINDER_SENT: number | null;
-        ONE_DAY_REMINDER_SENT: number | null;
-      }>(
-        `SELECT ROUND_NUMBER,
+const VOTING_COLS = `ROUND_NUMBER,
                 NOMINATION_LIST_ID,
                 NEXT_VOTE_AT,
                 FIVE_DAY_REMINDER_SENT,
-                ONE_DAY_REMINDER_SENT
-           FROM BOT_VOTING_INFO
-          ORDER BY ROUND_NUMBER`,
-        [],
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
+                ONE_DAY_REMINDER_SENT`;
 
-      const rows = (result.rows ?? []) as any[];
-      return rows.map((row) =>
-        mapRowToEntry(row as {
-          ROUND_NUMBER: number;
-          NOMINATION_LIST_ID: number | null;
-          NEXT_VOTE_AT: Date | string;
-          FIVE_DAY_REMINDER_SENT: number | null;
-          ONE_DAY_REMINDER_SENT: number | null;
-        }),
-      );
-    } finally {
-      await connection.close();
-    }
+export default class BotVotingInfo {
+  static async getAll(): Promise<IBotVotingInfoEntry[]> {
+    return oraQuery(
+      `SELECT ${VOTING_COLS}
+         FROM BOT_VOTING_INFO
+        ORDER BY ROUND_NUMBER`,
+      [],
+      mapRowToEntry,
+    );
   }
 
   static async getByRound(roundNumber: number): Promise<IBotVotingInfoEntry | null> {
     const round = normalizeRoundNumber(roundNumber);
-
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute<{
-        ROUND_NUMBER: number;
-        NOMINATION_LIST_ID: number | null;
-        NEXT_VOTE_AT: Date;
-        FIVE_DAY_REMINDER_SENT: number | null;
-        ONE_DAY_REMINDER_SENT: number | null;
-      }>(
-        `SELECT ROUND_NUMBER,
-                NOMINATION_LIST_ID,
-                NEXT_VOTE_AT,
-                FIVE_DAY_REMINDER_SENT,
-                ONE_DAY_REMINDER_SENT
-           FROM BOT_VOTING_INFO
-          WHERE ROUND_NUMBER = :round`,
-        { round },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const rows = (result.rows ?? []) as any[];
-      if (!rows.length) return null;
-
-      const row = rows[0] as {
-        ROUND_NUMBER: number;
-        NOMINATION_LIST_ID: number | null;
-        NEXT_VOTE_AT: Date | string;
-        FIVE_DAY_REMINDER_SENT: number | null;
-        ONE_DAY_REMINDER_SENT: number | null;
-      };
-      return mapRowToEntry(row);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery(
+      `SELECT ${VOTING_COLS}
+         FROM BOT_VOTING_INFO
+        WHERE ROUND_NUMBER = :round`,
+      { round },
+      mapRowToEntry,
+    );
+    return rows[0] ?? null;
   }
 
-  /**
-   * Return the entry for the highest round number in BOT_VOTING_INFO,
-   * or null if the table is empty.
-   */
   static async getCurrentRound(): Promise<IBotVotingInfoEntry | null> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute<{
-        ROUND_NUMBER: number;
-        NOMINATION_LIST_ID: number | null;
-        NEXT_VOTE_AT: Date | string;
-      }>(
-        `SELECT ROUND_NUMBER,
-                NOMINATION_LIST_ID,
-                NEXT_VOTE_AT,
-                FIVE_DAY_REMINDER_SENT,
-                ONE_DAY_REMINDER_SENT
-           FROM BOT_VOTING_INFO
-          WHERE ROUND_NUMBER = (
-            SELECT MAX(ROUND_NUMBER) FROM BOT_VOTING_INFO
-          )`,
-        [],
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const rows = (result.rows ?? []) as any[];
-      if (!rows.length) {
-        return null;
-      }
-
-      const row = rows[0] as {
-        ROUND_NUMBER: number;
-        NOMINATION_LIST_ID: number | null;
-        NEXT_VOTE_AT: Date | string;
-        FIVE_DAY_REMINDER_SENT: number | null;
-        ONE_DAY_REMINDER_SENT: number | null;
-      };
-
-      return mapRowToEntry(row);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery(
+      `SELECT ${VOTING_COLS}
+         FROM BOT_VOTING_INFO
+        WHERE ROUND_NUMBER = (
+          SELECT MAX(ROUND_NUMBER) FROM BOT_VOTING_INFO
+        )`,
+      [],
+      mapRowToEntry,
+    );
+    return rows[0] ?? null;
   }
 
-  /**
-   * Create or update a voting info row for the given round.
-   */
   static async setRoundInfo(
     roundNumber: number,
     nextVoteAt: Date | string,
@@ -204,29 +111,18 @@ export default class BotVotingInfo {
     const round = normalizeRoundNumber(roundNumber);
     const nextVote = normalizeDate(nextVoteAt);
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const updateResult = await connection.execute(
+    await oraWithConnection(async (conn) => {
+      const updateResult = await conn.execute(
         `UPDATE BOT_VOTING_INFO
             SET NOMINATION_LIST_ID = :nominationListId,
                 NEXT_VOTE_AT = :nextVoteAt
           WHERE ROUND_NUMBER = :round`,
-        {
-          round,
-          nominationListId,
-          nextVoteAt: nextVote,
-        },
+        { round, nominationListId, nextVoteAt: nextVote },
         { autoCommit: true },
       );
+      if ((updateResult.rowsAffected ?? 0) > 0) return;
 
-      const rowsUpdated = updateResult.rowsAffected ?? 0;
-      if (rowsUpdated > 0) {
-        return;
-      }
-
-      await connection.execute(
+      await conn.execute(
         `INSERT INTO BOT_VOTING_INFO (
            ROUND_NUMBER,
            NOMINATION_LIST_ID,
@@ -240,16 +136,10 @@ export default class BotVotingInfo {
            0,
            0
          )`,
-        {
-          round,
-          nominationListId,
-          nextVoteAt: nextVote,
-        },
+        { round, nominationListId, nextVoteAt: nextVote },
         { autoCommit: true },
       );
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async markReminderSent(
@@ -260,26 +150,16 @@ export default class BotVotingInfo {
     const column =
       reminder === "fiveDay" ? "FIVE_DAY_REMINDER_SENT" : "ONE_DAY_REMINDER_SENT";
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute(
-        `UPDATE BOT_VOTING_INFO
-            SET ${column} = 1
-          WHERE ROUND_NUMBER = :round`,
-        { round },
-        { autoCommit: true },
+    const result = await oraMutate(
+      `UPDATE BOT_VOTING_INFO
+          SET ${column} = 1
+        WHERE ROUND_NUMBER = :round`,
+      { round },
+    );
+    if ((result.rowsAffected ?? 0) === 0) {
+      throw new Error(
+        `No BOT_VOTING_INFO row found for round ${round} when updating ${column}.`,
       );
-
-      const rowsUpdated = result.rowsAffected ?? 0;
-      if (rowsUpdated === 0) {
-        throw new Error(
-          `No BOT_VOTING_INFO row found for round ${round} when updating ${column}.`,
-        );
-      }
-    } finally {
-      await connection.close();
     }
   }
 
@@ -289,30 +169,16 @@ export default class BotVotingInfo {
   ): Promise<void> {
     const round = normalizeRoundNumber(roundNumber);
     const nextVote = normalizeDate(nextVoteAt);
-
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute(
-        `UPDATE BOT_VOTING_INFO
-            SET NEXT_VOTE_AT = :nextVoteAt
-          WHERE ROUND_NUMBER = :round`,
-        {
-          round,
-          nextVoteAt: nextVote,
-        },
-        { autoCommit: true },
+    const result = await oraMutate(
+      `UPDATE BOT_VOTING_INFO
+          SET NEXT_VOTE_AT = :nextVoteAt
+        WHERE ROUND_NUMBER = :round`,
+      { round, nextVoteAt: nextVote },
+    );
+    if ((result.rowsAffected ?? 0) === 0) {
+      throw new Error(
+        `No BOT_VOTING_INFO row found for round ${round} when updating NEXT_VOTE_AT.`,
       );
-
-      const rowsUpdated = result.rowsAffected ?? 0;
-      if (rowsUpdated === 0) {
-        throw new Error(
-          `No BOT_VOTING_INFO row found for round ${round} when updating NEXT_VOTE_AT.`,
-        );
-      }
-    } finally {
-      await connection.close();
     }
   }
 
@@ -321,50 +187,27 @@ export default class BotVotingInfo {
     nominationListId: number | null,
   ): Promise<void> {
     const round = normalizeRoundNumber(roundNumber);
-
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute(
-        `UPDATE BOT_VOTING_INFO
-            SET NOMINATION_LIST_ID = :nominationListId
-          WHERE ROUND_NUMBER = :round`,
-        {
-          round,
-          nominationListId,
-        },
-        { autoCommit: true },
+    const result = await oraMutate(
+      `UPDATE BOT_VOTING_INFO
+          SET NOMINATION_LIST_ID = :nominationListId
+        WHERE ROUND_NUMBER = :round`,
+      { round, nominationListId },
+    );
+    if ((result.rowsAffected ?? 0) === 0) {
+      throw new Error(
+        `No BOT_VOTING_INFO row found for round ${round}` +
+        ` when updating NOMINATION_LIST_ID.`,
       );
-
-      const rowsUpdated = result.rowsAffected ?? 0;
-      if (rowsUpdated === 0) {
-        throw new Error(
-          `No BOT_VOTING_INFO row found for round ${round} when updating NOMINATION_LIST_ID.`,
-        );
-      }
-    } finally {
-      await connection.close();
     }
   }
 
   static async deleteRound(roundNumber: number): Promise<number> {
     const round = normalizeRoundNumber(roundNumber);
-
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute(
-        `DELETE FROM BOT_VOTING_INFO
-          WHERE ROUND_NUMBER = :round`,
-        { round },
-        { autoCommit: true },
-      );
-
-      return result.rowsAffected ?? 0;
-    } finally {
-      await connection.close();
-    }
+    const result = await oraMutate(
+      `DELETE FROM BOT_VOTING_INFO
+        WHERE ROUND_NUMBER = :round`,
+      { round },
+    );
+    return result.rowsAffected ?? 0;
   }
 }

--- a/src/classes/GameDbCsvImportMapping.ts
+++ b/src/classes/GameDbCsvImportMapping.ts
@@ -1,5 +1,4 @@
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 export type GameDbCsvTitleMapStatus = "MAPPED" | "SKIPPED";
 
@@ -43,36 +42,21 @@ function mapRow(row: {
 export async function getGameDbCsvTitleMapByNorm(
   titleNorm: string,
 ): Promise<IGameDbCsvTitleMap | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const res = await connection.execute<{
-      MAP_ID: number;
-      TITLE_RAW: string;
-      TITLE_NORM: string;
-      GAMEDB_GAME_ID: number | null;
-      STATUS: GameDbCsvTitleMapStatus;
-      CREATED_BY: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT MAP_ID,
-              TITLE_RAW,
-              TITLE_NORM,
-              GAMEDB_GAME_ID,
-              STATUS,
-              CREATED_BY,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP
-        WHERE TITLE_NORM = :titleNorm`,
-      { titleNorm },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = res.rows?.[0];
-    return row ? mapRow(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `SELECT MAP_ID,
+            TITLE_RAW,
+            TITLE_NORM,
+            GAMEDB_GAME_ID,
+            STATUS,
+            CREATED_BY,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP
+      WHERE TITLE_NORM = :titleNorm`,
+    { titleNorm },
+    mapRow,
+  );
+  return rows[0] ?? null;
 }
 
 export async function upsertGameDbCsvTitleMap(params: {
@@ -82,33 +66,27 @@ export async function upsertGameDbCsvTitleMap(params: {
   status: GameDbCsvTitleMapStatus;
   createdBy: string | null;
 }): Promise<void> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `MERGE INTO RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP t
-       USING (
-         SELECT :titleNorm AS TITLE_NORM FROM dual
-       ) s
-          ON (t.TITLE_NORM = s.TITLE_NORM)
-       WHEN MATCHED THEN
-         UPDATE SET
-           TITLE_RAW = :titleRaw,
-           GAMEDB_GAME_ID = :gameDbGameId,
-           STATUS = :status,
-           CREATED_BY = :createdBy
-       WHEN NOT MATCHED THEN
-         INSERT (TITLE_RAW, TITLE_NORM, GAMEDB_GAME_ID, STATUS, CREATED_BY)
-         VALUES (:titleRaw, :titleNorm, :gameDbGameId, :status, :createdBy)`,
-      {
-        titleRaw: params.titleRaw,
-        titleNorm: params.titleNorm,
-        gameDbGameId: params.gameDbGameId,
-        status: params.status,
-        createdBy: params.createdBy,
-      },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `MERGE INTO RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP t
+     USING (
+       SELECT :titleNorm AS TITLE_NORM FROM dual
+     ) s
+        ON (t.TITLE_NORM = s.TITLE_NORM)
+     WHEN MATCHED THEN
+       UPDATE SET
+         TITLE_RAW = :titleRaw,
+         GAMEDB_GAME_ID = :gameDbGameId,
+         STATUS = :status,
+         CREATED_BY = :createdBy
+     WHEN NOT MATCHED THEN
+       INSERT (TITLE_RAW, TITLE_NORM, GAMEDB_GAME_ID, STATUS, CREATED_BY)
+       VALUES (:titleRaw, :titleNorm, :gameDbGameId, :status, :createdBy)`,
+    {
+      titleRaw: params.titleRaw,
+      titleNorm: params.titleNorm,
+      gameDbGameId: params.gameDbGameId,
+      status: params.status,
+      createdBy: params.createdBy,
+    },
+  );
 }

--- a/src/classes/GameKey.ts
+++ b/src/classes/GameKey.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 export interface IGameKey {
   keyId: number;
@@ -18,7 +18,7 @@ function toDate(value: Date | string | null): Date | null {
   return value instanceof Date ? value : new Date(value);
 }
 
-function mapGameKeyRow(row: {
+type GameKeyRow = {
   KEY_ID: number;
   GAME_TITLE: string;
   PLATFORM: string;
@@ -28,7 +28,9 @@ function mapGameKeyRow(row: {
   CLAIMED_AT: Date | string | null;
   CREATED_AT: Date | string;
   UPDATED_AT: Date | string;
-}): IGameKey {
+};
+
+function mapGameKeyRow(row: GameKeyRow): IGameKey {
   return {
     keyId: Number(row.KEY_ID),
     gameTitle: row.GAME_TITLE,
@@ -42,96 +44,65 @@ function mapGameKeyRow(row: {
   };
 }
 
+const GAME_KEY_COLS = `KEY_ID,
+        GAME_TITLE,
+        PLATFORM,
+        KEY_VALUE,
+        DONOR_USER_ID,
+        CLAIMED_BY_USER_ID,
+        CLAIMED_AT,
+        CREATED_AT,
+        UPDATED_AT`;
+
 export async function createGameKey(
   title: string,
   platform: string,
   keyValue: string,
   donorUserId: string,
 ): Promise<IGameKey> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `INSERT INTO RPG_CLUB_GAME_KEYS (GAME_TITLE, PLATFORM, KEY_VALUE, DONOR_USER_ID)
-       VALUES (:title, :platform, :keyValue, :donorUserId)
-       RETURNING KEY_ID INTO :id`,
-      {
-        title,
-        platform,
-        keyValue,
-        donorUserId,
-        id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      { autoCommit: true },
-    );
-    const id = Number((result.outBinds as any)?.id?.[0] ?? 0);
-    if (!id) {
-      throw new Error("Failed to create game key.");
-    }
-    const key = await getGameKeyById(id, connection);
-    if (!key) {
-      throw new Error("Failed to load game key after creation.");
-    }
-    return key;
-  } finally {
-    await connection.close();
+  const result = await oraMutate(
+    `INSERT INTO RPG_CLUB_GAME_KEYS (GAME_TITLE, PLATFORM, KEY_VALUE, DONOR_USER_ID)
+     VALUES (:title, :platform, :keyValue, :donorUserId)
+     RETURNING KEY_ID INTO :id`,
+    {
+      title,
+      platform,
+      keyValue,
+      donorUserId,
+      id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+    },
+  );
+  const id = Number((result.outBinds as any)?.id?.[0] ?? 0);
+  if (!id) {
+    throw new Error("Failed to create game key.");
   }
+  const key = await getGameKeyById(id);
+  if (!key) {
+    throw new Error("Failed to load game key after creation.");
+  }
+  return key;
 }
 
-export async function getGameKeyById(
-  keyId: number,
-  existingConnection?: oracledb.Connection,
-): Promise<IGameKey | null> {
-  const connection = existingConnection ?? (await getOraclePool().getConnection());
-  try {
-    const result = await connection.execute<{
-      KEY_ID: number;
-      GAME_TITLE: string;
-      PLATFORM: string;
-      KEY_VALUE: string;
-      DONOR_USER_ID: string;
-      CLAIMED_BY_USER_ID: string | null;
-      CLAIMED_AT: Date | string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT KEY_ID,
-              GAME_TITLE,
-              PLATFORM,
-              KEY_VALUE,
-              DONOR_USER_ID,
-              CLAIMED_BY_USER_ID,
-              CLAIMED_AT,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_GAME_KEYS
-        WHERE KEY_ID = :id`,
-      { id: keyId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapGameKeyRow(row) : null;
-  } finally {
-    if (!existingConnection) {
-      await connection.close();
-    }
-  }
+export async function getGameKeyById(keyId: number): Promise<IGameKey | null> {
+  const rows = await oraQuery(
+    `SELECT ${GAME_KEY_COLS}
+       FROM RPG_CLUB_GAME_KEYS
+      WHERE KEY_ID = :id`,
+    { id: keyId },
+    mapGameKeyRow,
+  );
+  return rows[0] ?? null;
 }
 
 export async function countAvailableGameKeys(): Promise<number> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{ TOTAL: number | null }>(
-      `SELECT COUNT(*) AS TOTAL
-         FROM RPG_CLUB_GAME_KEYS
-        WHERE CLAIMED_BY_USER_ID IS NULL`,
-      {},
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return Number(row?.TOTAL ?? 0);
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `SELECT COUNT(*) AS TOTAL
+       FROM RPG_CLUB_GAME_KEYS
+      WHERE CLAIMED_BY_USER_ID IS NULL`,
+    {},
+    (row: { TOTAL: number | null }) => Number(row.TOTAL ?? 0),
+  );
+  return rows[0] ?? 0;
 }
 
 export async function listAvailableGameKeys(
@@ -140,107 +111,47 @@ export async function listAvailableGameKeys(
 ): Promise<IGameKey[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 50);
   const safeOffset = Math.max(offset, 0);
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      KEY_ID: number;
-      GAME_TITLE: string;
-      PLATFORM: string;
-      KEY_VALUE: string;
-      DONOR_USER_ID: string;
-      CLAIMED_BY_USER_ID: string | null;
-      CLAIMED_AT: Date | string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT KEY_ID,
-              GAME_TITLE,
-              PLATFORM,
-              KEY_VALUE,
-              DONOR_USER_ID,
-              CLAIMED_BY_USER_ID,
-              CLAIMED_AT,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_GAME_KEYS
-        WHERE CLAIMED_BY_USER_ID IS NULL
-        ORDER BY UPPER(GAME_TITLE), KEY_ID
-        OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-      { offset: safeOffset, limit: safeLimit },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    return (result.rows ?? []).map((row) => mapGameKeyRow(row));
-  } finally {
-    await connection.close();
-  }
+  return oraQuery(
+    `SELECT ${GAME_KEY_COLS}
+       FROM RPG_CLUB_GAME_KEYS
+      WHERE CLAIMED_BY_USER_ID IS NULL
+      ORDER BY UPPER(GAME_TITLE), KEY_ID
+      OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+    { offset: safeOffset, limit: safeLimit },
+    mapGameKeyRow,
+  );
 }
 
 export async function listKeysByDonor(userId: string): Promise<IGameKey[]> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      KEY_ID: number;
-      GAME_TITLE: string;
-      PLATFORM: string;
-      KEY_VALUE: string;
-      DONOR_USER_ID: string;
-      CLAIMED_BY_USER_ID: string | null;
-      CLAIMED_AT: Date | string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT KEY_ID,
-              GAME_TITLE,
-              PLATFORM,
-              KEY_VALUE,
-              DONOR_USER_ID,
-              CLAIMED_BY_USER_ID,
-              CLAIMED_AT,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_GAME_KEYS
-        WHERE DONOR_USER_ID = :userId
-        ORDER BY CREATED_AT DESC, KEY_ID DESC`,
-      { userId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    return (result.rows ?? []).map(mapGameKeyRow);
-  } finally {
-    await connection.close();
-  }
+  return oraQuery(
+    `SELECT ${GAME_KEY_COLS}
+       FROM RPG_CLUB_GAME_KEYS
+      WHERE DONOR_USER_ID = :userId
+      ORDER BY CREATED_AT DESC, KEY_ID DESC`,
+    { userId },
+    mapGameKeyRow,
+  );
 }
 
 export async function claimGameKey(
   keyId: number,
   userId: string,
 ): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `UPDATE RPG_CLUB_GAME_KEYS
-          SET CLAIMED_BY_USER_ID = :userId,
-              CLAIMED_AT = SYSTIMESTAMP
-        WHERE KEY_ID = :keyId
-          AND CLAIMED_BY_USER_ID IS NULL`,
-      { keyId, userId },
-      { autoCommit: true },
-    );
-    return (result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+  const result = await oraMutate(
+    `UPDATE RPG_CLUB_GAME_KEYS
+        SET CLAIMED_BY_USER_ID = :userId,
+            CLAIMED_AT = SYSTIMESTAMP
+      WHERE KEY_ID = :keyId
+        AND CLAIMED_BY_USER_ID IS NULL`,
+    { keyId, userId },
+  );
+  return (result.rowsAffected ?? 0) > 0;
 }
 
 export async function revokeGameKey(keyId: number): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `DELETE FROM RPG_CLUB_GAME_KEYS WHERE KEY_ID = :keyId`,
-      { keyId },
-      { autoCommit: true },
-    );
-    return (result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+  const result = await oraMutate(
+    `DELETE FROM RPG_CLUB_GAME_KEYS WHERE KEY_ID = :keyId`,
+    { keyId },
+  );
+  return (result.rowsAffected ?? 0) > 0;
 }

--- a/src/classes/GameSearchSynonym.ts
+++ b/src/classes/GameSearchSynonym.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 
 export type IGameSearchSynonym = {
   termId: number;
@@ -25,6 +25,8 @@ function mapSynonymRow(row: any): IGameSearchSynonym {
   };
 }
 
+const SYNONYM_COLS = `TERM_ID, GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_AT, CREATED_BY`;
+
 export default class GameSearchSynonym {
   static normalizeTerm(text: string): string {
     return normalizeSearchTerm(text);
@@ -32,68 +34,40 @@ export default class GameSearchSynonym {
 
   static async getGroupIdsForTerm(
     termText: string,
-    connection?: oracledb.Connection,
+    conn?: oracledb.Connection,
   ): Promise<number[]> {
     const norm = normalizeSearchTerm(termText);
     if (!norm) return [];
-    const pool = getOraclePool();
-    const activeConnection = connection ?? await pool.getConnection();
-    try {
-      const result = await activeConnection.execute(
-        `SELECT GROUP_ID
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE TERM_NORM = :termNorm`,
-        { termNorm: norm },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (result.rows ?? []).map((row: any) => Number(row.GROUP_ID));
-    } finally {
-      if (!connection) {
-        await activeConnection.close();
-      }
-    }
+    return oraQuery(
+      `SELECT GROUP_ID
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE TERM_NORM = :termNorm`,
+      { termNorm: norm },
+      (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
+      conn,
+    );
   }
 
   static async listGroupTerms(
     groupId: number,
-    connection?: oracledb.Connection,
+    conn?: oracledb.Connection,
   ): Promise<IGameSearchSynonym[]> {
-    const pool = getOraclePool();
-    const activeConnection = connection ?? await pool.getConnection();
-    try {
-      const result = await activeConnection.execute(
-        `SELECT TERM_ID, GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_AT, CREATED_BY
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE GROUP_ID = :groupId
-          ORDER BY TERM_TEXT ASC`,
-        { groupId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (result.rows ?? []).map((row) => mapSynonymRow(row));
-    } finally {
-      if (!connection) {
-        await activeConnection.close();
-      }
-    }
+    return oraQuery(
+      `SELECT ${SYNONYM_COLS}
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE GROUP_ID = :groupId
+        ORDER BY TERM_TEXT ASC`,
+      { groupId },
+      mapSynonymRow,
+      conn,
+    );
   }
 
-  static async getTermsForQuery(
-    query: string,
-    connection?: oracledb.Connection,
-  ): Promise<string[]> {
+  static async getTermsForQuery(query: string): Promise<string[]> {
     const norm = normalizeSearchTerm(query);
     if (!norm) return [];
-    const pool = getOraclePool();
-    const activeConnection = connection ?? await pool.getConnection();
-    try {
-      const groupResult = await activeConnection.execute(
-        `SELECT GROUP_ID
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE TERM_NORM = :termNorm`,
-        { termNorm: norm },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const groupIds = (groupResult.rows ?? []).map((row: any) => Number(row.GROUP_ID));
+    return oraWithConnection(async (conn) => {
+      const groupIds = await GameSearchSynonym.getGroupIdsForTerm(query, conn);
       if (!groupIds.length) return [];
       const binds: Record<string, number> = {};
       const placeholders = groupIds.map((groupId, index) => {
@@ -101,85 +75,69 @@ export default class GameSearchSynonym {
         binds[key] = groupId;
         return `:${key}`;
       });
-      const termResult = await activeConnection.execute(
+      return oraQuery(
         `SELECT DISTINCT TERM_TEXT
            FROM GAMEDB_SEARCH_SYNONYMS
           WHERE GROUP_ID IN (${placeholders.join(", ")})
           ORDER BY TERM_TEXT ASC`,
         binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row: { TERM_TEXT: string }) => String(row.TERM_TEXT),
+        conn,
       );
-      return (termResult.rows ?? []).map((row: any) => String(row.TERM_TEXT));
-    } finally {
-      if (!connection) {
-        await activeConnection.close();
-      }
-    }
+    });
   }
 
   static async listSynonyms(
     options: { query?: string; limit?: number } = {},
   ): Promise<IGameSearchSynonym[]> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
     const query = options.query?.trim().toLowerCase() ?? "";
     const searchQuery = query ? `%${query}%` : null;
     const normalizedQuery = query ? `%${normalizeSearchTerm(query)}%` : null;
     const limit = options.limit ?? 50;
-    try {
-      const result = await connection.execute(
-        `SELECT TERM_ID, GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_AT, CREATED_BY
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE (:searchQuery IS NULL
-             OR LOWER(TERM_TEXT) LIKE :searchQuery
-             OR TERM_NORM LIKE :normalizedQuery)
-          ORDER BY GROUP_ID ASC, TERM_TEXT ASC
-          FETCH FIRST :limit ROWS ONLY`,
-        { searchQuery, normalizedQuery, limit },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (result.rows ?? []).map((row) => mapSynonymRow(row));
-    } finally {
-      await connection.close();
-    }
+    return oraQuery(
+      `SELECT ${SYNONYM_COLS}
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE (:searchQuery IS NULL
+           OR LOWER(TERM_TEXT) LIKE :searchQuery
+           OR TERM_NORM LIKE :normalizedQuery)
+        ORDER BY GROUP_ID ASC, TERM_TEXT ASC
+        FETCH FIRST :limit ROWS ONLY`,
+      { searchQuery, normalizedQuery, limit },
+      mapSynonymRow,
+    );
   }
 
   static async countSynonymGroups(query?: string): Promise<number> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
     const cleanedQuery = query?.trim().toLowerCase() ?? "";
     const searchQuery = cleanedQuery ? `%${cleanedQuery}%` : null;
-    const normalizedQuery = cleanedQuery ? `%${normalizeSearchTerm(cleanedQuery)}%` : null;
-    try {
-      const result = await connection.execute(
-        `SELECT COUNT(DISTINCT GROUP_ID) AS CNT
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE (:searchQuery IS NULL
-             OR LOWER(TERM_TEXT) LIKE :searchQuery
-             OR TERM_NORM LIKE :normalizedQuery)`,
-        { searchQuery, normalizedQuery },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = (result.rows ?? [])[0] as any;
-      return Number(row?.CNT ?? 0);
-    } finally {
-      await connection.close();
-    }
+    const normalizedQuery = cleanedQuery
+      ? `%${normalizeSearchTerm(cleanedQuery)}%`
+      : null;
+    const rows = await oraQuery(
+      `SELECT COUNT(DISTINCT GROUP_ID) AS CNT
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE (:searchQuery IS NULL
+           OR LOWER(TERM_TEXT) LIKE :searchQuery
+           OR TERM_NORM LIKE :normalizedQuery)`,
+      { searchQuery, normalizedQuery },
+      (row: { CNT: number }) => Number(row.CNT ?? 0),
+    );
+    return rows[0] ?? 0;
   }
 
   static async listSynonymGroups(
     options: { query?: string; limit?: number; offset?: number } = {},
   ): Promise<IGameSearchSynonym[]> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
     const cleanedQuery = options.query?.trim().toLowerCase() ?? "";
     const searchQuery = cleanedQuery ? `%${cleanedQuery}%` : null;
-    const normalizedQuery = cleanedQuery ? `%${normalizeSearchTerm(cleanedQuery)}%` : null;
+    const normalizedQuery = cleanedQuery
+      ? `%${normalizeSearchTerm(cleanedQuery)}%`
+      : null;
     const limit = options.limit ?? 10;
     const offset = options.offset ?? 0;
 
-    try {
-      const groupResult = await connection.execute(
+    return oraWithConnection(async (conn) => {
+      const groupIds = await oraQuery(
         `SELECT DISTINCT GROUP_ID
            FROM GAMEDB_SEARCH_SYNONYMS
           WHERE (:searchQuery IS NULL
@@ -188,10 +146,9 @@ export default class GameSearchSynonym {
           ORDER BY GROUP_ID ASC
           OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
         { searchQuery, normalizedQuery, offset, limit },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
+        conn,
       );
-
-      const groupIds = (groupResult.rows ?? []).map((row: any) => Number(row.GROUP_ID));
       if (!groupIds.length) return [];
 
       const binds: Record<string, number> = {};
@@ -200,20 +157,16 @@ export default class GameSearchSynonym {
         binds[key] = groupId;
         return `:${key}`;
       });
-
-      const termResult = await connection.execute(
-        `SELECT TERM_ID, GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_AT, CREATED_BY
+      return oraQuery(
+        `SELECT ${SYNONYM_COLS}
            FROM GAMEDB_SEARCH_SYNONYMS
           WHERE GROUP_ID IN (${placeholders.join(", ")})
           ORDER BY GROUP_ID ASC, TERM_TEXT ASC`,
         binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        mapSynonymRow,
+        conn,
       );
-
-      return (termResult.rows ?? []).map((row) => mapSynonymRow(row));
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async addSynonymPair(
@@ -227,16 +180,14 @@ export default class GameSearchSynonym {
       throw new Error("Both term and match text are required.");
     }
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      const termGroups = await this.getGroupIdsForTerm(trimmedTerm, connection);
-      const matchGroups = await this.getGroupIdsForTerm(trimmedMatch, connection);
+    return oraWithConnection(async (conn) => {
+      const termGroups = await GameSearchSynonym.getGroupIdsForTerm(trimmedTerm, conn);
+      const matchGroups = await GameSearchSynonym.getGroupIdsForTerm(trimmedMatch, conn);
       const sharedGroup = termGroups.find((groupId) => matchGroups.includes(groupId));
       let groupId = sharedGroup ?? null;
 
       if (!groupId) {
-        const groupResult = await connection.execute(
+        const groupResult = await oraMutate(
           `INSERT INTO GAMEDB_SEARCH_SYNONYM_GROUPS (CREATED_BY)
            VALUES (:createdBy)
            RETURNING GROUP_ID INTO :groupId`,
@@ -244,29 +195,26 @@ export default class GameSearchSynonym {
             createdBy,
             groupId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
           },
-          { autoCommit: true },
+          conn,
         );
         groupId = Number((groupResult.outBinds as any)?.groupId?.[0]);
+        await conn.commit();
       }
 
-      const inserts = [trimmedTerm, trimmedMatch];
-      for (const text of inserts) {
+      for (const text of [trimmedTerm, trimmedMatch]) {
         const norm = normalizeSearchTerm(text);
         if (!norm) {
           throw new Error("Synonyms must include letters or numbers.");
         }
         try {
-          await connection.execute(
-            `INSERT INTO GAMEDB_SEARCH_SYNONYMS (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
+          await oraMutate(
+            `INSERT INTO GAMEDB_SEARCH_SYNONYMS
+               (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
              VALUES (:groupId, :termText, :termNorm, :createdBy)`,
-            {
-              groupId,
-              termText: text,
-              termNorm: norm,
-              createdBy,
-            },
-            { autoCommit: true },
+            { groupId, termText: text, termNorm: norm, createdBy },
+            conn,
           );
+          await conn.commit();
         } catch (err: any) {
           const msg = err?.message ?? "";
           if (!/ORA-00001/i.test(msg)) {
@@ -275,11 +223,11 @@ export default class GameSearchSynonym {
         }
       }
 
-      const terms = await this.listGroupTerms(groupId, connection);
-      return { groupId, terms };
-    } finally {
-      await connection.close();
-    }
+      return {
+        groupId: groupId as number,
+        terms: await GameSearchSynonym.listGroupTerms(groupId as number, conn),
+      };
+    });
   }
 
   static async updateSynonym(
@@ -295,21 +243,18 @@ export default class GameSearchSynonym {
       throw new Error("Term text must include letters or numbers.");
     }
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      await connection.execute(
+    return oraWithConnection(async (conn) => {
+      await oraMutate(
         `UPDATE GAMEDB_SEARCH_SYNONYMS
             SET TERM_TEXT = :termText,
                 TERM_NORM = :termNorm
           WHERE TERM_ID = :termId`,
         { termId, termText: trimmed, termNorm },
-        { autoCommit: true },
+        conn,
       );
-      return await this.getSynonymById(termId, connection);
-    } finally {
-      await connection.close();
-    }
+      await conn.commit();
+      return GameSearchSynonym.getSynonymById(termId, conn);
+    });
   }
 
   static async updateGroupTerms(
@@ -325,27 +270,25 @@ export default class GameSearchSynonym {
       throw new Error("A synonym group must contain at least two terms.");
     }
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      const existsResult = await connection.execute(
+    return oraWithConnection(async (conn) => {
+      const existsRows = await oraQuery(
         `SELECT COUNT(*) AS CNT
            FROM GAMEDB_SEARCH_SYNONYM_GROUPS
           WHERE GROUP_ID = :groupId`,
         { groupId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row: { CNT: number }) => Number(row.CNT ?? 0),
+        conn,
       );
-      const existsRow = (existsResult.rows ?? [])[0] as any;
-      if (Number(existsRow?.CNT ?? 0) === 0) {
+      if ((existsRows[0] ?? 0) === 0) {
         throw new Error("Synonym group not found.");
       }
 
-      await connection.execute(
-        `DELETE FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE GROUP_ID = :groupId`,
+      await oraMutate(
+        `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE GROUP_ID = :groupId`,
         { groupId },
-        { autoCommit: true },
+        conn,
       );
+      await conn.commit();
 
       for (const text of cleaned) {
         const norm = normalizeSearchTerm(text);
@@ -353,17 +296,14 @@ export default class GameSearchSynonym {
           throw new Error("Synonym terms must include letters or numbers.");
         }
         try {
-          await connection.execute(
-            `INSERT INTO GAMEDB_SEARCH_SYNONYMS (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
+          await oraMutate(
+            `INSERT INTO GAMEDB_SEARCH_SYNONYMS
+               (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
              VALUES (:groupId, :termText, :termNorm, :createdBy)`,
-            {
-              groupId,
-              termText: text,
-              termNorm: norm,
-              createdBy: updatedBy,
-            },
-            { autoCommit: true },
+            { groupId, termText: text, termNorm: norm, createdBy: updatedBy },
+            conn,
           );
+          await conn.commit();
         } catch (err: any) {
           const msg = err?.message ?? "";
           if (!/ORA-00001/i.test(msg)) {
@@ -372,11 +312,11 @@ export default class GameSearchSynonym {
         }
       }
 
-      const updatedTerms = await this.listGroupTerms(groupId, connection);
-      return { groupId, terms: updatedTerms };
-    } finally {
-      await connection.close();
-    }
+      return {
+        groupId,
+        terms: await GameSearchSynonym.listGroupTerms(groupId, conn),
+      };
+    });
   }
 
   static async createGroupTerms(
@@ -393,15 +333,12 @@ export default class GameSearchSynonym {
       seen.add(norm);
       cleaned.push(trimmed);
     }
-
     if (cleaned.length < 2) {
       throw new Error("A synonym group must contain at least two terms.");
     }
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      const groupResult = await connection.execute(
+    return oraWithConnection(async (conn) => {
+      const groupResult = await oraMutate(
         `INSERT INTO GAMEDB_SEARCH_SYNONYM_GROUPS (CREATED_BY)
          VALUES (:createdBy)
          RETURNING GROUP_ID INTO :groupId`,
@@ -409,134 +346,116 @@ export default class GameSearchSynonym {
           createdBy,
           groupId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
         },
-        { autoCommit: true },
+        conn,
       );
       const groupId = Number((groupResult.outBinds as any)?.groupId?.[0]);
       if (!Number.isInteger(groupId) || groupId <= 0) {
         throw new Error("Failed to create synonym group.");
       }
+      await conn.commit();
 
       for (const text of cleaned) {
         const norm = normalizeSearchTerm(text);
-        await connection.execute(
-          `INSERT INTO GAMEDB_SEARCH_SYNONYMS (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
+        await oraMutate(
+          `INSERT INTO GAMEDB_SEARCH_SYNONYMS
+             (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
            VALUES (:groupId, :termText, :termNorm, :createdBy)`,
-          {
-            groupId,
-            termText: text,
-            termNorm: norm,
-            createdBy,
-          },
-          { autoCommit: true },
+          { groupId, termText: text, termNorm: norm, createdBy },
+          conn,
         );
+        await conn.commit();
       }
 
-      const savedTerms = await this.listGroupTerms(groupId, connection);
-      return { groupId, terms: savedTerms };
-    } finally {
-      await connection.close();
-    }
+      return {
+        groupId,
+        terms: await GameSearchSynonym.listGroupTerms(groupId, conn),
+      };
+    });
   }
 
   static async deleteSynonym(termId: number): Promise<boolean> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      const groupResult = await connection.execute(
+    return oraWithConnection(async (conn) => {
+      const groupRows = await oraQuery(
         `SELECT GROUP_ID
            FROM GAMEDB_SEARCH_SYNONYMS
           WHERE TERM_ID = :termId`,
         { termId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
+        conn,
       );
-      const groupRow = (groupResult.rows ?? [])[0] as any;
-      const groupId = groupRow ? Number(groupRow.GROUP_ID) : null;
+      const groupId = groupRows[0] ?? null;
 
-      const result = await connection.execute(
+      const result = await oraMutate(
         `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE TERM_ID = :termId`,
         { termId },
-        { autoCommit: true },
+        conn,
       );
+      await conn.commit();
 
       if (groupId) {
-        const countResult = await connection.execute(
+        const countRows = await oraQuery(
           `SELECT COUNT(*) AS CNT
              FROM GAMEDB_SEARCH_SYNONYMS
             WHERE GROUP_ID = :groupId`,
           { groupId },
-          { outFormat: oracledb.OUT_FORMAT_OBJECT },
+          (row: { CNT: number }) => Number(row.CNT ?? 0),
+          conn,
         );
-        const countRow = (countResult.rows ?? [])[0] as any;
-        if (Number(countRow?.CNT ?? 0) === 0) {
-          await connection.execute(
+        if ((countRows[0] ?? 0) === 0) {
+          await oraMutate(
             `DELETE FROM GAMEDB_SEARCH_SYNONYM_GROUPS WHERE GROUP_ID = :groupId`,
             { groupId },
-            { autoCommit: true },
+            conn,
           );
+          await conn.commit();
         }
       }
 
       return (result.rowsAffected ?? 0) > 0;
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async deleteGroup(groupId: number): Promise<boolean> {
     if (!Number.isInteger(groupId) || groupId <= 0) return false;
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      const existsResult = await connection.execute(
+    return oraWithConnection(async (conn) => {
+      const existsRows = await oraQuery(
         `SELECT COUNT(*) AS CNT
            FROM GAMEDB_SEARCH_SYNONYM_GROUPS
           WHERE GROUP_ID = :groupId`,
         { groupId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row: { CNT: number }) => Number(row.CNT ?? 0),
+        conn,
       );
-      const existsRow = (existsResult.rows ?? [])[0] as any;
-      if (Number(existsRow?.CNT ?? 0) === 0) {
-        return false;
-      }
+      if ((existsRows[0] ?? 0) === 0) return false;
 
-      await connection.execute(
-        `DELETE FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE GROUP_ID = :groupId`,
+      await oraMutate(
+        `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE GROUP_ID = :groupId`,
         { groupId },
-        { autoCommit: true },
+        conn,
       );
-      await connection.execute(
-        `DELETE FROM GAMEDB_SEARCH_SYNONYM_GROUPS
-          WHERE GROUP_ID = :groupId`,
+      await conn.commit();
+      await oraMutate(
+        `DELETE FROM GAMEDB_SEARCH_SYNONYM_GROUPS WHERE GROUP_ID = :groupId`,
         { groupId },
-        { autoCommit: true },
+        conn,
       );
+      await conn.commit();
       return true;
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async getSynonymById(
     termId: number,
-    connection?: oracledb.Connection,
+    conn?: oracledb.Connection,
   ): Promise<IGameSearchSynonym | null> {
-    const pool = getOraclePool();
-    const activeConnection = connection ?? await pool.getConnection();
-    try {
-      const result = await activeConnection.execute(
-        `SELECT TERM_ID, GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_AT, CREATED_BY
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE TERM_ID = :termId`,
-        { termId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = (result.rows ?? [])[0] as any;
-      return row ? mapSynonymRow(row) : null;
-    } finally {
-      if (!connection) {
-        await activeConnection.close();
-      }
-    }
+    const rows = await oraQuery(
+      `SELECT ${SYNONYM_COLS}
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE TERM_ID = :termId`,
+      { termId },
+      mapSynonymRow,
+      conn,
+    );
+    return rows[0] ?? null;
   }
 }

--- a/src/classes/GameSearchSynonymDraft.ts
+++ b/src/classes/GameSearchSynonymDraft.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 
 export type ISynonymDraftPair = {
   term: string;
@@ -44,93 +44,74 @@ function mapDraftRow(row: any): ISynonymDraft {
 
 export default class GameSearchSynonymDraft {
   static async createDraft(userId: string): Promise<ISynonymDraft> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      const result = await connection.execute(
-        `INSERT INTO GAMEDB_SEARCH_SYNONYM_DRAFTS (USER_ID, PAIRS_JSON)
-         VALUES (:userId, :pairsJson)
-         RETURNING DRAFT_ID INTO :draftId`,
-        {
-          userId,
-          pairsJson: JSON.stringify([]),
-          draftId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-        },
-        { autoCommit: true },
-      );
-      const draftId = Number((result.outBinds as any)?.draftId?.[0]);
-      const draft = await this.getDraft(draftId, connection);
-      if (!draft) {
-        throw new Error("Failed to load synonym draft after creation.");
-      }
-      return draft;
-    } finally {
-      await connection.close();
+    const result = await oraMutate(
+      `INSERT INTO GAMEDB_SEARCH_SYNONYM_DRAFTS (USER_ID, PAIRS_JSON)
+       VALUES (:userId, :pairsJson)
+       RETURNING DRAFT_ID INTO :draftId`,
+      {
+        userId,
+        pairsJson: JSON.stringify([]),
+        draftId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+      },
+    );
+    const draftId = Number((result.outBinds as any)?.draftId?.[0]);
+    const draft = await this.getDraft(draftId);
+    if (!draft) {
+      throw new Error("Failed to load synonym draft after creation.");
     }
+    return draft;
   }
 
-  static async getDraft(
-    draftId: number,
-    connection?: oracledb.Connection,
-  ): Promise<ISynonymDraft | null> {
-    const pool = getOraclePool();
-    const activeConnection = connection ?? await pool.getConnection();
-    try {
-      const result = await activeConnection.execute(
-        `SELECT DRAFT_ID, USER_ID, PAIRS_JSON, CREATED_AT, UPDATED_AT
-           FROM GAMEDB_SEARCH_SYNONYM_DRAFTS
-          WHERE DRAFT_ID = :draftId`,
-        { draftId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT, fetchInfo: { 
-          PAIRS_JSON: { type: oracledb.STRING } } },
-      );
-      const row = (result.rows ?? [])[0] as any;
-      return row ? mapDraftRow(row) : null;
-    } finally {
-      if (!connection) {
-        await activeConnection.close();
-      }
-    }
+  static async getDraft(draftId: number): Promise<ISynonymDraft | null> {
+    const rows = await oraQuery(
+      `SELECT DRAFT_ID, USER_ID, PAIRS_JSON, CREATED_AT, UPDATED_AT
+         FROM GAMEDB_SEARCH_SYNONYM_DRAFTS
+        WHERE DRAFT_ID = :draftId`,
+      { draftId },
+      mapDraftRow,
+    );
+    return rows[0] ?? null;
   }
 
   static async appendPairs(
     draftId: number,
     pairs: ISynonymDraftPair[],
   ): Promise<ISynonymDraft | null> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      const existing = await this.getDraft(draftId, connection);
+    return oraWithConnection(async (conn) => {
+      const existing = await GameSearchSynonymDraft.getDraftWithConn(draftId, conn);
       if (!existing) return null;
       const combined = [...existing.pairs, ...pairs];
-      await connection.execute(
+      await oraMutate(
         `UPDATE GAMEDB_SEARCH_SYNONYM_DRAFTS
             SET PAIRS_JSON = :pairsJson,
                 UPDATED_AT = CURRENT_TIMESTAMP
           WHERE DRAFT_ID = :draftId`,
-        {
-          draftId,
-          pairsJson: JSON.stringify(combined),
-        },
-        { autoCommit: true },
+        { draftId, pairsJson: JSON.stringify(combined) },
+        conn,
       );
-      return await this.getDraft(draftId, connection);
-    } finally {
-      await connection.close();
-    }
+      return GameSearchSynonymDraft.getDraftWithConn(draftId, conn);
+    });
   }
 
   static async deleteDraft(draftId: number): Promise<void> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-    try {
-      await connection.execute(
-        `DELETE FROM GAMEDB_SEARCH_SYNONYM_DRAFTS WHERE DRAFT_ID = :draftId`,
-        { draftId },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `DELETE FROM GAMEDB_SEARCH_SYNONYM_DRAFTS WHERE DRAFT_ID = :draftId`,
+      { draftId },
+    );
+  }
+
+  private static async getDraftWithConn(
+    draftId: number,
+    conn: oracledb.Connection,
+  ): Promise<ISynonymDraft | null> {
+    const rows = await oraQuery(
+      `SELECT DRAFT_ID, USER_ID, PAIRS_JSON, CREATED_AT, UPDATED_AT
+         FROM GAMEDB_SEARCH_SYNONYM_DRAFTS
+        WHERE DRAFT_ID = :draftId`,
+      { draftId },
+      mapDraftRow,
+      conn,
+    );
+    return rows[0] ?? null;
   }
 }

--- a/src/classes/HltbCache.ts
+++ b/src/classes/HltbCache.ts
@@ -1,5 +1,4 @@
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 export type HltbCacheEntry = {
   gameId: number;
@@ -56,46 +55,26 @@ function mapRow(row: {
 export async function getHltbCacheByGameId(
   gameId: number,
 ): Promise<HltbCacheEntry | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      GAMEDB_GAME_ID: number;
-      HLTB_NAME: string | null;
-      HLTB_URL: string | null;
-      HLTB_IMAGE_URL: string | null;
-      MAIN: string | null;
-      MAIN_SIDES: string | null;
-      COMPLETIONIST: string | null;
-      SINGLE_PLAYER: string | null;
-      CO_OP: string | null;
-      VS: string | null;
-      SOURCE_QUERY: string | null;
-      SCRAPED_AT: Date | string | null;
-      UPDATED_AT: Date | string | null;
-    }>(
-      `SELECT GAMEDB_GAME_ID,
-              HLTB_NAME,
-              HLTB_URL,
-              HLTB_IMAGE_URL,
-              MAIN,
-              MAIN_SIDES,
-              COMPLETIONIST,
-              SINGLE_PLAYER,
-              CO_OP,
-              VS,
-              SOURCE_QUERY,
-              SCRAPED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_HLTB_CACHE
-        WHERE GAMEDB_GAME_ID = :gameId`,
-      { gameId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = (result.rows ?? [])[0];
-    return row ? mapRow(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `SELECT GAMEDB_GAME_ID,
+            HLTB_NAME,
+            HLTB_URL,
+            HLTB_IMAGE_URL,
+            MAIN,
+            MAIN_SIDES,
+            COMPLETIONIST,
+            SINGLE_PLAYER,
+            CO_OP,
+            VS,
+            SOURCE_QUERY,
+            SCRAPED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_HLTB_CACHE
+      WHERE GAMEDB_GAME_ID = :gameId`,
+    { gameId },
+    mapRow,
+  );
+  return rows[0] ?? null;
 }
 
 export async function upsertHltbCache(
@@ -113,72 +92,66 @@ export async function upsertHltbCache(
     sourceQuery?: string | null;
   },
 ): Promise<void> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `MERGE INTO RPG_CLUB_HLTB_CACHE t
-       USING (SELECT :gameId AS GAME_ID FROM dual) s
-          ON (t.GAMEDB_GAME_ID = s.GAME_ID)
-       WHEN MATCHED THEN
-         UPDATE SET
-           HLTB_NAME = :name,
-           HLTB_URL = :url,
-           HLTB_IMAGE_URL = :imageUrl,
-           MAIN = :main,
-           MAIN_SIDES = :mainSides,
-           COMPLETIONIST = :completionist,
-           SINGLE_PLAYER = :singlePlayer,
-           CO_OP = :coOp,
-           VS = :vs,
-           SOURCE_QUERY = :sourceQuery,
-           SCRAPED_AT = SYSTIMESTAMP,
-           UPDATED_AT = SYSTIMESTAMP
-       WHEN NOT MATCHED THEN
-         INSERT (
-           GAMEDB_GAME_ID,
-           HLTB_NAME,
-           HLTB_URL,
-           HLTB_IMAGE_URL,
-           MAIN,
-           MAIN_SIDES,
-           COMPLETIONIST,
-           SINGLE_PLAYER,
-           CO_OP,
-           VS,
-           SOURCE_QUERY,
-           SCRAPED_AT,
-           UPDATED_AT
-         ) VALUES (
-           :gameId,
-           :name,
-           :url,
-           :imageUrl,
-           :main,
-           :mainSides,
-           :completionist,
-           :singlePlayer,
-           :coOp,
-           :vs,
-           :sourceQuery,
-           SYSTIMESTAMP,
-           SYSTIMESTAMP
-         )`,
-      {
-        gameId,
-        name: payload.name ?? null,
-        url: payload.url ?? null,
-        imageUrl: payload.imageUrl ?? null,
-        main: payload.main ?? null,
-        mainSides: payload.mainSides ?? null,
-        completionist: payload.completionist ?? null,
-        singlePlayer: payload.singlePlayer ?? null,
-        coOp: payload.coOp ?? null,
-        vs: payload.vs ?? null,
-        sourceQuery: payload.sourceQuery ?? null,
-      },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `MERGE INTO RPG_CLUB_HLTB_CACHE t
+     USING (SELECT :gameId AS GAME_ID FROM dual) s
+        ON (t.GAMEDB_GAME_ID = s.GAME_ID)
+     WHEN MATCHED THEN
+       UPDATE SET
+         HLTB_NAME = :name,
+         HLTB_URL = :url,
+         HLTB_IMAGE_URL = :imageUrl,
+         MAIN = :main,
+         MAIN_SIDES = :mainSides,
+         COMPLETIONIST = :completionist,
+         SINGLE_PLAYER = :singlePlayer,
+         CO_OP = :coOp,
+         VS = :vs,
+         SOURCE_QUERY = :sourceQuery,
+         SCRAPED_AT = SYSTIMESTAMP,
+         UPDATED_AT = SYSTIMESTAMP
+     WHEN NOT MATCHED THEN
+       INSERT (
+         GAMEDB_GAME_ID,
+         HLTB_NAME,
+         HLTB_URL,
+         HLTB_IMAGE_URL,
+         MAIN,
+         MAIN_SIDES,
+         COMPLETIONIST,
+         SINGLE_PLAYER,
+         CO_OP,
+         VS,
+         SOURCE_QUERY,
+         SCRAPED_AT,
+         UPDATED_AT
+       ) VALUES (
+         :gameId,
+         :name,
+         :url,
+         :imageUrl,
+         :main,
+         :mainSides,
+         :completionist,
+         :singlePlayer,
+         :coOp,
+         :vs,
+         :sourceQuery,
+         SYSTIMESTAMP,
+         SYSTIMESTAMP
+       )`,
+    {
+      gameId,
+      name: payload.name ?? null,
+      url: payload.url ?? null,
+      imageUrl: payload.imageUrl ?? null,
+      main: payload.main ?? null,
+      mainSides: payload.mainSides ?? null,
+      completionist: payload.completionist ?? null,
+      singlePlayer: payload.singlePlayer ?? null,
+      coOp: payload.coOp ?? null,
+      vs: payload.vs ?? null,
+      sourceQuery: payload.sourceQuery ?? null,
+    },
+  );
 }

--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import {
+  oraQuery,
+  oraMutate,
+  oraWithConnection,
+  oraTransaction,
+} from "../db/SqlManager.js";
 
 export interface IMemberRecord {
   userId: string;
@@ -199,20 +204,23 @@ let nowPlayingLinkedThreadColumnAvailable: boolean | null = null;
 async function getNowPlayingThreadIdSql(connection: Connection): Promise<string> {
   if (nowPlayingLinkedThreadColumnAvailable === null) {
     try {
-      const res = await connection.execute<{ CNT: number }>(
+      const res = await oraQuery<{ CNT: number }, number>(
         `SELECT COUNT(*) AS CNT
            FROM ALL_TAB_COLUMNS
           WHERE OWNER = SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')
             AND TABLE_NAME = 'GAMEDB_GAMES'
             AND COLUMN_NAME = 'LINKED_THREAD_ID'`,
         {},
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row) => Number(row.CNT),
+        connection,
       );
-      nowPlayingLinkedThreadColumnAvailable = Number(res.rows?.[0]?.CNT ?? 0) > 0;
+      nowPlayingLinkedThreadColumnAvailable = (res[0] ?? 0) > 0;
     } catch (err) {
       nowPlayingLinkedThreadColumnAvailable = false;
       const msg = err instanceof Error ? err.message : String(err);
-      console.warn(`[Member] Failed to detect LINKED_THREAD_ID column; using legacy links: ${msg}`);
+      console.warn(
+        `[Member] Failed to detect LINKED_THREAD_ID column; using legacy links: ${msg}`,
+      );
     }
   }
 
@@ -246,31 +254,26 @@ function buildParams(record: IMemberRecord) {
 
 export default class Member {
   static async touchLastSeen(userId: string, when: Date = new Date()): Promise<void> {
-    const connection = await getOraclePool().getConnection();
     try {
-      await connection.execute(
+      await oraMutate(
         `UPDATE RPG_CLUB_USERS
             SET LAST_SEEN_AT = :lastSeen,
                 UPDATED_AT = SYSTIMESTAMP
           WHERE USER_ID = :userId`,
         { userId, lastSeen: when },
-        { autoCommit: true },
       );
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       console.error(`[Member] Failed to update last seen for ${userId}: ${msg}`);
-    } finally {
-      await connection.close();
     }
   }
 
   static async getNowPlaying(
     userId: string,
   ): Promise<IMemberNowPlayingEntry[]> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const threadIdSql = await getNowPlayingThreadIdSql(connection);
-      const res = await connection.execute<{
+    return oraWithConnection(async (conn) => {
+      const threadIdSql = await getNowPlayingThreadIdSql(conn);
+      const res = await conn.execute<{
         GAME_ID: number;
         TITLE: string;
         PLATFORM_ID: number | null;
@@ -356,16 +359,13 @@ export default class Member {
               : null,
         }))
         .slice(0, MAX_NOW_PLAYING);
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async getAllNowPlaying(): Promise<IMemberNowPlayingList[]> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const threadIdSql = await getNowPlayingThreadIdSql(connection);
-      const res = await connection.execute<{
+    return oraWithConnection(async (conn) => {
+      const threadIdSql = await getNowPlayingThreadIdSql(conn);
+      const res = await conn.execute<{
         USER_ID: string;
         USERNAME: string | null;
         GLOBAL_NAME: string | null;
@@ -451,49 +451,38 @@ export default class Member {
         const bName = (b.globalName ?? b.username ?? b.userId).toLowerCase();
         return aName.localeCompare(bName);
       });
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async getNowPlayingByGameIds(
     gameIds: number[],
   ): Promise<{ gameId: number; title: string; userId: string }[]> {
     if (!gameIds.length) return [];
-    const connection = await getOraclePool().getConnection();
     const placeholders = gameIds.map((_, idx) => `:id${idx}`);
     const binds: Record<string, number> = {};
     gameIds.forEach((id, idx) => {
       binds[`id${idx}`] = id;
     });
 
-    try {
-      const res = await connection.execute<{
-        GAME_ID: number;
-        TITLE: string;
-        USER_ID: string;
-      }>(
-        `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
-                g.TITLE,
-                u.USER_ID
-           FROM USER_NOW_PLAYING u
-           JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
-          WHERE u.GAMEDB_GAME_ID IN (${placeholders.join(", ")})
-            AND NVL(ru.IS_BOT, 0) = 0
-            AND ru.SERVER_LEFT_AT IS NULL
-          ORDER BY g.TITLE, u.USER_ID`,
-        binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
+      { gameId: number; title: string; userId: string }>(
+      `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
+              g.TITLE,
+              u.USER_ID
+         FROM USER_NOW_PLAYING u
+         JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
+        WHERE u.GAMEDB_GAME_ID IN (${placeholders.join(", ")})
+          AND NVL(ru.IS_BOT, 0) = 0
+          AND ru.SERVER_LEFT_AT IS NULL
+        ORDER BY g.TITLE, u.USER_ID`,
+      binds,
+      (row) => ({
         gameId: Number(row.GAME_ID),
         title: row.TITLE,
         userId: row.USER_ID,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async getNowPlayingByTitleSearch(
@@ -501,37 +490,28 @@ export default class Member {
   ): Promise<{ gameId: number; title: string; userId: string }[]> {
     const trimmed = query.trim().toLowerCase();
     if (!trimmed) return [];
-    const connection = await getOraclePool().getConnection();
     const searchQuery = `%${trimmed}%`;
     const normalizedQuery = `%${trimmed.replace(/[^a-z0-9]/g, "")}%`;
-    try {
-      const res = await connection.execute<{
-        GAME_ID: number;
-        TITLE: string;
-        USER_ID: string;
-      }>(
-        `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
-                g.TITLE,
-                u.USER_ID
-           FROM USER_NOW_PLAYING u
-           JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
-          WHERE (LOWER(g.TITLE) LIKE :searchQuery
-              OR REGEXP_REPLACE(LOWER(g.TITLE), '[^a-z0-9]', '') LIKE :normalizedQuery)
-            AND NVL(ru.IS_BOT, 0) = 0
-            AND ru.SERVER_LEFT_AT IS NULL
-          ORDER BY g.TITLE, u.USER_ID`,
-        { searchQuery, normalizedQuery },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
+      { gameId: number; title: string; userId: string }>(
+      `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
+              g.TITLE,
+              u.USER_ID
+         FROM USER_NOW_PLAYING u
+         JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
+        WHERE (LOWER(g.TITLE) LIKE :searchQuery
+            OR REGEXP_REPLACE(LOWER(g.TITLE), '[^a-z0-9]', '') LIKE :normalizedQuery)
+          AND NVL(ru.IS_BOT, 0) = 0
+          AND ru.SERVER_LEFT_AT IS NULL
+        ORDER BY g.TITLE, u.USER_ID`,
+      { searchQuery, normalizedQuery },
+      (row) => ({
         gameId: Number(row.GAME_ID),
         title: row.TITLE,
         userId: row.USER_ID,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async getNowPlayingEntries(
@@ -549,43 +529,51 @@ export default class Member {
     journalEnabled: boolean;
     hasJournalEntry: boolean;
   }[]> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        GAME_ID: number;
-        TITLE: string;
-        PLATFORM_ID: number | null;
-        PLATFORM_NAME: string | null;
-        PLATFORM_ABBREVIATION: string | null;
-        NOTE: string | null;
-        ADDED_AT: Date | string | null;
-        NOTE_UPDATED_AT: Date | string | null;
-        SORT_ORDER: number | null;
-        JOURNAL_ENABLED: number | null;
-      }>(
-        `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
-                g.TITLE,
-                u.PLATFORM_ID,
-                p.PLATFORM_NAME,
-                p.PLATFORM_ABBREVIATION,
-                u.NOTE,
-                u.ADDED_AT,
-                u.NOTE_UPDATED_AT,
-                u.SORT_ORDER,
-                jp.IS_ENABLED AS JOURNAL_ENABLED
-           FROM USER_NOW_PLAYING u
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
-           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
-           LEFT JOIN USER_GAME_JOURNAL_PREFS jp
-             ON jp.USER_ID = u.USER_ID
-            AND jp.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
-          WHERE u.USER_ID = :userId
-            AND u.GAMEDB_GAME_ID IS NOT NULL
-          ORDER BY u.SORT_ORDER NULLS LAST, u.ADDED_AT DESC, u.ENTRY_ID DESC`,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((r) => ({
+    return oraQuery<{
+      GAME_ID: number;
+      TITLE: string;
+      PLATFORM_ID: number | null;
+      PLATFORM_NAME: string | null;
+      PLATFORM_ABBREVIATION: string | null;
+      NOTE: string | null;
+      ADDED_AT: Date | string | null;
+      NOTE_UPDATED_AT: Date | string | null;
+      SORT_ORDER: number | null;
+      JOURNAL_ENABLED: number | null;
+    }, {
+      gameId: number;
+      title: string;
+      platformId: number | null;
+      platformName: string | null;
+      platformAbbreviation: string | null;
+      note: string | null;
+      addedAt: Date | null;
+      noteUpdatedAt: Date | null;
+      sortOrder: number | null;
+      journalEnabled: boolean;
+      hasJournalEntry: boolean;
+    }>(
+      `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
+              g.TITLE,
+              u.PLATFORM_ID,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              u.NOTE,
+              u.ADDED_AT,
+              u.NOTE_UPDATED_AT,
+              u.SORT_ORDER,
+              jp.IS_ENABLED AS JOURNAL_ENABLED
+         FROM USER_NOW_PLAYING u
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
+         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
+         LEFT JOIN USER_GAME_JOURNAL_PREFS jp
+           ON jp.USER_ID = u.USER_ID
+          AND jp.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
+        WHERE u.USER_ID = :userId
+          AND u.GAMEDB_GAME_ID IS NOT NULL
+        ORDER BY u.SORT_ORDER NULLS LAST, u.ADDED_AT DESC, u.ENTRY_ID DESC`,
+      { userId },
+      (r) => ({
         gameId: Number(r.GAME_ID),
         title: r.TITLE,
         platformId: r.PLATFORM_ID == null ? null : Number(r.PLATFORM_ID),
@@ -605,10 +593,8 @@ export default class Member {
         sortOrder: r.SORT_ORDER == null ? null : Number(r.SORT_ORDER),
         journalEnabled: Number(r.JOURNAL_ENABLED ?? 0) === 1,
         hasJournalEntry: false,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async getNowPlayingEntryMeta(
@@ -618,31 +604,25 @@ export default class Member {
     if (!Number.isInteger(gameId) || gameId <= 0) {
       throw new Error("Invalid GameDB id.");
     }
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        ADDED_AT: Date | string | null;
-      }>(
-        `SELECT ADDED_AT
-           FROM USER_NOW_PLAYING
-          WHERE USER_ID = :userId
-            AND GAMEDB_GAME_ID = :gameId`,
-        { userId, gameId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = res.rows?.[0];
-      if (!row) {
-        return null;
-      }
-      const addedAt = row.ADDED_AT instanceof Date
-        ? row.ADDED_AT
-        : row.ADDED_AT
-          ? new Date(row.ADDED_AT as any)
-          : null;
-      return { addedAt };
-    } finally {
-      await connection.close();
+    const rows = await oraQuery<{ ADDED_AT: Date | string | null }, { addedAt: Date | null }>(
+      `SELECT ADDED_AT
+         FROM USER_NOW_PLAYING
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+      { userId, gameId },
+      (row) => ({
+        addedAt: row.ADDED_AT instanceof Date
+          ? row.ADDED_AT
+          : row.ADDED_AT
+            ? new Date(row.ADDED_AT as any)
+            : null,
+      }),
+    );
+    const row = rows[0];
+    if (!row) {
+      return null;
     }
+    return row;
   }
 
   static async updateNowPlayingNote(
@@ -653,25 +633,19 @@ export default class Member {
     if (!Number.isInteger(gameId) || gameId <= 0) {
       throw new Error("Invalid GameDB id.");
     }
-    const connection = await getOraclePool().getConnection();
     const normalizedNote = note?.trim();
     const noteValue = normalizedNote ? normalizedNote : null;
     const noteUpdatedAt = noteValue ? new Date() : null;
 
-    try {
-      const res = await connection.execute(
-        `UPDATE USER_NOW_PLAYING
-            SET NOTE = :note,
-                NOTE_UPDATED_AT = :noteUpdatedAt
-          WHERE USER_ID = :userId
-            AND GAMEDB_GAME_ID = :gameId`,
-        { userId, gameId, note: noteValue, noteUpdatedAt },
-        { autoCommit: true },
-      );
-      return (res.rowsAffected ?? 0) > 0;
-    } finally {
-      await connection.close();
-    }
+    const res = await oraMutate(
+      `UPDATE USER_NOW_PLAYING
+          SET NOTE = :note,
+              NOTE_UPDATED_AT = :noteUpdatedAt
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+      { userId, gameId, note: noteValue, noteUpdatedAt },
+    );
+    return (res.rowsAffected ?? 0) > 0;
   }
 
   static async addNowPlaying(
@@ -686,59 +660,59 @@ export default class Member {
     if (!Number.isInteger(platformId) || platformId <= 0) {
       throw new Error("Invalid platform selection.");
     }
-    const connection = await getOraclePool().getConnection();
     const normalizedNote = note?.trim();
     const noteValue = normalizedNote ? normalizedNote : null;
     const noteUpdatedAt = noteValue ? new Date() : null;
 
     try {
-      const countRes = await connection.execute<{ CNT: number }>(
-        `SELECT COUNT(*) AS CNT FROM USER_NOW_PLAYING WHERE USER_ID = :userId`,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const count = Number((countRes.rows ?? [])[0]?.CNT ?? 0);
-      if (count >= MAX_NOW_PLAYING) {
-        throw new Error(`You can only track up to ${MAX_NOW_PLAYING} Now Playing titles.`);
-      }
+      await oraWithConnection(async (conn) => {
+        const countRes = await conn.execute<{ CNT: number }>(
+          `SELECT COUNT(*) AS CNT FROM USER_NOW_PLAYING WHERE USER_ID = :userId`,
+          { userId },
+          { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        );
+        const count = Number((countRes.rows ?? [])[0]?.CNT ?? 0);
+        if (count >= MAX_NOW_PLAYING) {
+          throw new Error(`You can only track up to ${MAX_NOW_PLAYING} Now Playing titles.`);
+        }
 
-      const sortRes = await connection.execute<{ MAX_SORT: number | null }>(
-        `SELECT MAX(SORT_ORDER) AS MAX_SORT
-           FROM USER_NOW_PLAYING
-          WHERE USER_ID = :userId`,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const maxSort = Number((sortRes.rows ?? [])[0]?.MAX_SORT ?? 0);
-      const nextSort = maxSort + 1;
+        const sortRes = await conn.execute<{ MAX_SORT: number | null }>(
+          `SELECT MAX(SORT_ORDER) AS MAX_SORT
+             FROM USER_NOW_PLAYING
+            WHERE USER_ID = :userId`,
+          { userId },
+          { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        );
+        const maxSort = Number((sortRes.rows ?? [])[0]?.MAX_SORT ?? 0);
+        const nextSort = maxSort + 1;
 
-      await connection.execute(
-        `INSERT INTO USER_NOW_PLAYING
-          (USER_ID, GAMEDB_GAME_ID, PLATFORM_ID, NOTE, NOTE_UPDATED_AT, SORT_ORDER)
-         VALUES (:userId, :gameId, :platformId, :note, :noteUpdatedAt, :sortOrder)`,
-        { userId, gameId, platformId, note: noteValue, noteUpdatedAt, sortOrder: nextSort },
-        { autoCommit: false },
-      );
-      await connection.execute(
-        `MERGE INTO USER_GAME_JOURNAL_PREFS p
-         USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
-            ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
-         WHEN MATCHED THEN
-           UPDATE SET IS_ENABLED = 1, UPDATED_AT = SYSTIMESTAMP
-         WHEN NOT MATCHED THEN
-           INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
-           VALUES (:userId, :gameId, 1, 0)`,
-        { userId, gameId },
-        { autoCommit: true },
-      );
+        await oraMutate(
+          `INSERT INTO USER_NOW_PLAYING
+            (USER_ID, GAMEDB_GAME_ID, PLATFORM_ID, NOTE, NOTE_UPDATED_AT, SORT_ORDER)
+           VALUES (:userId, :gameId, :platformId, :note, :noteUpdatedAt, :sortOrder)`,
+          { userId, gameId, platformId, note: noteValue, noteUpdatedAt, sortOrder: nextSort },
+          conn,
+        );
+        await oraMutate(
+          `MERGE INTO USER_GAME_JOURNAL_PREFS p
+           USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
+              ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
+           WHEN MATCHED THEN
+             UPDATE SET IS_ENABLED = 1, UPDATED_AT = SYSTIMESTAMP
+           WHEN NOT MATCHED THEN
+             INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
+             VALUES (:userId, :gameId, 1, 0)`,
+          { userId, gameId },
+          conn,
+        );
+        await conn.commit();
+      });
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       if (/unique/i.test(msg) || /UQ_USER_NOW_PLAYING/i.test(msg)) {
         throw new Error("That title is already in your Now Playing list.");
       }
       throw err;
-    } finally {
-      await connection.close();
     }
   }
 
@@ -746,32 +720,27 @@ export default class Member {
     userId: string,
     gameId: number,
   ): Promise<IGameJournalPreference | null> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        USER_ID: string;
-        GAMEDB_GAME_ID: number;
-        IS_ENABLED: number;
-      }>(
-        `SELECT USER_ID,
-                GAMEDB_GAME_ID,
-                IS_ENABLED
-           FROM USER_GAME_JOURNAL_PREFS
-          WHERE USER_ID = :userId
-            AND GAMEDB_GAME_ID = :gameId`,
-        { userId, gameId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = (res.rows ?? [])[0];
-      if (!row) return null;
-      return {
+    const rows = await oraQuery<{
+      USER_ID: string;
+      GAMEDB_GAME_ID: number;
+      IS_ENABLED: number;
+    }, IGameJournalPreference>(
+      `SELECT USER_ID,
+              GAMEDB_GAME_ID,
+              IS_ENABLED
+         FROM USER_GAME_JOURNAL_PREFS
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+      { userId, gameId },
+      (row) => ({
         userId: row.USER_ID,
         gameId: Number(row.GAMEDB_GAME_ID),
         isEnabled: Number(row.IS_ENABLED) === 1,
-      };
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
+    const row = rows[0];
+    if (!row) return null;
+    return row;
   }
 
   static async upsertGameJournalPreference(
@@ -779,29 +748,23 @@ export default class Member {
     gameId: number,
     isEnabled: boolean,
   ): Promise<void> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.execute(
-        `MERGE INTO USER_GAME_JOURNAL_PREFS p
-         USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
-            ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
-          WHEN MATCHED THEN
-            UPDATE SET IS_ENABLED = :isEnabled,
-                       DEFAULT_IS_PUBLIC = 1,
-                       UPDATED_AT = SYSTIMESTAMP
-          WHEN NOT MATCHED THEN
-            INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
-            VALUES (:userId, :gameId, :isEnabled, 1)`,
-        {
-          userId,
-          gameId,
-          isEnabled: isEnabled ? 1 : 0,
-        },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `MERGE INTO USER_GAME_JOURNAL_PREFS p
+       USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
+          ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
+        WHEN MATCHED THEN
+          UPDATE SET IS_ENABLED = :isEnabled,
+                     DEFAULT_IS_PUBLIC = 1,
+                     UPDATED_AT = SYSTIMESTAMP
+        WHEN NOT MATCHED THEN
+          INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
+          VALUES (:userId, :gameId, :isEnabled, 1)`,
+      {
+        userId,
+        gameId,
+        isEnabled: isEnabled ? 1 : 0,
+      },
+    );
   }
 
   static async getJournalStatusForGames(
@@ -817,7 +780,6 @@ export default class Member {
     if (!gameIds.length) return [];
     const uniqueIds = [...new Set(gameIds.filter((id) => Number.isInteger(id) && id > 0))];
     if (!uniqueIds.length) return [];
-    const connection = await getOraclePool().getConnection();
     const inlineTable = uniqueIds
       .map((_, idx) => `SELECT :id${idx} AS GAME_ID FROM DUAL`)
       .join(" UNION ALL ");
@@ -825,24 +787,21 @@ export default class Member {
     uniqueIds.forEach((id, idx) => {
       binds[`id${idx}`] = id;
     });
-    try {
-      const res = await connection.execute<{
-        GAME_ID: number;
-        JOURNAL_COUNT: number;
-        LAST_JOURNAL_AT: Date | string | null;
-      }>(
-        `SELECT gids.GAME_ID,
-                COUNT(*) AS JOURNAL_COUNT,
-                MAX(je.CREATED_AT) AS LAST_JOURNAL_AT
-           FROM (${inlineTable}) gids
-           LEFT JOIN USER_GAME_JOURNAL_ENTRIES je
-             ON je.USER_ID = :userId
-            AND je.GAMEDB_GAME_ID = gids.GAME_ID
-          GROUP BY gids.GAME_ID`,
-        binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{
+      GAME_ID: number;
+      JOURNAL_COUNT: number;
+      LAST_JOURNAL_AT: Date | string | null;
+    }, { gameId: number; journalCount: number; lastJournalAt: Date | null }>(
+      `SELECT gids.GAME_ID,
+              COUNT(*) AS JOURNAL_COUNT,
+              MAX(je.CREATED_AT) AS LAST_JOURNAL_AT
+         FROM (${inlineTable}) gids
+         LEFT JOIN USER_GAME_JOURNAL_ENTRIES je
+           ON je.USER_ID = :userId
+          AND je.GAMEDB_GAME_ID = gids.GAME_ID
+        GROUP BY gids.GAME_ID`,
+      binds,
+      (row) => ({
         gameId: Number(row.GAME_ID),
         journalCount: Number(row.JOURNAL_COUNT),
         lastJournalAt:
@@ -851,10 +810,8 @@ export default class Member {
             : row.LAST_JOURNAL_AT
               ? new Date(row.LAST_JOURNAL_AT as any)
               : null,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async getGameJournalEntries(
@@ -862,33 +819,19 @@ export default class Member {
     gameId: number,
     params?: { limit?: number; offset?: number },
   ): Promise<IGameJournalEntry[]> {
-    const connection = await getOraclePool().getConnection();
     const safeLimit = Math.min(Math.max(params?.limit ?? 5, 1), 25);
     const safeOffset = Math.max(params?.offset ?? 0, 0);
-    try {
-      const res = await connection.execute<{
-        ENTRY_ID: number;
-        USER_ID: string;
-        GAMEDB_GAME_ID: number;
-        ENTRY_TITLE: string | null;
-        ENTRY_BODY: string;
-        CREATED_AT: Date | string;
-        UPDATED_AT: Date | string;
-        ENTRY_NUMBER: number;
-      }>(
-        `WITH all_entries AS (
-           SELECT ENTRY_ID,
-                  USER_ID,
-                  GAMEDB_GAME_ID,
-                  ENTRY_TITLE,
-                  ENTRY_BODY,
-                  CREATED_AT,
-                  UPDATED_AT,
-                  ROW_NUMBER() OVER (ORDER BY CREATED_AT ASC, ENTRY_ID ASC) AS ENTRY_NUMBER
-             FROM USER_GAME_JOURNAL_ENTRIES
-            WHERE USER_ID = :userId
-              AND GAMEDB_GAME_ID = :gameId
-         )
+    return oraQuery<{
+      ENTRY_ID: number;
+      USER_ID: string;
+      GAMEDB_GAME_ID: number;
+      ENTRY_TITLE: string | null;
+      ENTRY_BODY: string;
+      CREATED_AT: Date | string;
+      UPDATED_AT: Date | string;
+      ENTRY_NUMBER: number;
+    }, IGameJournalEntry>(
+      `WITH all_entries AS (
          SELECT ENTRY_ID,
                 USER_ID,
                 GAMEDB_GAME_ID,
@@ -896,14 +839,24 @@ export default class Member {
                 ENTRY_BODY,
                 CREATED_AT,
                 UPDATED_AT,
-                ENTRY_NUMBER
-           FROM all_entries
-          ORDER BY CREATED_AT DESC, ENTRY_ID DESC
-          OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-        { userId, gameId, offset: safeOffset, limit: safeLimit },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((row) => ({
+                ROW_NUMBER() OVER (ORDER BY CREATED_AT ASC, ENTRY_ID ASC) AS ENTRY_NUMBER
+           FROM USER_GAME_JOURNAL_ENTRIES
+          WHERE USER_ID = :userId
+            AND GAMEDB_GAME_ID = :gameId
+       )
+       SELECT ENTRY_ID,
+              USER_ID,
+              GAMEDB_GAME_ID,
+              ENTRY_TITLE,
+              ENTRY_BODY,
+              CREATED_AT,
+              UPDATED_AT,
+              ENTRY_NUMBER
+         FROM all_entries
+        ORDER BY CREATED_AT DESC, ENTRY_ID DESC
+        OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+      { userId, gameId, offset: safeOffset, limit: safeLimit },
+      (row) => ({
         entryId: Number(row.ENTRY_ID),
         entryNumber: Number(row.ENTRY_NUMBER),
         userId: row.USER_ID,
@@ -912,27 +865,20 @@ export default class Member {
         body: row.ENTRY_BODY,
         createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT),
         updatedAt: row.UPDATED_AT instanceof Date ? row.UPDATED_AT : new Date(row.UPDATED_AT),
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async countGameJournalEntries(userId: string, gameId: number): Promise<number> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{ CNT: number }>(
-        `SELECT COUNT(*) AS CNT
-           FROM USER_GAME_JOURNAL_ENTRIES
-          WHERE USER_ID = :userId
-            AND GAMEDB_GAME_ID = :gameId`,
-        { userId, gameId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return Number((res.rows ?? [])[0]?.CNT ?? 0);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery<{ CNT: number }, number>(
+      `SELECT COUNT(*) AS CNT
+         FROM USER_GAME_JOURNAL_ENTRIES
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+      { userId, gameId },
+      (row) => Number(row.CNT),
+    );
+    return rows[0] ?? 0;
   }
 
   static async addGameJournalEntry(params: {
@@ -941,71 +887,59 @@ export default class Member {
     title?: string | null;
     body: string;
   }): Promise<void> {
-    const connection = await getOraclePool().getConnection();
     const titleValue = params.title?.trim() ? params.title.trim() : null;
     const bodyValue = params.body.trim();
     if (!bodyValue) {
       throw new Error("Journal body cannot be empty.");
     }
-    try {
-      await connection.execute(
-        `INSERT INTO USER_GAME_JOURNAL_ENTRIES
-          (USER_ID, GAMEDB_GAME_ID, ENTRY_TITLE, ENTRY_BODY, IS_PUBLIC)
-         VALUES
-          (:userId, :gameId, :title, :body, 1)`,
-        {
-          userId: params.userId,
-          gameId: params.gameId,
-          title: titleValue,
-          body: bodyValue,
-        },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `INSERT INTO USER_GAME_JOURNAL_ENTRIES
+        (USER_ID, GAMEDB_GAME_ID, ENTRY_TITLE, ENTRY_BODY, IS_PUBLIC)
+       VALUES
+        (:userId, :gameId, :title, :body, 1)`,
+      {
+        userId: params.userId,
+        gameId: params.gameId,
+        title: titleValue,
+        body: bodyValue,
+      },
+    );
   }
 
   static async getGameJournalEntryForUser(
     userId: string,
     entryId: number,
   ): Promise<IGameJournalEntry | null> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        ENTRY_ID: number;
-        USER_ID: string;
-        GAMEDB_GAME_ID: number;
-        ENTRY_TITLE: string | null;
-        ENTRY_BODY: string;
-        CREATED_AT: Date | string;
-        UPDATED_AT: Date | string;
-        ENTRY_NUMBER: number;
-      }>(
-        `SELECT e.ENTRY_ID,
-                e.USER_ID,
-                e.GAMEDB_GAME_ID,
-                e.ENTRY_TITLE,
-                e.ENTRY_BODY,
-                e.CREATED_AT,
-                e.UPDATED_AT,
-                (SELECT COUNT(*) + 1
-                   FROM USER_GAME_JOURNAL_ENTRIES e2
-                  WHERE e2.USER_ID = e.USER_ID
-                    AND e2.GAMEDB_GAME_ID = e.GAMEDB_GAME_ID
-                    AND (e2.CREATED_AT < e.CREATED_AT
-                         OR (e2.CREATED_AT = e.CREATED_AT AND e2.ENTRY_ID < e.ENTRY_ID))
-                ) AS ENTRY_NUMBER
-           FROM USER_GAME_JOURNAL_ENTRIES e
-          WHERE e.USER_ID = :userId
-            AND e.ENTRY_ID = :entryId
-          FETCH FIRST 1 ROWS ONLY`,
-        { userId, entryId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = (res.rows ?? [])[0];
-      if (!row) return null;
-      return {
+    const rows = await oraQuery<{
+      ENTRY_ID: number;
+      USER_ID: string;
+      GAMEDB_GAME_ID: number;
+      ENTRY_TITLE: string | null;
+      ENTRY_BODY: string;
+      CREATED_AT: Date | string;
+      UPDATED_AT: Date | string;
+      ENTRY_NUMBER: number;
+    }, IGameJournalEntry>(
+      `SELECT e.ENTRY_ID,
+              e.USER_ID,
+              e.GAMEDB_GAME_ID,
+              e.ENTRY_TITLE,
+              e.ENTRY_BODY,
+              e.CREATED_AT,
+              e.UPDATED_AT,
+              (SELECT COUNT(*) + 1
+                 FROM USER_GAME_JOURNAL_ENTRIES e2
+                WHERE e2.USER_ID = e.USER_ID
+                  AND e2.GAMEDB_GAME_ID = e.GAMEDB_GAME_ID
+                  AND (e2.CREATED_AT < e.CREATED_AT
+                       OR (e2.CREATED_AT = e.CREATED_AT AND e2.ENTRY_ID < e.ENTRY_ID))
+              ) AS ENTRY_NUMBER
+         FROM USER_GAME_JOURNAL_ENTRIES e
+        WHERE e.USER_ID = :userId
+          AND e.ENTRY_ID = :entryId
+        FETCH FIRST 1 ROWS ONLY`,
+      { userId, entryId },
+      (row) => ({
         entryId: Number(row.ENTRY_ID),
         entryNumber: Number(row.ENTRY_NUMBER),
         userId: row.USER_ID,
@@ -1014,10 +948,11 @@ export default class Member {
         body: row.ENTRY_BODY,
         createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT),
         updatedAt: row.UPDATED_AT instanceof Date ? row.UPDATED_AT : new Date(row.UPDATED_AT),
-      };
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
+    const row = rows[0];
+    if (!row) return null;
+    return row;
   }
 
   static async updateGameJournalEntry(params: {
@@ -1026,7 +961,6 @@ export default class Member {
     title?: string | null;
     body?: string;
   }): Promise<boolean> {
-    const connection = await getOraclePool().getConnection();
     const fields: string[] = [];
     const binds: Record<string, unknown> = {
       userId: params.userId,
@@ -1048,35 +982,24 @@ export default class Member {
     if (!fields.length) return false;
     fields.push("UPDATED_AT = SYSTIMESTAMP");
 
-    try {
-      const res = await connection.execute(
-        `UPDATE USER_GAME_JOURNAL_ENTRIES
-            SET ${fields.join(", ")}
-          WHERE USER_ID = :userId
-            AND ENTRY_ID = :entryId`,
-        binds as Record<string, any>,
-        { autoCommit: true },
-      );
-      return Number(res.rowsAffected ?? 0) > 0;
-    } finally {
-      await connection.close();
-    }
+    const res = await oraMutate(
+      `UPDATE USER_GAME_JOURNAL_ENTRIES
+          SET ${fields.join(", ")}
+        WHERE USER_ID = :userId
+          AND ENTRY_ID = :entryId`,
+      binds as Record<string, any>,
+    );
+    return Number(res.rowsAffected ?? 0) > 0;
   }
 
   static async deleteGameJournalEntry(userId: string, entryId: number): Promise<boolean> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute(
-        `DELETE FROM USER_GAME_JOURNAL_ENTRIES
-          WHERE USER_ID = :userId
-            AND ENTRY_ID = :entryId`,
-        { userId, entryId },
-        { autoCommit: true },
-      );
-      return Number(res.rowsAffected ?? 0) > 0;
-    } finally {
-      await connection.close();
-    }
+    const res = await oraMutate(
+      `DELETE FROM USER_GAME_JOURNAL_ENTRIES
+        WHERE USER_ID = :userId
+          AND ENTRY_ID = :entryId`,
+      { userId, entryId },
+    );
+    return Number(res.rowsAffected ?? 0) > 0;
   }
 
   static async updateNowPlayingSort(
@@ -1084,44 +1007,35 @@ export default class Member {
     orderedGameIds: number[],
   ): Promise<boolean> {
     if (!orderedGameIds.length) return false;
-    const connection = await getOraclePool().getConnection();
-    try {
+    return oraWithConnection(async (conn) => {
       const binds = orderedGameIds.map((gameId, idx) => ({
         userId,
         gameId,
         sortOrder: idx + 1,
       }));
-      const result = await connection.executeMany(
+      const result = await conn.executeMany(
         `UPDATE USER_NOW_PLAYING
             SET SORT_ORDER = :sortOrder
           WHERE USER_ID = :userId
             AND GAMEDB_GAME_ID = :gameId`,
         binds,
-        { autoCommit: true },
       );
+      await conn.commit();
       return (result.rowsAffected ?? 0) > 0;
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async removeNowPlaying(userId: string, gameId: number): Promise<boolean> {
     if (!Number.isInteger(gameId) || gameId <= 0) {
       throw new Error("Invalid GameDB id.");
     }
-    const connection = await getOraclePool().getConnection();
 
-    try {
-      const res = await connection.execute(
-        `DELETE FROM USER_NOW_PLAYING WHERE USER_ID = :userId AND GAMEDB_GAME_ID = :gameId`,
-        { userId, gameId },
-        { autoCommit: true },
-      );
-      const rows = (res as any).rowsAffected ?? 0;
-      return rows > 0;
-    } finally {
-      await connection.close();
-    }
+    const res = await oraMutate(
+      `DELETE FROM USER_NOW_PLAYING WHERE USER_ID = :userId AND GAMEDB_GAME_ID = :gameId`,
+      { userId, gameId },
+    );
+    const rows = (res as any).rowsAffected ?? 0;
+    return rows > 0;
   }
 
   static async addCompletion(params: {
@@ -1161,12 +1075,11 @@ export default class Member {
         throw new Error("Playtime must have at most 2 decimal places.");
       }
     }
-    const connection = await getOraclePool().getConnection();
     const normalizedNote = note?.trim();
     const noteValue = normalizedNote ? normalizedNote : null;
 
-    try {
-      const result = await connection.execute<{ COMPLETION_ID: number }>(
+    return oraTransaction(async (conn) => {
+      const result = await oraMutate(
         `
         INSERT INTO USER_GAME_COMPLETIONS (
           USER_ID, GAMEDB_GAME_ID, COMPLETION_TYPE, PLATFORM_ID,
@@ -1186,81 +1099,69 @@ export default class Member {
           note: noteValue,
           completionId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
         },
-        { autoCommit: false },
+        conn,
       );
 
       const id = (result.outBinds as any)?.completionId?.[0];
       if (!id) throw new Error("Failed to save completion (no id returned).");
 
-      const verify = await connection.execute<{ CNT: number }>(
-        `SELECT COUNT(*) AS CNT FROM USER_GAME_COMPLETIONS WHERE COMPLETION_ID = :id AND USER_ID = :userId`,
+      const verify = await oraQuery<{ CNT: number }, number>(
+        `SELECT COUNT(*) AS CNT FROM USER_GAME_COMPLETIONS
+          WHERE COMPLETION_ID = :id AND USER_ID = :userId`,
         { id, userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row) => Number(row.CNT),
+        conn,
       );
-      const exists = Number((verify.rows ?? [])[0]?.CNT ?? 0) > 0;
+      const exists = (verify[0] ?? 0) > 0;
       if (!exists) {
         throw new Error("Completion insert verification failed (row not found after insert).");
       }
 
-      await connection.commit();
       return Number(id);
-    } catch (err) {
-      await connection.rollback().catch(() => {});
-      throw err;
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async getCompletion(completionId: number): Promise<ICompletionRecord | null> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        COMPLETION_ID: number;
-        GAME_ID: number;
-        TITLE: string;
-        COMPLETION_TYPE: string;
-        PLATFORM_ID: number | null;
-        COMPLETED_AT: Date | null;
-        FINAL_PLAYTIME_HRS: number | null;
-        CREATED_AT: Date;
-        THREAD_ID: string | null;
-        NOTE: string | null;
-      }>(
-        `
-        SELECT c.COMPLETION_ID,
-               g.GAME_ID,
-               g.TITLE,
-               c.COMPLETION_TYPE,
-               c.PLATFORM_ID,
-               c.COMPLETED_AT,
-               c.FINAL_PLAYTIME_HRS,
-               c.CREATED_AT,
-               c.NOTE,
-               COALESCE(
-                  (
-                    SELECT MIN(tgl.THREAD_ID)
-                    FROM THREAD_GAME_LINKS tgl
-                    WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  ),
-                  (
-                    SELECT MIN(th.THREAD_ID)
-                    FROM THREADS th
-                    WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  )
-                ) AS THREAD_ID
-          FROM USER_GAME_COMPLETIONS c
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE c.COMPLETION_ID = :completionId
-        `,
-        { completionId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const row = (res.rows ?? [])[0];
-      if (!row) return null;
-
-      return {
+    const rows = await oraQuery<{
+      COMPLETION_ID: number;
+      GAME_ID: number;
+      TITLE: string;
+      COMPLETION_TYPE: string;
+      PLATFORM_ID: number | null;
+      COMPLETED_AT: Date | null;
+      FINAL_PLAYTIME_HRS: number | null;
+      CREATED_AT: Date;
+      THREAD_ID: string | null;
+      NOTE: string | null;
+    }, ICompletionRecord>(
+      `
+      SELECT c.COMPLETION_ID,
+             g.GAME_ID,
+             g.TITLE,
+             c.COMPLETION_TYPE,
+             c.PLATFORM_ID,
+             c.COMPLETED_AT,
+             c.FINAL_PLAYTIME_HRS,
+             c.CREATED_AT,
+             c.NOTE,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.THREAD_ID)
+                  FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                ),
+                (
+                  SELECT MIN(th.THREAD_ID)
+                  FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                )
+              ) AS THREAD_ID
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE c.COMPLETION_ID = :completionId
+      `,
+      { completionId },
+      (row) => ({
         completionId: Number(row.COMPLETION_ID),
         gameId: Number(row.GAME_ID),
         title: String(row.TITLE),
@@ -1282,65 +1183,57 @@ export default class Member {
               : new Date(),
         threadId: row.THREAD_ID ?? null,
         note: row.NOTE ?? null,
-      };
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
+
+    return rows[0] ?? null;
   }
 
   static async getCompletionForUser(
     userId: string,
     completionId: number,
   ): Promise<ICompletionRecord | null> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        COMPLETION_ID: number;
-        GAME_ID: number;
-        TITLE: string;
-        COMPLETION_TYPE: string;
-        PLATFORM_ID: number | null;
-        COMPLETED_AT: Date | null;
-        FINAL_PLAYTIME_HRS: number | null;
-        CREATED_AT: Date;
-        THREAD_ID: string | null;
-        NOTE: string | null;
-      }>(
-        `
-        SELECT c.COMPLETION_ID,
-               g.GAME_ID,
-               g.TITLE,
-               c.COMPLETION_TYPE,
-               c.PLATFORM_ID,
-               c.COMPLETED_AT,
-               c.FINAL_PLAYTIME_HRS,
-               c.CREATED_AT,
-               c.NOTE,
-               COALESCE(
-                  (
-                    SELECT MIN(tgl.THREAD_ID)
-                    FROM THREAD_GAME_LINKS tgl
-                    WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  ),
-                  (
-                    SELECT MIN(th.THREAD_ID)
-                    FROM THREADS th
-                    WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  )
-                ) AS THREAD_ID
-          FROM USER_GAME_COMPLETIONS c
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE c.USER_ID = :userId
-           AND c.COMPLETION_ID = :completionId
-        `,
-        { userId, completionId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const row = (res.rows ?? [])[0];
-      if (!row) return null;
-
-      return {
+    const rows = await oraQuery<{
+      COMPLETION_ID: number;
+      GAME_ID: number;
+      TITLE: string;
+      COMPLETION_TYPE: string;
+      PLATFORM_ID: number | null;
+      COMPLETED_AT: Date | null;
+      FINAL_PLAYTIME_HRS: number | null;
+      CREATED_AT: Date;
+      THREAD_ID: string | null;
+      NOTE: string | null;
+    }, ICompletionRecord>(
+      `
+      SELECT c.COMPLETION_ID,
+             g.GAME_ID,
+             g.TITLE,
+             c.COMPLETION_TYPE,
+             c.PLATFORM_ID,
+             c.COMPLETED_AT,
+             c.FINAL_PLAYTIME_HRS,
+             c.CREATED_AT,
+             c.NOTE,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.THREAD_ID)
+                  FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                ),
+                (
+                  SELECT MIN(th.THREAD_ID)
+                  FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                )
+              ) AS THREAD_ID
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE c.USER_ID = :userId
+         AND c.COMPLETION_ID = :completionId
+      `,
+      { userId, completionId },
+      (row) => ({
         completionId: Number(row.COMPLETION_ID),
         gameId: Number(row.GAME_ID),
         title: String(row.TITLE),
@@ -1362,10 +1255,10 @@ export default class Member {
               : new Date(),
         threadId: row.THREAD_ID ?? null,
         note: row.NOTE ?? null,
-      };
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
+
+    return rows[0] ?? null;
   }
 
   static async getCompletionByGameId(
@@ -1375,56 +1268,48 @@ export default class Member {
     if (!Number.isInteger(gameId) || gameId <= 0) {
       throw new Error("Invalid GameDB id.");
     }
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        COMPLETION_ID: number;
-        GAME_ID: number;
-        TITLE: string;
-        COMPLETION_TYPE: string;
-        PLATFORM_ID: number | null;
-        COMPLETED_AT: Date | null;
-        FINAL_PLAYTIME_HRS: number | null;
-        CREATED_AT: Date;
-        THREAD_ID: string | null;
-        NOTE: string | null;
-      }>(
-        `
-        SELECT c.COMPLETION_ID,
-               g.GAME_ID,
-               g.TITLE,
-               c.COMPLETION_TYPE,
-               c.PLATFORM_ID,
-               c.COMPLETED_AT,
-               c.FINAL_PLAYTIME_HRS,
-               c.CREATED_AT,
-               c.NOTE,
-               COALESCE(
-                  (
-                    SELECT MIN(tgl.THREAD_ID)
-                    FROM THREAD_GAME_LINKS tgl
-                    WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  ),
-                  (
-                    SELECT MIN(th.THREAD_ID)
-                    FROM THREADS th
-                    WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  )
-                ) AS THREAD_ID
-          FROM USER_GAME_COMPLETIONS c
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE c.USER_ID = :userId
-           AND c.GAMEDB_GAME_ID = :gameId
-         FETCH FIRST 1 ROWS ONLY
-        `,
-        { userId, gameId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const row = (res.rows ?? [])[0];
-      if (!row) return null;
-
-      return {
+    const rows = await oraQuery<{
+      COMPLETION_ID: number;
+      GAME_ID: number;
+      TITLE: string;
+      COMPLETION_TYPE: string;
+      PLATFORM_ID: number | null;
+      COMPLETED_AT: Date | null;
+      FINAL_PLAYTIME_HRS: number | null;
+      CREATED_AT: Date;
+      THREAD_ID: string | null;
+      NOTE: string | null;
+    }, ICompletionRecord>(
+      `
+      SELECT c.COMPLETION_ID,
+             g.GAME_ID,
+             g.TITLE,
+             c.COMPLETION_TYPE,
+             c.PLATFORM_ID,
+             c.COMPLETED_AT,
+             c.FINAL_PLAYTIME_HRS,
+             c.CREATED_AT,
+             c.NOTE,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.THREAD_ID)
+                  FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                ),
+                (
+                  SELECT MIN(th.THREAD_ID)
+                  FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                )
+              ) AS THREAD_ID
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE c.USER_ID = :userId
+         AND c.GAMEDB_GAME_ID = :gameId
+       FETCH FIRST 1 ROWS ONLY
+      `,
+      { userId, gameId },
+      (row) => ({
         completionId: Number(row.COMPLETION_ID),
         gameId: Number(row.GAME_ID),
         title: String(row.TITLE),
@@ -1446,10 +1331,10 @@ export default class Member {
               : new Date(),
         threadId: row.THREAD_ID ?? null,
         note: row.NOTE ?? null,
-      };
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
+
+    return rows[0] ?? null;
   }
 
   static async getCompletions(params: {
@@ -1460,7 +1345,6 @@ export default class Member {
     title?: string;
   }): Promise<ICompletionRecord[]> {
     const { userId, limit, offset = 0, year = null, title } = params;
-    const connection = await getOraclePool().getConnection();
     const safeLimit = Math.min(Math.max(limit, 1), 1000);
     const safeOffset = Math.max(offset, 0);
 
@@ -1477,52 +1361,48 @@ export default class Member {
       binds.title = title;
     }
 
-    try {
-      const res = await connection.execute<{
-        COMPLETION_ID: number;
-        GAME_ID: number;
-        TITLE: string;
-        COMPLETION_TYPE: string;
-        PLATFORM_ID: number | null;
-        COMPLETED_AT: Date | null;
-        FINAL_PLAYTIME_HRS: number | null;
-        CREATED_AT: Date;
-        THREAD_ID: string | null;
-        NOTE: string | null;
-      }>(
-        `
-        SELECT c.COMPLETION_ID,
-               g.GAME_ID,
-               g.TITLE,
-               c.COMPLETION_TYPE,
-               c.PLATFORM_ID,
-               c.COMPLETED_AT,
-               c.FINAL_PLAYTIME_HRS,
-               c.CREATED_AT,
-               c.NOTE,
-               COALESCE(
-                  (
-                    SELECT MIN(tgl.THREAD_ID)
-                    FROM THREAD_GAME_LINKS tgl
-                    WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  ),
-                  (
-                    SELECT MIN(th.THREAD_ID)
-                    FROM THREADS th
-                    WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  )
-                ) AS THREAD_ID
-          FROM USER_GAME_COMPLETIONS c
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE ${clauses.join(" AND ")}
-         ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC
-         OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY
-        `,
-        binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{
+      COMPLETION_ID: number;
+      GAME_ID: number;
+      TITLE: string;
+      COMPLETION_TYPE: string;
+      PLATFORM_ID: number | null;
+      COMPLETED_AT: Date | null;
+      FINAL_PLAYTIME_HRS: number | null;
+      CREATED_AT: Date;
+      THREAD_ID: string | null;
+      NOTE: string | null;
+    }, ICompletionRecord>(
+      `
+      SELECT c.COMPLETION_ID,
+             g.GAME_ID,
+             g.TITLE,
+             c.COMPLETION_TYPE,
+             c.PLATFORM_ID,
+             c.COMPLETED_AT,
+             c.FINAL_PLAYTIME_HRS,
+             c.CREATED_AT,
+             c.NOTE,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.THREAD_ID)
+                  FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                ),
+                (
+                  SELECT MIN(th.THREAD_ID)
+                  FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                )
+              ) AS THREAD_ID
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE ${clauses.join(" AND ")}
+       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC
+       OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY
+      `,
+      binds,
+      (row) => ({
         completionId: Number(row.COMPLETION_ID),
         gameId: Number(row.GAME_ID),
         title: String(row.TITLE),
@@ -1544,59 +1424,52 @@ export default class Member {
               : new Date(),
         threadId: row.THREAD_ID ?? null,
         note: row.NOTE ?? null,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async getAllCompletions(userId: string): Promise<ICompletionRecord[]> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        COMPLETION_ID: number;
-        GAME_ID: number;
-        TITLE: string;
-        COMPLETION_TYPE: string;
-        PLATFORM_ID: number | null;
-        COMPLETED_AT: Date | null;
-        FINAL_PLAYTIME_HRS: number | null;
-        CREATED_AT: Date;
-        THREAD_ID: string | null;
-        NOTE: string | null;
-      }>(
-        `
-        SELECT c.COMPLETION_ID,
-               g.GAME_ID,
-               g.TITLE,
-               c.COMPLETION_TYPE,
-               c.PLATFORM_ID,
-               c.COMPLETED_AT,
-               c.FINAL_PLAYTIME_HRS,
-               c.CREATED_AT,
-               c.NOTE,
-               COALESCE(
-                  (
-                    SELECT MIN(tgl.THREAD_ID)
-                    FROM THREAD_GAME_LINKS tgl
-                    WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  ),
-                  (
-                    SELECT MIN(th.THREAD_ID)
-                    FROM THREADS th
-                    WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  )
-                ) AS THREAD_ID
-          FROM USER_GAME_COMPLETIONS c
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE c.USER_ID = :userId
-         ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.CREATED_AT DESC, c.COMPLETION_ID DESC
-        `,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{
+      COMPLETION_ID: number;
+      GAME_ID: number;
+      TITLE: string;
+      COMPLETION_TYPE: string;
+      PLATFORM_ID: number | null;
+      COMPLETED_AT: Date | null;
+      FINAL_PLAYTIME_HRS: number | null;
+      CREATED_AT: Date;
+      THREAD_ID: string | null;
+      NOTE: string | null;
+    }, ICompletionRecord>(
+      `
+      SELECT c.COMPLETION_ID,
+             g.GAME_ID,
+             g.TITLE,
+             c.COMPLETION_TYPE,
+             c.PLATFORM_ID,
+             c.COMPLETED_AT,
+             c.FINAL_PLAYTIME_HRS,
+             c.CREATED_AT,
+             c.NOTE,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.THREAD_ID)
+                  FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                ),
+                (
+                  SELECT MIN(th.THREAD_ID)
+                  FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                )
+              ) AS THREAD_ID
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE c.USER_ID = :userId
+       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.CREATED_AT DESC, c.COMPLETION_ID DESC
+      `,
+      { userId },
+      (row) => ({
         completionId: Number(row.COMPLETION_ID),
         gameId: Number(row.GAME_ID),
         title: String(row.TITLE),
@@ -1618,10 +1491,8 @@ export default class Member {
               : new Date(),
         threadId: row.THREAD_ID ?? null,
         note: row.NOTE ?? null,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async countCompletions(
@@ -1629,7 +1500,6 @@ export default class Member {
     year?: number | "unknown" | null,
     title?: string,
   ): Promise<number> {
-    const connection = await getOraclePool().getConnection();
     const clauses: string[] = ["c.USER_ID = :userId"];
     const binds: Record<string, any> = { userId };
     if (year === "unknown") {
@@ -1643,21 +1513,17 @@ export default class Member {
       binds.title = title;
     }
 
-    try {
-      const res = await connection.execute<{ CNT: number }>(
-        `
-        SELECT COUNT(*) AS CNT
-          FROM USER_GAME_COMPLETIONS c
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE ${clauses.join(" AND ")}
-        `,
-        binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return Number((res.rows ?? [])[0]?.CNT ?? 0);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery<{ CNT: number }, number>(
+      `
+      SELECT COUNT(*) AS CNT
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE ${clauses.join(" AND ")}
+      `,
+      binds,
+      (row) => Number(row.CNT),
+    );
+    return rows[0] ?? 0;
   }
 
   static async updateCompletion(
@@ -1687,7 +1553,7 @@ export default class Member {
       binds.completedAt = updates.completedAt;
     }
     if (updates.platformId !== undefined) {
-      if (updates.platformId != null && 
+      if (updates.platformId != null &&
         (!Number.isInteger(updates.platformId) || updates.platformId <= 0)) {
         throw new Error("Invalid platform selection.");
       }
@@ -1706,79 +1572,62 @@ export default class Member {
 
     if (!fields.length) return false;
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute(
-        `
-        UPDATE USER_GAME_COMPLETIONS
-           SET ${fields.join(", ")}
-         WHERE COMPLETION_ID = :completionId
-           AND USER_ID = :userId
-        `,
-        binds,
-        { autoCommit: true },
-      );
-      const rows = (res as any).rowsAffected ?? 0;
-      return rows > 0;
-    } finally {
-      await connection.close();
-    }
+    const res = await oraMutate(
+      `
+      UPDATE USER_GAME_COMPLETIONS
+         SET ${fields.join(", ")}
+       WHERE COMPLETION_ID = :completionId
+         AND USER_ID = :userId
+      `,
+      binds,
+    );
+    const rows = (res as any).rowsAffected ?? 0;
+    return rows > 0;
   }
 
   static async deleteCompletion(userId: string, completionId: number): Promise<boolean> {
     if (!Number.isInteger(completionId) || completionId <= 0) {
       throw new Error("Invalid completion id.");
     }
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute(
-        `
-        DELETE FROM USER_GAME_COMPLETIONS
-         WHERE COMPLETION_ID = :completionId
-           AND USER_ID = :userId
-        `,
-        { completionId, userId },
-        { autoCommit: true },
-      );
-      const rows = (res as any).rowsAffected ?? 0;
-      return rows > 0;
-    } finally {
-      await connection.close();
-    }
+    const res = await oraMutate(
+      `
+      DELETE FROM USER_GAME_COMPLETIONS
+       WHERE COMPLETION_ID = :completionId
+         AND USER_ID = :userId
+      `,
+      { completionId, userId },
+    );
+    const rows = (res as any).rowsAffected ?? 0;
+    return rows > 0;
   }
 
   static async getRecentNickHistory(
     userId: string,
     limit: number = 5,
   ): Promise<IMemberNickHistory[]> {
-    const connection = await getOraclePool().getConnection();
     const safeLimit = Math.min(Math.max(limit, 1), 20);
     try {
-      const result = await connection.execute<{
+      return await oraQuery<{
         OLD_NICK: string | null;
         NEW_NICK: string | null;
         CHANGED_AT: Date;
-      }>(
+      }, IMemberNickHistory>(
         `SELECT OLD_NICK, NEW_NICK, CHANGED_AT
            FROM RPG_CLUB_USER_NICK_HISTORY
           WHERE USER_ID = :userId
           ORDER BY CHANGED_AT DESC
           FETCH FIRST :limit ROWS ONLY`,
         { userId, limit: safeLimit },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row) => ({
+          oldNick: row.OLD_NICK ?? null,
+          newNick: row.NEW_NICK ?? null,
+          changedAt: row.CHANGED_AT,
+        }),
       );
-
-      return (result.rows ?? []).map((row) => ({
-        oldNick: row.OLD_NICK ?? null,
-        newNick: row.NEW_NICK ?? null,
-        changedAt: row.CHANGED_AT,
-      }));
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       console.error(`[Member] Failed to load nick history for ${userId}: ${msg}`);
       return [];
-    } finally {
-      await connection.close();
     }
   }
 
@@ -1791,7 +1640,6 @@ export default class Member {
     globalName: string | null;
     count: number;
   }[]> {
-    const connection = await getOraclePool().getConnection();
     const safeLimit = Math.min(Math.max(limit, 1), 100);
     const clauses: string[] = ["u.SERVER_LEFT_AT IS NULL"];
     const binds: Record<string, any> = { limit: safeLimit };
@@ -1800,41 +1648,33 @@ export default class Member {
       binds.title = title;
     }
 
-    try {
-      const res = await connection.execute<{
-        USER_ID: string;
-        USERNAME: string | null;
-        GLOBAL_NAME: string | null;
-        CNT: number;
-      }>(
-        `
-        SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME, COUNT(*) AS CNT
-          FROM USER_GAME_COMPLETIONS c
-          JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE ${clauses.join(" AND ")}
-         GROUP BY c.USER_ID, u.USERNAME, u.GLOBAL_NAME
-         ORDER BY CNT DESC
-         FETCH FIRST :limit ROWS ONLY
-        `,
-        binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{
+      USER_ID: string;
+      USERNAME: string | null;
+      GLOBAL_NAME: string | null;
+      CNT: number;
+    }, { userId: string; username: string | null; globalName: string | null; count: number }>(
+      `
+      SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME, COUNT(*) AS CNT
+        FROM USER_GAME_COMPLETIONS c
+        JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE ${clauses.join(" AND ")}
+       GROUP BY c.USER_ID, u.USERNAME, u.GLOBAL_NAME
+       ORDER BY CNT DESC
+       FETCH FIRST :limit ROWS ONLY
+      `,
+      binds,
+      (row) => ({
         userId: row.USER_ID,
         username: row.USERNAME ?? null,
         globalName: row.GLOBAL_NAME ?? null,
         count: Number(row.CNT),
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async search(filters: IMemberSearchFilters): Promise<IMemberSearchResult[]> {
-    const connection = await getOraclePool().getConnection();
-
     const safeLimit = Math.min(Math.max(filters.limit ?? 50, 1), 100);
     const clauses: string[] = [];
     const params: Record<string, any> = { limit: safeLimit };
@@ -1893,55 +1733,48 @@ export default class Member {
 
     const where = clauses.length ? clauses.join(" AND ") : "1=1";
 
-    try {
-      const result = await connection.execute<{
-        USER_ID: string;
-        USERNAME: string | null;
-        GLOBAL_NAME: string | null;
-        IS_BOT: number;
-        COMPLETIONATOR_URL: string | null;
-        STEAM_URL: string | null;
-        PSN_USERNAME: string | null;
-        XBL_USERNAME: string | null;
-        NSW_FRIEND_CODE: string | null;
-        ROLE_ADMIN: number;
-        ROLE_MODERATOR: number;
-        ROLE_REGULAR: number;
-        ROLE_MEMBER: number;
-        ROLE_NEWCOMER: number;
-        SERVER_LEFT_AT: Date | null;
-        SERVER_JOINED_AT: Date | null;
-        LAST_SEEN_AT: Date | null;
-      }>(
-        `SELECT USER_ID,
-                USERNAME,
-                GLOBAL_NAME,
-                IS_BOT,
-                COMPLETIONATOR_URL,
-                STEAM_URL,
-                PSN_USERNAME,
-                XBL_USERNAME,
-                NSW_FRIEND_CODE,
-                ROLE_ADMIN,
-                ROLE_MODERATOR,
-                ROLE_REGULAR,
-                ROLE_MEMBER,
-                ROLE_NEWCOMER,
-                SERVER_LEFT_AT,
-                SERVER_JOINED_AT,
-                LAST_SEEN_AT
-           FROM RPG_CLUB_USERS
-          WHERE ${where}
-          ORDER BY COALESCE(UPPER(GLOBAL_NAME), UPPER(USERNAME), USER_ID)
-          FETCH FIRST :limit ROWS ONLY`,
-        params,
-        {
-          outFormat: oracledb.OUT_FORMAT_OBJECT,
-        },
-      );
-
-      const rows = result.rows ?? [];
-      return rows.map<IMemberSearchResult>((row) => ({
+    return oraQuery<{
+      USER_ID: string;
+      USERNAME: string | null;
+      GLOBAL_NAME: string | null;
+      IS_BOT: number;
+      COMPLETIONATOR_URL: string | null;
+      STEAM_URL: string | null;
+      PSN_USERNAME: string | null;
+      XBL_USERNAME: string | null;
+      NSW_FRIEND_CODE: string | null;
+      ROLE_ADMIN: number;
+      ROLE_MODERATOR: number;
+      ROLE_REGULAR: number;
+      ROLE_MEMBER: number;
+      ROLE_NEWCOMER: number;
+      SERVER_LEFT_AT: Date | null;
+      SERVER_JOINED_AT: Date | null;
+      LAST_SEEN_AT: Date | null;
+    }, IMemberSearchResult>(
+      `SELECT USER_ID,
+              USERNAME,
+              GLOBAL_NAME,
+              IS_BOT,
+              COMPLETIONATOR_URL,
+              STEAM_URL,
+              PSN_USERNAME,
+              XBL_USERNAME,
+              NSW_FRIEND_CODE,
+              ROLE_ADMIN,
+              ROLE_MODERATOR,
+              ROLE_REGULAR,
+              ROLE_MEMBER,
+              ROLE_NEWCOMER,
+              SERVER_LEFT_AT,
+              SERVER_JOINED_AT,
+              LAST_SEEN_AT
+         FROM RPG_CLUB_USERS
+        WHERE ${where}
+        ORDER BY COALESCE(UPPER(GLOBAL_NAME), UPPER(USERNAME), USER_ID)
+        FETCH FIRST :limit ROWS ONLY`,
+      params,
+      (row) => ({
         userId: row.USER_ID,
         username: row.USERNAME ?? null,
         globalName: row.GLOBAL_NAME ?? null,
@@ -1959,10 +1792,8 @@ export default class Member {
         serverLeftAt: row.SERVER_LEFT_AT ?? null,
         serverJoinedAt: row.SERVER_JOINED_AT ?? null,
         lastSeenAt: row.LAST_SEEN_AT ?? null,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async setMessageCount(userId: string, count: number): Promise<void> {
@@ -1981,10 +1812,8 @@ export default class Member {
   }
 
   static async getByUserId(userId: string): Promise<IMemberRecord | null> {
-    const connection = await getOraclePool().getConnection();
-
-    try {
-      const result = await connection.execute<{
+    return oraWithConnection(async (conn) => {
+      const result = await conn.execute<{
         USER_ID: string;
         IS_BOT: number;
         USERNAME: string | null;
@@ -2068,9 +1897,7 @@ export default class Member {
         profileImage: row.PROFILE_IMAGE ?? null,
         profileImageAt: row.PROFILE_IMAGE_AT ?? null,
       };
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async updateNowPlayingPlatform(
@@ -2084,20 +1911,14 @@ export default class Member {
     if (!Number.isInteger(platformId) || platformId <= 0) {
       throw new Error("Invalid platform selection.");
     }
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute(
-        `UPDATE USER_NOW_PLAYING
-            SET PLATFORM_ID = :platformId
-          WHERE USER_ID = :userId
-            AND GAMEDB_GAME_ID = :gameId`,
-        { userId, gameId, platformId },
-        { autoCommit: true },
-      );
-      return (res.rowsAffected ?? 0) > 0;
-    } finally {
-      await connection.close();
-    }
+    const res = await oraMutate(
+      `UPDATE USER_NOW_PLAYING
+          SET PLATFORM_ID = :platformId
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+      { userId, gameId, platformId },
+    );
+    return (res.rowsAffected ?? 0) > 0;
   }
 
   static async getAvatarHistory(
@@ -2107,9 +1928,8 @@ export default class Member {
   ): Promise<IAvatarHistoryRecord[]> {
     const safeLimit = Math.min(Math.max(limit, 1), 50);
     const safeOffset = Math.max(offset, 0);
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{
+    return oraWithConnection(async (conn) => {
+      const result = await conn.execute<{
         EVENT_ID: number;
         USER_ID: string;
         AVATAR_HASH: string | null;
@@ -2144,9 +1964,7 @@ export default class Member {
             ? row.CHANGED_AT
             : new Date(row.CHANGED_AT as any),
       }));
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async getCompletionsForGame(
@@ -2156,53 +1974,48 @@ export default class Member {
     if (!Number.isInteger(gameId) || gameId <= 0) {
       throw new Error("Invalid GameDB id.");
     }
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        COMPLETION_ID: number;
-        GAME_ID: number;
-        TITLE: string;
-        COMPLETION_TYPE: string;
-        PLATFORM_ID: number | null;
-        COMPLETED_AT: Date | null;
-        FINAL_PLAYTIME_HRS: number | null;
-        CREATED_AT: Date;
-        THREAD_ID: string | null;
-        NOTE: string | null;
-      }>(
-        `
-        SELECT c.COMPLETION_ID,
-               g.GAME_ID,
-               g.TITLE,
-               c.COMPLETION_TYPE,
-               c.PLATFORM_ID,
-               c.COMPLETED_AT,
-               c.FINAL_PLAYTIME_HRS,
-               c.CREATED_AT,
-               c.NOTE,
-               COALESCE(
-                  (
-                    SELECT MIN(tgl.THREAD_ID)
-                    FROM THREAD_GAME_LINKS tgl
-                    WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  ),
-                  (
-                    SELECT MIN(th.THREAD_ID)
-                    FROM THREADS th
-                    WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  )
-                ) AS THREAD_ID
-          FROM USER_GAME_COMPLETIONS c
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE c.USER_ID = :userId
-           AND c.GAMEDB_GAME_ID = :gameId
-         ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC
-        `,
-        { userId, gameId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{
+      COMPLETION_ID: number;
+      GAME_ID: number;
+      TITLE: string;
+      COMPLETION_TYPE: string;
+      PLATFORM_ID: number | null;
+      COMPLETED_AT: Date | null;
+      FINAL_PLAYTIME_HRS: number | null;
+      CREATED_AT: Date;
+      THREAD_ID: string | null;
+      NOTE: string | null;
+    }, ICompletionRecord>(
+      `
+      SELECT c.COMPLETION_ID,
+             g.GAME_ID,
+             g.TITLE,
+             c.COMPLETION_TYPE,
+             c.PLATFORM_ID,
+             c.COMPLETED_AT,
+             c.FINAL_PLAYTIME_HRS,
+             c.CREATED_AT,
+             c.NOTE,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.THREAD_ID)
+                  FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                ),
+                (
+                  SELECT MIN(th.THREAD_ID)
+                  FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                )
+              ) AS THREAD_ID
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE c.USER_ID = :userId
+         AND c.GAMEDB_GAME_ID = :gameId
+       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC
+      `,
+      { userId, gameId },
+      (row) => ({
         completionId: Number(row.COMPLETION_ID),
         gameId: Number(row.GAME_ID),
         title: String(row.TITLE),
@@ -2224,10 +2037,8 @@ export default class Member {
               : new Date(),
         threadId: row.THREAD_ID ?? null,
         note: row.NOTE ?? null,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async getRecentCompletionForGame(
@@ -2244,58 +2055,50 @@ export default class Member {
     const startDate = new Date(ref.getTime() - windowMs);
     const endDate = new Date(ref.getTime() + windowMs);
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        COMPLETION_ID: number;
-        GAME_ID: number;
-        TITLE: string;
-        COMPLETION_TYPE: string;
-        PLATFORM_ID: number | null;
-        COMPLETED_AT: Date | null;
-        FINAL_PLAYTIME_HRS: number | null;
-        CREATED_AT: Date;
-        THREAD_ID: string | null;
-        NOTE: string | null;
-      }>(
-        `
-        SELECT c.COMPLETION_ID,
-               g.GAME_ID,
-               g.TITLE,
-               c.COMPLETION_TYPE,
-               c.PLATFORM_ID,
-               c.COMPLETED_AT,
-               c.FINAL_PLAYTIME_HRS,
-               c.CREATED_AT,
-               c.NOTE,
-               COALESCE(
-                  (
-                    SELECT MIN(tgl.THREAD_ID)
-                    FROM THREAD_GAME_LINKS tgl
-                    WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  ),
-                  (
-                    SELECT MIN(th.THREAD_ID)
-                    FROM THREADS th
-                    WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                  )
-                ) AS THREAD_ID
-          FROM USER_GAME_COMPLETIONS c
-          JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         WHERE c.USER_ID = :userId
-           AND c.GAMEDB_GAME_ID = :gameId
-           AND COALESCE(c.COMPLETED_AT, c.CREATED_AT) BETWEEN :startDate AND :endDate
-         ORDER BY COALESCE(c.COMPLETED_AT, c.CREATED_AT) DESC
-         FETCH FIRST 1 ROWS ONLY
-        `,
-        { userId, gameId, startDate, endDate },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const row = (res.rows ?? [])[0];
-      if (!row) return null;
-
-      return {
+    const rows = await oraQuery<{
+      COMPLETION_ID: number;
+      GAME_ID: number;
+      TITLE: string;
+      COMPLETION_TYPE: string;
+      PLATFORM_ID: number | null;
+      COMPLETED_AT: Date | null;
+      FINAL_PLAYTIME_HRS: number | null;
+      CREATED_AT: Date;
+      THREAD_ID: string | null;
+      NOTE: string | null;
+    }, ICompletionRecord>(
+      `
+      SELECT c.COMPLETION_ID,
+             g.GAME_ID,
+             g.TITLE,
+             c.COMPLETION_TYPE,
+             c.PLATFORM_ID,
+             c.COMPLETED_AT,
+             c.FINAL_PLAYTIME_HRS,
+             c.CREATED_AT,
+             c.NOTE,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.THREAD_ID)
+                  FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                ),
+                (
+                  SELECT MIN(th.THREAD_ID)
+                  FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                )
+              ) AS THREAD_ID
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE c.USER_ID = :userId
+         AND c.GAMEDB_GAME_ID = :gameId
+         AND COALESCE(c.COMPLETED_AT, c.CREATED_AT) BETWEEN :startDate AND :endDate
+       ORDER BY COALESCE(c.COMPLETED_AT, c.CREATED_AT) DESC
+       FETCH FIRST 1 ROWS ONLY
+      `,
+      { userId, gameId, startDate, endDate },
+      (row) => ({
         completionId: Number(row.COMPLETION_ID),
         gameId: Number(row.GAME_ID),
         title: String(row.TITLE),
@@ -2317,87 +2120,75 @@ export default class Member {
               : new Date(),
         threadId: row.THREAD_ID ?? null,
         note: row.NOTE ?? null,
-      };
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
+
+    return rows[0] ?? null;
   }
 
   static async getGiveawayDonorNotifySetting(userId: string): Promise<boolean> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{ DONOR_NOTIFY_ON_CLAIM: number | null }>(
-        `SELECT DONOR_NOTIFY_ON_CLAIM
-           FROM RPG_CLUB_USERS
-          WHERE USER_ID = :userId`,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = result.rows?.[0];
-      return Boolean(row?.DONOR_NOTIFY_ON_CLAIM);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery<{ DONOR_NOTIFY_ON_CLAIM: number | null }, boolean>(
+      `SELECT DONOR_NOTIFY_ON_CLAIM
+         FROM RPG_CLUB_USERS
+        WHERE USER_ID = :userId`,
+      { userId },
+      (row) => Boolean(row.DONOR_NOTIFY_ON_CLAIM),
+    );
+    return rows[0] ?? false;
   }
 
   static async setGiveawayDonorNotifySetting(
     userId: string,
     enabled: boolean,
   ): Promise<void> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute(
+    await oraWithConnection(async (conn) => {
+      const result = await oraMutate(
         `UPDATE RPG_CLUB_USERS
             SET DONOR_NOTIFY_ON_CLAIM = :enabled
           WHERE USER_ID = :userId`,
         { userId, enabled: enabled ? 1 : 0 },
-        { autoCommit: true },
+        conn,
       );
+      await conn.commit();
       if ((result.rowsAffected ?? 0) > 0) {
         return;
       }
 
       try {
-        await connection.execute(
+        await oraMutate(
           `INSERT INTO RPG_CLUB_USERS (USER_ID, DONOR_NOTIFY_ON_CLAIM)
            VALUES (:userId, :enabled)`,
           { userId, enabled: enabled ? 1 : 0 },
-          { autoCommit: true },
+          conn,
         );
+        await conn.commit();
       } catch (err: any) {
         const code = err?.code ?? err?.errorNum;
         if (code === "ORA-00001") {
-          await connection.execute(
+          await oraMutate(
             `UPDATE RPG_CLUB_USERS
                 SET DONOR_NOTIFY_ON_CLAIM = :enabled
               WHERE USER_ID = :userId`,
             { userId, enabled: enabled ? 1 : 0 },
-            { autoCommit: true },
+            conn,
           );
+          await conn.commit();
         } else {
           throw err;
         }
       }
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async countAvatarHistory(userId: string): Promise<number> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{ TOTAL: number | null }>(
-        `SELECT COUNT(*) AS TOTAL
-           FROM RPG_CLUB_USER_AVATAR_HISTORY
-          WHERE USER_ID = :userId`,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = result.rows?.[0];
-      return Number(row?.TOTAL ?? 0);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery<{ TOTAL: number | null }, number>(
+      `SELECT COUNT(*) AS TOTAL
+         FROM RPG_CLUB_USER_AVATAR_HISTORY
+        WHERE USER_ID = :userId`,
+      { userId },
+      (row) => Number(row.TOTAL ?? 0),
+    );
+    return rows[0] ?? 0;
   }
 
   static async insertAvatarHistoryRecord(
@@ -2406,89 +2197,68 @@ export default class Member {
     avatarUrl: string,
     avatarBlob: Buffer | null,
   ): Promise<void> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.execute(
-        `INSERT INTO RPG_CLUB_USER_AVATAR_HISTORY (USER_ID, AVATAR_HASH, AVATAR_URL, AVATAR_BLOB)
-         VALUES (:userId, :avatarHash, :avatarUrl, :avatarBlob)`,
-        { userId, avatarHash, avatarUrl, avatarBlob },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `INSERT INTO RPG_CLUB_USER_AVATAR_HISTORY (USER_ID, AVATAR_HASH, AVATAR_URL, AVATAR_BLOB)
+       VALUES (:userId, :avatarHash, :avatarUrl, :avatarBlob)`,
+      { userId, avatarHash, avatarUrl, avatarBlob },
+    );
   }
 
   static async getAllMembersAvatarHistoryCounts(): Promise<IMemberAvatarHistoryCount[]> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{
-        USER_ID: string;
-        USERNAME: string | null;
-        GLOBAL_NAME: string | null;
-        TOTAL: number;
-      }>(
-        `SELECT h.USER_ID,
-                u.USERNAME,
-                u.GLOBAL_NAME,
-                COUNT(*) AS TOTAL
-           FROM RPG_CLUB_USER_AVATAR_HISTORY h
-           JOIN RPG_CLUB_USERS u ON u.USER_ID = h.USER_ID
-          WHERE NVL(u.IS_BOT, 0) = 0
-            AND u.SERVER_LEFT_AT IS NULL
-          GROUP BY h.USER_ID, u.USERNAME, u.GLOBAL_NAME
-          ORDER BY COALESCE(u.GLOBAL_NAME, u.USERNAME, h.USER_ID)`,
-        {},
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (result.rows ?? []).map((row) => ({
+    return oraQuery<{
+      USER_ID: string;
+      USERNAME: string | null;
+      GLOBAL_NAME: string | null;
+      TOTAL: number;
+    }, IMemberAvatarHistoryCount>(
+      `SELECT h.USER_ID,
+              u.USERNAME,
+              u.GLOBAL_NAME,
+              COUNT(*) AS TOTAL
+         FROM RPG_CLUB_USER_AVATAR_HISTORY h
+         JOIN RPG_CLUB_USERS u ON u.USER_ID = h.USER_ID
+        WHERE NVL(u.IS_BOT, 0) = 0
+          AND u.SERVER_LEFT_AT IS NULL
+        GROUP BY h.USER_ID, u.USERNAME, u.GLOBAL_NAME
+        ORDER BY COALESCE(u.GLOBAL_NAME, u.USERNAME, h.USER_ID)`,
+      {},
+      (row) => ({
         userId: String(row.USER_ID),
         username: row.USERNAME ?? null,
         globalName: row.GLOBAL_NAME ?? null,
         count: Number(row.TOTAL),
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async getMembersWithPlatforms(): Promise<IMemberPlatformRecord[]> {
-    const connection = await getOraclePool().getConnection();
-
-    try {
-      const result = await connection.execute<{
-        USER_ID: string;
-        USERNAME: string | null;
-        GLOBAL_NAME: string | null;
-        STEAM_URL: string | null;
-        PSN_USERNAME: string | null;
-        XBL_USERNAME: string | null;
-        NSW_FRIEND_CODE: string | null;
-        SERVER_LEFT_AT: Date | null;
-      }>(
-        `SELECT USER_ID,
-                USERNAME,
-                GLOBAL_NAME,
-                STEAM_URL,
-                PSN_USERNAME,
-                XBL_USERNAME,
-                NSW_FRIEND_CODE,
-                SERVER_LEFT_AT
-           FROM RPG_CLUB_USERS
-          WHERE (STEAM_URL IS NOT NULL
-                 OR PSN_USERNAME IS NOT NULL
-                 OR XBL_USERNAME IS NOT NULL
-                 OR NSW_FRIEND_CODE IS NOT NULL)
-            AND NVL(IS_BOT, 0) = 0
-            AND SERVER_LEFT_AT IS NULL`,
-        {},
-        {
-          outFormat: oracledb.OUT_FORMAT_OBJECT,
-        },
-      );
-
-      const rows = result.rows ?? [];
-      const members = rows.map<IMemberPlatformRecord>((row) => ({
+    const members = await oraQuery<{
+      USER_ID: string;
+      USERNAME: string | null;
+      GLOBAL_NAME: string | null;
+      STEAM_URL: string | null;
+      PSN_USERNAME: string | null;
+      XBL_USERNAME: string | null;
+      NSW_FRIEND_CODE: string | null;
+      SERVER_LEFT_AT: Date | null;
+    }, IMemberPlatformRecord>(
+      `SELECT USER_ID,
+              USERNAME,
+              GLOBAL_NAME,
+              STEAM_URL,
+              PSN_USERNAME,
+              XBL_USERNAME,
+              NSW_FRIEND_CODE,
+              SERVER_LEFT_AT
+         FROM RPG_CLUB_USERS
+        WHERE (STEAM_URL IS NOT NULL
+               OR PSN_USERNAME IS NOT NULL
+               OR XBL_USERNAME IS NOT NULL
+               OR NSW_FRIEND_CODE IS NOT NULL)
+          AND NVL(IS_BOT, 0) = 0
+          AND SERVER_LEFT_AT IS NULL`,
+      {},
+      (row) => ({
         userId: row.USER_ID,
         username: row.USERNAME ?? null,
         globalName: row.GLOBAL_NAME ?? null,
@@ -2496,16 +2266,14 @@ export default class Member {
         psnUsername: row.PSN_USERNAME ?? null,
         xblUsername: row.XBL_USERNAME ?? null,
         nswFriendCode: row.NSW_FRIEND_CODE ?? null,
-      }));
+      }),
+    );
 
-      return members.sort((a, b) => {
-        const aName = (a.globalName ?? a.username ?? a.userId).toLowerCase();
-        const bName = (b.globalName ?? b.username ?? b.userId).toLowerCase();
-        return aName.localeCompare(bName);
-      });
-    } finally {
-      await connection.close();
-    }
+    return members.sort((a, b) => {
+      const aName = (a.globalName ?? a.username ?? a.userId).toLowerCase();
+      const bName = (b.globalName ?? b.username ?? b.userId).toLowerCase();
+      return aName.localeCompare(bName);
+    });
   }
 
   static async upsert(
@@ -2513,12 +2281,10 @@ export default class Member {
     opts?: { connection?: Connection },
   ): Promise<void> {
     const externalConn = opts?.connection ?? null;
-    const connection = externalConn ?? (await getOraclePool().getConnection());
-
     const params = buildParams(record);
 
-    try {
-      const update = await connection.execute(
+    async function doUpsert(conn: oracledb.Connection): Promise<void> {
+      const update = await oraMutate(
         `UPDATE RPG_CLUB_USERS
             SET IS_BOT = :isBot,
                 USERNAME = :username,
@@ -2541,14 +2307,15 @@ export default class Member {
                 UPDATED_AT = SYSTIMESTAMP
           WHERE USER_ID = :userId`,
         params,
-        { autoCommit: true },
+        conn,
       );
+      await conn.commit();
 
       const rowsUpdated = update.rowsAffected ?? 0;
       if (rowsUpdated > 0) return;
 
       try {
-        await connection.execute(
+        await oraMutate(
           `INSERT INTO RPG_CLUB_USERS (
              USER_ID, IS_BOT, USERNAME, GLOBAL_NAME, AVATAR_BLOB,
              SERVER_JOINED_AT, SERVER_LEFT_AT, LAST_SEEN_AT, LAST_FETCHED_AT,
@@ -2565,12 +2332,13 @@ export default class Member {
              SYSTIMESTAMP, SYSTIMESTAMP
            )`,
           params,
-          { autoCommit: true },
+          conn,
         );
+        await conn.commit();
       } catch (insErr: any) {
         const code = insErr?.code ?? insErr?.errorNum;
         if (code === "ORA-00001") {
-          await connection.execute(
+          await oraMutate(
             `UPDATE RPG_CLUB_USERS
                 SET IS_BOT = :isBot,
                     USERNAME = :username,
@@ -2593,27 +2361,29 @@ export default class Member {
                     UPDATED_AT = SYSTIMESTAMP
               WHERE USER_ID = :userId`,
             params,
-            { autoCommit: true },
+            conn,
           );
+          await conn.commit();
         } else {
           throw insErr;
         }
       }
-    } finally {
-      if (!externalConn) {
-        await connection.close();
-      }
+    }
+
+    if (externalConn) {
+      await doUpsert(externalConn);
+    } else {
+      await oraWithConnection(doUpsert);
     }
   }
 
   static async markDepartedNotIn(userIds: string[]): Promise<number> {
     if (!userIds.length) return 0;
 
-    const connection = await getOraclePool().getConnection();
     const chunkSize = 999; // Oracle IN clause limit per statement (safe)
     let totalUpdated = 0;
 
-    try {
+    await oraWithConnection(async (conn) => {
       for (let i = 0; i < userIds.length; i += chunkSize) {
         const chunk = userIds.slice(i, i + chunkSize);
         const binds: Record<string, string> = {};
@@ -2631,86 +2401,73 @@ export default class Member {
              AND USER_ID NOT IN (${placeholders.join(", ")})
         `;
 
-        const result = await connection.execute(sql, binds, { autoCommit: true });
+        const result = await oraMutate(sql, binds, conn);
         totalUpdated += result.rowsAffected ?? 0;
+        await conn.commit();
       }
-    } finally {
-      await connection.close();
-    }
+    });
 
     return totalUpdated;
   }
 
   static async getGameJournalList(userId: string): Promise<IGameJournalListEntry[]> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        GAME_ID: number;
-        TITLE: string;
-        TOTAL_ENTRIES: number;
-      }>(
-        `SELECT g.GAME_ID,
-                g.TITLE,
-                COUNT(e.ENTRY_ID) AS TOTAL_ENTRIES
-           FROM USER_GAME_JOURNAL_PREFS jp
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = jp.GAMEDB_GAME_ID
-           LEFT JOIN USER_GAME_JOURNAL_ENTRIES e
-             ON e.USER_ID = jp.USER_ID
-            AND e.GAMEDB_GAME_ID = jp.GAMEDB_GAME_ID
-          WHERE jp.USER_ID = :userId
-            AND jp.IS_ENABLED = 1
-          GROUP BY g.GAME_ID, g.TITLE
-         HAVING COUNT(e.ENTRY_ID) > 0
-          ORDER BY g.TITLE`,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{
+      GAME_ID: number;
+      TITLE: string;
+      TOTAL_ENTRIES: number;
+    }, IGameJournalListEntry>(
+      `SELECT g.GAME_ID,
+              g.TITLE,
+              COUNT(e.ENTRY_ID) AS TOTAL_ENTRIES
+         FROM USER_GAME_JOURNAL_PREFS jp
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = jp.GAMEDB_GAME_ID
+         LEFT JOIN USER_GAME_JOURNAL_ENTRIES e
+           ON e.USER_ID = jp.USER_ID
+          AND e.GAMEDB_GAME_ID = jp.GAMEDB_GAME_ID
+        WHERE jp.USER_ID = :userId
+          AND jp.IS_ENABLED = 1
+        GROUP BY g.GAME_ID, g.TITLE
+       HAVING COUNT(e.ENTRY_ID) > 0
+        ORDER BY g.TITLE`,
+      { userId },
+      (row) => ({
         gameId: Number(row.GAME_ID),
         title: row.TITLE,
         totalEntries: Number(row.TOTAL_ENTRIES ?? 0),
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async getAllJournalUsers(): Promise<IJournalUserSummary[]> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{
-        USER_ID: string;
-        USERNAME: string | null;
-        GLOBAL_NAME: string | null;
-        GAME_COUNT: number;
-        ENTRY_COUNT: number;
-      }>(
-        `SELECT u.USER_ID,
-                u.USERNAME,
-                u.GLOBAL_NAME,
-                COUNT(DISTINCT je.GAMEDB_GAME_ID) AS GAME_COUNT,
-                COUNT(je.ENTRY_ID) AS ENTRY_COUNT
-           FROM USER_GAME_JOURNAL_ENTRIES je
-           JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
-          WHERE NVL(u.IS_BOT, 0) = 0
-            AND u.SERVER_LEFT_AT IS NULL
-          GROUP BY u.USER_ID, u.USERNAME, u.GLOBAL_NAME
-          ORDER BY COUNT(DISTINCT je.GAMEDB_GAME_ID) DESC,
-                   u.GLOBAL_NAME NULLS LAST,
-                   u.USERNAME NULLS LAST`,
-        {},
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{
+      USER_ID: string;
+      USERNAME: string | null;
+      GLOBAL_NAME: string | null;
+      GAME_COUNT: number;
+      ENTRY_COUNT: number;
+    }, IJournalUserSummary>(
+      `SELECT u.USER_ID,
+              u.USERNAME,
+              u.GLOBAL_NAME,
+              COUNT(DISTINCT je.GAMEDB_GAME_ID) AS GAME_COUNT,
+              COUNT(je.ENTRY_ID) AS ENTRY_COUNT
+         FROM USER_GAME_JOURNAL_ENTRIES je
+         JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
+        WHERE NVL(u.IS_BOT, 0) = 0
+          AND u.SERVER_LEFT_AT IS NULL
+        GROUP BY u.USER_ID, u.USERNAME, u.GLOBAL_NAME
+        ORDER BY COUNT(DISTINCT je.GAMEDB_GAME_ID) DESC,
+                 u.GLOBAL_NAME NULLS LAST,
+                 u.USERNAME NULLS LAST`,
+      {},
+      (row) => ({
         userId: row.USER_ID,
         username: row.USERNAME ?? null,
         globalName: row.GLOBAL_NAME ?? null,
         gameCount: Number(row.GAME_COUNT ?? 0),
         entryCount: Number(row.ENTRY_COUNT ?? 0),
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async searchJournalEntries(params: {
@@ -2720,109 +2477,93 @@ export default class Member {
     limit: number;
     offset: number;
   }): Promise<{ rows: IJournalSearchResult[]; total: number }> {
-    const connection = await getOraclePool().getConnection();
     const safeLimit = Math.min(Math.max(params.limit, 1), 25);
     const safeOffset = Math.max(params.offset, 0);
     const searchTerm = params.query.trim();
-    try {
-      const res = await connection.execute<{
-        TOTAL_COUNT: number;
-        ENTRY_ID: number;
-        USER_ID: string;
-        GLOBAL_NAME: string | null;
-        USERNAME: string | null;
-        GAMEDB_GAME_ID: number;
-        GAME_TITLE: string;
-        ENTRY_TITLE: string | null;
-        ENTRY_BODY: string;
-        CREATED_AT: Date | string;
-      }>(
-        `SELECT COUNT(*) OVER () AS TOTAL_COUNT,
-                je.ENTRY_ID,
-                je.USER_ID,
-                u.GLOBAL_NAME,
-                u.USERNAME,
-                je.GAMEDB_GAME_ID,
-                g.TITLE         AS GAME_TITLE,
-                je.ENTRY_TITLE,
-                je.ENTRY_BODY,
-                je.CREATED_AT
-           FROM USER_GAME_JOURNAL_ENTRIES je
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = je.GAMEDB_GAME_ID
-           JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
-          WHERE (
-                  UPPER(je.ENTRY_TITLE) LIKE '%' || UPPER(:searchTerm) || '%'
-               OR UPPER(je.ENTRY_BODY)  LIKE '%' || UPPER(:searchTerm) || '%'
-                )
-            AND (:userId IS NULL OR je.USER_ID = :userId)
-            AND (:gameId IS NULL OR je.GAMEDB_GAME_ID = :gameId)
-          ORDER BY je.CREATED_AT DESC, je.ENTRY_ID DESC
-          OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-        {
-          searchTerm,
-          userId: params.userId ?? null,
-          gameId: params.gameId ?? null,
-          offset: safeOffset,
-          limit: safeLimit,
-        },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const rows = res.rows ?? [];
-      const total = rows.length > 0 ? Number(rows[0].TOTAL_COUNT) : 0;
-      return {
-        total,
-        rows: rows.map((row) => ({
-          entryId: Number(row.ENTRY_ID),
-          userId: row.USER_ID,
-          globalName: row.GLOBAL_NAME ?? null,
-          username: row.USERNAME ?? null,
-          gameId: Number(row.GAMEDB_GAME_ID),
-          gameTitle: row.GAME_TITLE,
-          entryTitle: row.ENTRY_TITLE ?? null,
-          body: row.ENTRY_BODY,
-          createdAt: row.CREATED_AT instanceof Date
-            ? row.CREATED_AT
-            : new Date(row.CREATED_AT),
-        })),
-      };
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery<{
+      TOTAL_COUNT: number;
+      ENTRY_ID: number;
+      USER_ID: string;
+      GLOBAL_NAME: string | null;
+      USERNAME: string | null;
+      GAMEDB_GAME_ID: number;
+      GAME_TITLE: string;
+      ENTRY_TITLE: string | null;
+      ENTRY_BODY: string;
+      CREATED_AT: Date | string;
+    }, IJournalSearchResult & { totalCount: number }>(
+      `SELECT COUNT(*) OVER () AS TOTAL_COUNT,
+              je.ENTRY_ID,
+              je.USER_ID,
+              u.GLOBAL_NAME,
+              u.USERNAME,
+              je.GAMEDB_GAME_ID,
+              g.TITLE         AS GAME_TITLE,
+              je.ENTRY_TITLE,
+              je.ENTRY_BODY,
+              je.CREATED_AT
+         FROM USER_GAME_JOURNAL_ENTRIES je
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = je.GAMEDB_GAME_ID
+         JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
+        WHERE (
+                UPPER(je.ENTRY_TITLE) LIKE '%' || UPPER(:searchTerm) || '%'
+             OR UPPER(je.ENTRY_BODY)  LIKE '%' || UPPER(:searchTerm) || '%'
+              )
+          AND (:userId IS NULL OR je.USER_ID = :userId)
+          AND (:gameId IS NULL OR je.GAMEDB_GAME_ID = :gameId)
+        ORDER BY je.CREATED_AT DESC, je.ENTRY_ID DESC
+        OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+      {
+        searchTerm,
+        userId: params.userId ?? null,
+        gameId: params.gameId ?? null,
+        offset: safeOffset,
+        limit: safeLimit,
+      },
+      (row) => ({
+        totalCount: Number(row.TOTAL_COUNT),
+        entryId: Number(row.ENTRY_ID),
+        userId: row.USER_ID,
+        globalName: row.GLOBAL_NAME ?? null,
+        username: row.USERNAME ?? null,
+        gameId: Number(row.GAMEDB_GAME_ID),
+        gameTitle: row.GAME_TITLE,
+        entryTitle: row.ENTRY_TITLE ?? null,
+        body: row.ENTRY_BODY,
+        createdAt: row.CREATED_AT instanceof Date
+          ? row.CREATED_AT
+          : new Date(row.CREATED_AT),
+      }),
+    );
+    const total = rows.length > 0 ? rows[0].totalCount : 0;
+    return {
+      total,
+      rows: rows.map(({ totalCount: _tc, ...rest }) => rest),
+    };
   }
 
   static async updateEmojiName(userId: string, emojiName: string | null): Promise<void> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.execute(
-        `UPDATE RPG_CLUB_USERS
-            SET EMOJI_NAME = :emojiName,
-                UPDATED_AT = SYSTIMESTAMP
-          WHERE USER_ID = :userId`,
-        { userId, emojiName },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `UPDATE RPG_CLUB_USERS
+          SET EMOJI_NAME = :emojiName,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE USER_ID = :userId`,
+      { userId, emojiName },
+    );
   }
 
   static async getAllWithEmojiName(): Promise<Array<{ userId: string; emojiName: string }>> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const res = await connection.execute<{ USER_ID: string; EMOJI_NAME: string }>(
-        `SELECT USER_ID, EMOJI_NAME
-           FROM RPG_CLUB_USERS
-          WHERE EMOJI_NAME IS NOT NULL`,
-        {},
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{ USER_ID: string; EMOJI_NAME: string },
+      { userId: string; emojiName: string }>(
+      `SELECT USER_ID, EMOJI_NAME
+         FROM RPG_CLUB_USERS
+        WHERE EMOJI_NAME IS NOT NULL`,
+      {},
+      (row) => ({
         userId: row.USER_ID,
         emojiName: row.EMOJI_NAME,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async upsertJournalMessageContext(
@@ -2832,40 +2573,28 @@ export default class Member {
     ownerUserId: string,
     gameId: number,
   ): Promise<void> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.execute(
-        `MERGE INTO JOURNAL_MESSAGE_CONTEXTS dst
-         USING (SELECT :channelId AS CHANNEL_ID, :messageId AS MESSAGE_ID FROM DUAL) src
-            ON (dst.CHANNEL_ID = src.CHANNEL_ID AND dst.MESSAGE_ID = src.MESSAGE_ID)
-          WHEN MATCHED THEN
-            UPDATE SET CREATED_AT_MS = :createdAtMs,
-                       OWNER_USER_ID = :ownerUserId,
-                       GAME_ID       = :gameId
-          WHEN NOT MATCHED THEN
-            INSERT (CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID)
-            VALUES (:channelId, :messageId, :createdAtMs, :ownerUserId, :gameId)`,
-        { channelId, messageId, createdAtMs, ownerUserId, gameId },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `MERGE INTO JOURNAL_MESSAGE_CONTEXTS dst
+       USING (SELECT :channelId AS CHANNEL_ID, :messageId AS MESSAGE_ID FROM DUAL) src
+          ON (dst.CHANNEL_ID = src.CHANNEL_ID AND dst.MESSAGE_ID = src.MESSAGE_ID)
+        WHEN MATCHED THEN
+          UPDATE SET CREATED_AT_MS = :createdAtMs,
+                     OWNER_USER_ID = :ownerUserId,
+                     GAME_ID       = :gameId
+        WHEN NOT MATCHED THEN
+          INSERT (CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID)
+          VALUES (:channelId, :messageId, :createdAtMs, :ownerUserId, :gameId)`,
+      { channelId, messageId, createdAtMs, ownerUserId, gameId },
+    );
   }
 
   static async deleteJournalMessageContext(channelId: string, messageId: string): Promise<void> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.execute(
-        `DELETE FROM JOURNAL_MESSAGE_CONTEXTS
-          WHERE CHANNEL_ID = :channelId
-            AND MESSAGE_ID = :messageId`,
-        { channelId, messageId },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `DELETE FROM JOURNAL_MESSAGE_CONTEXTS
+        WHERE CHANNEL_ID = :channelId
+          AND MESSAGE_ID = :messageId`,
+      { channelId, messageId },
+    );
   }
 
   static async loadActiveJournalMessageContexts(
@@ -2877,45 +2606,34 @@ export default class Member {
     ownerUserId: string;
     gameId: number;
   }>> {
-    const connection = await getOraclePool().getConnection();
     const cutoffMs = Date.now() - ttlMs;
-    try {
-      const res = await connection.execute<{
-        CHANNEL_ID: string;
-        MESSAGE_ID: string;
-        CREATED_AT_MS: number;
-        OWNER_USER_ID: string;
-        GAME_ID: number;
-      }>(
-        `SELECT CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID
-           FROM JOURNAL_MESSAGE_CONTEXTS
-          WHERE CREATED_AT_MS >= :cutoffMs`,
-        { cutoffMs },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      return (res.rows ?? []).map((row) => ({
+    return oraQuery<{
+      CHANNEL_ID: string;
+      MESSAGE_ID: string;
+      CREATED_AT_MS: number;
+      OWNER_USER_ID: string;
+      GAME_ID: number;
+    }, { channelId: string; messageId: string; createdAt: number;
+        ownerUserId: string; gameId: number }>(
+      `SELECT CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID
+         FROM JOURNAL_MESSAGE_CONTEXTS
+        WHERE CREATED_AT_MS >= :cutoffMs`,
+      { cutoffMs },
+      (row) => ({
         channelId: row.CHANNEL_ID,
         messageId: row.MESSAGE_ID,
         createdAt: Number(row.CREATED_AT_MS),
         ownerUserId: row.OWNER_USER_ID,
         gameId: Number(row.GAME_ID),
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   }
 
   static async pruneExpiredJournalMessageContexts(ttlMs: number): Promise<void> {
-    const connection = await getOraclePool().getConnection();
     const cutoffMs = Date.now() - ttlMs;
-    try {
-      await connection.execute(
-        `DELETE FROM JOURNAL_MESSAGE_CONTEXTS WHERE CREATED_AT_MS < :cutoffMs`,
-        { cutoffMs },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `DELETE FROM JOURNAL_MESSAGE_CONTEXTS WHERE CREATED_AT_MS < :cutoffMs`,
+      { cutoffMs },
+    );
   }
 }

--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -2538,7 +2538,17 @@ export default class Member {
     const total = rows.length > 0 ? rows[0].totalCount : 0;
     return {
       total,
-      rows: rows.map(({ totalCount: _tc, ...rest }) => rest),
+      rows: rows.map((row): IJournalSearchResult => ({
+        entryId: row.entryId,
+        userId: row.userId,
+        globalName: row.globalName,
+        username: row.username,
+        gameId: row.gameId,
+        gameTitle: row.gameTitle,
+        entryTitle: row.entryTitle,
+        body: row.body,
+        createdAt: row.createdAt,
+      })),
     };
   }
 

--- a/src/classes/PresencePromptHistory.ts
+++ b/src/classes/PresencePromptHistory.ts
@@ -1,5 +1,4 @@
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 import { normalizePresenceGameTitle } from "./PresencePromptOptOut.js";
 
 export type PresencePromptStatus =
@@ -16,39 +15,22 @@ export default class PresencePromptHistory {
     gameTitle: string,
   ): Promise<void> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.execute(
-        `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_HISTORY
-          (PROMPT_ID, USER_ID, GAME_TITLE, GAME_TITLE_NORM, STATUS)
-         VALUES (:promptId, :userId, :gameTitle, :gameTitleNorm, 'PENDING')`,
-        {
-          promptId,
-          userId,
-          gameTitle,
-          gameTitleNorm: normalized,
-        },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_HISTORY
+        (PROMPT_ID, USER_ID, GAME_TITLE, GAME_TITLE_NORM, STATUS)
+       VALUES (:promptId, :userId, :gameTitle, :gameTitleNorm, 'PENDING')`,
+      { promptId, userId, gameTitle, gameTitleNorm: normalized },
+    );
   }
 
   static async markResolved(promptId: string, status: PresencePromptStatus): Promise<void> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.execute(
-        `UPDATE RPG_CLUB_PRESENCE_PROMPT_HISTORY
-            SET STATUS = :status,
-                RESOLVED_AT = SYSTIMESTAMP
-          WHERE PROMPT_ID = :promptId`,
-        { status, promptId },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `UPDATE RPG_CLUB_PRESENCE_PROMPT_HISTORY
+          SET STATUS = :status,
+              RESOLVED_AT = SYSTIMESTAMP
+        WHERE PROMPT_ID = :promptId`,
+      { status, promptId },
+    );
   }
 
   static async getLastPromptDateForGame(
@@ -56,61 +38,43 @@ export default class PresencePromptHistory {
     gameTitle: string,
   ): Promise<Date | null> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{ CREATED_AT: Date }>(
-        `SELECT CREATED_AT
-           FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
-          WHERE USER_ID = :userId
-            AND GAME_TITLE_NORM = :gameTitleNorm
-          ORDER BY CREATED_AT DESC
-          FETCH NEXT 1 ROWS ONLY`,
-        { userId, gameTitleNorm: normalized },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = result.rows?.[0];
-      if (!row?.CREATED_AT) return null;
-      return row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT as any);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery(
+      `SELECT CREATED_AT
+         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
+        WHERE USER_ID = :userId
+          AND GAME_TITLE_NORM = :gameTitleNorm
+        ORDER BY CREATED_AT DESC
+        FETCH NEXT 1 ROWS ONLY`,
+      { userId, gameTitleNorm: normalized },
+      (row: { CREATED_AT: Date | string }) =>
+        row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT as string),
+    );
+    return rows[0] ?? null;
   }
 
   static async countPendingForGame(userId: string, gameTitle: string): Promise<number> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{ CNT: number }>(
-        `SELECT COUNT(*) AS CNT
-           FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
-          WHERE USER_ID = :userId
-            AND GAME_TITLE_NORM = :gameTitleNorm
-            AND STATUS = 'PENDING'`,
-        { userId, gameTitleNorm: normalized },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = result.rows?.[0];
-      return Number(row?.CNT ?? 0);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery(
+      `SELECT COUNT(*) AS CNT
+         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
+        WHERE USER_ID = :userId
+          AND GAME_TITLE_NORM = :gameTitleNorm
+          AND STATUS = 'PENDING'`,
+      { userId, gameTitleNorm: normalized },
+      (row: { CNT: number }) => Number(row.CNT ?? 0),
+    );
+    return rows[0] ?? 0;
   }
 
   static async countPendingForUser(userId: string): Promise<number> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{ CNT: number }>(
-        `SELECT COUNT(*) AS CNT
-           FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
-          WHERE USER_ID = :userId
-            AND STATUS = 'PENDING'`,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = result.rows?.[0];
-      return Number(row?.CNT ?? 0);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery(
+      `SELECT COUNT(*) AS CNT
+         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
+        WHERE USER_ID = :userId
+          AND STATUS = 'PENDING'`,
+      { userId },
+      (row: { CNT: number }) => Number(row.CNT ?? 0),
+    );
+    return rows[0] ?? 0;
   }
 }

--- a/src/classes/PresencePromptOptOut.ts
+++ b/src/classes/PresencePromptOptOut.ts
@@ -1,5 +1,4 @@
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 const OPT_OUT_ALL_TOKEN = "__ALL__";
 
@@ -9,44 +8,32 @@ export function normalizePresenceGameTitle(title: string): string {
 
 export default class PresencePromptOptOut {
   static async isOptedOutAll(userId: string): Promise<boolean> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{ CNT: number }>(
-        `SELECT COUNT(*) AS CNT
-           FROM RPG_CLUB_PRESENCE_PROMPT_OPTS
-          WHERE USER_ID = :userId
-            AND SCOPE = 'ALL'
-            AND GAME_TITLE_NORM = :token`,
-        { userId, token: OPT_OUT_ALL_TOKEN },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const count = Number((result.rows ?? [])[0]?.CNT ?? 0);
-      return count > 0;
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery(
+      `SELECT COUNT(*) AS CNT
+         FROM RPG_CLUB_PRESENCE_PROMPT_OPTS
+        WHERE USER_ID = :userId
+          AND SCOPE = 'ALL'
+          AND GAME_TITLE_NORM = :token`,
+      { userId, token: OPT_OUT_ALL_TOKEN },
+      (row: { CNT: number }) => Number(row.CNT ?? 0),
+    );
+    return (rows[0] ?? 0) > 0;
   }
 
   static async isOptedOutGame(userId: string, gameTitle: string): Promise<boolean> {
     const normalized = normalizePresenceGameTitle(gameTitle);
     if (!normalized) return false;
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{ CNT: number }>(
-        `SELECT COUNT(*) AS CNT
-           FROM RPG_CLUB_PRESENCE_PROMPT_OPTS
-          WHERE USER_ID = :userId
-            AND SCOPE = 'GAME'
-            AND GAME_TITLE_NORM = :gameTitleNorm`,
-        { userId, gameTitleNorm: normalized },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const count = Number((result.rows ?? [])[0]?.CNT ?? 0);
-      return count > 0;
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery(
+      `SELECT COUNT(*) AS CNT
+         FROM RPG_CLUB_PRESENCE_PROMPT_OPTS
+        WHERE USER_ID = :userId
+          AND SCOPE = 'GAME'
+          AND GAME_TITLE_NORM = :gameTitleNorm`,
+      { userId, gameTitleNorm: normalized },
+      (row: { CNT: number }) => Number(row.CNT ?? 0),
+    );
+    return (rows[0] ?? 0) > 0;
   }
 
   static async addOptOutAll(userId: string): Promise<void> {
@@ -65,27 +52,18 @@ export default class PresencePromptOptOut {
     normalizedTitle: string,
     gameTitle: string | null,
   ): Promise<void> {
-    const connection = await getOraclePool().getConnection();
     try {
-      await connection.execute(
+      await oraMutate(
         `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_OPTS
           (USER_ID, SCOPE, GAME_TITLE, GAME_TITLE_NORM)
          VALUES (:userId, :scope, :gameTitle, :gameTitleNorm)`,
-        {
-          userId,
-          scope,
-          gameTitle,
-          gameTitleNorm: normalizedTitle,
-        },
-        { autoCommit: true },
+        { userId, scope, gameTitle, gameTitleNorm: normalizedTitle },
       );
     } catch (err: any) {
       const code = err?.code ?? err?.errorNum;
       if (code !== "ORA-00001") {
         throw err;
       }
-    } finally {
-      await connection.close();
     }
   }
 }

--- a/src/classes/PublicReminder.ts
+++ b/src/classes/PublicReminder.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 export type RecurrenceUnit = "minutes" | "hours" | "days" | "weeks" | "months" | "years";
 
@@ -22,85 +22,74 @@ export async function createReminder(
   recurUnit: RecurrenceUnit | null,
   createdBy: string | null,
 ): Promise<IPublicReminder> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `INSERT INTO RPG_CLUB_PUBLIC_REMINDERS (
-         CHANNEL_ID,
-         MESSAGE,
-         DUE_AT,
-         RECUR_EVERY,
-         RECUR_UNIT,
-         ENABLED,
-         CREATED_BY
-       ) VALUES (
-         :channelId,
-         :message,
-         :dueAt,
-         :recurEvery,
-         :recurUnit,
-         1,
-         :createdBy
-       )
-       RETURNING REMINDER_ID INTO :id`,
-      {
-        channelId,
-        message,
-        dueAt,
-        recurEvery,
-        recurUnit,
-        createdBy,
-        id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      { autoCommit: true },
-    );
-    const id = (result.outBinds as any)?.id?.[0] ?? 0;
-    return {
-      reminderId: Number(id),
+  const result = await oraMutate(
+    `INSERT INTO RPG_CLUB_PUBLIC_REMINDERS (
+       CHANNEL_ID,
+       MESSAGE,
+       DUE_AT,
+       RECUR_EVERY,
+       RECUR_UNIT,
+       ENABLED,
+       CREATED_BY
+     ) VALUES (
+       :channelId,
+       :message,
+       :dueAt,
+       :recurEvery,
+       :recurUnit,
+       1,
+       :createdBy
+     )
+     RETURNING REMINDER_ID INTO :id`,
+    {
       channelId,
       message,
       dueAt,
       recurEvery,
       recurUnit,
-      enabled: true,
       createdBy,
-    };
-  } finally {
-    await connection.close();
-  }
+      id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+    },
+  );
+  const id = (result.outBinds as any)?.id?.[0] ?? 0;
+  return {
+    reminderId: Number(id),
+    channelId,
+    message,
+    dueAt,
+    recurEvery,
+    recurUnit,
+    enabled: true,
+    createdBy,
+  };
 }
 
 export async function listUpcomingReminders(limit: number = 20): Promise<IPublicReminder[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 100);
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
+  return oraQuery(
+    `SELECT REMINDER_ID,
+            CHANNEL_ID,
+            MESSAGE,
+            DUE_AT,
+            RECUR_EVERY,
+            RECUR_UNIT,
+            ENABLED,
+            CREATED_BY
+       FROM RPG_CLUB_PUBLIC_REMINDERS
+      WHERE ENABLED = 1
+      ORDER BY DUE_AT ASC
+      FETCH FIRST :limit ROWS ONLY`,
+    { limit: safeLimit },
+    (row: {
       REMINDER_ID: number;
       CHANNEL_ID: string;
       MESSAGE: string;
-      DUE_AT: Date;
+      DUE_AT: Date | string;
       RECUR_EVERY: number | null;
       RECUR_UNIT: RecurrenceUnit | null;
       ENABLED: number;
       CREATED_BY: string | null;
-    }>(
-      `SELECT REMINDER_ID,
-              CHANNEL_ID,
-              MESSAGE,
-              DUE_AT,
-              RECUR_EVERY,
-              RECUR_UNIT,
-              ENABLED,
-              CREATED_BY
-         FROM RPG_CLUB_PUBLIC_REMINDERS
-        WHERE ENABLED = 1
-        ORDER BY DUE_AT ASC
-        FETCH FIRST :limit ROWS ONLY`,
-      { limit: safeLimit },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-
-    return (result.rows ?? []).map((row) => ({
+    }): IPublicReminder => ({
       reminderId: Number(row.REMINDER_ID),
       channelId: row.CHANNEL_ID,
       message: row.MESSAGE,
@@ -109,55 +98,35 @@ export async function listUpcomingReminders(limit: number = 20): Promise<IPublic
       recurUnit: (row.RECUR_UNIT as RecurrenceUnit | null) ?? null,
       enabled: (row.ENABLED ?? 0) === 1,
       createdBy: row.CREATED_BY ?? null,
-    }));
-  } finally {
-    await connection.close();
-  }
+    }),
+  );
 }
 
 export async function deleteReminder(reminderId: number): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `DELETE FROM RPG_CLUB_PUBLIC_REMINDERS WHERE REMINDER_ID = :id`,
-      { id: reminderId },
-      { autoCommit: true },
-    );
-    return (result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+  const result = await oraMutate(
+    `DELETE FROM RPG_CLUB_PUBLIC_REMINDERS WHERE REMINDER_ID = :id`,
+    { id: reminderId },
+  );
+  return (result.rowsAffected ?? 0) > 0;
 }
 
 export async function updateReminderDueDate(
   reminderId: number,
   nextDue: Date,
 ): Promise<void> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `UPDATE RPG_CLUB_PUBLIC_REMINDERS
-          SET DUE_AT = :nextDue
-        WHERE REMINDER_ID = :id`,
-      { nextDue, id: reminderId },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE RPG_CLUB_PUBLIC_REMINDERS
+        SET DUE_AT = :nextDue
+      WHERE REMINDER_ID = :id`,
+    { nextDue, id: reminderId },
+  );
 }
 
 export async function disableReminder(reminderId: number): Promise<void> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `UPDATE RPG_CLUB_PUBLIC_REMINDERS
-          SET ENABLED = 0
-        WHERE REMINDER_ID = :id`,
-      { id: reminderId },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE RPG_CLUB_PUBLIC_REMINDERS
+        SET ENABLED = 0
+      WHERE REMINDER_ID = :id`,
+    { id: reminderId },
+  );
 }

--- a/src/classes/Reminder.ts
+++ b/src/classes/Reminder.ts
@@ -1,5 +1,6 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import type { Connection } from "oracledb";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 export interface IReminderRecord {
   reminderId: number;
@@ -14,10 +15,9 @@ export interface IReminderRecord {
   updatedAt: Date | null;
 }
 
-type Connection = oracledb.Connection;
-
 const REMINDER_COLUMNS =
-  "REMINDER_ID, USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT, FAILURE_COUNT, FAILED_AT, CREATED_AT, UPDATED_AT";
+  "REMINDER_ID, USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT," +
+  " FAILURE_COUNT, FAILED_AT, CREATED_AT, UPDATED_AT";
 
 function normalizeReminderId(value: number): number {
   const id = Number(value);
@@ -53,7 +53,7 @@ function normalizeContent(value: string): string {
   return trimmed.slice(0, 400);
 }
 
-function mapRowToReminder(row: {
+type ReminderRow = {
   REMINDER_ID: number;
   USER_ID: string;
   REMIND_AT: Date | string;
@@ -64,20 +64,18 @@ function mapRowToReminder(row: {
   FAILED_AT: Date | string | null;
   CREATED_AT: Date | string | null;
   UPDATED_AT: Date | string | null;
-}): IReminderRecord {
+};
+
+function mapRowToReminder(row: ReminderRow): IReminderRecord {
   const reminderId = normalizeReminderId(row.REMINDER_ID);
   const remindAt = normalizeDate(row.REMIND_AT);
   const content = normalizeContent(row.CONTENT);
   const isNoisy = Boolean(row.IS_NOISY);
 
   const sentAt =
-    row.SENT_AT === null || row.SENT_AT === undefined
-      ? null
-      : normalizeDate(row.SENT_AT);
+    row.SENT_AT === null || row.SENT_AT === undefined ? null : normalizeDate(row.SENT_AT);
   const failedAt =
-    row.FAILED_AT === null || row.FAILED_AT === undefined
-      ? null
-      : normalizeDate(row.FAILED_AT);
+    row.FAILED_AT === null || row.FAILED_AT === undefined ? null : normalizeDate(row.FAILED_AT);
   const createdAt =
     row.CREATED_AT === null || row.CREATED_AT === undefined
       ? null
@@ -112,77 +110,43 @@ export default class Reminder {
     const normalizedContent = normalizeContent(content);
     const noisyVal = isNoisy ? 1 : 0;
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
+    const result = await oraMutate(
+      `INSERT INTO USER_REMINDERS (
+         USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT, FAILURE_COUNT,
+         FAILED_AT, CREATED_AT, UPDATED_AT
+       ) VALUES (
+         :userId, :remindAt, :content, :noisyVal, NULL, 0, NULL,
+         SYSTIMESTAMP, SYSTIMESTAMP
+       )
+       RETURNING REMINDER_ID INTO :reminderId`,
+      {
+        userId,
+        remindAt: normalizedDate,
+        content: normalizedContent,
+        noisyVal,
+        reminderId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+      },
+    );
 
-    try {
-      const result = await connection.execute(
-        `INSERT INTO USER_REMINDERS (
-           USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT, FAILURE_COUNT, FAILED_AT, CREATED_AT, UPDATED_AT
-         ) VALUES (
-           :userId, :remindAt, :content, :noisyVal, NULL, 0, NULL, SYSTIMESTAMP, SYSTIMESTAMP
-         )
-         RETURNING REMINDER_ID INTO :reminderId`,
-        {
-          userId,
-          remindAt: normalizedDate,
-          content: normalizedContent,
-          noisyVal,
-          reminderId: {
-            dir: oracledb.BIND_OUT,
-            type: oracledb.NUMBER,
-          },
-        },
-        { autoCommit: true },
-      );
+    const out = (result.outBinds ?? {}) as { reminderId?: number[] };
+    const reminderId = normalizeReminderId(out.reminderId?.[0] ?? 0);
 
-      const out = (result.outBinds ?? {}) as { reminderId?: number[] };
-      const reminderId = normalizeReminderId(out.reminderId?.[0] ?? 0);
-
-      const inserted = await Reminder.getById(reminderId, { connection });
-      if (!inserted) {
-        throw new Error(`Failed to read inserted reminder ${reminderId}.`);
-      }
-      return inserted;
-    } finally {
-      await connection.close();
+    const inserted = await Reminder.getById(reminderId);
+    if (!inserted) {
+      throw new Error(`Failed to read inserted reminder ${reminderId}.`);
     }
+    return inserted;
   }
 
   static async listByUser(userId: string): Promise<IReminderRecord[]> {
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute(
-        `SELECT ${REMINDER_COLUMNS}
-           FROM USER_REMINDERS
-          WHERE USER_ID = :userId
-          ORDER BY REMIND_AT`,
-        { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const rows = (result.rows ?? []) as any[];
-      return rows.map((row) =>
-        mapRowToReminder(
-          row as {
-            REMINDER_ID: number;
-            USER_ID: string;
-            REMIND_AT: Date | string;
-            CONTENT: string;
-            IS_NOISY: number;
-            SENT_AT: Date | string | null;
-            FAILURE_COUNT: number;
-            FAILED_AT: Date | string | null;
-            CREATED_AT: Date | string | null;
-            UPDATED_AT: Date | string | null;
-          },
-        ),
-      );
-    } finally {
-      await connection.close();
-    }
+    return oraQuery(
+      `SELECT ${REMINDER_COLUMNS}
+         FROM USER_REMINDERS
+        WHERE USER_ID = :userId
+        ORDER BY REMIND_AT`,
+      { userId },
+      mapRowToReminder,
+    );
   }
 
   static async getById(
@@ -190,62 +154,26 @@ export default class Reminder {
     opts?: { connection?: Connection },
   ): Promise<IReminderRecord | null> {
     const id = normalizeReminderId(reminderId);
-    const externalConn = opts?.connection ?? null;
-    const connection = externalConn ?? (await getOraclePool().getConnection());
-
-    try {
-      const result = await connection.execute(
-        `SELECT ${REMINDER_COLUMNS}
-           FROM USER_REMINDERS
-          WHERE REMINDER_ID = :reminderId`,
-        { reminderId: id },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const rows = (result.rows ?? []) as any[];
-      if (!rows.length) {
-        return null;
-      }
-
-      const row = rows[0] as {
-        REMINDER_ID: number;
-        USER_ID: string;
-        REMIND_AT: Date | string;
-        CONTENT: string;
-        IS_NOISY: number;
-        SENT_AT: Date | string | null;
-        FAILURE_COUNT: number;
-        FAILED_AT: Date | string | null;
-        CREATED_AT: Date | string | null;
-        UPDATED_AT: Date | string | null;
-      };
-
-      return mapRowToReminder(row);
-    } finally {
-      if (!externalConn) {
-        await connection.close();
-      }
-    }
+    const rows = await oraQuery(
+      `SELECT ${REMINDER_COLUMNS}
+         FROM USER_REMINDERS
+        WHERE REMINDER_ID = :reminderId`,
+      { reminderId: id },
+      mapRowToReminder,
+      opts?.connection,
+    );
+    return rows[0] ?? null;
   }
 
   static async delete(reminderId: number, userId: string): Promise<boolean> {
     const id = normalizeReminderId(reminderId);
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute(
-        `DELETE FROM USER_REMINDERS
-          WHERE REMINDER_ID = :reminderId
-            AND USER_ID = :userId`,
-        { reminderId: id, userId },
-        { autoCommit: true },
-      );
-
-      return (result.rowsAffected ?? 0) > 0;
-    } finally {
-      await connection.close();
-    }
+    const result = await oraMutate(
+      `DELETE FROM USER_REMINDERS
+        WHERE REMINDER_ID = :reminderId
+          AND USER_ID = :userId`,
+      { reminderId: id, userId },
+    );
+    return (result.rowsAffected ?? 0) > 0;
   }
 
   static async snooze(
@@ -256,95 +184,61 @@ export default class Reminder {
     const id = normalizeReminderId(reminderId);
     const normalizedDate = normalizeDate(remindAt);
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
+    const result = await oraMutate(
+      `UPDATE USER_REMINDERS
+          SET REMIND_AT = :remindAt,
+              SENT_AT = NULL,
+              FAILURE_COUNT = 0,
+              FAILED_AT = NULL,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE REMINDER_ID = :reminderId
+          AND USER_ID = :userId`,
+      { reminderId: id, userId, remindAt: normalizedDate },
+    );
 
-    try {
-      const result = await connection.execute(
-        `UPDATE USER_REMINDERS
-            SET REMIND_AT = :remindAt,
-                SENT_AT = NULL,
-                FAILURE_COUNT = 0,
-                FAILED_AT = NULL,
-                UPDATED_AT = SYSTIMESTAMP
-          WHERE REMINDER_ID = :reminderId
-            AND USER_ID = :userId`,
-        { reminderId: id, userId, remindAt: normalizedDate },
-        { autoCommit: true },
-      );
-
-      if ((result.rowsAffected ?? 0) === 0) {
-        return null;
-      }
-
-      return await Reminder.getById(reminderId, { connection });
-    } finally {
-      await connection.close();
+    if ((result.rowsAffected ?? 0) === 0) {
+      return null;
     }
+    return Reminder.getById(reminderId);
   }
 
   static async markSent(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute(
-        `UPDATE USER_REMINDERS
-            SET SENT_AT = SYSTIMESTAMP,
-                FAILURE_COUNT = 0,
-                FAILED_AT = NULL,
-                UPDATED_AT = SYSTIMESTAMP
-          WHERE REMINDER_ID = :reminderId`,
-        { reminderId: id },
-        { autoCommit: true },
-      );
-
-      if ((result.rowsAffected ?? 0) === 0) {
-        throw new Error(`No reminder found for id ${id} when marking as sent.`);
-      }
-    } finally {
-      await connection.close();
+    const result = await oraMutate(
+      `UPDATE USER_REMINDERS
+          SET SENT_AT = SYSTIMESTAMP,
+              FAILURE_COUNT = 0,
+              FAILED_AT = NULL,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE REMINDER_ID = :reminderId`,
+      { reminderId: id },
+    );
+    if ((result.rowsAffected ?? 0) === 0) {
+      throw new Error(`No reminder found for id ${id} when marking as sent.`);
     }
   }
 
   static async recordFailure(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      await connection.execute(
-        `UPDATE USER_REMINDERS
-            SET FAILURE_COUNT = FAILURE_COUNT + 1,
-                FAILED_AT = SYSTIMESTAMP,
-                UPDATED_AT = SYSTIMESTAMP
-          WHERE REMINDER_ID = :reminderId`,
-        { reminderId: id },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `UPDATE USER_REMINDERS
+          SET FAILURE_COUNT = FAILURE_COUNT + 1,
+              FAILED_AT = SYSTIMESTAMP,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE REMINDER_ID = :reminderId`,
+      { reminderId: id },
+    );
   }
 
   static async markFailedPermanently(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      await connection.execute(
-        `UPDATE USER_REMINDERS
-            SET SENT_AT = SYSTIMESTAMP,
-                UPDATED_AT = SYSTIMESTAMP
-          WHERE REMINDER_ID = :reminderId`,
-        { reminderId: id },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `UPDATE USER_REMINDERS
+          SET SENT_AT = SYSTIMESTAMP,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE REMINDER_ID = :reminderId`,
+      { reminderId: id },
+    );
   }
 
   static async getDueUndelivered(
@@ -354,44 +248,19 @@ export default class Reminder {
     const normalizedDate = normalizeDate(cutoff);
     const safeLimit = Math.max(1, Math.min(limit, 100));
 
-    const pool = getOraclePool();
-    const connection = await pool.getConnection();
-
-    try {
-      const result = await connection.execute(
-        `SELECT ${REMINDER_COLUMNS}
-           FROM (
-             SELECT ${REMINDER_COLUMNS}
-               FROM USER_REMINDERS
-              WHERE REMIND_AT <= :cutoff
-                AND SENT_AT IS NULL
-                AND FAILURE_COUNT < 5
-              ORDER BY REMIND_AT
-           )
-          WHERE ROWNUM <= :limit`,
-        { cutoff: normalizedDate, limit: safeLimit },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const rows = (result.rows ?? []) as any[];
-      return rows.map((row) =>
-        mapRowToReminder(
-          row as {
-            REMINDER_ID: number;
-            USER_ID: string;
-            REMIND_AT: Date | string;
-            CONTENT: string;
-            IS_NOISY: number;
-            SENT_AT: Date | string | null;
-            FAILURE_COUNT: number;
-            FAILED_AT: Date | string | null;
-            CREATED_AT: Date | string | null;
-            UPDATED_AT: Date | string | null;
-          },
-        ),
-      );
-    } finally {
-      await connection.close();
-    }
+    return oraQuery(
+      `SELECT ${REMINDER_COLUMNS}
+         FROM (
+           SELECT ${REMINDER_COLUMNS}
+             FROM USER_REMINDERS
+            WHERE REMIND_AT <= :cutoff
+              AND SENT_AT IS NULL
+              AND FAILURE_COUNT < 5
+            ORDER BY REMIND_AT
+         )
+        WHERE ROWNUM <= :limit`,
+      { cutoff: normalizedDate, limit: safeLimit },
+      mapRowToReminder,
+    );
   }
 }

--- a/src/classes/Starboard.ts
+++ b/src/classes/Starboard.ts
@@ -1,5 +1,4 @@
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 export type StarboardRecord = {
   messageId: string;
@@ -12,61 +11,49 @@ export type StarboardRecord = {
 
 export default class Starboard {
   static async getByMessageId(messageId: string): Promise<StarboardRecord | null> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{
+    const rows = await oraQuery(
+      `SELECT MESSAGE_ID,
+              CHANNEL_ID,
+              STARBOARD_MESSAGE_ID,
+              AUTHOR_ID,
+              STAR_COUNT,
+              CREATED_AT
+         FROM RPG_CLUB_STARBOARD
+        WHERE MESSAGE_ID = :messageId`,
+      { messageId },
+      (row: {
         MESSAGE_ID: string;
         CHANNEL_ID: string;
         STARBOARD_MESSAGE_ID: string;
         AUTHOR_ID: string;
         STAR_COUNT: number;
-        CREATED_AT: Date;
-      }>(
-        `SELECT MESSAGE_ID,
-                CHANNEL_ID,
-                STARBOARD_MESSAGE_ID,
-                AUTHOR_ID,
-                STAR_COUNT,
-                CREATED_AT
-           FROM RPG_CLUB_STARBOARD
-          WHERE MESSAGE_ID = :messageId`,
-        { messageId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const row = result.rows?.[0];
-      if (!row) return null;
-      return {
+        CREATED_AT: Date | string;
+      }): StarboardRecord => ({
         messageId: row.MESSAGE_ID,
         channelId: row.CHANNEL_ID,
         starboardMessageId: row.STARBOARD_MESSAGE_ID,
         authorId: row.AUTHOR_ID,
         starCount: Number(row.STAR_COUNT ?? 0),
-        createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : 
-          new Date(row.CREATED_AT as any),
-      };
-    } finally {
-      await connection.close();
-    }
+        createdAt: row.CREATED_AT instanceof Date
+          ? row.CREATED_AT
+          : new Date(row.CREATED_AT),
+      }),
+    );
+    return rows[0] ?? null;
   }
 
   static async insert(record: Omit<StarboardRecord, "createdAt">): Promise<void> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.execute(
-        `INSERT INTO RPG_CLUB_STARBOARD
-          (MESSAGE_ID, CHANNEL_ID, STARBOARD_MESSAGE_ID, AUTHOR_ID, STAR_COUNT)
-         VALUES (:messageId, :channelId, :starboardMessageId, :authorId, :starCount)`,
-        {
-          messageId: record.messageId,
-          channelId: record.channelId,
-          starboardMessageId: record.starboardMessageId,
-          authorId: record.authorId,
-          starCount: record.starCount,
-        },
-        { autoCommit: true },
-      );
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `INSERT INTO RPG_CLUB_STARBOARD
+        (MESSAGE_ID, CHANNEL_ID, STARBOARD_MESSAGE_ID, AUTHOR_ID, STAR_COUNT)
+       VALUES (:messageId, :channelId, :starboardMessageId, :authorId, :starCount)`,
+      {
+        messageId: record.messageId,
+        channelId: record.channelId,
+        starboardMessageId: record.starboardMessageId,
+        authorId: record.authorId,
+        starCount: record.starCount,
+      },
+    );
   }
 }

--- a/src/classes/SteamCollectionImport.ts
+++ b/src/classes/SteamCollectionImport.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
 
 export type SteamCollectionImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type SteamCollectionImportItemStatus =
@@ -69,7 +69,7 @@ function toDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
 }
 
-function mapImport(row: {
+type ImportRow = {
   IMPORT_ID: number;
   USER_ID: string;
   STATUS: SteamCollectionImportStatus;
@@ -80,7 +80,9 @@ function mapImport(row: {
   SOURCE_PROFILE_NAME: string | null;
   CREATED_AT: Date | string;
   UPDATED_AT: Date | string;
-}): ISteamCollectionImport {
+};
+
+function mapImport(row: ImportRow): ISteamCollectionImport {
   return {
     importId: Number(row.IMPORT_ID),
     userId: row.USER_ID,
@@ -95,7 +97,7 @@ function mapImport(row: {
   };
 }
 
-function mapItem(row: {
+type ItemRow = {
   ITEM_ID: number;
   IMPORT_ID: number;
   ROW_INDEX: number;
@@ -114,7 +116,9 @@ function mapItem(row: {
   COLLECTION_ENTRY_ID: number | null;
   RESULT_REASON: SteamCollectionImportResultReason | null;
   ERROR_TEXT: string | null;
-}): ISteamCollectionImportItem {
+};
+
+function mapItem(row: ItemRow): ISteamCollectionImportItem {
   return {
     itemId: Number(row.ITEM_ID),
     importId: Number(row.IMPORT_ID),
@@ -141,7 +145,7 @@ function mapItem(row: {
   };
 }
 
-function mapAppMap(row: {
+type AppMapRow = {
   MAP_ID: number;
   STEAM_APP_ID: number;
   GAMEDB_GAME_ID: number | null;
@@ -149,7 +153,9 @@ function mapAppMap(row: {
   CREATED_BY: string | null;
   CREATED_AT: Date | string;
   UPDATED_AT: Date | string;
-}): ISteamAppGameDbMap {
+};
+
+function mapAppMap(row: AppMapRow): ISteamAppGameDbMap {
   return {
     mapId: Number(row.MAP_ID),
     steamAppId: Number(row.STEAM_APP_ID),
@@ -161,6 +167,38 @@ function mapAppMap(row: {
   };
 }
 
+const IMPORT_SELECT_SQL = `SELECT IMPORT_ID,
+       USER_ID,
+       STATUS,
+       CURRENT_INDEX,
+       TOTAL_COUNT,
+       STEAM_ID64,
+       STEAM_PROFILE_REF,
+       SOURCE_PROFILE_NAME,
+       CREATED_AT,
+       UPDATED_AT
+  FROM RPG_CLUB_STEAM_COLLECTION_IMPORTS`;
+
+const ITEM_SELECT_SQL = `SELECT ITEM_ID,
+       IMPORT_ID,
+       ROW_INDEX,
+       STEAM_APP_ID,
+       STEAM_APP_NAME,
+       PLAYTIME_FOREVER_MIN,
+       PLAYTIME_WINDOWS_MIN,
+       PLAYTIME_MAC_MIN,
+       PLAYTIME_LINUX_MIN,
+       PLAYTIME_DECK_MIN,
+       LAST_PLAYED_AT,
+       STATUS,
+       MATCH_CONFIDENCE,
+       MATCH_CANDIDATE_JSON,
+       GAMEDB_GAME_ID,
+       COLLECTION_ENTRY_ID,
+       RESULT_REASON,
+       ERROR_TEXT
+  FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS`;
+
 export async function createSteamCollectionImportSession(params: {
   userId: string;
   totalCount: number;
@@ -168,9 +206,8 @@ export async function createSteamCollectionImportSession(params: {
   steamProfileRef: string | null;
   sourceProfileName: string | null;
 }): Promise<ISteamCollectionImport> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
+  return oraWithConnection(async (conn) => {
+    const insert = await oraMutate(
       `INSERT INTO RPG_CLUB_STEAM_COLLECTION_IMPORTS (
          USER_ID,
          STATUS,
@@ -196,23 +233,17 @@ export async function createSteamCollectionImportSession(params: {
         sourceProfileName: params.sourceProfileName,
         id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
       },
-      { autoCommit: true },
+      conn,
     );
+    await conn.commit();
 
-    const id = Number((result.outBinds as { id?: number[] }).id?.[0] ?? 0);
-    if (!id) {
-      throw new Error("Failed to create Steam collection import session.");
-    }
+    const id = Number((insert.outBinds as { id?: number[] }).id?.[0] ?? 0);
+    if (!id) throw new Error("Failed to create Steam collection import session.");
 
-    const session = await getSteamCollectionImportById(id, connection);
-    if (!session) {
-      throw new Error("Failed to load Steam collection import session.");
-    }
-
+    const session = await getSteamCollectionImportById(id, conn);
+    if (!session) throw new Error("Failed to load Steam collection import session.");
     return session;
-  } finally {
-    await connection.close();
-  }
+  });
 }
 
 export async function insertSteamCollectionImportItems(
@@ -231,10 +262,9 @@ export async function insertSteamCollectionImportItems(
 ): Promise<void> {
   if (!items.length) return;
 
-  const connection = await getOraclePool().getConnection();
-  try {
+  await oraTransaction(async (conn) => {
     for (const item of items) {
-      await connection.execute(
+      await oraMutate(
         `INSERT INTO RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS (
            IMPORT_ID,
            ROW_INDEX,
@@ -272,259 +302,95 @@ export async function insertSteamCollectionImportItems(
           playtimeDeckMin: item.playtimeDeckMin,
           lastPlayedAt: item.lastPlayedAt,
         },
-        { autoCommit: false },
+        conn,
       );
     }
-    await connection.commit();
-  } catch (error) {
-    await connection.rollback().catch(() => {});
-    throw error;
-  } finally {
-    await connection.close();
-  }
+  });
 }
 
 export async function getSteamCollectionImportById(
   importId: number,
   existingConnection?: oracledb.Connection,
 ): Promise<ISteamCollectionImport | null> {
-  const connection = existingConnection ?? (await getOraclePool().getConnection());
-  try {
-    const result = await connection.execute<{
-      IMPORT_ID: number;
-      USER_ID: string;
-      STATUS: SteamCollectionImportStatus;
-      CURRENT_INDEX: number;
-      TOTAL_COUNT: number;
-      STEAM_ID64: string;
-      STEAM_PROFILE_REF: string | null;
-      SOURCE_PROFILE_NAME: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT IMPORT_ID,
-              USER_ID,
-              STATUS,
-              CURRENT_INDEX,
-              TOTAL_COUNT,
-              STEAM_ID64,
-              STEAM_PROFILE_REF,
-              SOURCE_PROFILE_NAME,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_STEAM_COLLECTION_IMPORTS
-        WHERE IMPORT_ID = :importId`,
-      { importId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapImport(row) : null;
-  } finally {
-    if (!existingConnection) {
-      await connection.close();
-    }
-  }
+  const rows = await oraQuery(
+    `${IMPORT_SELECT_SQL} WHERE IMPORT_ID = :importId`,
+    { importId },
+    mapImport,
+    existingConnection,
+  );
+  return rows[0] ?? null;
 }
 
 export async function getActiveSteamCollectionImportForUser(
   userId: string,
 ): Promise<ISteamCollectionImport | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      IMPORT_ID: number;
-      USER_ID: string;
-      STATUS: SteamCollectionImportStatus;
-      CURRENT_INDEX: number;
-      TOTAL_COUNT: number;
-      STEAM_ID64: string;
-      STEAM_PROFILE_REF: string | null;
-      SOURCE_PROFILE_NAME: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT IMPORT_ID,
-              USER_ID,
-              STATUS,
-              CURRENT_INDEX,
-              TOTAL_COUNT,
-              STEAM_ID64,
-              STEAM_PROFILE_REF,
-              SOURCE_PROFILE_NAME,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_STEAM_COLLECTION_IMPORTS
-        WHERE USER_ID = :userId
-          AND STATUS IN ('ACTIVE', 'PAUSED')
-        ORDER BY CREATED_AT DESC, IMPORT_ID DESC
-        FETCH FIRST 1 ROWS ONLY`,
-      { userId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapImport(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `${IMPORT_SELECT_SQL}
+     WHERE USER_ID = :userId
+       AND STATUS IN ('ACTIVE', 'PAUSED')
+     ORDER BY CREATED_AT DESC, IMPORT_ID DESC
+     FETCH FIRST 1 ROWS ONLY`,
+    { userId },
+    mapImport,
+  );
+  return rows[0] ?? null;
 }
 
 export async function setSteamCollectionImportStatus(
   importId: number,
   status: SteamCollectionImportStatus,
 ): Promise<void> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
-          SET STATUS = :status
-        WHERE IMPORT_ID = :importId`,
-      { status, importId },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
+        SET STATUS = :status
+      WHERE IMPORT_ID = :importId`,
+    { status, importId },
+  );
 }
 
 export async function updateSteamCollectionImportIndex(
   importId: number,
   currentIndex: number,
 ): Promise<void> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
-          SET CURRENT_INDEX = :currentIndex
-        WHERE IMPORT_ID = :importId`,
-      { currentIndex, importId },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
+        SET CURRENT_INDEX = :currentIndex
+      WHERE IMPORT_ID = :importId`,
+    { currentIndex, importId },
+  );
+}
+
+async function fetchItemWithJsonCol(
+  sql: string,
+  binds: Record<string, string | number>,
+): Promise<ISteamCollectionImportItem | null> {
+  return oraWithConnection(async (conn) => {
+    const result = await conn.execute<ItemRow>(sql, binds, {
+      outFormat: oracledb.OUT_FORMAT_OBJECT,
+      fetchInfo: { MATCH_CANDIDATE_JSON: { type: oracledb.STRING } },
+    });
+    const row = result.rows?.[0];
+    return row ? mapItem(row) : null;
+  });
 }
 
 export async function getSteamCollectionImportItemById(
   itemId: number,
 ): Promise<ISteamCollectionImportItem | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      ITEM_ID: number;
-      IMPORT_ID: number;
-      ROW_INDEX: number;
-      STEAM_APP_ID: number;
-      STEAM_APP_NAME: string;
-      PLAYTIME_FOREVER_MIN: number | null;
-      PLAYTIME_WINDOWS_MIN: number | null;
-      PLAYTIME_MAC_MIN: number | null;
-      PLAYTIME_LINUX_MIN: number | null;
-      PLAYTIME_DECK_MIN: number | null;
-      LAST_PLAYED_AT: Date | string | null;
-      STATUS: SteamCollectionImportItemStatus;
-      MATCH_CONFIDENCE: SteamCollectionMatchConfidence | null;
-      MATCH_CANDIDATE_JSON: string | null;
-      GAMEDB_GAME_ID: number | null;
-      COLLECTION_ENTRY_ID: number | null;
-      RESULT_REASON: SteamCollectionImportResultReason | null;
-      ERROR_TEXT: string | null;
-    }>(
-      `SELECT ITEM_ID,
-              IMPORT_ID,
-              ROW_INDEX,
-              STEAM_APP_ID,
-              STEAM_APP_NAME,
-              PLAYTIME_FOREVER_MIN,
-              PLAYTIME_WINDOWS_MIN,
-              PLAYTIME_MAC_MIN,
-              PLAYTIME_LINUX_MIN,
-              PLAYTIME_DECK_MIN,
-              LAST_PLAYED_AT,
-              STATUS,
-              MATCH_CONFIDENCE,
-              MATCH_CANDIDATE_JSON,
-              GAMEDB_GAME_ID,
-              COLLECTION_ENTRY_ID,
-              RESULT_REASON,
-              ERROR_TEXT
-         FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
-        WHERE ITEM_ID = :itemId`,
-      { itemId },
-      {
-        outFormat: oracledb.OUT_FORMAT_OBJECT,
-        fetchInfo: {
-          MATCH_CANDIDATE_JSON: { type: oracledb.STRING },
-        },
-      },
-    );
-    const row = result.rows?.[0];
-    return row ? mapItem(row) : null;
-  } finally {
-    await connection.close();
-  }
+  return fetchItemWithJsonCol(`${ITEM_SELECT_SQL} WHERE ITEM_ID = :itemId`, { itemId });
 }
 
 export async function getNextPendingSteamCollectionImportItem(
   importId: number,
 ): Promise<ISteamCollectionImportItem | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      ITEM_ID: number;
-      IMPORT_ID: number;
-      ROW_INDEX: number;
-      STEAM_APP_ID: number;
-      STEAM_APP_NAME: string;
-      PLAYTIME_FOREVER_MIN: number | null;
-      PLAYTIME_WINDOWS_MIN: number | null;
-      PLAYTIME_MAC_MIN: number | null;
-      PLAYTIME_LINUX_MIN: number | null;
-      PLAYTIME_DECK_MIN: number | null;
-      LAST_PLAYED_AT: Date | string | null;
-      STATUS: SteamCollectionImportItemStatus;
-      MATCH_CONFIDENCE: SteamCollectionMatchConfidence | null;
-      MATCH_CANDIDATE_JSON: string | null;
-      GAMEDB_GAME_ID: number | null;
-      COLLECTION_ENTRY_ID: number | null;
-      RESULT_REASON: SteamCollectionImportResultReason | null;
-      ERROR_TEXT: string | null;
-    }>(
-      `SELECT ITEM_ID,
-              IMPORT_ID,
-              ROW_INDEX,
-              STEAM_APP_ID,
-              STEAM_APP_NAME,
-              PLAYTIME_FOREVER_MIN,
-              PLAYTIME_WINDOWS_MIN,
-              PLAYTIME_MAC_MIN,
-              PLAYTIME_LINUX_MIN,
-              PLAYTIME_DECK_MIN,
-              LAST_PLAYED_AT,
-              STATUS,
-              MATCH_CONFIDENCE,
-              MATCH_CANDIDATE_JSON,
-              GAMEDB_GAME_ID,
-              COLLECTION_ENTRY_ID,
-              RESULT_REASON,
-              ERROR_TEXT
-         FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
-        WHERE IMPORT_ID = :importId
-          AND STATUS = 'PENDING'
-        ORDER BY ROW_INDEX ASC
-        FETCH FIRST 1 ROWS ONLY`,
-      { importId },
-      {
-        outFormat: oracledb.OUT_FORMAT_OBJECT,
-        fetchInfo: {
-          MATCH_CANDIDATE_JSON: { type: oracledb.STRING },
-        },
-      },
-    );
-    const row = result.rows?.[0];
-    return row ? mapItem(row) : null;
-  } finally {
-    await connection.close();
-  }
+  return fetchItemWithJsonCol(
+    `${ITEM_SELECT_SQL}
+     WHERE IMPORT_ID = :importId
+       AND STATUS = 'PENDING'
+     ORDER BY ROW_INDEX ASC
+     FETCH FIRST 1 ROWS ONLY`,
+    { importId },
+  );
 }
 
 export async function updateSteamCollectionImportItem(
@@ -571,22 +437,14 @@ export async function updateSteamCollectionImportItem(
     binds.errorText = updates.errorText;
   }
 
-  if (!setParts.length) {
-    return;
-  }
+  if (!setParts.length) return;
 
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
-          SET ${setParts.join(", ")}
-        WHERE ITEM_ID = :itemId`,
-      binds,
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
+        SET ${setParts.join(", ")}
+      WHERE ITEM_ID = :itemId`,
+    binds,
+  );
 }
 
 export async function countSteamCollectionImportItems(
@@ -598,105 +456,67 @@ export async function countSteamCollectionImportItems(
   skipped: number;
   failed: number;
 }> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      STATUS: SteamCollectionImportItemStatus;
-      CNT: number;
-    }>(
-      `SELECT STATUS, COUNT(*) AS CNT
-         FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
-        WHERE IMPORT_ID = :importId
-        GROUP BY STATUS`,
-      { importId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-
-    const counts = {
-      pending: 0,
-      added: 0,
-      updated: 0,
-      skipped: 0,
-      failed: 0,
-    };
-
-    for (const row of result.rows ?? []) {
-      const status = String(row.STATUS).toUpperCase();
-      const value = Number(row.CNT ?? 0);
-      if (status === "PENDING") counts.pending = value;
-      else if (status === "ADDED") counts.added = value;
-      else if (status === "UPDATED") counts.updated = value;
-      else if (status === "SKIPPED") counts.skipped = value;
-      else if (status === "FAILED") counts.failed = value;
-    }
-
-    return counts;
-  } finally {
-    await connection.close();
+  const rows = await oraQuery(
+    `SELECT STATUS, COUNT(*) AS CNT
+       FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY STATUS`,
+    { importId },
+    (row: { STATUS: SteamCollectionImportItemStatus; CNT: number }) => row,
+  );
+  const counts = { pending: 0, added: 0, updated: 0, skipped: 0, failed: 0 };
+  for (const row of rows) {
+    const status = String(row.STATUS).toUpperCase();
+    const value = Number(row.CNT ?? 0);
+    if (status === "PENDING") counts.pending = value;
+    else if (status === "ADDED") counts.added = value;
+    else if (status === "UPDATED") counts.updated = value;
+    else if (status === "SKIPPED") counts.skipped = value;
+    else if (status === "FAILED") counts.failed = value;
   }
+  return counts;
 }
 
 export async function countSteamCollectionImportResultReasons(
   importId: number,
 ): Promise<Record<string, number>> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      RESULT_REASON: string | null;
-      CNT: number;
-    }>(
-      `SELECT RESULT_REASON, COUNT(*) AS CNT
-         FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
-        WHERE IMPORT_ID = :importId
-          AND RESULT_REASON IS NOT NULL
-        GROUP BY RESULT_REASON`,
-      { importId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-
-    const counts: Record<string, number> = {};
-    for (const row of result.rows ?? []) {
-      const key = String(row.RESULT_REASON ?? "").trim();
-      if (!key.length) continue;
-      counts[key] = Number(row.CNT ?? 0);
-    }
-    return counts;
-  } finally {
-    await connection.close();
+  const rows = await oraQuery(
+    `SELECT RESULT_REASON, COUNT(*) AS CNT
+       FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+        AND RESULT_REASON IS NOT NULL
+      GROUP BY RESULT_REASON`,
+    { importId },
+    (row: { RESULT_REASON: string | null; CNT: number }) => row,
+  );
+  const counts: Record<string, number> = {};
+  for (const row of rows) {
+    const key = String(row.RESULT_REASON ?? "").trim();
+    if (!key.length) continue;
+    counts[key] = Number(row.CNT ?? 0);
   }
+  return counts;
 }
 
 export async function getSteamAppGameDbMapByAppId(
   steamAppId: number,
+  existingConnection?: oracledb.Connection,
 ): Promise<ISteamAppGameDbMap | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      MAP_ID: number;
-      STEAM_APP_ID: number;
-      GAMEDB_GAME_ID: number | null;
-      STATUS: SteamAppGameDbMapStatus;
-      CREATED_BY: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT MAP_ID,
-              STEAM_APP_ID,
-              GAMEDB_GAME_ID,
-              STATUS,
-              CREATED_BY,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_STEAM_APP_GAMEDB_MAP
-        WHERE STEAM_APP_ID = :steamAppId`,
-      { steamAppId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapAppMap(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `SELECT MAP_ID,
+            STEAM_APP_ID,
+            GAMEDB_GAME_ID,
+            STATUS,
+            CREATED_BY,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_STEAM_APP_GAMEDB_MAP
+      WHERE STEAM_APP_ID = :steamAppId`,
+    { steamAppId },
+    mapAppMap,
+    existingConnection,
+  );
+  return rows[0] ?? null;
 }
 
 export async function upsertSteamAppGameDbMap(params: {
@@ -705,9 +525,8 @@ export async function upsertSteamAppGameDbMap(params: {
   status: SteamAppGameDbMapStatus;
   createdBy: string | null;
 }): Promise<ISteamAppGameDbMap> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
+  return oraWithConnection(async (conn) => {
+    await oraMutate(
       `MERGE INTO RPG_CLUB_STEAM_APP_GAMEDB_MAP m
        USING (
          SELECT :steamAppId AS steamAppId,
@@ -738,17 +557,14 @@ export async function upsertSteamAppGameDbMap(params: {
         status: params.status,
         createdBy: params.createdBy,
       },
-      { autoCommit: true },
+      conn,
     );
+    await conn.commit();
 
-    const mapping = await getSteamAppGameDbMapByAppId(params.steamAppId);
-    if (!mapping) {
-      throw new Error("Failed to load Steam app mapping.");
-    }
+    const mapping = await getSteamAppGameDbMapByAppId(params.steamAppId, conn);
+    if (!mapping) throw new Error("Failed to load Steam app mapping.");
     return mapping;
-  } finally {
-    await connection.close();
-  }
+  });
 }
 
 export async function getSteamAppHistoricalMappedGameIds(params: {
@@ -756,40 +572,32 @@ export async function getSteamAppHistoricalMappedGameIds(params: {
   excludeUserId?: string;
   limit?: number;
 }): Promise<number[]> {
-  const limit = Number.isInteger(params.limit) && (params.limit ?? 0) > 0 ? 
-    Number(params.limit) : 5;
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      GAMEDB_GAME_ID: number;
-    }>(
-      `SELECT t.GAMEDB_GAME_ID
-         FROM (
-           SELECT ii.GAMEDB_GAME_ID,
-                  COUNT(*) AS CNT,
-                  MAX(ii.ITEM_ID) AS LAST_ITEM_ID
-             FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS ii
-             JOIN RPG_CLUB_STEAM_COLLECTION_IMPORTS i
-               ON i.IMPORT_ID = ii.IMPORT_ID
-            WHERE ii.STEAM_APP_ID = :steamAppId
-              AND ii.GAMEDB_GAME_ID IS NOT NULL
-              AND ii.RESULT_REASON = 'MANUAL_REMAP'
-              AND (:excludeUserId IS NULL OR i.USER_ID <> :excludeUserId)
-            GROUP BY ii.GAMEDB_GAME_ID
-            ORDER BY CNT DESC, LAST_ITEM_ID DESC
-         ) t
-        WHERE ROWNUM <= :limit`,
-      {
-        steamAppId: params.steamAppId,
-        excludeUserId: params.excludeUserId ?? null,
-        limit,
-      },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    return (result.rows ?? [])
-      .map((row) => Number(row.GAMEDB_GAME_ID))
-      .filter((value) => Number.isInteger(value) && value > 0);
-  } finally {
-    await connection.close();
-  }
+  const limit = Number.isInteger(params.limit) && (params.limit ?? 0) > 0
+    ? Number(params.limit) : 5;
+
+  const rows = await oraQuery(
+    `SELECT t.GAMEDB_GAME_ID
+       FROM (
+         SELECT ii.GAMEDB_GAME_ID,
+                COUNT(*) AS CNT,
+                MAX(ii.ITEM_ID) AS LAST_ITEM_ID
+           FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS ii
+           JOIN RPG_CLUB_STEAM_COLLECTION_IMPORTS i
+             ON i.IMPORT_ID = ii.IMPORT_ID
+          WHERE ii.STEAM_APP_ID = :steamAppId
+            AND ii.GAMEDB_GAME_ID IS NOT NULL
+            AND ii.RESULT_REASON = 'MANUAL_REMAP'
+            AND (:excludeUserId IS NULL OR i.USER_ID <> :excludeUserId)
+          GROUP BY ii.GAMEDB_GAME_ID
+          ORDER BY CNT DESC, LAST_ITEM_ID DESC
+       ) t
+      WHERE ROWNUM <= :limit`,
+    {
+      steamAppId: params.steamAppId,
+      excludeUserId: params.excludeUserId ?? null,
+      limit,
+    },
+    (row: { GAMEDB_GAME_ID: number }) => Number(row.GAMEDB_GAME_ID),
+  );
+  return rows.filter((value) => Number.isInteger(value) && value > 0);
 }

--- a/src/classes/Thread.ts
+++ b/src/classes/Thread.ts
@@ -1,5 +1,4 @@
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraTransaction, oraWithConnection } from "../db/SqlManager.js";
 
 type NullableDate = Date | null;
 
@@ -16,216 +15,182 @@ export async function upsertThreadRecord(params: {
   lastSeenAt: NullableDate;
   skipLinking?: "Y" | "N";
 }): Promise<void> {
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    await connection.execute(
-      `
-      MERGE INTO THREADS t
-      USING (
-        SELECT
-          :threadId       AS THREAD_ID,
-          :forumChannelId AS FORUM_CHANNEL_ID,
-          :threadName     AS THREAD_NAME,
-          :isArchived     AS IS_ARCHIVED,
-          :createdAt      AS CREATED_AT,
-          :lastSeenAt     AS LAST_SEEN_AT,
-          :skipLinking    AS SKIP_LINKING
-        FROM DUAL
-      ) s
-      ON (t.THREAD_ID = s.THREAD_ID)
-      WHEN MATCHED THEN UPDATE SET
-        t.THREAD_NAME      = s.THREAD_NAME,
-        t.FORUM_CHANNEL_ID = s.FORUM_CHANNEL_ID,
-        t.IS_ARCHIVED      = s.IS_ARCHIVED,
-        t.LAST_SEEN_AT     = s.LAST_SEEN_AT
-      WHEN NOT MATCHED THEN INSERT (
-        THREAD_ID, FORUM_CHANNEL_ID, THREAD_NAME, IS_ARCHIVED, CREATED_AT, LAST_SEEN_AT, SKIP_LINKING
-      ) VALUES (
-        s.THREAD_ID, s.FORUM_CHANNEL_ID, s.THREAD_NAME, s.IS_ARCHIVED, s.CREATED_AT, s.LAST_SEEN_AT, s.SKIP_LINKING
-      )
-      `,
-      {
-        threadId: params.threadId,
-        forumChannelId: params.forumChannelId,
-        threadName: params.threadName,
-        isArchived: toYN(params.isArchived),
-        createdAt: params.createdAt,
-        lastSeenAt: params.lastSeenAt,
-        skipLinking: params.skipLinking ?? "N",
-      },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `MERGE INTO THREADS t
+     USING (
+       SELECT
+         :threadId       AS THREAD_ID,
+         :forumChannelId AS FORUM_CHANNEL_ID,
+         :threadName     AS THREAD_NAME,
+         :isArchived     AS IS_ARCHIVED,
+         :createdAt      AS CREATED_AT,
+         :lastSeenAt     AS LAST_SEEN_AT,
+         :skipLinking    AS SKIP_LINKING
+       FROM DUAL
+     ) s
+     ON (t.THREAD_ID = s.THREAD_ID)
+     WHEN MATCHED THEN UPDATE SET
+       t.THREAD_NAME      = s.THREAD_NAME,
+       t.FORUM_CHANNEL_ID = s.FORUM_CHANNEL_ID,
+       t.IS_ARCHIVED      = s.IS_ARCHIVED,
+       t.LAST_SEEN_AT     = s.LAST_SEEN_AT
+     WHEN NOT MATCHED THEN INSERT (
+       THREAD_ID, FORUM_CHANNEL_ID, THREAD_NAME, IS_ARCHIVED,
+       CREATED_AT, LAST_SEEN_AT, SKIP_LINKING
+     ) VALUES (
+       s.THREAD_ID, s.FORUM_CHANNEL_ID, s.THREAD_NAME, s.IS_ARCHIVED,
+       s.CREATED_AT, s.LAST_SEEN_AT, s.SKIP_LINKING
+     )`,
+    {
+      threadId: params.threadId,
+      forumChannelId: params.forumChannelId,
+      threadName: params.threadName,
+      isArchived: toYN(params.isArchived),
+      createdAt: params.createdAt,
+      lastSeenAt: params.lastSeenAt,
+      skipLinking: params.skipLinking ?? "N",
+    },
+  );
 }
 
-export async function setThreadGameLink(threadId: string, gameId: number | null): Promise<void> {
+export async function setThreadGameLink(
+  threadId: string,
+  gameId: number | null,
+): Promise<void> {
   if (gameId !== null && (!Number.isInteger(gameId) || gameId <= 0)) {
     throw new Error("Invalid GameDB game id.");
   }
 
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
+  await oraTransaction(async (conn) => {
     if (gameId === null) {
-      await connection.execute(
+      await oraMutate(
         `DELETE FROM THREAD_GAME_LINKS WHERE THREAD_ID = :threadId`,
         { threadId },
-        { autoCommit: false },
+        conn,
       );
     } else {
-      await connection.execute(
-        `
-        MERGE INTO THREAD_GAME_LINKS tgt
-        USING (
-          SELECT :threadId AS THREAD_ID, :gameId AS GAMEDB_GAME_ID FROM DUAL
-        ) src
-        ON (tgt.THREAD_ID = src.THREAD_ID AND tgt.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
-        WHEN NOT MATCHED THEN
-          INSERT (THREAD_ID, GAMEDB_GAME_ID, LINKED_AT)
-          VALUES (src.THREAD_ID, src.GAMEDB_GAME_ID, SYSTIMESTAMP)
-        `,
+      await oraMutate(
+        `MERGE INTO THREAD_GAME_LINKS tgt
+         USING (
+           SELECT :threadId AS THREAD_ID, :gameId AS GAMEDB_GAME_ID FROM DUAL
+         ) src
+         ON (tgt.THREAD_ID = src.THREAD_ID AND tgt.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
+         WHEN NOT MATCHED THEN
+           INSERT (THREAD_ID, GAMEDB_GAME_ID, LINKED_AT)
+           VALUES (src.THREAD_ID, src.GAMEDB_GAME_ID, SYSTIMESTAMP)`,
         { threadId, gameId },
-        { autoCommit: false },
+        conn,
       );
     }
 
-    await connection.execute(
-      `
-      UPDATE THREADS t
-      SET GAMEDB_GAME_ID = (
-        SELECT MIN(g.GAMEDB_GAME_ID) FROM THREAD_GAME_LINKS g WHERE g.THREAD_ID = t.THREAD_ID
-      )
-      WHERE t.THREAD_ID = :threadId
-      `,
+    await oraMutate(
+      `UPDATE THREADS t
+       SET GAMEDB_GAME_ID = (
+         SELECT MIN(g.GAMEDB_GAME_ID)
+           FROM THREAD_GAME_LINKS g
+          WHERE g.THREAD_ID = t.THREAD_ID
+       )
+       WHERE t.THREAD_ID = :threadId`,
       { threadId },
-      { autoCommit: false },
+      conn,
     );
-
-    await connection.commit();
-  } catch (err) {
-    await connection.rollback().catch(() => {});
-    throw err;
-  } finally {
-    await connection.close();
-  }
+  });
 }
 
-export async function removeThreadGameLink(threadId: string, gameId?: number): Promise<number> {
-  if (gameId !== undefined && (gameId === null || !Number.isInteger(gameId) || gameId <= 0)) {
+export async function removeThreadGameLink(
+  threadId: string,
+  gameId?: number,
+): Promise<number> {
+  if (
+    gameId !== undefined &&
+    (gameId === null || !Number.isInteger(gameId) || gameId <= 0)
+  ) {
     throw new Error("Invalid GameDB game id.");
   }
 
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    const res = await connection.execute(
-      `
-      DELETE FROM THREAD_GAME_LINKS
-      WHERE THREAD_ID = :threadId
-      ${gameId ? "AND GAMEDB_GAME_ID = :gameId" : ""}
-      `,
+  return oraTransaction(async (conn) => {
+    const res = await oraMutate(
+      `DELETE FROM THREAD_GAME_LINKS
+       WHERE THREAD_ID = :threadId
+       ${gameId ? "AND GAMEDB_GAME_ID = :gameId" : ""}`,
       gameId ? { threadId, gameId } : { threadId },
-      { autoCommit: false },
+      conn,
     );
 
-    await connection.execute(
-      `
-      UPDATE THREADS t
-      SET GAMEDB_GAME_ID = (
-        SELECT MIN(g.GAMEDB_GAME_ID) FROM THREAD_GAME_LINKS g WHERE g.THREAD_ID = t.THREAD_ID
-      )
-      WHERE t.THREAD_ID = :threadId
-      `,
+    await oraMutate(
+      `UPDATE THREADS t
+       SET GAMEDB_GAME_ID = (
+         SELECT MIN(g.GAMEDB_GAME_ID)
+           FROM THREAD_GAME_LINKS g
+          WHERE g.THREAD_ID = t.THREAD_ID
+       )
+       WHERE t.THREAD_ID = :threadId`,
       { threadId },
-      { autoCommit: false },
+      conn,
     );
 
-    await connection.commit();
-    return (res as any).rowsAffected ?? 0;
-  } catch (err) {
-    await connection.rollback().catch(() => {});
-    throw err;
-  } finally {
-    await connection.close();
-  }
+    return res.rowsAffected ?? 0;
+  });
 }
 
-export async function setThreadSkipLinking(threadId: string, skip: boolean): Promise<void> {
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    await connection.execute(
-      `
-      UPDATE THREADS
-      SET SKIP_LINKING = :skip
-      WHERE THREAD_ID = :threadId
-      `,
-      { skip: toYN(skip), threadId },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+export async function setThreadSkipLinking(
+  threadId: string,
+  skip: boolean,
+): Promise<void> {
+  await oraMutate(
+    `UPDATE THREADS
+        SET SKIP_LINKING = :skip
+      WHERE THREAD_ID = :threadId`,
+    { skip: toYN(skip), threadId },
+  );
 }
 
 export async function getThreadSkipLinking(threadId: string): Promise<boolean> {
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    const res = await connection.execute<{ SKIP_LINKING: string }>(
-      `SELECT SKIP_LINKING FROM THREADS WHERE THREAD_ID = :threadId`,
-      { threadId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = (res.rows ?? [])[0] as any;
-    const flag = row?.SKIP_LINKING ?? "N";
-    return String(flag).toUpperCase() === "Y";
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `SELECT SKIP_LINKING FROM THREADS WHERE THREAD_ID = :threadId`,
+    { threadId },
+    (row: { SKIP_LINKING: string }) => String(row.SKIP_LINKING ?? "N").toUpperCase() === "Y",
+  );
+  return rows[0] ?? false;
 }
 
 export async function getThreadLinkInfo(
   threadId: string,
 ): Promise<{ skipLinking: boolean; gamedbGameIds: number[] }> {
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    const infoRes = await connection.execute<{ SKIP_LINKING: string }>(
+  return oraWithConnection(async (conn) => {
+    const [skipFlag] = await oraQuery(
       `SELECT SKIP_LINKING FROM THREADS WHERE THREAD_ID = :threadId`,
       { threadId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      (row: { SKIP_LINKING: string }) =>
+        String(row.SKIP_LINKING ?? "N").toUpperCase() === "Y",
+      conn,
     );
-    const row = (infoRes.rows ?? [])[0] as any;
-    const skipFlag = String(row?.SKIP_LINKING ?? "N").toUpperCase() === "Y";
 
-    const linksRes = await connection.execute<{ GAMEDB_GAME_ID: number }>(
+    const gameIds = await oraQuery(
       `SELECT GAMEDB_GAME_ID FROM THREAD_GAME_LINKS WHERE THREAD_ID = :threadId`,
       { threadId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      (row: { GAMEDB_GAME_ID: number }) => Number(row.GAMEDB_GAME_ID),
+      conn,
     );
-    const gameIds = (linksRes.rows ?? []).map((r) => Number(r.GAMEDB_GAME_ID));
 
     if (!gameIds.length) {
-      const legacyRes = await connection.execute<{ GAMEDB_GAME_ID: number | null }>(
+      const legacyIds = await oraQuery(
         `SELECT GAMEDB_GAME_ID FROM THREADS WHERE THREAD_ID = :threadId`,
         { threadId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row: { GAMEDB_GAME_ID: number | null }) =>
+          row.GAMEDB_GAME_ID != null ? Number(row.GAMEDB_GAME_ID) : null,
+        conn,
       );
-      const legacyRow = (legacyRes.rows ?? [])[0] as any;
-      if (legacyRow?.GAMEDB_GAME_ID != null) {
-        gameIds.push(Number(legacyRow.GAMEDB_GAME_ID));
+      for (const id of legacyIds) {
+        if (id != null) gameIds.push(id);
       }
     }
 
-    const uniqueIds = Array.from(new Set(gameIds));
-    return { skipLinking: skipFlag, gamedbGameIds: uniqueIds };
-  } finally {
-    await connection.close();
-  }
+    return {
+      skipLinking: skipFlag ?? false,
+      gamedbGameIds: Array.from(new Set(gameIds)),
+    };
+  });
 }
 
 export async function getThreadGameIds(threadId: string): Promise<number[]> {
@@ -234,26 +199,21 @@ export async function getThreadGameIds(threadId: string): Promise<number[]> {
 }
 
 export async function getThreadsByGameId(gameId: number): Promise<string[]> {
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    const linksRes = await connection.execute<{ THREAD_ID: string }>(
+  return oraWithConnection(async (conn) => {
+    const threadIds = await oraQuery(
       `SELECT THREAD_ID FROM THREAD_GAME_LINKS WHERE GAMEDB_GAME_ID = :gameId`,
       { gameId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      (row: { THREAD_ID: string }) => String(row.THREAD_ID),
+      conn,
     );
-    const threadIds = (linksRes.rows ?? []).map((r) => String(r.THREAD_ID));
 
-    // Also check legacy column in THREADS table
-    const legacyRes = await connection.execute<{ THREAD_ID: string }>(
+    const legacyIds = await oraQuery(
       `SELECT THREAD_ID FROM THREADS WHERE GAMEDB_GAME_ID = :gameId`,
       { gameId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
+      (row: { THREAD_ID: string }) => String(row.THREAD_ID),
+      conn,
     );
-    const legacyIds = (legacyRes.rows ?? []).map((r) => String(r.THREAD_ID));
 
     return Array.from(new Set([...threadIds, ...legacyIds]));
-  } finally {
-    await connection.close();
-  }
+  });
 }

--- a/src/classes/Todo.ts
+++ b/src/classes/Todo.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 export interface ITodoItem {
   todoId: number;
@@ -47,26 +47,7 @@ function mapTodoRow(row: {
   };
 }
 
-export async function fetchTodoById(
-  todoId: number,
-  existingConnection?: oracledb.Connection,
-): Promise<ITodoItem | null> {
-  const connection = existingConnection ?? (await getOraclePool().getConnection());
-  try {
-    const result = await connection.execute<{
-      TODO_ID: number;
-      TITLE: string;
-      DETAILS: string | null;
-      TODO_CATEGORY: string | null;
-      TODO_SIZE: string | null;
-      CREATED_BY: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-      COMPLETED_AT: Date | string | null;
-      COMPLETED_BY: string | null;
-      IS_COMPLETED: number;
-    }>(
-      `SELECT TODO_ID,
+const TODO_COLS = `TODO_ID,
               TITLE,
               DETAILS,
               TODO_CATEGORY,
@@ -76,20 +57,17 @@ export async function fetchTodoById(
               UPDATED_AT,
               COMPLETED_AT,
               COMPLETED_BY,
-              IS_COMPLETED
-         FROM RPG_CLUB_TODOS
-        WHERE TODO_ID = :id`,
-      { id: todoId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
+              IS_COMPLETED`;
 
-    const row = result.rows?.[0];
-    return row ? mapTodoRow(row) : null;
-  } finally {
-    if (!existingConnection) {
-      await connection.close();
-    }
-  }
+export async function fetchTodoById(todoId: number): Promise<ITodoItem | null> {
+  const rows = await oraQuery(
+    `SELECT ${TODO_COLS}
+       FROM RPG_CLUB_TODOS
+      WHERE TODO_ID = :id`,
+    { id: todoId },
+    mapTodoRow,
+  );
+  return rows[0] ?? null;
 }
 
 export async function createTodo(
@@ -99,34 +77,28 @@ export async function createTodo(
   todoSize: string | null,
   createdBy: string | null,
 ): Promise<ITodoItem> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `INSERT INTO RPG_CLUB_TODOS (TITLE, DETAILS, TODO_CATEGORY, TODO_SIZE, CREATED_BY)
-       VALUES (:title, :details, :todoCategory, :todoSize, :createdBy)
-       RETURNING TODO_ID INTO :id`,
-      {
-        title,
-        details,
-        todoCategory,
-        todoSize,
-        createdBy,
-        id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      { autoCommit: true },
-    );
-    const id = Number((result.outBinds as any)?.id?.[0] ?? 0);
-    if (!id) {
-      throw new Error("Failed to create TODO.");
-    }
-    const todo = await fetchTodoById(id, connection);
-    if (!todo) {
-      throw new Error("Failed to load TODO after creation.");
-    }
-    return todo;
-  } finally {
-    await connection.close();
+  const result = await oraMutate(
+    `INSERT INTO RPG_CLUB_TODOS (TITLE, DETAILS, TODO_CATEGORY, TODO_SIZE, CREATED_BY)
+     VALUES (:title, :details, :todoCategory, :todoSize, :createdBy)
+     RETURNING TODO_ID INTO :id`,
+    {
+      title,
+      details,
+      todoCategory,
+      todoSize,
+      createdBy,
+      id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+    },
+  );
+  const id = Number((result.outBinds as any)?.id?.[0] ?? 0);
+  if (!id) {
+    throw new Error("Failed to create TODO.");
   }
+  const todo = await fetchTodoById(id);
+  if (!todo) {
+    throw new Error("Failed to load TODO after creation.");
+  }
+  return todo;
 }
 
 export async function listTodos(
@@ -134,45 +106,16 @@ export async function listTodos(
   limit: number = 100,
 ): Promise<ITodoItem[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 200);
-  const connection = await getOraclePool().getConnection();
-  try {
-    const whereClause = includeCompleted ? "" : "WHERE IS_COMPLETED = 0";
-    const result = await connection.execute<{
-      TODO_ID: number;
-      TITLE: string;
-      DETAILS: string | null;
-      TODO_CATEGORY: string | null;
-      TODO_SIZE: string | null;
-      CREATED_BY: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-      COMPLETED_AT: Date | string | null;
-      COMPLETED_BY: string | null;
-      IS_COMPLETED: number;
-    }>(
-      `SELECT TODO_ID,
-              TITLE,
-              DETAILS,
-              TODO_CATEGORY,
-              TODO_SIZE,
-              CREATED_BY,
-              CREATED_AT,
-              UPDATED_AT,
-              COMPLETED_AT,
-              COMPLETED_BY,
-              IS_COMPLETED
-         FROM RPG_CLUB_TODOS
-         ${whereClause}
-        ORDER BY IS_COMPLETED ASC, CREATED_AT ASC
-        FETCH FIRST :limit ROWS ONLY`,
-      { limit: safeLimit },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-
-    return (result.rows ?? []).map((row) => mapTodoRow(row));
-  } finally {
-    await connection.close();
-  }
+  const whereClause = includeCompleted ? "" : "WHERE IS_COMPLETED = 0";
+  return oraQuery(
+    `SELECT ${TODO_COLS}
+       FROM RPG_CLUB_TODOS
+       ${whereClause}
+      ORDER BY IS_COMPLETED ASC, CREATED_AT ASC
+      FETCH FIRST :limit ROWS ONLY`,
+    { limit: safeLimit },
+    mapTodoRow,
+  );
 }
 
 export async function updateTodo(
@@ -182,114 +125,123 @@ export async function updateTodo(
   todoCategory: string | null | undefined,
   todoSize: string | null | undefined,
 ): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const titleProvided = title !== undefined ? 1 : 0;
-    const detailsProvided = details !== undefined ? 1 : 0;
-    const categoryProvided = todoCategory !== undefined ? 1 : 0;
-    const sizeProvided = todoSize !== undefined ? 1 : 0;
-    const result = await connection.execute(
-      `UPDATE RPG_CLUB_TODOS
-          SET TITLE = CASE WHEN :titleProvided = 1 THEN :title ELSE TITLE END,
-              DETAILS = CASE WHEN :detailsProvided = 1 THEN :details ELSE DETAILS END,
-              TODO_CATEGORY = CASE
-                WHEN :categoryProvided = 1 THEN :todoCategory
-                ELSE TODO_CATEGORY
-              END,
-              TODO_SIZE = CASE
-                WHEN :sizeProvided = 1 THEN :todoSize
-                ELSE TODO_SIZE
-              END
-        WHERE TODO_ID = :id`,
-      {
-        id: todoId,
-        title,
-        details,
-        todoCategory,
-        todoSize,
-        titleProvided,
-        detailsProvided,
-        categoryProvided,
-        sizeProvided,
-      },
-      { autoCommit: true },
-    );
-    return (result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+  const titleProvided = title !== undefined ? 1 : 0;
+  const detailsProvided = details !== undefined ? 1 : 0;
+  const categoryProvided = todoCategory !== undefined ? 1 : 0;
+  const sizeProvided = todoSize !== undefined ? 1 : 0;
+  const result = await oraMutate(
+    `UPDATE RPG_CLUB_TODOS
+        SET TITLE = CASE WHEN :titleProvided = 1 THEN :title ELSE TITLE END,
+            DETAILS = CASE WHEN :detailsProvided = 1 THEN :details ELSE DETAILS END,
+            TODO_CATEGORY = CASE
+              WHEN :categoryProvided = 1 THEN :todoCategory
+              ELSE TODO_CATEGORY
+            END,
+            TODO_SIZE = CASE
+              WHEN :sizeProvided = 1 THEN :todoSize
+              ELSE TODO_SIZE
+            END
+      WHERE TODO_ID = :id`,
+    {
+      id: todoId,
+      title,
+      details,
+      todoCategory,
+      todoSize,
+      titleProvided,
+      detailsProvided,
+      categoryProvided,
+      sizeProvided,
+    },
+  );
+  return (result.rowsAffected ?? 0) > 0;
 }
 
 export async function deleteTodo(todoId: number): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `DELETE FROM RPG_CLUB_TODOS WHERE TODO_ID = :id`,
-      { id: todoId },
-      { autoCommit: true },
-    );
-    return (result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+  const result = await oraMutate(
+    `DELETE FROM RPG_CLUB_TODOS WHERE TODO_ID = :id`,
+    { id: todoId },
+  );
+  return (result.rowsAffected ?? 0) > 0;
 }
 
-export async function completeTodo(todoId: number, completedBy: string | null): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `UPDATE RPG_CLUB_TODOS
-          SET IS_COMPLETED = 1,
-              COMPLETED_AT = SYSTIMESTAMP,
-              COMPLETED_BY = :completedBy
-        WHERE TODO_ID = :id
-          AND IS_COMPLETED = 0`,
-      { id: todoId, completedBy },
-      { autoCommit: true },
-    );
-    return (result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+export async function completeTodo(
+  todoId: number,
+  completedBy: string | null,
+): Promise<boolean> {
+  const result = await oraMutate(
+    `UPDATE RPG_CLUB_TODOS
+        SET IS_COMPLETED = 1,
+            COMPLETED_AT = SYSTIMESTAMP,
+            COMPLETED_BY = :completedBy
+      WHERE TODO_ID = :id
+        AND IS_COMPLETED = 0`,
+    { id: todoId, completedBy },
+  );
+  return (result.rowsAffected ?? 0) > 0;
 }
 
 export async function countTodos(): Promise<{ open: number; completed: number }> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      OPEN_COUNT: number | null;
-      COMPLETED_COUNT: number | null;
-    }>(
-      `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
-              SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT
-         FROM RPG_CLUB_TODOS`,
-      {},
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return {
-      open: Number(row?.OPEN_COUNT ?? 0),
-      completed: Number(row?.COMPLETED_COUNT ?? 0),
-    };
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
+            SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT
+       FROM RPG_CLUB_TODOS`,
+    {},
+    (row: { OPEN_COUNT: number | null; COMPLETED_COUNT: number | null }) => ({
+      open: Number(row.OPEN_COUNT ?? 0),
+      completed: Number(row.COMPLETED_COUNT ?? 0),
+    }),
+  );
+  return rows[0] ?? { open: 0, completed: 0 };
 }
 
 export async function countTodoSummary(): Promise<{
   open: number;
   completed: number;
-  openByCategory: { 
-    newFeatures: number; 
-    improvements: number; 
-    defects: number; 
-    blocked: number; 
+  openByCategory: {
+    newFeatures: number;
+    improvements: number;
+    defects: number;
+    blocked: number;
     refactoring: number;
   };
 }> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
+  const rows = await oraQuery(
+    `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
+            SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'New Features' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_NEW_FEATURES,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Improvements' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_IMPROVEMENTS,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Defects' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_DEFECTS,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Blocked' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_BLOCKED,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Refactoring' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_REFACTORING
+       FROM RPG_CLUB_TODOS`,
+    {},
+    (row: {
       OPEN_COUNT: number | null;
       COMPLETED_COUNT: number | null;
       OPEN_NEW_FEATURES: number | null;
@@ -297,56 +249,27 @@ export async function countTodoSummary(): Promise<{
       OPEN_DEFECTS: number | null;
       OPEN_BLOCKED: number | null;
       OPEN_REFACTORING: number | null;
-    }>(
-      `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
-              SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT,
-              SUM(
-                CASE
-                  WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'New Features' THEN 1
-                  ELSE 0
-                END
-              ) AS OPEN_NEW_FEATURES,
-              SUM(
-                CASE
-                  WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Improvements' THEN 1
-                  ELSE 0
-                END
-              ) AS OPEN_IMPROVEMENTS,
-              SUM(
-                CASE
-                  WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Defects' THEN 1
-                  ELSE 0
-                END
-              ) AS OPEN_DEFECTS,
-              SUM(
-                CASE
-                  WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Blocked' THEN 1
-                  ELSE 0
-                END
-              ) AS OPEN_BLOCKED,
-              SUM(
-                CASE
-                  WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Refactoring' THEN 1
-                  ELSE 0
-                END
-              ) AS OPEN_REFACTORING
-         FROM RPG_CLUB_TODOS`,
-      {},
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return {
-      open: Number(row?.OPEN_COUNT ?? 0),
-      completed: Number(row?.COMPLETED_COUNT ?? 0),
+    }) => ({
+      open: Number(row.OPEN_COUNT ?? 0),
+      completed: Number(row.COMPLETED_COUNT ?? 0),
       openByCategory: {
-        newFeatures: Number(row?.OPEN_NEW_FEATURES ?? 0),
-        improvements: Number(row?.OPEN_IMPROVEMENTS ?? 0),
-        defects: Number(row?.OPEN_DEFECTS ?? 0),
-        blocked: Number(row?.OPEN_BLOCKED ?? 0),
-        refactoring: Number(row?.OPEN_REFACTORING ?? 0),
+        newFeatures: Number(row.OPEN_NEW_FEATURES ?? 0),
+        improvements: Number(row.OPEN_IMPROVEMENTS ?? 0),
+        defects: Number(row.OPEN_DEFECTS ?? 0),
+        blocked: Number(row.OPEN_BLOCKED ?? 0),
+        refactoring: Number(row.OPEN_REFACTORING ?? 0),
       },
-    };
-  } finally {
-    await connection.close();
-  }
+    }),
+  );
+  return rows[0] ?? {
+    open: 0,
+    completed: 0,
+    openByCategory: {
+      newFeatures: 0,
+      improvements: 0,
+      defects: 0,
+      blocked: 0,
+      refactoring: 0,
+    },
+  };
 }

--- a/src/classes/UserActivityIcon.ts
+++ b/src/classes/UserActivityIcon.ts
@@ -1,6 +1,5 @@
-import oracledb from "oracledb";
 import type { Activity } from "discord.js";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraTransaction } from "../db/SqlManager.js";
 
 export type IUserActivityIconRow = {
   userId: string;
@@ -64,8 +63,12 @@ function collectActivityRecords(activities: readonly Activity[]): ActivityRecord
     const activityNameNorm = normalizeActivityName(activityName);
     const largeRef = activity.assets?.largeImage?.trim();
     const smallRef = activity.assets?.smallImage?.trim();
-    const largeUrl = activity.assets?.largeImageURL({ extension: "png", forceStatic: true })?.trim();
-    const smallUrl = activity.assets?.smallImageURL({ extension: "png", forceStatic: true })?.trim();
+    const largeUrl = activity.assets
+      ?.largeImageURL({ extension: "png", forceStatic: true })
+      ?.trim();
+    const smallUrl = activity.assets
+      ?.smallImageURL({ extension: "png", forceStatic: true })
+      ?.trim();
 
     if (largeRef && largeUrl) {
       records.push({
@@ -89,6 +92,42 @@ function collectActivityRecords(activities: readonly Activity[]): ActivityRecord
   return records;
 }
 
+const MERGE_SQL = `MERGE INTO RPG_CLUB_USER_ACTIVITY_ICONS t
+USING (
+  SELECT
+    :userId AS USER_ID,
+    :username AS USERNAME,
+    :activityName AS ACTIVITY_NAME,
+    :activityNameNorm AS ACTIVITY_NAME_NORM,
+    :iconType AS ICON_TYPE,
+    :sourceRef AS SOURCE_REF,
+    :iconUrl AS ICON_URL
+  FROM dual
+) s
+ON (
+  t.USER_ID = s.USER_ID
+  AND t.ACTIVITY_NAME_NORM = s.ACTIVITY_NAME_NORM
+  AND t.ICON_TYPE = s.ICON_TYPE
+  AND t.SOURCE_REF = s.SOURCE_REF
+)
+WHEN MATCHED THEN
+  UPDATE SET
+    t.USERNAME = s.USERNAME,
+    t.ICON_URL = s.ICON_URL,
+    t.LAST_SEEN_AT = SYSTIMESTAMP,
+    t.SEEN_COUNT = t.SEEN_COUNT + 1
+WHEN NOT MATCHED THEN
+  INSERT (
+    USER_ID, USERNAME, ACTIVITY_NAME, ACTIVITY_NAME_NORM,
+    ICON_TYPE, SOURCE_REF, ICON_URL,
+    FIRST_SEEN_AT, LAST_SEEN_AT, SEEN_COUNT
+  )
+  VALUES (
+    s.USER_ID, s.USERNAME, s.ACTIVITY_NAME, s.ACTIVITY_NAME_NORM,
+    s.ICON_TYPE, s.SOURCE_REF, s.ICON_URL,
+    SYSTIMESTAMP, SYSTIMESTAMP, 1
+  )`;
+
 export default class UserActivityIcon {
   static async recordFromPresence(
     userId: string,
@@ -99,74 +138,19 @@ export default class UserActivityIcon {
     const records = collectActivityRecords(activities);
     if (!records.length) return;
 
-    const connection = await getOraclePool().getConnection();
-    try {
+    await oraTransaction(async (conn) => {
       for (const record of records) {
-        await connection.execute(
-          `MERGE INTO RPG_CLUB_USER_ACTIVITY_ICONS t
-           USING (
-             SELECT
-               :userId AS USER_ID,
-               :username AS USERNAME,
-               :activityName AS ACTIVITY_NAME,
-               :activityNameNorm AS ACTIVITY_NAME_NORM,
-               :iconType AS ICON_TYPE,
-               :sourceRef AS SOURCE_REF,
-               :iconUrl AS ICON_URL
-             FROM dual
-           ) s
-           ON (
-             t.USER_ID = s.USER_ID
-             AND t.ACTIVITY_NAME_NORM = s.ACTIVITY_NAME_NORM
-             AND t.ICON_TYPE = s.ICON_TYPE
-             AND t.SOURCE_REF = s.SOURCE_REF
-           )
-           WHEN MATCHED THEN
-             UPDATE SET
-               t.USERNAME = s.USERNAME,
-               t.ICON_URL = s.ICON_URL,
-               t.LAST_SEEN_AT = SYSTIMESTAMP,
-               t.SEEN_COUNT = t.SEEN_COUNT + 1
-           WHEN NOT MATCHED THEN
-             INSERT (
-               USER_ID,
-               USERNAME,
-               ACTIVITY_NAME,
-               ACTIVITY_NAME_NORM,
-               ICON_TYPE,
-               SOURCE_REF,
-               ICON_URL,
-               FIRST_SEEN_AT,
-               LAST_SEEN_AT,
-               SEEN_COUNT
-             )
-             VALUES (
-               s.USER_ID,
-               s.USERNAME,
-               s.ACTIVITY_NAME,
-               s.ACTIVITY_NAME_NORM,
-               s.ICON_TYPE,
-               s.SOURCE_REF,
-               s.ICON_URL,
-               SYSTIMESTAMP,
-               SYSTIMESTAMP,
-               1
-             )`,
-          {
-            userId,
-            username,
-            activityName: record.activityName,
-            activityNameNorm: record.activityNameNorm,
-            iconType: record.iconType,
-            sourceRef: record.sourceRef,
-            iconUrl: record.iconUrl,
-          },
-        );
+        await conn.execute(MERGE_SQL, {
+          userId,
+          username,
+          activityName: record.activityName,
+          activityNameNorm: record.activityNameNorm,
+          iconType: record.iconType,
+          sourceRef: record.sourceRef,
+          iconUrl: record.iconUrl,
+        });
       }
-      await connection.commit();
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async getRecentForUser(
@@ -200,54 +184,48 @@ export default class UserActivityIcon {
     let bindIndex = 0;
     for (const group of userGroups) {
       const groupKeys: string[] = [];
-      for (const userId of group) {
+      for (const uid of group) {
         const key = `userId${bindIndex}`;
         groupKeys.push(`:${key}`);
-        binds[key] = userId;
+        binds[key] = uid;
         bindIndex += 1;
       }
       userGroupClauses.push(`USER_ID IN (${groupKeys.join(", ")})`);
     }
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<{
+    return oraQuery(
+      `SELECT
+         USER_ID,
+         ACTIVITY_NAME,
+         ICON_TYPE,
+         SOURCE_REF,
+         ICON_URL,
+         LAST_SEEN_AT
+       FROM RPG_CLUB_USER_ACTIVITY_ICONS
+       WHERE (${userGroupClauses.join(" OR ")})
+         AND LAST_SEEN_AT >= SYSTIMESTAMP - NUMTODSINTERVAL(:days, 'DAY')
+         AND (:activityNameNorm IS NULL OR ACTIVITY_NAME_NORM = :activityNameNorm)
+         AND (:iconType IS NULL OR ICON_TYPE = :iconType)
+       ORDER BY LAST_SEEN_AT DESC`,
+      binds,
+      (row: {
         USER_ID: string;
         ACTIVITY_NAME: string;
         ICON_TYPE: "large" | "small";
         SOURCE_REF: string;
         ICON_URL: string;
-        LAST_SEEN_AT: Date;
-      }>(
-        `SELECT
-           USER_ID,
-           ACTIVITY_NAME,
-           ICON_TYPE,
-           SOURCE_REF,
-           ICON_URL,
-           LAST_SEEN_AT
-         FROM RPG_CLUB_USER_ACTIVITY_ICONS
-         WHERE (${userGroupClauses.join(" OR ")})
-           AND LAST_SEEN_AT >= SYSTIMESTAMP - NUMTODSINTERVAL(:days, 'DAY')
-           AND (:activityNameNorm IS NULL OR ACTIVITY_NAME_NORM = :activityNameNorm)
-           AND (:iconType IS NULL OR ICON_TYPE = :iconType)
-         ORDER BY LAST_SEEN_AT DESC`,
-        binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      return (result.rows ?? []).map((row) => ({
+        LAST_SEEN_AT: Date | string;
+      }): IUserActivityIconRow => ({
         userId: row.USER_ID,
         activityName: row.ACTIVITY_NAME,
         iconType: row.ICON_TYPE,
         sourceRef: row.SOURCE_REF,
         iconUrl: row.ICON_URL,
-        lastSeenAt: row.LAST_SEEN_AT instanceof Date
-          ? row.LAST_SEEN_AT
-          : new Date(row.LAST_SEEN_AT),
-      }));
-    } finally {
-      await connection.close();
-    }
+        lastSeenAt:
+          row.LAST_SEEN_AT instanceof Date
+            ? row.LAST_SEEN_AT
+            : new Date(row.LAST_SEEN_AT),
+      }),
+    );
   }
 }

--- a/src/classes/UserChannelMessageCount.ts
+++ b/src/classes/UserChannelMessageCount.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraWithConnection } from "../db/SqlManager.js";
 
 type ChannelCountBind = {
   userId: string;
@@ -16,87 +16,76 @@ export default class UserChannelMessageCount {
   ): Promise<void> {
     if (!channelId || counts.size === 0) return;
 
-    const rows: ChannelCountBind[] = Array.from(counts.entries()).map(([userId, count]) => ({
-      userId,
-      channelId,
-      count,
-      scanned: scannedAt,
-    }));
+    const rows: ChannelCountBind[] = Array.from(counts.entries()).map(
+      ([userId, count]) => ({ userId, channelId, count, scanned: scannedAt }),
+    );
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      await connection.executeMany(
-        `MERGE INTO RPG_CLUB_USER_CHANNEL_COUNTS t
-          USING (
-            SELECT :userId AS user_id,
-                   :channelId AS channel_id,
-                   :count AS message_count,
-                   :scanned AS scanned
-              FROM dual
-          ) s
-             ON (t.USER_ID = s.user_id AND t.CHANNEL_ID = s.channel_id)
-           WHEN MATCHED THEN
-             UPDATE SET t.MESSAGE_COUNT = NVL(t.MESSAGE_COUNT, 0) + s.message_count,
-                        t.LAST_SCANNED_AT = s.scanned,
-                        t.UPDATED_AT = SYSTIMESTAMP
-           WHEN NOT MATCHED THEN
-             INSERT (USER_ID, CHANNEL_ID, MESSAGE_COUNT, LAST_SCANNED_AT, CREATED_AT, UPDATED_AT)
-             VALUES (s.user_id, s.channel_id, s.message_count, s.scanned, SYSTIMESTAMP, SYSTIMESTAMP)`,
-        rows,
-        {
-          autoCommit: true,
-          bindDefs: {
-            userId: { type: oracledb.STRING, maxSize: 30 },
-            channelId: { type: oracledb.STRING, maxSize: 30 },
-            count: { type: oracledb.NUMBER },
-            scanned: { type: oracledb.DATE },
+    await oraWithConnection(async (conn) => {
+      try {
+        await conn.executeMany(
+          `MERGE INTO RPG_CLUB_USER_CHANNEL_COUNTS t
+            USING (
+              SELECT :userId AS user_id,
+                     :channelId AS channel_id,
+                     :count AS message_count,
+                     :scanned AS scanned
+                FROM dual
+            ) s
+               ON (t.USER_ID = s.user_id AND t.CHANNEL_ID = s.channel_id)
+             WHEN MATCHED THEN
+               UPDATE SET t.MESSAGE_COUNT = NVL(t.MESSAGE_COUNT, 0) + s.message_count,
+                          t.LAST_SCANNED_AT = s.scanned,
+                          t.UPDATED_AT = SYSTIMESTAMP
+             WHEN NOT MATCHED THEN
+               INSERT (USER_ID, CHANNEL_ID, MESSAGE_COUNT, LAST_SCANNED_AT,
+                       CREATED_AT, UPDATED_AT)
+               VALUES (s.user_id, s.channel_id, s.message_count, s.scanned,
+                       SYSTIMESTAMP, SYSTIMESTAMP)`,
+          rows,
+          {
+            autoCommit: true,
+            bindDefs: {
+              userId: { type: oracledb.STRING, maxSize: 30 },
+              channelId: { type: oracledb.STRING, maxSize: 30 },
+              count: { type: oracledb.NUMBER },
+              scanned: { type: oracledb.DATE },
+            },
           },
-        },
-      );
-    } catch (err: any) {
-      const msg = err?.message ?? String(err);
-      console.error(
-        `[UserChannelMessageCount] Failed to upsert counts for channel ${channelId}: ${msg}`,
-      );
-    } finally {
-      await connection.close();
-    }
+        );
+      } catch (err: any) {
+        const msg = err?.message ?? String(err);
+        console.error(
+          `[UserChannelMessageCount] Failed to upsert counts for channel` +
+          ` ${channelId}: ${msg}`,
+        );
+      }
+    });
   }
 
   static async getScannedChannelIds(): Promise<Set<string>> {
-    const connection = await getOraclePool().getConnection();
     try {
-      const result = await connection.execute<{ CHANNEL_ID: string }>(
+      const rows = await oraQuery(
         `SELECT DISTINCT CHANNEL_ID FROM RPG_CLUB_USER_CHANNEL_COUNTS`,
         [],
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row: { CHANNEL_ID: string }) => row.CHANNEL_ID,
       );
-      const ids = new Set<string>();
-      for (const row of result.rows ?? []) {
-        if (row.CHANNEL_ID) {
-          ids.add(row.CHANNEL_ID);
-        }
-      }
-      return ids;
+      return new Set(rows.filter(Boolean));
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       console.error(`[UserChannelMessageCount] Failed to load scanned channel ids: ${msg}`);
       return new Set<string>();
-    } finally {
-      await connection.close();
     }
   }
 
   static async getChannelScanMeta(): Promise<Map<string, Date>> {
-    const connection = await getOraclePool().getConnection();
     try {
-      const result = await connection.execute<{ CHANNEL_ID: string; LAST_SCANNED_AT: Date }>(
+      const rows = await oraQuery(
         `SELECT CHANNEL_ID, LAST_SCANNED_AT FROM RPG_CLUB_USER_CHANNEL_COUNTS`,
         [],
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
+        (row: { CHANNEL_ID: string; LAST_SCANNED_AT: Date }) => row,
       );
       const map = new Map<string, Date>();
-      for (const row of result.rows ?? []) {
+      for (const row of rows) {
         if (row.CHANNEL_ID && row.LAST_SCANNED_AT) {
           map.set(row.CHANNEL_ID, row.LAST_SCANNED_AT);
         }
@@ -104,10 +93,10 @@ export default class UserChannelMessageCount {
       return map;
     } catch (err: any) {
       const msg = err?.message ?? String(err);
-      console.error(`[UserChannelMessageCount] Failed to load channel scan metadata: ${msg}`);
+      console.error(
+        `[UserChannelMessageCount] Failed to load channel scan metadata: ${msg}`,
+      );
       return new Map<string, Date>();
-    } finally {
-      await connection.close();
     }
   }
 }

--- a/src/classes/UserGameCollection.ts
+++ b/src/classes/UserGameCollection.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 
 export const COLLECTION_OWNERSHIP_TYPES = [
   "Digital",
@@ -95,35 +95,36 @@ function mapEntry(row: CollectionRow): IUserGameCollectionEntry {
   };
 }
 
+const ENTRY_SELECT_SQL = `SELECT c.ENTRY_ID,
+       c.USER_ID,
+       c.GAMEDB_GAME_ID,
+       g.TITLE,
+       c.PLATFORM_ID,
+       p.PLATFORM_NAME,
+       p.PLATFORM_ABBREVIATION,
+       c.OWNERSHIP_TYPE,
+       c.NOTE,
+       c.IS_SHARED,
+       c.CREATED_AT,
+       c.UPDATED_AT
+  FROM USER_GAME_COLLECTIONS c
+  JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+  LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID`;
+
 async function getEntryById(
   entryId: number,
   userId: string,
-  connection: oracledb.Connection,
+  conn: oracledb.Connection,
 ): Promise<IUserGameCollectionEntry | null> {
-  const result = await connection.execute<CollectionRow>(
-    `SELECT c.ENTRY_ID,
-            c.USER_ID,
-            c.GAMEDB_GAME_ID,
-            g.TITLE,
-            c.PLATFORM_ID,
-            p.PLATFORM_NAME,
-            p.PLATFORM_ABBREVIATION,
-            c.OWNERSHIP_TYPE,
-            c.NOTE,
-            c.IS_SHARED,
-            c.CREATED_AT,
-            c.UPDATED_AT
-       FROM USER_GAME_COLLECTIONS c
-       JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
-      WHERE c.ENTRY_ID = :entryId
-        AND c.USER_ID = :userId`,
+  const rows = await oraQuery(
+    `${ENTRY_SELECT_SQL}
+     WHERE c.ENTRY_ID = :entryId
+       AND c.USER_ID = :userId`,
     { entryId, userId },
-    { outFormat: oracledb.OUT_FORMAT_OBJECT },
+    mapEntry,
+    conn,
   );
-
-  const row = result.rows?.[0];
-  return row ? mapEntry(row) : null;
+  return rows[0] ?? null;
 }
 
 export default class UserGameCollection {
@@ -149,56 +150,57 @@ export default class UserGameCollection {
       throw new Error("Note must be 500 characters or fewer.");
     }
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const insert = await connection.execute<{ ENTRY_ID: number }>(
-        `INSERT INTO USER_GAME_COLLECTIONS (
-           USER_ID,
-           GAMEDB_GAME_ID,
-           PLATFORM_ID,
-           OWNERSHIP_TYPE,
-           NOTE,
-           IS_SHARED
-         ) VALUES (
-           :userId,
-           :gameId,
-           :platformId,
-           :ownershipType,
-           :note,
-           :isShared
-         )
-         RETURNING ENTRY_ID INTO :entryId`,
-        {
-          userId,
-          gameId,
-          platformId,
-          ownershipType,
-          note,
-          isShared,
-          entryId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-        },
-        { autoCommit: true },
+    return oraWithConnection(async (conn) => {
+      let insert: oracledb.Result<unknown>;
+      try {
+        insert = await oraMutate(
+          `INSERT INTO USER_GAME_COLLECTIONS (
+             USER_ID,
+             GAMEDB_GAME_ID,
+             PLATFORM_ID,
+             OWNERSHIP_TYPE,
+             NOTE,
+             IS_SHARED
+           ) VALUES (
+             :userId,
+             :gameId,
+             :platformId,
+             :ownershipType,
+             :note,
+             :isShared
+           )
+           RETURNING ENTRY_ID INTO :entryId`,
+          {
+            userId,
+            gameId,
+            platformId,
+            ownershipType,
+            note,
+            isShared,
+            entryId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+          },
+          conn,
+        );
+        await conn.commit();
+      } catch (err: any) {
+        const msg = String(err?.message ?? "");
+        if (/ORA-00001/i.test(msg) || /unique constraint/i.test(msg)) {
+          throw new Error(
+            "That game/platform/ownership entry already exists in your collection.",
+          );
+        }
+        throw err;
+      }
+
+      const entryId = Number(
+        (insert.outBinds as { entryId?: number[] })?.entryId?.[0] ?? 0,
       );
+      if (!entryId) throw new Error("Failed to create collection entry.");
 
-      const entryId = Number((insert.outBinds as any)?.entryId?.[0] ?? 0);
-      if (!entryId) {
-        throw new Error("Failed to create collection entry.");
-      }
-
-      const saved = await getEntryById(entryId, userId, connection);
-      if (!saved) {
-        throw new Error("Failed to load created collection entry.");
-      }
+      const saved = await getEntryById(entryId, userId, conn);
+      if (!saved) throw new Error("Failed to load created collection entry.");
       return saved;
-    } catch (err: any) {
-      const msg = String(err?.message ?? "");
-      if (/ORA-00001/i.test(msg) || /unique constraint/i.test(msg)) {
-        throw new Error("That game/platform/ownership entry already exists in your collection.");
-      }
-      throw err;
-    } finally {
-      await connection.close();
-    }
+    });
   }
 
   static async getEntryForUser(
@@ -208,13 +210,14 @@ export default class UserGameCollection {
     if (!Number.isInteger(entryId) || entryId <= 0) {
       throw new Error("Invalid entry id.");
     }
-
-    const connection = await getOraclePool().getConnection();
-    try {
-      return await getEntryById(entryId, userId, connection);
-    } finally {
-      await connection.close();
-    }
+    const rows = await oraQuery(
+      `${ENTRY_SELECT_SQL}
+       WHERE c.ENTRY_ID = :entryId
+         AND c.USER_ID = :userId`,
+      { entryId, userId },
+      mapEntry,
+    );
+    return rows[0] ?? null;
   }
 
   static async updateEntryForUser(
@@ -231,10 +234,10 @@ export default class UserGameCollection {
     }
 
     const updateParts: string[] = [];
-    const binds: Record<string, any> = { entryId, userId };
+    const binds: Record<string, string | number | null> = { entryId, userId };
 
     if (updates.platformId !== undefined) {
-      if (updates.platformId != null && 
+      if (updates.platformId != null &&
         (!Number.isInteger(updates.platformId) || updates.platformId <= 0)) {
         throw new Error("Invalid platform id.");
       }
@@ -260,51 +263,44 @@ export default class UserGameCollection {
       throw new Error("No collection fields were provided to update.");
     }
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute(
-        `UPDATE USER_GAME_COLLECTIONS
-            SET ${updateParts.join(", ")}
-          WHERE ENTRY_ID = :entryId
-            AND USER_ID = :userId`,
-        binds,
-        { autoCommit: true },
-      );
-
-      if ((result.rowsAffected ?? 0) <= 0) {
-        return null;
+    return oraWithConnection(async (conn) => {
+      let result: oracledb.Result<unknown>;
+      try {
+        result = await oraMutate(
+          `UPDATE USER_GAME_COLLECTIONS
+              SET ${updateParts.join(", ")}
+            WHERE ENTRY_ID = :entryId
+              AND USER_ID = :userId`,
+          binds,
+          conn,
+        );
+        await conn.commit();
+      } catch (err: any) {
+        const msg = String(err?.message ?? "");
+        if (/ORA-00001/i.test(msg) || /unique constraint/i.test(msg)) {
+          throw new Error(
+            "That game/platform/ownership entry already exists in your collection.",
+          );
+        }
+        throw err;
       }
 
-      return await getEntryById(entryId, userId, connection);
-    } catch (err: any) {
-      const msg = String(err?.message ?? "");
-      if (/ORA-00001/i.test(msg) || /unique constraint/i.test(msg)) {
-        throw new Error("That game/platform/ownership entry already exists in your collection.");
-      }
-      throw err;
-    } finally {
-      await connection.close();
-    }
+      if ((result.rowsAffected ?? 0) <= 0) return null;
+      return getEntryById(entryId, userId, conn);
+    });
   }
 
   static async removeEntryForUser(entryId: number, userId: string): Promise<boolean> {
     if (!Number.isInteger(entryId) || entryId <= 0) {
       throw new Error("Invalid entry id.");
     }
-
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute(
-        `DELETE FROM USER_GAME_COLLECTIONS
-          WHERE ENTRY_ID = :entryId
-            AND USER_ID = :userId`,
-        { entryId, userId },
-        { autoCommit: true },
-      );
-      return (result.rowsAffected ?? 0) > 0;
-    } finally {
-      await connection.close();
-    }
+    const result = await oraMutate(
+      `DELETE FROM USER_GAME_COLLECTIONS
+        WHERE ENTRY_ID = :entryId
+          AND USER_ID = :userId`,
+      { entryId, userId },
+    );
+    return (result.rowsAffected ?? 0) > 0;
   }
 
   static async searchEntries(filters: {
@@ -317,7 +313,7 @@ export default class UserGameCollection {
   }): Promise<IUserGameCollectionEntry[]> {
     const targetUserId = filters.targetUserId;
     const where: string[] = ["c.USER_ID = :targetUserId"];
-    const binds: Record<string, any> = { targetUserId };
+    const binds: Record<string, string | number | null> = { targetUserId };
 
     if (filters.title?.trim()) {
       where.push("LOWER(g.TITLE) LIKE :title");
@@ -326,7 +322,9 @@ export default class UserGameCollection {
 
     if (filters.platform?.trim()) {
       where.push(
-        "(LOWER(NVL(p.PLATFORM_NAME, '')) LIKE :platform OR LOWER(NVL(p.PLATFORM_CODE, '')) LIKE :platform OR LOWER(NVL(p.PLATFORM_ABBREVIATION, '')) LIKE :platform)",
+        "(LOWER(NVL(p.PLATFORM_NAME, '')) LIKE :platform " +
+        "OR LOWER(NVL(p.PLATFORM_CODE, '')) LIKE :platform " +
+        "OR LOWER(NVL(p.PLATFORM_ABBREVIATION, '')) LIKE :platform)",
       );
       binds.platform = `%${filters.platform.trim().toLowerCase()}%`;
     }
@@ -354,35 +352,28 @@ export default class UserGameCollection {
     }
     const fetchClause = hasLimit ? "FETCH FIRST :limit ROWS ONLY" : "";
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<CollectionRow>(
-        `SELECT c.ENTRY_ID,
-                c.USER_ID,
-                c.GAMEDB_GAME_ID,
-                g.TITLE,
-                c.PLATFORM_ID,
-                p.PLATFORM_NAME,
-                p.PLATFORM_ABBREVIATION,
-                c.OWNERSHIP_TYPE,
-                c.NOTE,
-                c.IS_SHARED,
-                c.CREATED_AT,
-                c.UPDATED_AT
-           FROM USER_GAME_COLLECTIONS c
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-          LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
-          WHERE ${where.join(" AND ")}
-          ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
-          ${fetchClause}`,
-        binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      return (result.rows ?? []).map(mapEntry);
-    } finally {
-      await connection.close();
-    }
+    return oraQuery(
+      `SELECT c.ENTRY_ID,
+              c.USER_ID,
+              c.GAMEDB_GAME_ID,
+              g.TITLE,
+              c.PLATFORM_ID,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              c.OWNERSHIP_TYPE,
+              c.NOTE,
+              c.IS_SHARED,
+              c.CREATED_AT,
+              c.UPDATED_AT
+         FROM USER_GAME_COLLECTIONS c
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+        LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
+        WHERE ${where.join(" AND ")}
+        ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
+        ${fetchClause}`,
+      binds,
+      mapEntry,
+    );
   }
 
   static async getOverviewForUser(userId: string): Promise<{
@@ -393,23 +384,15 @@ export default class UserGameCollection {
       throw new Error("Invalid user id.");
     }
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const totalResult = await connection.execute<{ TOTAL_COUNT: number }>(
+    const [totalRows, platformRows] = await Promise.all([
+      oraQuery(
         `SELECT COUNT(*) AS TOTAL_COUNT
            FROM USER_GAME_COLLECTIONS
           WHERE USER_ID = :userId`,
         { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const totalCount = Number(totalResult.rows?.[0]?.TOTAL_COUNT ?? 0);
-
-      const result = await connection.execute<{
-        PLATFORM_ID: number | null;
-        PLATFORM_NAME: string | null;
-        PLATFORM_ABBREVIATION: string | null;
-        TOTAL_COUNT: number;
-      }>(
+        (row: { TOTAL_COUNT: number }) => row,
+      ),
+      oraQuery(
         `SELECT c.PLATFORM_ID,
                 p.PLATFORM_NAME,
                 p.PLATFORM_ABBREVIATION,
@@ -422,20 +405,24 @@ export default class UserGameCollection {
                    LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
                    c.PLATFORM_ID`,
         { userId },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
+        (row: {
+          PLATFORM_ID: number | null;
+          PLATFORM_NAME: string | null;
+          PLATFORM_ABBREVIATION: string | null;
+          TOTAL_COUNT: number;
+        }) => ({
+          platformId: row.PLATFORM_ID == null ? null : Number(row.PLATFORM_ID),
+          platformName: row.PLATFORM_NAME ?? null,
+          platformAbbreviation: row.PLATFORM_ABBREVIATION ?? null,
+          total: Number(row.TOTAL_COUNT ?? 0),
+        }),
+      ),
+    ]);
 
-      const platformCounts = (result.rows ?? []).map((row) => ({
-        platformId: row.PLATFORM_ID == null ? null : Number(row.PLATFORM_ID),
-        platformName: row.PLATFORM_NAME ?? null,
-        platformAbbreviation: row.PLATFORM_ABBREVIATION ?? null,
-        total: Number(row.TOTAL_COUNT ?? 0),
-      }));
-
-      return { totalCount, platformCounts };
-    } finally {
-      await connection.close();
-    }
+    return {
+      totalCount: Number(totalRows[0]?.TOTAL_COUNT ?? 0),
+      platformCounts: platformRows,
+    };
   }
 
   static async getOverviewForAllUsers(): Promise<{
@@ -443,22 +430,13 @@ export default class UserGameCollection {
     platformCounts: IUserGameCollectionOverviewEntry[];
     users: IUserGameCollectionUserOverview[];
   }> {
-    const connection = await getOraclePool().getConnection();
-    try {
-      const totalResult = await connection.execute<{ TOTAL_COUNT: number }>(
-        `SELECT COUNT(*) AS TOTAL_COUNT
-           FROM USER_GAME_COLLECTIONS`,
+    const [totalRows, platformRows, userRows] = await Promise.all([
+      oraQuery(
+        `SELECT COUNT(*) AS TOTAL_COUNT FROM USER_GAME_COLLECTIONS`,
         {},
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-      const totalCount = Number(totalResult.rows?.[0]?.TOTAL_COUNT ?? 0);
-
-      const platformResult = await connection.execute<{
-        PLATFORM_ID: number | null;
-        PLATFORM_NAME: string | null;
-        PLATFORM_ABBREVIATION: string | null;
-        TOTAL_COUNT: number;
-      }>(
+        (row: { TOTAL_COUNT: number }) => row,
+      ),
+      oraQuery(
         `SELECT c.PLATFORM_ID,
                 p.PLATFORM_NAME,
                 p.PLATFORM_ABBREVIATION,
@@ -470,25 +448,19 @@ export default class UserGameCollection {
                    LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
                    c.PLATFORM_ID`,
         {},
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const platformCounts = (platformResult.rows ?? []).map((row) => ({
-        platformId: row.PLATFORM_ID == null ? null : Number(row.PLATFORM_ID),
-        platformName: row.PLATFORM_NAME ?? null,
-        platformAbbreviation: row.PLATFORM_ABBREVIATION ?? null,
-        total: Number(row.TOTAL_COUNT ?? 0),
-      }));
-
-      const userResult = await connection.execute<{
-        USER_ID: string;
-        USERNAME: string | null;
-        GLOBAL_NAME: string | null;
-        PLATFORM_ID: number | null;
-        PLATFORM_NAME: string | null;
-        PLATFORM_ABBREVIATION: string | null;
-        TOTAL_COUNT: number;
-      }>(
+        (row: {
+          PLATFORM_ID: number | null;
+          PLATFORM_NAME: string | null;
+          PLATFORM_ABBREVIATION: string | null;
+          TOTAL_COUNT: number;
+        }) => ({
+          platformId: row.PLATFORM_ID == null ? null : Number(row.PLATFORM_ID),
+          platformName: row.PLATFORM_NAME ?? null,
+          platformAbbreviation: row.PLATFORM_ABBREVIATION ?? null,
+          total: Number(row.TOTAL_COUNT ?? 0),
+        }),
+      ),
+      oraQuery(
         `SELECT c.USER_ID,
                 u.USERNAME,
                 u.GLOBAL_NAME,
@@ -512,44 +484,54 @@ export default class UserGameCollection {
                    LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
                    c.PLATFORM_ID`,
         {},
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
+        (row: {
+          USER_ID: string;
+          USERNAME: string | null;
+          GLOBAL_NAME: string | null;
+          PLATFORM_ID: number | null;
+          PLATFORM_NAME: string | null;
+          PLATFORM_ABBREVIATION: string | null;
+          TOTAL_COUNT: number;
+        }) => row,
+      ),
+    ]);
 
-      const usersById = new Map<string, IUserGameCollectionUserOverview>();
-      for (const row of userResult.rows ?? []) {
-        const userId = row.USER_ID;
-        const existing = usersById.get(userId);
-        const platformEntry: IUserGameCollectionOverviewEntry = {
-          platformId: row.PLATFORM_ID == null ? null : Number(row.PLATFORM_ID),
-          platformName: row.PLATFORM_NAME ?? null,
-          platformAbbreviation: row.PLATFORM_ABBREVIATION ?? null,
-          total: Number(row.TOTAL_COUNT ?? 0),
-        };
+    const usersById = new Map<string, IUserGameCollectionUserOverview>();
+    for (const row of userRows) {
+      const userId = row.USER_ID;
+      const existing = usersById.get(userId);
+      const platformEntry: IUserGameCollectionOverviewEntry = {
+        platformId: row.PLATFORM_ID == null ? null : Number(row.PLATFORM_ID),
+        platformName: row.PLATFORM_NAME ?? null,
+        platformAbbreviation: row.PLATFORM_ABBREVIATION ?? null,
+        total: Number(row.TOTAL_COUNT ?? 0),
+      };
 
-        if (existing) {
-          existing.platformCounts.push(platformEntry);
-          existing.totalCount += platformEntry.total;
-        } else {
-          usersById.set(userId, {
-            userId,
-            username: row.USERNAME ?? null,
-            globalName: row.GLOBAL_NAME ?? null,
-            totalCount: platformEntry.total,
-            platformCounts: [platformEntry],
-          });
-        }
+      if (existing) {
+        existing.platformCounts.push(platformEntry);
+        existing.totalCount += platformEntry.total;
+      } else {
+        usersById.set(userId, {
+          userId,
+          username: row.USERNAME ?? null,
+          globalName: row.GLOBAL_NAME ?? null,
+          totalCount: platformEntry.total,
+          platformCounts: [platformEntry],
+        });
       }
-
-      const users = Array.from(usersById.values()).sort((a, b) => {
-        const aName = (a.globalName ?? a.username ?? a.userId).toLowerCase();
-        const bName = (b.globalName ?? b.username ?? b.userId).toLowerCase();
-        return aName.localeCompare(bName);
-      });
-
-      return { totalCount, platformCounts, users };
-    } finally {
-      await connection.close();
     }
+
+    const users = Array.from(usersById.values()).sort((a, b) => {
+      const aName = (a.globalName ?? a.username ?? a.userId).toLowerCase();
+      const bName = (b.globalName ?? b.username ?? b.userId).toLowerCase();
+      return aName.localeCompare(bName);
+    });
+
+    return {
+      totalCount: Number(totalRows[0]?.TOTAL_COUNT ?? 0),
+      platformCounts: platformRows,
+      users,
+    };
   }
 
   static async autocompleteEntries(
@@ -558,54 +540,51 @@ export default class UserGameCollection {
     limit: number = 25,
   ): Promise<IUserGameCollectionAutocompleteEntry[]> {
     const trimmed = query.trim().toLowerCase();
-    const binds: Record<string, any> = {
+    const binds: Record<string, string | number> = {
       userId,
       limit: Math.max(1, Math.min(limit, 25)),
     };
 
     const titleWhere = trimmed
-      ? "AND (LOWER(g.TITLE) LIKE :query OR LOWER(NVL(p.PLATFORM_NAME, '')) LIKE :query OR LOWER(c.OWNERSHIP_TYPE) LIKE :query)"
+      ? "AND (LOWER(g.TITLE) LIKE :query " +
+        "OR LOWER(NVL(p.PLATFORM_NAME, '')) LIKE :query " +
+        "OR LOWER(c.OWNERSHIP_TYPE) LIKE :query)"
       : "";
 
     if (trimmed) {
       binds.query = `%${trimmed}%`;
     }
 
-    const connection = await getOraclePool().getConnection();
-    try {
-      const result = await connection.execute<CollectionRow>(
-        `SELECT c.ENTRY_ID,
-                c.USER_ID,
-                c.GAMEDB_GAME_ID,
-                g.TITLE,
-                c.PLATFORM_ID,
-                p.PLATFORM_NAME,
-                p.PLATFORM_ABBREVIATION,
-                c.OWNERSHIP_TYPE,
-                c.NOTE,
-                c.IS_SHARED,
-                c.CREATED_AT,
-                c.UPDATED_AT
-           FROM USER_GAME_COLLECTIONS c
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
-          WHERE c.USER_ID = :userId
-            ${titleWhere}
-          ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
-          FETCH FIRST :limit ROWS ONLY`,
-        binds,
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
+    const rows = await oraQuery(
+      `SELECT c.ENTRY_ID,
+              c.USER_ID,
+              c.GAMEDB_GAME_ID,
+              g.TITLE,
+              c.PLATFORM_ID,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              c.OWNERSHIP_TYPE,
+              c.NOTE,
+              c.IS_SHARED,
+              c.CREATED_AT,
+              c.UPDATED_AT
+         FROM USER_GAME_COLLECTIONS c
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
+        WHERE c.USER_ID = :userId
+          ${titleWhere}
+        ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
+        FETCH FIRST :limit ROWS ONLY`,
+      binds,
+      mapEntry,
+    );
 
-      return (result.rows ?? []).map((row) => ({
-        entryId: Number(row.ENTRY_ID),
-        gameId: Number(row.GAMEDB_GAME_ID),
-        title: row.TITLE,
-        platformName: row.PLATFORM_NAME ?? null,
-        ownershipType: row.OWNERSHIP_TYPE,
-      }));
-    } finally {
-      await connection.close();
-    }
+    return rows.map((row) => ({
+      entryId: row.entryId,
+      gameId: row.gameId,
+      title: row.title,
+      platformName: row.platformName,
+      ownershipType: row.ownershipType,
+    }));
   }
 }

--- a/src/classes/XboxCollectionImport.ts
+++ b/src/classes/XboxCollectionImport.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
 
 export type XboxCollectionImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type XboxCollectionImportItemStatus =
@@ -78,7 +78,7 @@ function toDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
 }
 
-function mapImport(row: {
+type ImportRow = {
   IMPORT_ID: number;
   USER_ID: string;
   STATUS: XboxCollectionImportStatus;
@@ -92,7 +92,9 @@ function mapImport(row: {
   TEMPLATE_VERSION: string | null;
   CREATED_AT: Date | string;
   UPDATED_AT: Date | string;
-}): IXboxCollectionImport {
+};
+
+function mapImport(row: ImportRow): IXboxCollectionImport {
   return {
     importId: Number(row.IMPORT_ID),
     userId: row.USER_ID,
@@ -110,7 +112,7 @@ function mapImport(row: {
   };
 }
 
-function mapItem(row: {
+type ItemRow = {
   ITEM_ID: number;
   IMPORT_ID: number;
   ROW_INDEX: number;
@@ -132,7 +134,9 @@ function mapItem(row: {
   COLLECTION_ENTRY_ID: number | null;
   RESULT_REASON: XboxCollectionImportResultReason | null;
   ERROR_TEXT: string | null;
-}): IXboxCollectionImportItem {
+};
+
+function mapItem(row: ItemRow): IXboxCollectionImportItem {
   return {
     itemId: Number(row.ITEM_ID),
     importId: Number(row.IMPORT_ID),
@@ -158,7 +162,7 @@ function mapItem(row: {
   };
 }
 
-function mapTitleMap(row: {
+type TitleMapRow = {
   MAP_ID: number;
   XBOX_TITLE_ID: string;
   GAMEDB_GAME_ID: number | null;
@@ -166,7 +170,9 @@ function mapTitleMap(row: {
   CREATED_BY: string | null;
   CREATED_AT: Date | string;
   UPDATED_AT: Date | string;
-}): IXboxTitleGameDbMap {
+};
+
+function mapTitleMap(row: TitleMapRow): IXboxTitleGameDbMap {
   return {
     mapId: Number(row.MAP_ID),
     xboxTitleId: row.XBOX_TITLE_ID,
@@ -178,6 +184,44 @@ function mapTitleMap(row: {
   };
 }
 
+const IMPORT_SELECT_SQL = `SELECT IMPORT_ID,
+       USER_ID,
+       STATUS,
+       CURRENT_INDEX,
+       TOTAL_COUNT,
+       XUID,
+       GAMERTAG,
+       SOURCE_TYPE,
+       SOURCE_FILE_NAME,
+       SOURCE_FILE_SIZE,
+       TEMPLATE_VERSION,
+       CREATED_AT,
+       UPDATED_AT
+  FROM RPG_CLUB_XBOX_COLLECTION_IMPORTS`;
+
+const ITEM_SELECT_SQL = `SELECT ITEM_ID,
+       IMPORT_ID,
+       ROW_INDEX,
+       XBOX_TITLE_ID,
+       XBOX_PRODUCT_ID,
+       XBOX_TITLE_NAME,
+       RAW_PLATFORM,
+       RAW_OWNERSHIP_TYPE,
+       RAW_NOTE,
+       RAW_GAMEDB_ID,
+       RAW_IGDB_ID,
+       PLATFORM_ID,
+       OWNERSHIP_TYPE,
+       NOTE,
+       STATUS,
+       MATCH_CONFIDENCE,
+       MATCH_CANDIDATE_JSON,
+       GAMEDB_GAME_ID,
+       COLLECTION_ENTRY_ID,
+       RESULT_REASON,
+       ERROR_TEXT
+  FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS`;
+
 export async function createXboxCollectionImportSession(params: {
   userId: string;
   totalCount: number;
@@ -188,9 +232,8 @@ export async function createXboxCollectionImportSession(params: {
   sourceFileSize: number | null;
   templateVersion: string | null;
 }): Promise<IXboxCollectionImport> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
+  return oraWithConnection(async (conn) => {
+    const insert = await oraMutate(
       `INSERT INTO RPG_CLUB_XBOX_COLLECTION_IMPORTS (
          USER_ID,
          STATUS,
@@ -225,23 +268,17 @@ export async function createXboxCollectionImportSession(params: {
         templateVersion: params.templateVersion,
         id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
       },
-      { autoCommit: true },
+      conn,
     );
+    await conn.commit();
 
-    const id = Number((result.outBinds as { id?: number[] }).id?.[0] ?? 0);
-    if (!id) {
-      throw new Error("Failed to create Xbox collection import session.");
-    }
+    const id = Number((insert.outBinds as { id?: number[] }).id?.[0] ?? 0);
+    if (!id) throw new Error("Failed to create Xbox collection import session.");
 
-    const session = await getXboxCollectionImportById(id, connection);
-    if (!session) {
-      throw new Error("Failed to load Xbox collection import session.");
-    }
-
+    const session = await getXboxCollectionImportById(id, conn);
+    if (!session) throw new Error("Failed to load Xbox collection import session.");
     return session;
-  } finally {
-    await connection.close();
-  }
+  });
 }
 
 export async function insertXboxCollectionImportItems(
@@ -263,10 +300,9 @@ export async function insertXboxCollectionImportItems(
 ): Promise<void> {
   if (!items.length) return;
 
-  const connection = await getOraclePool().getConnection();
-  try {
+  await oraTransaction(async (conn) => {
     for (const item of items) {
-      await connection.execute(
+      await oraMutate(
         `INSERT INTO RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS (
            IMPORT_ID,
            ROW_INDEX,
@@ -313,268 +349,87 @@ export async function insertXboxCollectionImportItems(
           ownershipType: item.ownershipType,
           note: item.note,
         },
-        { autoCommit: true },
+        conn,
       );
     }
-  } finally {
-    await connection.close();
-  }
+  });
 }
 
 export async function getXboxCollectionImportById(
   importId: number,
   connectionOverride?: oracledb.Connection,
 ): Promise<IXboxCollectionImport | null> {
-  const connection = connectionOverride ?? await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      IMPORT_ID: number;
-      USER_ID: string;
-      STATUS: XboxCollectionImportStatus;
-      CURRENT_INDEX: number;
-      TOTAL_COUNT: number;
-      XUID: string | null;
-      GAMERTAG: string | null;
-      SOURCE_TYPE: "API" | "CSV";
-      SOURCE_FILE_NAME: string | null;
-      SOURCE_FILE_SIZE: number | null;
-      TEMPLATE_VERSION: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT IMPORT_ID,
-              USER_ID,
-              STATUS,
-              CURRENT_INDEX,
-              TOTAL_COUNT,
-              XUID,
-              GAMERTAG,
-              SOURCE_TYPE,
-              SOURCE_FILE_NAME,
-              SOURCE_FILE_SIZE,
-              TEMPLATE_VERSION,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_XBOX_COLLECTION_IMPORTS
-        WHERE IMPORT_ID = :importId`,
-      { importId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapImport(row) : null;
-  } finally {
-    if (!connectionOverride) {
-      await connection.close();
-    }
-  }
+  const rows = await oraQuery(
+    `${IMPORT_SELECT_SQL} WHERE IMPORT_ID = :importId`,
+    { importId },
+    mapImport,
+    connectionOverride,
+  );
+  return rows[0] ?? null;
 }
 
 export async function getActiveXboxCollectionImportForUser(
   userId: string,
 ): Promise<IXboxCollectionImport | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      IMPORT_ID: number;
-      USER_ID: string;
-      STATUS: XboxCollectionImportStatus;
-      CURRENT_INDEX: number;
-      TOTAL_COUNT: number;
-      XUID: string | null;
-      GAMERTAG: string | null;
-      SOURCE_TYPE: "API" | "CSV";
-      SOURCE_FILE_NAME: string | null;
-      SOURCE_FILE_SIZE: number | null;
-      TEMPLATE_VERSION: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT IMPORT_ID,
-              USER_ID,
-              STATUS,
-              CURRENT_INDEX,
-              TOTAL_COUNT,
-              XUID,
-              GAMERTAG,
-              SOURCE_TYPE,
-              SOURCE_FILE_NAME,
-              SOURCE_FILE_SIZE,
-              TEMPLATE_VERSION,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_XBOX_COLLECTION_IMPORTS
-        WHERE USER_ID = :userId
-          AND STATUS IN ('ACTIVE', 'PAUSED')
-        ORDER BY IMPORT_ID DESC`,
-      { userId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapImport(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `${IMPORT_SELECT_SQL}
+     WHERE USER_ID = :userId
+       AND STATUS IN ('ACTIVE', 'PAUSED')
+     ORDER BY IMPORT_ID DESC`,
+    { userId },
+    mapImport,
+  );
+  return rows[0] ?? null;
 }
 
 export async function setXboxCollectionImportStatus(
   importId: number,
   status: XboxCollectionImportStatus,
 ): Promise<void> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
-          SET STATUS = :status
-        WHERE IMPORT_ID = :importId`,
-      { importId, status },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
+        SET STATUS = :status
+      WHERE IMPORT_ID = :importId`,
+    { importId, status },
+  );
 }
 
 export async function updateXboxCollectionImportIndex(
   importId: number,
   currentIndex: number,
 ): Promise<void> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
-          SET CURRENT_INDEX = :currentIndex
-        WHERE IMPORT_ID = :importId`,
-      { importId, currentIndex },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
+        SET CURRENT_INDEX = :currentIndex
+      WHERE IMPORT_ID = :importId`,
+    { importId, currentIndex },
+  );
 }
 
 export async function getXboxCollectionImportItemById(
   itemId: number,
 ): Promise<IXboxCollectionImportItem | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      ITEM_ID: number;
-      IMPORT_ID: number;
-      ROW_INDEX: number;
-      XBOX_TITLE_ID: string | null;
-      XBOX_PRODUCT_ID: string | null;
-      XBOX_TITLE_NAME: string;
-      RAW_PLATFORM: string | null;
-      RAW_OWNERSHIP_TYPE: string | null;
-      RAW_NOTE: string | null;
-      RAW_GAMEDB_ID: number | null;
-      RAW_IGDB_ID: number | null;
-      PLATFORM_ID: number | null;
-      OWNERSHIP_TYPE: string | null;
-      NOTE: string | null;
-      STATUS: XboxCollectionImportItemStatus;
-      MATCH_CONFIDENCE: XboxCollectionMatchConfidence | null;
-      MATCH_CANDIDATE_JSON: string | null;
-      GAMEDB_GAME_ID: number | null;
-      COLLECTION_ENTRY_ID: number | null;
-      RESULT_REASON: XboxCollectionImportResultReason | null;
-      ERROR_TEXT: string | null;
-    }>(
-      `SELECT ITEM_ID,
-              IMPORT_ID,
-              ROW_INDEX,
-              XBOX_TITLE_ID,
-              XBOX_PRODUCT_ID,
-              XBOX_TITLE_NAME,
-              RAW_PLATFORM,
-              RAW_OWNERSHIP_TYPE,
-              RAW_NOTE,
-              RAW_GAMEDB_ID,
-              RAW_IGDB_ID,
-              PLATFORM_ID,
-              OWNERSHIP_TYPE,
-              NOTE,
-              STATUS,
-              MATCH_CONFIDENCE,
-              MATCH_CANDIDATE_JSON,
-              GAMEDB_GAME_ID,
-              COLLECTION_ENTRY_ID,
-              RESULT_REASON,
-              ERROR_TEXT
-         FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
-        WHERE ITEM_ID = :itemId`,
-      { itemId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapItem(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `${ITEM_SELECT_SQL} WHERE ITEM_ID = :itemId`,
+    { itemId },
+    mapItem,
+  );
+  return rows[0] ?? null;
 }
 
 export async function getNextPendingXboxCollectionImportItem(
   importId: number,
 ): Promise<IXboxCollectionImportItem | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      ITEM_ID: number;
-      IMPORT_ID: number;
-      ROW_INDEX: number;
-      XBOX_TITLE_ID: string | null;
-      XBOX_PRODUCT_ID: string | null;
-      XBOX_TITLE_NAME: string;
-      RAW_PLATFORM: string | null;
-      RAW_OWNERSHIP_TYPE: string | null;
-      RAW_NOTE: string | null;
-      RAW_GAMEDB_ID: number | null;
-      RAW_IGDB_ID: number | null;
-      PLATFORM_ID: number | null;
-      OWNERSHIP_TYPE: string | null;
-      NOTE: string | null;
-      STATUS: XboxCollectionImportItemStatus;
-      MATCH_CONFIDENCE: XboxCollectionMatchConfidence | null;
-      MATCH_CANDIDATE_JSON: string | null;
-      GAMEDB_GAME_ID: number | null;
-      COLLECTION_ENTRY_ID: number | null;
-      RESULT_REASON: XboxCollectionImportResultReason | null;
-      ERROR_TEXT: string | null;
-    }>(
-      `SELECT ITEM_ID,
-              IMPORT_ID,
-              ROW_INDEX,
-              XBOX_TITLE_ID,
-              XBOX_PRODUCT_ID,
-              XBOX_TITLE_NAME,
-              RAW_PLATFORM,
-              RAW_OWNERSHIP_TYPE,
-              RAW_NOTE,
-              RAW_GAMEDB_ID,
-              RAW_IGDB_ID,
-              PLATFORM_ID,
-              OWNERSHIP_TYPE,
-              NOTE,
-              STATUS,
-              MATCH_CONFIDENCE,
-              MATCH_CANDIDATE_JSON,
-              GAMEDB_GAME_ID,
-              COLLECTION_ENTRY_ID,
-              RESULT_REASON,
-              ERROR_TEXT
-         FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
-        WHERE IMPORT_ID = :importId
-          AND STATUS = 'PENDING'
-        ORDER BY ROW_INDEX ASC
-        FETCH FIRST 1 ROWS ONLY`,
-      { importId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapItem(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `${ITEM_SELECT_SQL}
+     WHERE IMPORT_ID = :importId
+       AND STATUS = 'PENDING'
+     ORDER BY ROW_INDEX ASC
+     FETCH FIRST 1 ROWS ONLY`,
+    { importId },
+    mapItem,
+  );
+  return rows[0] ?? null;
 }
 
 export async function updateXboxCollectionImportItem(
@@ -623,18 +478,12 @@ export async function updateXboxCollectionImportItem(
 
   if (!fields.length) return;
 
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
-      `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
-          SET ${fields.join(", ")}
-        WHERE ITEM_ID = :itemId`,
-      binds,
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
+        SET ${fields.join(", ")}
+      WHERE ITEM_ID = :itemId`,
+    binds,
+  );
 }
 
 export async function countXboxCollectionImportItems(
@@ -646,99 +495,64 @@ export async function countXboxCollectionImportItems(
   skipped: number;
   failed: number;
 }> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      STATUS: XboxCollectionImportItemStatus;
-      CNT: number;
-    }>(
-      `SELECT STATUS, COUNT(*) AS CNT
-         FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
-        WHERE IMPORT_ID = :importId
-        GROUP BY STATUS`,
-      { importId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const counts = {
-      pending: 0,
-      added: 0,
-      updated: 0,
-      skipped: 0,
-      failed: 0,
-    };
-    for (const row of result.rows ?? []) {
-      const status = row.STATUS;
-      const count = Number(row.CNT ?? 0);
-      if (status === "PENDING") counts.pending = count;
-      if (status === "ADDED") counts.added = count;
-      if (status === "UPDATED") counts.updated = count;
-      if (status === "SKIPPED") counts.skipped = count;
-      if (status === "FAILED") counts.failed = count;
-    }
-    return counts;
-  } finally {
-    await connection.close();
+  const rows = await oraQuery(
+    `SELECT STATUS, COUNT(*) AS CNT
+       FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY STATUS`,
+    { importId },
+    (row: { STATUS: XboxCollectionImportItemStatus; CNT: number }) => row,
+  );
+  const counts = { pending: 0, added: 0, updated: 0, skipped: 0, failed: 0 };
+  for (const row of rows) {
+    const count = Number(row.CNT ?? 0);
+    if (row.STATUS === "PENDING") counts.pending = count;
+    if (row.STATUS === "ADDED") counts.added = count;
+    if (row.STATUS === "UPDATED") counts.updated = count;
+    if (row.STATUS === "SKIPPED") counts.skipped = count;
+    if (row.STATUS === "FAILED") counts.failed = count;
   }
+  return counts;
 }
 
 export async function countXboxCollectionImportResultReasons(
   importId: number,
 ): Promise<Record<string, number>> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      RESULT_REASON: XboxCollectionImportResultReason | null;
-      CNT: number;
-    }>(
-      `SELECT RESULT_REASON, COUNT(*) AS CNT
-         FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
-        WHERE IMPORT_ID = :importId
-        GROUP BY RESULT_REASON`,
-      { importId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const counts: Record<string, number> = {};
-    for (const row of result.rows ?? []) {
-      if (!row.RESULT_REASON) continue;
-      counts[row.RESULT_REASON] = Number(row.CNT ?? 0);
-    }
-    return counts;
-  } finally {
-    await connection.close();
+  const rows = await oraQuery(
+    `SELECT RESULT_REASON, COUNT(*) AS CNT
+       FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY RESULT_REASON`,
+    { importId },
+    (row: { RESULT_REASON: XboxCollectionImportResultReason | null; CNT: number }) => row,
+  );
+  const counts: Record<string, number> = {};
+  for (const row of rows) {
+    if (!row.RESULT_REASON) continue;
+    counts[row.RESULT_REASON] = Number(row.CNT ?? 0);
   }
+  return counts;
 }
 
 export async function getXboxTitleGameDbMapByTitleId(
   xboxTitleId: string,
+  existingConnection?: oracledb.Connection,
 ): Promise<IXboxTitleGameDbMap | null> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      MAP_ID: number;
-      XBOX_TITLE_ID: string;
-      GAMEDB_GAME_ID: number | null;
-      STATUS: XboxTitleGameDbMapStatus;
-      CREATED_BY: string | null;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-    }>(
-      `SELECT MAP_ID,
-              XBOX_TITLE_ID,
-              GAMEDB_GAME_ID,
-              STATUS,
-              CREATED_BY,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_XBOX_TITLE_GAMEDB_MAP
-        WHERE XBOX_TITLE_ID = :xboxTitleId`,
-      { xboxTitleId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    const row = result.rows?.[0];
-    return row ? mapTitleMap(row) : null;
-  } finally {
-    await connection.close();
-  }
+  const rows = await oraQuery(
+    `SELECT MAP_ID,
+            XBOX_TITLE_ID,
+            GAMEDB_GAME_ID,
+            STATUS,
+            CREATED_BY,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_XBOX_TITLE_GAMEDB_MAP
+      WHERE XBOX_TITLE_ID = :xboxTitleId`,
+    { xboxTitleId },
+    mapTitleMap,
+    existingConnection,
+  );
+  return rows[0] ?? null;
 }
 
 export async function upsertXboxTitleGameDbMap(params: {
@@ -747,9 +561,8 @@ export async function upsertXboxTitleGameDbMap(params: {
   status: XboxTitleGameDbMapStatus;
   createdBy: string | null;
 }): Promise<IXboxTitleGameDbMap> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    await connection.execute(
+  return oraWithConnection(async (conn) => {
+    await oraMutate(
       `MERGE INTO RPG_CLUB_XBOX_TITLE_GAMEDB_MAP m
        USING (
          SELECT :xboxTitleId AS xboxTitleId,
@@ -780,17 +593,14 @@ export async function upsertXboxTitleGameDbMap(params: {
         status: params.status,
         createdBy: params.createdBy,
       },
-      { autoCommit: true },
+      conn,
     );
+    await conn.commit();
 
-    const mapping = await getXboxTitleGameDbMapByTitleId(params.xboxTitleId);
-    if (!mapping) {
-      throw new Error("Failed to load Xbox title mapping.");
-    }
+    const mapping = await getXboxTitleGameDbMapByTitleId(params.xboxTitleId, conn);
+    if (!mapping) throw new Error("Failed to load Xbox title mapping.");
     return mapping;
-  } finally {
-    await connection.close();
-  }
+  });
 }
 
 export async function getXboxTitleHistoricalMappedGameIds(params: {
@@ -798,40 +608,32 @@ export async function getXboxTitleHistoricalMappedGameIds(params: {
   excludeUserId?: string;
   limit?: number;
 }): Promise<number[]> {
-  const limit = Number.isInteger(params.limit) && 
+  const limit = Number.isInteger(params.limit) &&
     (params.limit ?? 0) > 0 ? Number(params.limit) : 5;
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute<{
-      GAMEDB_GAME_ID: number;
-    }>(
-      `SELECT t.GAMEDB_GAME_ID
-         FROM (
-           SELECT ii.GAMEDB_GAME_ID,
-                  COUNT(*) AS CNT,
-                  MAX(ii.ITEM_ID) AS LAST_ITEM_ID
-             FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS ii
-             JOIN RPG_CLUB_XBOX_COLLECTION_IMPORTS i
-               ON i.IMPORT_ID = ii.IMPORT_ID
-            WHERE ii.XBOX_TITLE_ID = :xboxTitleId
-              AND ii.GAMEDB_GAME_ID IS NOT NULL
-              AND ii.RESULT_REASON = 'MANUAL_REMAP'
-              AND (:excludeUserId IS NULL OR i.USER_ID <> :excludeUserId)
-            GROUP BY ii.GAMEDB_GAME_ID
-            ORDER BY CNT DESC, LAST_ITEM_ID DESC
-         ) t
-        WHERE ROWNUM <= :limit`,
-      {
-        xboxTitleId: params.xboxTitleId,
-        excludeUserId: params.excludeUserId ?? null,
-        limit,
-      },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-    return (result.rows ?? [])
-      .map((row) => Number(row.GAMEDB_GAME_ID))
-      .filter((value) => Number.isInteger(value) && value > 0);
-  } finally {
-    await connection.close();
-  }
+
+  const rows = await oraQuery(
+    `SELECT t.GAMEDB_GAME_ID
+       FROM (
+         SELECT ii.GAMEDB_GAME_ID,
+                COUNT(*) AS CNT,
+                MAX(ii.ITEM_ID) AS LAST_ITEM_ID
+           FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS ii
+           JOIN RPG_CLUB_XBOX_COLLECTION_IMPORTS i
+             ON i.IMPORT_ID = ii.IMPORT_ID
+          WHERE ii.XBOX_TITLE_ID = :xboxTitleId
+            AND ii.GAMEDB_GAME_ID IS NOT NULL
+            AND ii.RESULT_REASON = 'MANUAL_REMAP'
+            AND (:excludeUserId IS NULL OR i.USER_ID <> :excludeUserId)
+          GROUP BY ii.GAMEDB_GAME_ID
+          ORDER BY CNT DESC, LAST_ITEM_ID DESC
+       ) t
+      WHERE ROWNUM <= :limit`,
+    {
+      xboxTitleId: params.xboxTitleId,
+      excludeUserId: params.excludeUserId ?? null,
+      limit,
+    },
+    (row: { GAMEDB_GAME_ID: number }) => Number(row.GAMEDB_GAME_ID),
+  );
+  return rows.filter((value) => Number.isInteger(value) && value > 0);
 }

--- a/src/commands/admin/sql-health-check.service.ts
+++ b/src/commands/admin/sql-health-check.service.ts
@@ -1,6 +1,6 @@
 import { EmbedBuilder, MessageFlags } from "discord.js";
 import type { CommandInteraction } from "discord.js";
-import { getOraclePool } from "../../db/oracleClient.js";
+import { oraWithConnection } from "../../db/SqlManager.js";
 import { getPostgresPool } from "../../db/postgresClient.js";
 import { safeReply } from "../../functions/InteractionUtils.js";
 
@@ -14,15 +14,13 @@ interface IHealthResult {
 
 async function checkOracle(): Promise<IHealthResult> {
   const start = Date.now();
-  let connection;
   try {
-    connection = await getOraclePool().getConnection();
-    await connection.execute("SELECT 1 FROM DUAL");
+    await oraWithConnection(async (conn) => {
+      await conn.execute("SELECT 1 FROM DUAL");
+    });
     return { ok: true, latencyMs: Date.now() - start, error: null };
   } catch (err) {
     return { ok: false, latencyMs: null, error: String(err) };
-  } finally {
-    try { await connection?.close(); } catch { /* ignore */ }
   }
 }
 

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -28,7 +28,6 @@ import {
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
 import Member, { type IMemberRecord } from "../classes/Member.js";
-import { getOraclePool } from "../db/oracleClient.js";
 import Game, { type IGame } from "../classes/Game.js";
 import { STANDARD_PLATFORM_IDS } from "../config/standardPlatforms.js";
 import { igdbService } from "../services/IGDB/IgdbService.js";
@@ -749,27 +748,6 @@ export class SuperAdmin {
 
     const members = await guild.members.fetch();
     const departedCount = await Member.markDepartedNotIn(Array.from(members.keys()));
-    const pool = getOraclePool();
-    let connection = await pool.getConnection();
-    const isRecoverableOracleError = (err: any): boolean => {
-      const code = err?.code ?? err?.errorNum;
-      const msg = err?.message ?? "";
-      return (
-        code === "NJS-500" ||
-        code === "NJS-503" ||
-        code === "ORA-03138" ||
-        code === "ORA-03146" ||
-        /DPI-1010|ORA-03135|end-of-file on communication channel/i.test(msg)
-      );
-    };
-    const reopenConnection = async () => {
-      try {
-        await connection?.close();
-      } catch {
-        // ignore
-      }
-      connection = await pool.getConnection();
-    };
 
     let successCount = 0;
     let failCount = 0;
@@ -783,113 +761,89 @@ export class SuperAdmin {
       return !a.equals(b);
     };
 
-    try {
-      for (const member of members.values()) {
-        const user = member.user;
-        const existing = await Member.getByUserId(user.id);
+    for (const member of members.values()) {
+      const user = member.user;
+      const existing = await Member.getByUserId(user.id);
 
-        // Build avatar blob (throttled per-user)
-        let avatarBlob: Buffer | null = null;
-        const avatarUrl = user.displayAvatarURL({ extension: "png", size: 512, forceStatic: true });
-        if (avatarUrl) {
-          try {
-            const { buffer } = await downloadImageBuffer(avatarUrl);
-            avatarBlob = buffer;
-          } catch {
-            // ignore avatar fetch failures
-          }
-        }
-
-        const hasRole = (id?: string | null): number => {
-          if (!id) return 0;
-          return member.roles.cache.has(id) ? 1 : 0;
-        };
-        const adminFlag =
-          hasRole(roleMap.admin) || member.permissions.has("Administrator") ? 1 : 0;
-        const moderatorFlag =
-          hasRole(roleMap.mod) || member.permissions.has("ManageMessages") ? 1 : 0;
-        const regularFlag = hasRole(roleMap.regular);
-        const memberFlag = hasRole(roleMap.member);
-        const newcomerFlag = hasRole(roleMap.newcomer);
-
-        const baseRecord: IMemberRecord = {
-          userId: user.id,
-          isBot: user.bot ? 1 : 0,
-          username: user.username,
-          globalName: (user as any).globalName ?? null,
-          avatarBlob: null,
-          serverJoinedAt: member.joinedAt ?? existing?.serverJoinedAt ?? null,
-          serverLeftAt: null,
-          lastSeenAt: existing?.lastSeenAt ?? null,
-          roleAdmin: adminFlag,
-          roleModerator: moderatorFlag,
-          roleRegular: regularFlag,
-          roleMember: memberFlag,
-          roleNewcomer: newcomerFlag,
-          messageCount: existing?.messageCount ?? null,
-          completionatorUrl: existing?.completionatorUrl ?? null,
-          psnUsername: existing?.psnUsername ?? null,
-          xblUsername: existing?.xblUsername ?? null,
-          nswFriendCode: existing?.nswFriendCode ?? null,
-          steamUrl: existing?.steamUrl ?? null,
-          profileImage: existing?.profileImage ?? null,
-          profileImageAt: existing?.profileImageAt ?? null,
-        };
-
-        let avatarToUse: Buffer | null = avatarBlob;
-        if (!avatarToUse && existing?.avatarBlob) {
-          avatarToUse = existing.avatarBlob;
-        } else if (avatarToUse && existing?.avatarBlob) {
-          if (!avatarBuffersDifferent(avatarToUse, existing.avatarBlob)) {
-            avatarToUse = existing.avatarBlob;
-          }
-        }
-
-        const execUpsert = async (avatarData: Buffer | null) => {
-          const record: IMemberRecord = { ...baseRecord, avatarBlob: avatarData };
-          await Member.upsert(record, { connection });
-        };
-
+      let avatarBlob: Buffer | null = null;
+      const avatarUrl = user.displayAvatarURL({ extension: "png", size: 512, forceStatic: true });
+      if (avatarUrl) {
         try {
-          await execUpsert(avatarToUse);
-          successCount++;
-        } catch (err) {
-          const code = (err as any)?.code ?? (err as any)?.errorNum;
+          const { buffer } = await downloadImageBuffer(avatarUrl);
+          avatarBlob = buffer;
+        } catch {
+          // ignore avatar fetch failures
+        }
+      }
 
-          if (code === "ORA-03146") {
-            try {
-              await execUpsert(null);
-              successCount++;
-              continue;
-            } catch (retryErr) {
-              failCount++;
-              console.error(`Failed to upsert user ${user.id} after stripping avatar`, retryErr);
-              continue;
-            }
-          }
+      const hasRole = (id?: string | null): number => {
+        if (!id) return 0;
+        return member.roles.cache.has(id) ? 1 : 0;
+      };
+      const adminFlag =
+        hasRole(roleMap.admin) || member.permissions.has("Administrator") ? 1 : 0;
+      const moderatorFlag =
+        hasRole(roleMap.mod) || member.permissions.has("ManageMessages") ? 1 : 0;
+      const regularFlag = hasRole(roleMap.regular);
+      const memberFlag = hasRole(roleMap.member);
+      const newcomerFlag = hasRole(roleMap.newcomer);
 
-          if (isRecoverableOracleError(err)) {
-            await reopenConnection();
-            try {
-              await execUpsert(avatarBlob);
-              successCount++;
-              continue;
-            } catch (retryErr) {
-              failCount++;
-              console.error(`Failed to upsert user ${user.id} after retry`, retryErr);
-            }
-          } else {
+      const baseRecord: IMemberRecord = {
+        userId: user.id,
+        isBot: user.bot ? 1 : 0,
+        username: user.username,
+        globalName: (user as any).globalName ?? null,
+        avatarBlob: null,
+        serverJoinedAt: member.joinedAt ?? existing?.serverJoinedAt ?? null,
+        serverLeftAt: null,
+        lastSeenAt: existing?.lastSeenAt ?? null,
+        roleAdmin: adminFlag,
+        roleModerator: moderatorFlag,
+        roleRegular: regularFlag,
+        roleMember: memberFlag,
+        roleNewcomer: newcomerFlag,
+        messageCount: existing?.messageCount ?? null,
+        completionatorUrl: existing?.completionatorUrl ?? null,
+        psnUsername: existing?.psnUsername ?? null,
+        xblUsername: existing?.xblUsername ?? null,
+        nswFriendCode: existing?.nswFriendCode ?? null,
+        steamUrl: existing?.steamUrl ?? null,
+        profileImage: existing?.profileImage ?? null,
+        profileImageAt: existing?.profileImageAt ?? null,
+      };
+
+      let avatarToUse: Buffer | null = avatarBlob;
+      if (!avatarToUse && existing?.avatarBlob) {
+        avatarToUse = existing.avatarBlob;
+      } else if (avatarToUse && existing?.avatarBlob) {
+        if (!avatarBuffersDifferent(avatarToUse, existing.avatarBlob)) {
+          avatarToUse = existing.avatarBlob;
+        }
+      }
+
+      try {
+        await Member.upsert({ ...baseRecord, avatarBlob: avatarToUse });
+        successCount++;
+      } catch (err) {
+        const code = (err as any)?.code ?? (err as any)?.errorNum;
+        if (code === "ORA-03146") {
+          try {
+            await Member.upsert({ ...baseRecord, avatarBlob: null });
+            successCount++;
+            await delay(1000);
+            continue;
+          } catch (retryErr) {
             failCount++;
-            console.error(`Failed to upsert user ${user.id}`, err);
+            console.error(`Failed to upsert user ${user.id} after stripping avatar`, retryErr);
+            await delay(1000);
+            continue;
           }
         }
-
-        // throttle: one user per second
-        await delay(1000);
-
+        failCount++;
+        console.error(`Failed to upsert user ${user.id}`, err);
       }
-    } finally {
-      await connection.close();
+
+      await delay(1000);
     }
 
     await safeReply(interaction, buildTextReply(`Member scan complete. Upserts succeeded: ${successCount}. Failed: ${failCount}. ` +

--- a/src/db/SqlManager.ts
+++ b/src/db/SqlManager.ts
@@ -1,0 +1,80 @@
+import oracledb from "oracledb";
+import { getOraclePool } from "./oracleClient.js";
+
+export { pgQuery, pgTransaction } from "./postgresClient.js";
+
+/**
+ * Runs a SELECT and maps each row with `mapper`. Defaults to OUT_FORMAT_OBJECT.
+ * Pass `existingConn` to reuse a connection (caller manages its lifecycle).
+ */
+export async function oraQuery<RowT extends object, R>(
+  sql: string,
+  params: oracledb.BindParameters,
+  mapper: (row: RowT) => R,
+  existingConn?: oracledb.Connection,
+): Promise<R[]> {
+  const conn = existingConn ?? (await getOraclePool().getConnection());
+  try {
+    const result = await conn.execute<RowT>(sql, params, {
+      outFormat: oracledb.OUT_FORMAT_OBJECT,
+    });
+    return (result.rows ?? []).map(mapper);
+  } finally {
+    if (!existingConn) await conn.close();
+  }
+}
+
+/**
+ * Runs a single DML statement with autoCommit:true.
+ * Returns the full Result so callers can inspect rowsAffected / outBinds.
+ * Pass `existingConn` to reuse a connection (no autoCommit in that case).
+ */
+export async function oraMutate(
+  sql: string,
+  params: oracledb.BindParameters,
+  existingConn?: oracledb.Connection,
+): Promise<oracledb.Result<unknown>> {
+  const conn = existingConn ?? (await getOraclePool().getConnection());
+  try {
+    return await conn.execute(sql, params, {
+      autoCommit: existingConn ? false : true,
+    });
+  } finally {
+    if (!existingConn) await conn.close();
+  }
+}
+
+/**
+ * Acquires a connection, runs `callback`, then closes it.
+ * Each statement inside should use autoCommit:true (or pass conn to oraMutate).
+ * For atomic multi-statement operations, use oraTransaction instead.
+ */
+export async function oraWithConnection<T>(
+  callback: (conn: oracledb.Connection) => Promise<T>,
+): Promise<T> {
+  const conn = await getOraclePool().getConnection();
+  try {
+    return await callback(conn);
+  } finally {
+    await conn.close();
+  }
+}
+
+/**
+ * Runs `callback` inside a transaction. Commits on success, rolls back on throw.
+ */
+export async function oraTransaction<T>(
+  callback: (conn: oracledb.Connection) => Promise<T>,
+): Promise<T> {
+  const conn = await getOraclePool().getConnection();
+  try {
+    const result = await callback(conn);
+    await conn.commit();
+    return result;
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    await conn.close();
+  }
+}

--- a/src/functions/SetPresence.ts
+++ b/src/functions/SetPresence.ts
@@ -1,7 +1,6 @@
 import { ActivityType, Client } from "discord.js";
 import type { AnyRepliable } from "./InteractionUtils.js";
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 
 const PRESENCE_TABLE: string = "BOT_PRESENCE_HISTORY";
 
@@ -11,24 +10,12 @@ async function savePresenceToDatabase(
   username: string | null,
 ): Promise<void> {
   try {
-    const pool: oracledb.Pool = getOraclePool();
-    const connection: oracledb.Connection = await pool.getConnection();
-
-    try {
-      await connection.execute(
-        `INSERT INTO ${PRESENCE_TABLE} (ACTIVITY_NAME, SET_AT, SET_BY_USER_ID, SET_BY_USERNAME)
-         VALUES (:activityName, SYSTIMESTAMP, :userId, :username)`,
-        {
-          activityName,
-          userId,
-          username,
-        },
-        { autoCommit: true },
-      );
-      console.log("Presence saved to database.");
-    } finally {
-      await connection.close();
-    }
+    await oraMutate(
+      `INSERT INTO ${PRESENCE_TABLE} (ACTIVITY_NAME, SET_AT, SET_BY_USER_ID, SET_BY_USERNAME)
+       VALUES (:activityName, SYSTIMESTAMP, :userId, :username)`,
+      { activityName, userId, username },
+    );
+    console.log("Presence saved to database.");
   } catch (error) {
     console.error("Error saving presence to database:", error);
   }
@@ -58,35 +45,19 @@ async function internalSetPresence(
 
 async function readLatestPresenceFromDatabase(): Promise<string | null> {
   try {
-    const pool: oracledb.Pool = getOraclePool();
-    const connection: oracledb.Connection = await pool.getConnection();
-
-    try {
-      const result: oracledb.Result<{ ACTIVITY_NAME: string }> =
-        await connection.execute<{ ACTIVITY_NAME: string }>(
-          `SELECT ACTIVITY_NAME
-             FROM ${PRESENCE_TABLE}
-            ORDER BY SET_AT DESC
-            FETCH FIRST 1 ROW ONLY`,
-          [],
-          { outFormat: oracledb.OUT_FORMAT_OBJECT },
-        );
-
-      const rows: { ACTIVITY_NAME: string }[] = result.rows ?? [];
-      if (!rows.length) {
-        return null;
-      }
-
-      const row: { ACTIVITY_NAME: string } = rows[0];
-      const activityName: string = row.ACTIVITY_NAME;
-      if (typeof activityName === "string" && activityName.trim().length > 0) {
-        return activityName;
-      }
-
-      return null;
-    } finally {
-      await connection.close();
+    const rows = await oraQuery(
+      `SELECT ACTIVITY_NAME
+         FROM ${PRESENCE_TABLE}
+        ORDER BY SET_AT DESC
+        FETCH FIRST 1 ROWS ONLY`,
+      {},
+      (row: { ACTIVITY_NAME: string }) => row.ACTIVITY_NAME,
+    );
+    const activityName = rows[0] ?? null;
+    if (typeof activityName === "string" && activityName.trim().length > 0) {
+      return activityName;
     }
+    return null;
   } catch (error) {
     console.error("Error reading presence from database:", error);
     return null;
@@ -104,47 +75,27 @@ export async function getPresenceHistory(limit: number): Promise<IPresenceHistor
   const safeLimit: number = Number.isInteger(limit) && limit > 0 ? Math.min(limit, 50) : 5;
 
   try {
-    const pool: oracledb.Pool = getOraclePool();
-    const connection: oracledb.Connection = await pool.getConnection();
-
-    try {
-      const result: oracledb.Result<{
+    return oraQuery(
+      `SELECT ACTIVITY_NAME,
+              SET_AT,
+              SET_BY_USER_ID,
+              SET_BY_USERNAME
+         FROM ${PRESENCE_TABLE}
+        ORDER BY SET_AT DESC
+        FETCH FIRST :limit ROWS ONLY`,
+      { limit: safeLimit },
+      (row: {
         ACTIVITY_NAME: string;
         SET_AT: Date;
         SET_BY_USER_ID: string | null;
         SET_BY_USERNAME: string | null;
-      }> = await connection.execute<{
-        ACTIVITY_NAME: string;
-        SET_AT: Date;
-        SET_BY_USER_ID: string | null;
-        SET_BY_USERNAME: string | null;
-      }>(
-        `SELECT ACTIVITY_NAME,
-                SET_AT,
-                SET_BY_USER_ID,
-                SET_BY_USERNAME
-           FROM ${PRESENCE_TABLE}
-          ORDER BY SET_AT DESC
-          FETCH FIRST :limit ROWS ONLY`,
-        { limit: safeLimit },
-        { outFormat: oracledb.OUT_FORMAT_OBJECT },
-      );
-
-      const rows: {
-        ACTIVITY_NAME: string;
-        SET_AT: Date;
-        SET_BY_USER_ID: string | null;
-        SET_BY_USERNAME: string | null;
-      }[] = result.rows ?? [];
-      return rows.map((row) => ({
+      }) => ({
         activityName: row.ACTIVITY_NAME,
         setAt: row.SET_AT ?? null,
         setByUserId: row.SET_BY_USER_ID ?? null,
         setByUsername: row.SET_BY_USERNAME ?? null,
-      }));
-    } finally {
-      await connection.close();
-    }
+      }),
+    );
   } catch (error) {
     console.error("Error loading presence history from database:", error);
     return [];

--- a/src/scripts/import-igdb-platforms.ts
+++ b/src/scripts/import-igdb-platforms.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import oracledb from "oracledb";
 import { initOraclePool, getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 import { igdbService, type IGDBPlatform } from "../services/IGDB/IgdbService.js";
 
 type UpsertResult = "inserted" | "updated" | "unchanged";
@@ -60,34 +61,33 @@ const validatePlatform = (platform: IGDBPlatform): string | null => {
 };
 
 const codeConflicts = async (
-  connection: oracledb.Connection,
+  conn: oracledb.Connection,
   code: string,
   igdbId: number,
 ): Promise<boolean> => {
-  const result = await connection.execute<{
-    PLATFORM_ID: number;
-  }>(
+  const rows = await oraQuery(
     `SELECT PLATFORM_ID
        FROM GAMEDB_PLATFORMS
       WHERE PLATFORM_CODE = :code
         AND (IGDB_PLATFORM_ID IS NULL OR IGDB_PLATFORM_ID != :igdbId)`,
     { code, igdbId },
-    { outFormat: oracledb.OUT_FORMAT_OBJECT },
+    (row: { PLATFORM_ID: number }) => row,
+    conn,
   );
-  return Boolean((result.rows ?? [])[0]);
+  return rows.length > 0;
 };
 
 const resolvePlatformCode = async (
-  connection: oracledb.Connection,
+  conn: oracledb.Connection,
   platform: IGDBPlatform,
 ): Promise<string> => {
   const preferred: string = derivePlatformCode(platform);
-  if (!(await codeConflicts(connection, preferred, platform.id))) {
+  if (!(await codeConflicts(conn, preferred, platform.id))) {
     return preferred;
   }
 
   const fallback: string = buildFallbackCode(platform.name, platform.id);
-  if (!(await codeConflicts(connection, fallback, platform.id))) {
+  if (!(await codeConflicts(conn, fallback, platform.id))) {
     return fallback;
   }
 
@@ -95,45 +95,37 @@ const resolvePlatformCode = async (
   return lastResort.length > 20 ? lastResort.slice(0, 20) : lastResort;
 };
 
+type ExistingPlatformRow = {
+  PLATFORM_ID: number;
+  PLATFORM_CODE: string;
+  PLATFORM_NAME: string;
+  PLATFORM_ABBREVIATION: string | null;
+  PLATFORM_SLUG: string | null;
+  PLATFORM_CHECKSUM: string | null;
+  IGDB_UPDATED_AT: number | null;
+  IGDB_PLATFORM_ID: number;
+};
+
 const upsertPlatform = async (
-  connection: oracledb.Connection,
+  conn: oracledb.Connection,
   platform: IGDBPlatform,
   mode: WriteMode,
 ): Promise<UpsertResult> => {
-  const existingResult = await connection.execute<{
-    PLATFORM_ID: number;
-    PLATFORM_CODE: string;
-    PLATFORM_NAME: string;
-    PLATFORM_ABBREVIATION: string | null;
-    PLATFORM_SLUG: string | null;
-    PLATFORM_CHECKSUM: string | null;
-    IGDB_UPDATED_AT: number | null;
-    IGDB_PLATFORM_ID: number;
-  }>(
+  const existingRows = await oraQuery(
     `SELECT PLATFORM_ID, PLATFORM_CODE, PLATFORM_NAME,
             PLATFORM_ABBREVIATION, PLATFORM_SLUG, PLATFORM_CHECKSUM, IGDB_UPDATED_AT,
             IGDB_PLATFORM_ID
        FROM GAMEDB_PLATFORMS
       WHERE IGDB_PLATFORM_ID = :igdbId`,
     { igdbId: platform.id },
-    { outFormat: oracledb.OUT_FORMAT_OBJECT },
+    (row: ExistingPlatformRow) => row,
+    conn,
   );
 
-  const existingRow = (existingResult.rows ?? [])[0] as
-    | {
-        PLATFORM_ID: number;
-        PLATFORM_CODE: string;
-        PLATFORM_NAME: string;
-        PLATFORM_ABBREVIATION: string | null;
-        PLATFORM_SLUG: string | null;
-        PLATFORM_CHECKSUM: string | null;
-        IGDB_UPDATED_AT: number | null;
-        IGDB_PLATFORM_ID: number;
-      }
-    | undefined;
+  const existingRow = existingRows[0] ?? null;
 
   const desiredName: string = platform.name.trim();
-  const desiredCode: string = await resolvePlatformCode(connection, platform);
+  const desiredCode: string = await resolvePlatformCode(conn, platform);
   const desiredAbbrev: string | null = normalizeOptional(platform.abbreviation);
   const desiredSlug: string | null = normalizeOptional(platform.slug);
   const desiredChecksum: string | null = normalizeChecksum(platform.checksum);
@@ -141,7 +133,7 @@ const upsertPlatform = async (
 
   if (!existingRow) {
     if (mode === "write") {
-      await connection.execute(
+      await oraMutate(
         `INSERT INTO GAMEDB_PLATFORMS (
            PLATFORM_CODE,
            PLATFORM_NAME,
@@ -169,7 +161,7 @@ const upsertPlatform = async (
           updatedAt: desiredUpdatedAt,
           igdbId: platform.id,
         },
-        { autoCommit: false },
+        conn,
       );
     }
     return "inserted";
@@ -181,17 +173,14 @@ const upsertPlatform = async (
       ? String(existingRow.PLATFORM_ABBREVIATION)
       : null;
   const currentSlug: string | null =
-    existingRow.PLATFORM_SLUG !== null
-      ? String(existingRow.PLATFORM_SLUG)
-      : null;
+    existingRow.PLATFORM_SLUG !== null ? String(existingRow.PLATFORM_SLUG) : null;
   const currentChecksum: string | null =
     existingRow.PLATFORM_CHECKSUM !== null
       ? String(existingRow.PLATFORM_CHECKSUM)
       : null;
   const currentUpdatedAt: number | null =
-    existingRow.IGDB_UPDATED_AT !== null
-      ? Number(existingRow.IGDB_UPDATED_AT)
-      : null;
+    existingRow.IGDB_UPDATED_AT !== null ? Number(existingRow.IGDB_UPDATED_AT) : null;
+
   const needsUpdate: boolean =
     currentName !== desiredName ||
     currentAbbrev !== desiredAbbrev ||
@@ -204,7 +193,7 @@ const upsertPlatform = async (
   }
 
   if (mode === "write") {
-    await connection.execute(
+    await oraMutate(
       `UPDATE GAMEDB_PLATFORMS
           SET PLATFORM_NAME = :name,
               PLATFORM_ABBREVIATION = :abbreviation,
@@ -220,7 +209,7 @@ const upsertPlatform = async (
         updatedAt: desiredUpdatedAt,
         platformId: existingRow.PLATFORM_ID,
       },
-      { autoCommit: false },
+      conn,
     );
   }
   return "updated";
@@ -230,8 +219,6 @@ const main = async (): Promise<void> => {
   const args: string[] = process.argv.slice(2);
   const mode: WriteMode = args.includes("--dry-run") ? "dry-run" : "write";
   await initOraclePool();
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
 
   let offset: number = 0;
   let page: number = 1;
@@ -240,70 +227,71 @@ const main = async (): Promise<void> => {
   let totalSeen: number = 0;
   let totalSkipped: number = 0;
 
-  try {
-    while (true) {
-      const platforms: IGDBPlatform[] =
-        await igdbService.getPlatformsPage(DEFAULT_LIMIT, offset);
-      const pageCount: number = platforms.length;
-      totalSeen += pageCount;
+  await oraWithConnection(async (conn) => {
+    try {
+      while (true) {
+        const platforms: IGDBPlatform[] =
+          await igdbService.getPlatformsPage(DEFAULT_LIMIT, offset);
+        const pageCount: number = platforms.length;
+        totalSeen += pageCount;
 
-      let pageInserted: number = 0;
-      let pageUpdated: number = 0;
-      let pageSkipped: number = 0;
+        let pageInserted: number = 0;
+        let pageUpdated: number = 0;
+        let pageSkipped: number = 0;
 
-      try {
-        for (const platform of platforms) {
-          const invalidReason: string | null = validatePlatform(platform);
-          if (invalidReason) {
-            console.warn(
-              `Skipping platform with invalid data (id: ${String(platform?.id)}): ${invalidReason}`,
-            );
-            pageSkipped += 1;
-            continue;
+        try {
+          for (const platform of platforms) {
+            const invalidReason: string | null = validatePlatform(platform);
+            if (invalidReason) {
+              console.warn(
+                `Skipping platform with invalid data (id: ${String(platform?.id)}): ${invalidReason}`,
+              );
+              pageSkipped += 1;
+              continue;
+            }
+            const result: UpsertResult = await upsertPlatform(conn, platform, mode);
+            if (result === "inserted") pageInserted += 1;
+            if (result === "updated") pageUpdated += 1;
           }
-          const result: UpsertResult = await upsertPlatform(connection, platform, mode);
-          if (result === "inserted") pageInserted += 1;
-          if (result === "updated") pageUpdated += 1;
+
+          if (mode === "write") {
+            await conn.commit();
+          }
+        } catch (err) {
+          if (mode === "write") {
+            await conn.rollback();
+          }
+          throw err;
         }
 
-        if (mode === "write") {
-          await connection.commit();
+        totalInserted += pageInserted;
+        totalUpdated += pageUpdated;
+        totalSkipped += pageSkipped;
+
+        console.log(
+          `Page ${page} (offset ${offset}) - fetched ${pageCount}, ` +
+          `inserted ${pageInserted}, updated ${pageUpdated}, skipped ${pageSkipped}` +
+          (mode === "dry-run" ? " [dry-run]" : ""),
+        );
+
+        if (pageCount < DEFAULT_LIMIT) {
+          break;
         }
-      } catch (err) {
-        if (mode === "write") {
-          await connection.rollback();
-        }
-        throw err;
+
+        offset += DEFAULT_LIMIT;
+        page += 1;
+        await sleep(RATE_LIMIT_DELAY_MS);
       }
-
-      totalInserted += pageInserted;
-      totalUpdated += pageUpdated;
-      totalSkipped += pageSkipped;
 
       console.log(
-        `Page ${page} (offset ${offset}) - fetched ${pageCount}, ` +
-        `inserted ${pageInserted}, updated ${pageUpdated}, skipped ${pageSkipped}` +
-        (mode === "dry-run" ? " [dry-run]" : ""),
+        `Done. Total fetched ${totalSeen}, inserted ${totalInserted}, ` +
+        `updated ${totalUpdated}, skipped ${totalSkipped}` +
+        (mode === "dry-run" ? " [dry-run]." : "."),
       );
-
-      if (pageCount < DEFAULT_LIMIT) {
-        break;
-      }
-
-      offset += DEFAULT_LIMIT;
-      page += 1;
-      await sleep(RATE_LIMIT_DELAY_MS);
+    } finally {
+      await getOraclePool().close(0);
     }
-
-    console.log(
-      `Done. Total fetched ${totalSeen}, inserted ${totalInserted}, ` +
-      `updated ${totalUpdated}, skipped ${totalSkipped}` +
-      (mode === "dry-run" ? " [dry-run]." : "."),
-    );
-  } finally {
-    await connection.close();
-    await pool.close(0);
-  }
+  });
 };
 
 main().catch((err: unknown) => {

--- a/src/scripts/reimport-release-dates.ts
+++ b/src/scripts/reimport-release-dates.ts
@@ -1,7 +1,7 @@
 import "dotenv/config";
 import { initOraclePool, getOraclePool } from "../db/oracleClient.js";
+import { oraQuery, oraMutate } from "../db/SqlManager.js";
 import Game from "../classes/Game.js";
-import oracledb from "oracledb";
 
 type ScriptMode = "dry-run" | "write";
 
@@ -15,61 +15,33 @@ const sleep = (ms: number): Promise<void> =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
 async function getGamesWithIgdbIds(): Promise<IGameWithIgdb[]> {
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    const result = await connection.execute<{
-      GAME_ID: number;
-      TITLE: string;
-      IGDB_ID: number;
-    }>(
-      `SELECT GAME_ID, TITLE, IGDB_ID
-         FROM GAMEDB_GAMES
-        WHERE IGDB_ID IS NOT NULL
-        ORDER BY GAME_ID`,
-      {},
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-
-    return (result.rows ?? []).map((row) => ({
+  return oraQuery(
+    `SELECT GAME_ID, TITLE, IGDB_ID
+       FROM GAMEDB_GAMES
+      WHERE IGDB_ID IS NOT NULL
+      ORDER BY GAME_ID`,
+    {},
+    (row: { GAME_ID: number; TITLE: string; IGDB_ID: number }) => ({
       gameId: Number(row.GAME_ID),
       title: String(row.TITLE),
       igdbId: Number(row.IGDB_ID),
-    }));
-  } finally {
-    await connection.close();
-  }
+    }),
+  );
 }
 
 async function deleteGameReleases(gameId: number): Promise<number> {
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    const result = await connection.execute(
-      `DELETE FROM GAMEDB_RELEASES WHERE GAME_ID = :gameId`,
-      { gameId },
-      { autoCommit: true },
-    );
-    return Number(result.rowsAffected ?? 0);
-  } finally {
-    await connection.close();
-  }
+  const result = await oraMutate(
+    `DELETE FROM GAMEDB_RELEASES WHERE GAME_ID = :gameId`,
+    { gameId },
+  );
+  return Number(result.rowsAffected ?? 0);
 }
 
 async function clearInitialReleaseDate(gameId: number): Promise<void> {
-  const pool = getOraclePool();
-  const connection = await pool.getConnection();
-  try {
-    await connection.execute(
-      `UPDATE GAMEDB_GAMES
-          SET INITIAL_RELEASE_DATE = NULL
-        WHERE GAME_ID = :gameId`,
-      { gameId },
-      { autoCommit: true },
-    );
-  } finally {
-    await connection.close();
-  }
+  await oraMutate(
+    `UPDATE GAMEDB_GAMES SET INITIAL_RELEASE_DATE = NULL WHERE GAME_ID = :gameId`,
+    { gameId },
+  );
 }
 
 async function reimportReleaseDates(
@@ -105,16 +77,16 @@ async function reimportReleaseDates(
         await Game.importReleaseDatesFromIgdb(game.gameId, game.igdbId);
         imported++;
         console.log(
-          `${progress} ✓ Imported release dates for "${game.title}" (ID: ${game.gameId})`,
+          `${progress} Imported release dates for "${game.title}" (ID: ${game.gameId})`,
         );
       } else {
         const releases = await Game.getGameReleases(game.gameId);
         console.log(
-          `${progress} [DRY RUN] Would clear ${releases.length} release(s) and reimport for "${game.title}" (ID: ${game.gameId})`,
+          `${progress} [DRY RUN] Would clear ${releases.length} release(s)` +
+          ` and reimport for "${game.title}" (ID: ${game.gameId})`,
         );
       }
 
-      // Rate limiting to avoid overwhelming IGDB API
       if (processed % 10 === 0) {
         await sleep(500);
       } else {
@@ -123,7 +95,7 @@ async function reimportReleaseDates(
     } catch (err: any) {
       failed++;
       console.error(
-        `${progress} ✗ Failed to process "${game.title}" (ID: ${game.gameId}): ${err?.message ?? err}`,
+        `${progress} Failed to process "${game.title}" (ID: ${game.gameId}): ${err?.message ?? err}`,
       );
     }
   }
@@ -147,10 +119,10 @@ async function main(): Promise<void> {
   const mode: ScriptMode = modeArg === "write" ? "write" : "dry-run";
 
   if (mode === "dry-run") {
-    console.log("\n⚠️  Running in DRY-RUN mode. No changes will be made.");
+    console.log("\n  Running in DRY-RUN mode. No changes will be made.");
     console.log("   Use 'npm run script:reimport-releases write' to execute.\n");
   } else {
-    console.log("\n⚠️  Running in WRITE mode. This will modify the database!");
+    console.log("\n  Running in WRITE mode. This will modify the database!");
     console.log("   Press Ctrl+C within 5 seconds to cancel...\n");
     await sleep(5000);
   }

--- a/src/services/IGDB/IgdbScanService.ts
+++ b/src/services/IGDB/IgdbScanService.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "../../db/oracleClient.js";
+import { oraWithConnection } from "../../db/SqlManager.js";
 import Game from "../../classes/Game.js";
 import { igdbService } from "./IgdbService.js";
 
@@ -51,11 +51,11 @@ function hasIgdbConfig(): boolean {
 }
 
 async function listScanCandidates(
-  connection: oracledb.Connection,
+  conn: oracledb.Connection,
   cutoff: Date,
   limit: number,
 ): Promise<IgdbScanCandidate[]> {
-  const result = await connection.execute<{
+  const result = await conn.execute<{
     GAME_ID: number;
     TITLE: string;
     IGDB_ID: number;
@@ -82,11 +82,8 @@ async function listScanCandidates(
   }));
 }
 
-async function countScanCandidates(
-  connection: oracledb.Connection,
-  cutoff: Date,
-): Promise<number> {
-  const result = await connection.execute<{ TOTAL: number }>(
+async function countScanCandidates(conn: oracledb.Connection, cutoff: Date): Promise<number> {
+  const result = await conn.execute<{ TOTAL: number }>(
     `SELECT COUNT(*) AS TOTAL
        FROM GAMEDB_GAMES
       WHERE IGDB_ID IS NOT NULL
@@ -94,7 +91,6 @@ async function countScanCandidates(
     { cutoff },
     { outFormat: oracledb.OUT_FORMAT_OBJECT },
   );
-
   const row = (result.rows ?? [])[0] as { TOTAL?: number } | undefined;
   return Number(row?.TOTAL ?? 0);
 }
@@ -108,92 +104,83 @@ export async function igdbScanTick(): Promise<void> {
   }
 
   const cutoff = new Date(Date.now() - (config.minAgeDays * 24 * 60 * 60 * 1000));
-  const pool = getOraclePool();
-  let connection: oracledb.Connection | null = null;
 
   try {
-    connection = await pool.getConnection();
-    const totalEligible = await countScanCandidates(connection, cutoff);
-    const candidates = await listScanCandidates(connection, cutoff, config.batchSize);
-    if (!candidates.length) {
+    await oraWithConnection(async (conn) => {
+      const totalEligible = await countScanCandidates(conn, cutoff);
+      const candidates = await listScanCandidates(conn, cutoff, config.batchSize);
+      if (!candidates.length) {
+        console.log(
+          "[IGDB Scan] No games queued for refresh.",
+          `Interval: ${(config.intervalMs / 60000).toFixed(1)}m,`,
+          `Batch: ${config.batchSize},`,
+          `Min age: ${config.minAgeDays}d,`,
+          `Remaining: ${totalEligible}.`,
+        );
+        return;
+      }
+
+      let successCount = 0;
+      let failCount = 0;
+      let releaseUpdated = 0;
+      let descriptionUpdated = 0;
+      const startedAt = Date.now();
+
+      for (const candidate of candidates) {
+        try {
+          const details = await igdbService.getGameDetails(candidate.igdbId);
+          if (!details) {
+            console.warn(
+              `[IGDB Scan] No IGDB details returned for ${candidate.title}` +
+              ` (ID: ${candidate.gameId}).`,
+            );
+            await Game.touchGameUpdatedAt(candidate.gameId);
+            continue;
+          }
+
+          const summary = details.summary?.trim() ?? "";
+          if (summary.length > 0) {
+            await Game.updateGameDescription(candidate.gameId, summary);
+            descriptionUpdated++;
+          }
+
+          const releases = details.release_dates ?? [];
+          if (releases.length > 0) {
+            await Game.refreshReleaseDates(candidate.gameId, releases);
+            releaseUpdated++;
+          }
+
+          await Game.touchGameUpdatedAt(candidate.gameId);
+          successCount++;
+
+          if (config.throttleMs > 0) {
+            await sleep(config.throttleMs);
+          }
+        } catch (err: any) {
+          failCount++;
+          console.error(
+            `[IGDB Scan] Failed to refresh ${candidate.title} (ID: ${candidate.gameId}):`,
+            err?.message ?? err,
+          );
+        }
+      }
+
+      const elapsedMs = Date.now() - startedAt;
+      const remaining = Math.max(totalEligible - candidates.length, 0);
       console.log(
-        "[IGDB Scan] No games queued for refresh.",
+        "[IGDB Scan] Completed batch.",
         `Interval: ${(config.intervalMs / 60000).toFixed(1)}m,`,
         `Batch: ${config.batchSize},`,
         `Min age: ${config.minAgeDays}d,`,
-        `Remaining: ${totalEligible}.`,
+        `Total eligible: ${totalEligible},`,
+        `Remaining: ${remaining},`,
+        `Success: ${successCount}, Failed: ${failCount},`,
+        `Descriptions: ${descriptionUpdated}, Releases: ${releaseUpdated},`,
+        `Elapsed: ${(elapsedMs / 1000).toFixed(1)}s.`,
       );
-      return;
-    }
-
-    let successCount = 0;
-    let failCount = 0;
-    let releaseUpdated = 0;
-    let descriptionUpdated = 0;
-    const startedAt = Date.now();
-
-    for (const candidate of candidates) {
-      try {
-        const details = await igdbService.getGameDetails(candidate.igdbId);
-        if (!details) {
-          const missingDetailsMessage =
-            `[IGDB Scan] No IGDB details returned for ${candidate.title} ` +
-            `(ID: ${candidate.gameId}).`;
-          console.warn(missingDetailsMessage);
-          await Game.touchGameUpdatedAt(candidate.gameId);
-          continue;
-        }
-
-        const summary = details.summary?.trim() ?? "";
-        if (summary.length > 0) {
-          await Game.updateGameDescription(candidate.gameId, summary);
-          descriptionUpdated++;
-        }
-
-        const releases = details.release_dates ?? [];
-        if (releases.length > 0) {
-          await Game.refreshReleaseDates(candidate.gameId, releases);
-          releaseUpdated++;
-        }
-
-        await Game.touchGameUpdatedAt(candidate.gameId);
-        successCount++;
-
-        if (config.throttleMs > 0) {
-          await sleep(config.throttleMs);
-        }
-      } catch (err: any) {
-        failCount++;
-        console.error(
-          `[IGDB Scan] Failed to refresh ${candidate.title} (ID: ${candidate.gameId}):`,
-          err?.message ?? err,
-        );
-      }
-    }
-
-    const elapsedMs = Date.now() - startedAt;
-    const remaining = Math.max(totalEligible - candidates.length, 0);
-    console.log(
-      "[IGDB Scan] Completed batch.",
-      `Interval: ${(config.intervalMs / 60000).toFixed(1)}m,`,
-      `Batch: ${config.batchSize},`,
-      `Min age: ${config.minAgeDays}d,`,
-      `Total eligible: ${totalEligible},`,
-      `Remaining: ${remaining},`,
-      `Success: ${successCount}, Failed: ${failCount},`,
-      `Descriptions: ${descriptionUpdated}, Releases: ${releaseUpdated},`,
-      `Elapsed: ${(elapsedMs / 1000).toFixed(1)}s.`,
-    );
+    });
   } catch (err) {
     console.error("[IGDB Scan] Batch failed:", err);
-  } finally {
-    if (connection) {
-      try {
-        await connection.close();
-      } catch (closeErr) {
-        console.error("[IGDB Scan] Error closing connection:", closeErr);
-      }
-    }
   }
 }
 

--- a/src/services/RssFeedService.ts
+++ b/src/services/RssFeedService.ts
@@ -1,8 +1,8 @@
 import Parser from "rss-parser";
 import crypto from "node:crypto";
 import type { Client } from "discordx";
-import oracledb from "oracledb";
-import { getOraclePool } from "../db/oracleClient.js";
+import type oracledb from "oracledb";
+import { oraWithConnection } from "../db/SqlManager.js";
 import {
   listFeeds,
   markItemsSeen,
@@ -143,23 +143,16 @@ export function startRssFeedService(client: Client): void {
     }
     isPolling = true;
 
-    let connection: oracledb.Connection | null = null;
     try {
-      connection = await getOraclePool().getConnection();
-      const feeds = await listFeeds(connection);
-      for (const feed of feeds) {
-        await processFeed(client, feed, connection);
-      }
+      await oraWithConnection(async (conn) => {
+        const feeds = await listFeeds(conn);
+        for (const feed of feeds) {
+          await processFeed(client, feed, conn);
+        }
+      });
     } catch (err) {
       console.error("[RSS] Polling error:", err);
     } finally {
-      if (connection) {
-        try {
-          await connection.close();
-        } catch (closeErr) {
-          console.error("[RSS] Error closing connection:", closeErr);
-        }
-      }
       isPolling = false;
     }
   };

--- a/src/services/raw-modal/RawModalSession.ts
+++ b/src/services/raw-modal/RawModalSession.ts
@@ -1,6 +1,6 @@
 import type { RawModalFeature, RawModalFlow } from "./RawModalScope.js";
 import oracledb from "oracledb";
-import { getOraclePool } from "../../db/oracleClient.js";
+import { oraQuery, oraMutate, oraWithConnection } from "../../db/SqlManager.js";
 
 export const RAW_MODAL_SESSION_STATUSES = ["open", "submitted", "expired"] as const;
 export type RawModalSessionStatus = (typeof RAW_MODAL_SESSION_STATUSES)[number];
@@ -108,14 +108,25 @@ export function buildRawModalSessionExpiry(
   return new Date(now.getTime() + Math.max(1, ttlMinutes) * 60 * 1000);
 }
 
+const SESSION_SELECT_SQL = `SELECT SESSION_ID,
+       OWNER_USER_ID,
+       FEATURE_ID,
+       FLOW_ID,
+       STATE_JSON,
+       STATUS,
+       EXPIRES_AT,
+       GUILD_ID,
+       CHANNEL_ID,
+       CREATED_AT,
+       UPDATED_AT
+  FROM RPG_CLUB_RAW_MODAL_SESSIONS`;
+
 export async function createRawModalSessionRecord(
   input: IRawModalSessionCreateInput,
 ): Promise<IRawModalSessionRecord> {
-  const connection = await getOraclePool().getConnection();
-  try {
+  return oraWithConnection(async (conn) => {
     const session = normalizeCreateInput(input);
-
-    await connection.execute(
+    await oraMutate(
       `INSERT INTO RPG_CLUB_RAW_MODAL_SESSIONS
          (SESSION_ID, OWNER_USER_ID, FEATURE_ID, FLOW_ID, STATE_JSON, EXPIRES_AT, STATUS, GUILD_ID, CHANNEL_ID)
        VALUES
@@ -131,68 +142,41 @@ export async function createRawModalSessionRecord(
         guildId: session.guildId,
         channelId: session.channelId,
       },
-      { autoCommit: true },
+      conn,
     );
+    await conn.commit();
 
-    const saved = await getRawModalSessionRecord(session.sessionId, connection);
+    const saved = await getRawModalSessionRecord(session.sessionId, conn);
     if (!saved) {
       throw new Error("Failed to create raw modal session.");
     }
     return saved;
-  } finally {
-    await connection.close();
-  }
+  });
 }
 
 export async function getRawModalSessionRecord(
   sessionId: string,
   existingConnection?: oracledb.Connection,
 ): Promise<IRawModalSessionRecord | null> {
-  const connection = existingConnection ?? (await getOraclePool().getConnection());
-  try {
-    const result = await connection.execute<RawModalSessionRow>(
-      `SELECT SESSION_ID,
-              OWNER_USER_ID,
-              FEATURE_ID,
-              FLOW_ID,
-              STATE_JSON,
-              STATUS,
-              EXPIRES_AT,
-              GUILD_ID,
-              CHANNEL_ID,
-              CREATED_AT,
-              UPDATED_AT
-         FROM RPG_CLUB_RAW_MODAL_SESSIONS
-        WHERE SESSION_ID = :sessionId`,
-      { sessionId },
-      { outFormat: oracledb.OUT_FORMAT_OBJECT },
-    );
-
-    const row = result.rows?.[0];
-    return row ? mapRawModalSessionRow(row) : null;
-  } finally {
-    if (!existingConnection) {
-      await connection.close();
-    }
-  }
+  const rows = await oraQuery(
+    `${SESSION_SELECT_SQL} WHERE SESSION_ID = :sessionId`,
+    { sessionId },
+    mapRawModalSessionRow,
+    existingConnection,
+  );
+  return rows[0] ?? null;
 }
 
 export async function updateRawModalSessionStatus(
   input: IRawModalSessionUpdateInput,
 ): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `UPDATE RPG_CLUB_RAW_MODAL_SESSIONS
-          SET STATUS = :status
-        WHERE SESSION_ID = :sessionId`,
-      { status: toDbStatus(input.status), sessionId: input.sessionId },
-      { autoCommit: true },
-    );
-    return Number(result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+  const result = await oraMutate(
+    `UPDATE RPG_CLUB_RAW_MODAL_SESSIONS
+        SET STATUS = :status
+      WHERE SESSION_ID = :sessionId`,
+    { status: toDbStatus(input.status), sessionId: input.sessionId },
+  );
+  return Number(result.rowsAffected ?? 0) > 0;
 }
 
 export async function claimRawModalSessionForSubmit(
@@ -200,27 +184,16 @@ export async function claimRawModalSessionForSubmit(
   ownerUserId: string,
   now: Date = new Date(),
 ): Promise<boolean> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `UPDATE RPG_CLUB_RAW_MODAL_SESSIONS
-          SET STATUS = 'SUBMITTED'
-        WHERE SESSION_ID = :sessionId
-          AND OWNER_USER_ID = :ownerUserId
-          AND STATUS = 'OPEN'
-          AND EXPIRES_AT > :nowTs`,
-      {
-        sessionId,
-        ownerUserId,
-        nowTs: now,
-      },
-      { autoCommit: true },
-    );
-
-    return Number(result.rowsAffected ?? 0) > 0;
-  } finally {
-    await connection.close();
-  }
+  const result = await oraMutate(
+    `UPDATE RPG_CLUB_RAW_MODAL_SESSIONS
+        SET STATUS = 'SUBMITTED'
+      WHERE SESSION_ID = :sessionId
+        AND OWNER_USER_ID = :ownerUserId
+        AND STATUS = 'OPEN'
+        AND EXPIRES_AT > :nowTs`,
+    { sessionId, ownerUserId, nowTs: now },
+  );
+  return Number(result.rowsAffected ?? 0) > 0;
 }
 
 export async function expireRawModalSession(sessionId: string): Promise<boolean> {
@@ -228,17 +201,11 @@ export async function expireRawModalSession(sessionId: string): Promise<boolean>
 }
 
 export async function deleteExpiredRawModalSessions(cutoffDate: Date): Promise<number> {
-  const connection = await getOraclePool().getConnection();
-  try {
-    const result = await connection.execute(
-      `DELETE FROM RPG_CLUB_RAW_MODAL_SESSIONS
-        WHERE EXPIRES_AT < :cutoffDate
-          AND STATUS IN ('OPEN', 'EXPIRED')`,
-      { cutoffDate },
-      { autoCommit: true },
-    );
-    return Number(result.rowsAffected ?? 0);
-  } finally {
-    await connection.close();
-  }
+  const result = await oraMutate(
+    `DELETE FROM RPG_CLUB_RAW_MODAL_SESSIONS
+      WHERE EXPIRES_AT < :cutoffDate
+        AND STATUS IN ('OPEN', 'EXPIRED')`,
+    { cutoffDate },
+  );
+  return Number(result.rowsAffected ?? 0);
 }


### PR DESCRIPTION
## Summary

- Eliminates all direct `getOraclePool().getConnection()` + `try/finally connection.close()` patterns across the entire codebase
- Migrates 24+ files to use centralized `oraQuery`, `oraMutate`, `oraWithConnection`, and `oraTransaction` helpers from `SqlManager.ts`
- Preserves all special-case patterns: `fetchInfo` for BLOB/CLOB columns, `executeMany` for batch operations, optional connection passthrough for callers sharing a connection, and manual commit/rollback for scripts with page-level transactions

## Files migrated

Classes: `CollectionCsvImport`, `CompletionatorImport`, `Game`, `GameDbCsvImport`, `GameReleaseAnnouncement`, `Gotm`, `GotmAuditImport`, `Member`, `Nomination`, `NrGotm`, `RssFeed`, `SteamCollectionImport`, `Suggestion`, `SuggestionReviewSession`, `UserGameCollection`, `XboxCollectionImport`

Services/functions: `SetPresence`, `RawModalSession`, `RssFeedService`, `IgdbScanService`, `sql-health-check.service`

Scripts: `reimport-release-dates`, `import-igdb-platforms`

Commands: `superadmin.command` (memberscan simplified to not share a long-lived connection)

## Test plan

- [x] `tsc --noEmit` passes with no errors
- [x] `npm run lint` passes (only pre-existing errors in unrelated files remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)