### PR TITLE
feat: centralized SQL registry for all domain classes

### DIFF
--- a/SQL_MIGRATION_PLAN.md
+++ b/SQL_MIGRATION_PLAN.md
@@ -1,0 +1,246 @@
+# SQL Centralization Plan: Oracle + PostgreSQL Dual-Dialect Registry
+
+## Context
+
+SQL statements are currently embedded inline throughout domain class files (`Game.ts`, `Member.ts`, etc.), making the Oracle-to-PostgreSQL migration opaque and error-prone. The goal is to extract every SQL statement into a centralized registry so that:
+
+1. Both Oracle and PostgreSQL variants live side-by-side in one place.
+2. A dialect-aware getter in `SqlManager` selects the right variant at runtime.
+3. Domain classes hold zero raw SQL -- only call sites.
+
+This is the intermediate step between the current Oracle-only codebase and a future API-driven architecture.
+
+---
+
+## New Types (add to `src/db/SqlManager.ts`)
+
+```typescript
+export type Dialect = "oracle" | "postgres";
+
+export interface SqlEntry {
+  oracle: string;
+  postgres: string;
+}
+
+/** Pick the dialect-appropriate string from a static SqlEntry. */
+export function getSql(entry: SqlEntry, dialect: Dialect): string {
+  return entry[dialect];
+}
+
+/**
+ * Pick the dialect-appropriate string from a dynamic (factory) SqlEntry.
+ * Used for queries that build WHERE/ORDER clauses at runtime.
+ */
+export function getSqlDynamic<TArgs extends unknown[]>(
+  factory: (...args: TArgs) => SqlEntry,
+  dialect: Dialect,
+  ...args: TArgs
+): string {
+  return factory(...args)[dialect];
+}
+```
+
+---
+
+## SQL File Layout
+
+Mirror the domain class structure under `src/db/sql/`:
+
+```
+src/db/sql/
+  types.ts                  -- re-exports Dialect, SqlEntry (source of truth)
+  game.sql.ts               -- GameSql object  (~105 statements)
+  member.sql.ts             -- MemberSql object (~131 statements)
+  reminder.sql.ts           -- ReminderSql
+  gotm.sql.ts               -- GotmSql / NrGotmSql
+  gameSearchSynonym.sql.ts  -- GameSearchSynonymSql
+  xboxCollectionImport.sql.ts
+  steamCollectionImport.sql.ts
+  suggestion.sql.ts
+  thread.sql.ts
+  starboard.sql.ts
+  userActivity.sql.ts       -- UserActivityIcon, UserChannelMessageCount
+  userGameCollection.sql.ts
+  publicReminder.sql.ts
+  todo.sql.ts
+  rssFeed.sql.ts
+  hltbCache.sql.ts
+  index.ts                  -- barrel re-export of all Sql* objects
+```
+
+Each `*.sql.ts` file exports a single `const XxxSql` object. Keys are camelCase query names. Values are either `SqlEntry` (static) or a factory `(...dynamicParts) => SqlEntry` (dynamic).
+
+---
+
+## Static SQL Entry Pattern
+
+```typescript
+// src/db/sql/game.sql.ts
+import type { SqlEntry } from "./types.js";
+
+export const GameSql = {
+  getById: {
+    oracle: `SELECT GAME_ID, TITLE, ... FROM GAMEDB_GAMES WHERE GAME_ID = :id`,
+    postgres: `SELECT game_id, title, ... FROM gamedb_games WHERE game_id = $1`,
+  } satisfies SqlEntry,
+  // ...
+};
+```
+
+---
+
+## Dynamic SQL Entry Pattern
+
+Dynamic SQL (WHERE clause builders, IN-list expanders) is stored as a factory function that returns a `SqlEntry`:
+
+```typescript
+export const GameSql = {
+  searchGames: (whereClause: string, orderBy: string) =>
+    ({
+      oracle: `WITH upcoming AS (...)
+               SELECT ... FROM GAMEDB_GAMES g
+               LEFT JOIN upcoming u ON u.GAME_ID = g.GAME_ID
+               WHERE ${whereClause}
+               ORDER BY ${orderBy}`,
+      postgres: `WITH upcoming AS (...)
+                 SELECT ... FROM gamedb_games g
+                 LEFT JOIN upcoming u ON u.game_id = g.game_id
+                 WHERE ${whereClause}
+                 ORDER BY ${orderBy}`,
+    }) satisfies SqlEntry,
+};
+```
+
+Dynamic parts (whereClause, orderBy) are always code-generated, never raw user input -- this preserves the existing security posture.
+
+---
+
+## Oracle -> PostgreSQL Syntax Mapping
+
+| Oracle | PostgreSQL |
+|---|---|
+| `:paramName` bind | `$1, $2, ...` positional |
+| `SYSDATE` | `NOW()` |
+| `SYSTIMESTAMP` | `NOW()` |
+| `ROWNUM <= n` | `LIMIT n` |
+| `LISTAGG(x, ',') WITHIN GROUP (ORDER BY y)` | `STRING_AGG(x, ',' ORDER BY y)` |
+| `MERGE INTO t USING dual ON (...) WHEN NOT MATCHED THEN INSERT` | `INSERT INTO t ... ON CONFLICT (...) DO UPDATE SET ...` / `DO NOTHING` |
+| `INSERT ... RETURNING x INTO :outVar` (with `BIND_OUT`) | `INSERT ... RETURNING x` (result in `rows[0]`) |
+| `SELECT ... FROM dual` | `SELECT ...` (omit FROM dual) |
+| `VARCHAR2` | `TEXT` or `VARCHAR` |
+| `NUMBER` | `NUMERIC` or `INTEGER` |
+| `DATE` | `TIMESTAMP` |
+| `NVL(x, y)` | `COALESCE(x, y)` |
+| `DECODE(x, v, r, def)` | `CASE WHEN x = v THEN r ELSE def END` |
+| `CONNECT BY LEVEL` | `generate_series()` |
+
+### Bind Parameter Offset for IN-list Builders
+
+Oracle uses named binds (`:id0`, `:id1`), which are order-independent.
+PostgreSQL uses positional (`$1`, `$2`), so IN-list factory functions must accept a `startOffset` parameter:
+
+```typescript
+buildInList: (ids: number[], startOffset = 1) => {
+  const oraPlaceholders = ids.map((_, i) => `:id${i}`).join(", ");
+  const pgPlaceholders  = ids.map((_, i) => `$${startOffset + i}`).join(", ");
+  return {
+    oracle:   `WHERE GAME_ID IN (${oraPlaceholders})`,
+    postgres: `WHERE game_id IN (${pgPlaceholders})`,
+  } satisfies SqlEntry;
+},
+```
+
+---
+
+## Migration Steps Per File
+
+For each domain class:
+
+1. Create the corresponding `src/db/sql/xxx.sql.ts` file.
+2. Copy every SQL string literal (and factory) out of the class into the new file as a named `SqlEntry`.
+3. Replace the inline SQL in the class with a `getSql(XxxSql.queryName, dialect)` call (or `getSqlDynamic` for factories).
+4. Import `dialect` from a shared runtime config (see below).
+5. Run `tsc --noEmit` after each file to catch type errors.
+
+### Execution Order (by statement count, largest first)
+
+1. `Member.ts` (131 statements) -> `member.sql.ts`
+2. `Game.ts` (105 statements) -> `game.sql.ts`
+3. `XboxCollectionImport.ts` (29) -> `xboxCollectionImport.sql.ts`
+4. `SteamCollectionImport.ts` (29) -> `steamCollectionImport.sql.ts`
+5. `GameSearchSynonym.ts` / `GameSearchSynonymDraft.ts` (23) -> `gameSearchSynonym.sql.ts`
+6. Remaining classes (~130 statements spread across ~18 files)
+
+---
+
+## Dialect Runtime Selection
+
+Add a `DB_DIALECT` env var (`"oracle"` | `"postgres"`) read once at startup:
+
+```typescript
+// src/db/dialect.ts
+import type { Dialect } from "./sql/types.js";
+
+export function getDialect(): Dialect {
+  const d = process.env.DB_DIALECT;
+  if (d !== "oracle" && d !== "postgres") {
+    throw new Error(`DB_DIALECT must be "oracle" or "postgres", got: ${d}`);
+  }
+  return d;
+}
+```
+
+Domain classes call `getDialect()` once per method (or cache it at module load). No global mutable state needed.
+
+---
+
+## Files to Create
+
+| File | Action |
+|---|---|
+| `src/db/sql/types.ts` | New -- `Dialect`, `SqlEntry` types |
+| `src/db/sql/game.sql.ts` | New -- extracted from `Game.ts` |
+| `src/db/sql/member.sql.ts` | New -- extracted from `Member.ts` |
+| `src/db/sql/reminder.sql.ts` | New -- from `Reminder.ts`, `PublicReminder.ts` |
+| `src/db/sql/gotm.sql.ts` | New -- from `Gotm.ts`, `NrGotm.ts` |
+| `src/db/sql/gameSearchSynonym.sql.ts` | New -- from `GameSearchSynonym.ts` / draft |
+| `src/db/sql/xboxCollectionImport.sql.ts` | New |
+| `src/db/sql/steamCollectionImport.sql.ts` | New |
+| `src/db/sql/suggestion.sql.ts` | New -- from `Suggestion.ts`, `SuggestionReviewSession.ts` |
+| `src/db/sql/thread.sql.ts` | New |
+| `src/db/sql/starboard.sql.ts` | New |
+| `src/db/sql/userActivity.sql.ts` | New |
+| `src/db/sql/userGameCollection.sql.ts` | New |
+| `src/db/sql/todo.sql.ts` | New |
+| `src/db/sql/rssFeed.sql.ts` | New |
+| `src/db/sql/hltbCache.sql.ts` | New |
+| `src/db/sql/index.ts` | New -- barrel |
+| `src/db/dialect.ts` | New -- `getDialect()` |
+| `src/db/SqlManager.ts` | Update -- add `getSql`, `getSqlDynamic`, `Dialect`, `SqlEntry` exports |
+
+## Files to Modify (domain classes)
+
+All files in `src/classes/` that contain inline SQL. No logic changes -- SQL string extraction only.
+
+---
+
+## Verification
+
+After each class migration:
+
+```bash
+tsc --noEmit
+```
+
+End-to-end (requires both DBs running):
+- Set `DB_DIALECT=oracle` and exercise the affected commands manually.
+- Set `DB_DIALECT=postgres` and repeat.
+- Confirm query results match between dialects for representative cases.
+
+---
+
+## Out of Scope
+
+- Postgres schema creation / migration scripts (separate effort).
+- Switching the live bot off Oracle (happens after PostgreSQL schema is validated).
+- Any logic changes in domain classes beyond SQL extraction.

--- a/src/db/SqlManager.ts
+++ b/src/db/SqlManager.ts
@@ -2,6 +2,8 @@ import oracledb from "oracledb";
 import { getOraclePool } from "./oracleClient.js";
 
 export { pgQuery, pgTransaction } from "./postgresClient.js";
+export type { Dialect, SqlEntry } from "./sql/types.js";
+export { getSql, getSqlDynamic } from "./sql/index.js";
 
 /**
  * Runs a SELECT and maps each row with `mapper`. Defaults to OUT_FORMAT_OBJECT.

--- a/src/db/dialect.ts
+++ b/src/db/dialect.ts
@@ -1,0 +1,7 @@
+import type { Dialect } from "./sql/types.js";
+
+export function getDialect(): Dialect {
+  const raw = process.env.DB_DIALECT ?? "oracle";
+  if (raw === "oracle" || raw === "postgres") return raw;
+  throw new Error(`Unknown DB_DIALECT: "${raw}". Expected "oracle" or "postgres".`);
+}

--- a/src/db/sql/adminWizardSession.sql.ts
+++ b/src/db/sql/adminWizardSession.sql.ts
@@ -1,0 +1,79 @@
+import type { SqlEntry } from "./types.js";
+
+export const AdminWizardSessionSql = {
+  getActive: {
+    oracle: `SELECT SESSION_ID,
+            COMMAND_KEY,
+            OWNER_USER_ID,
+            CHANNEL_ID,
+            GUILD_ID,
+            STATUS,
+            STATE_JSON,
+            LAST_UPDATED_AT,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_ADMIN_WIZARD_SESSIONS
+      WHERE COMMAND_KEY = :commandKey
+        AND OWNER_USER_ID = :ownerUserId
+        AND CHANNEL_ID = :channelId
+        AND STATUS = 'ACTIVE'
+      ORDER BY LAST_UPDATED_AT DESC
+      FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  saveSession: {
+    oracle: `MERGE INTO RPG_CLUB_ADMIN_WIZARD_SESSIONS t
+      USING (
+        SELECT :commandKey AS COMMAND_KEY,
+               :ownerUserId AS OWNER_USER_ID,
+               :channelId AS CHANNEL_ID,
+               :guildId AS GUILD_ID,
+               :stateJson AS STATE_JSON,
+               :lastUpdatedAt AS LAST_UPDATED_AT
+          FROM dual
+      ) src
+         ON (t.COMMAND_KEY = src.COMMAND_KEY
+             AND t.OWNER_USER_ID = src.OWNER_USER_ID
+             AND t.CHANNEL_ID = src.CHANNEL_ID
+             AND t.STATUS = 'ACTIVE')
+    WHEN MATCHED THEN
+      UPDATE SET t.STATE_JSON = src.STATE_JSON,
+                 t.GUILD_ID = src.GUILD_ID,
+                 t.LAST_UPDATED_AT = src.LAST_UPDATED_AT
+    WHEN NOT MATCHED THEN
+      INSERT (SESSION_ID, COMMAND_KEY, OWNER_USER_ID, CHANNEL_ID, GUILD_ID, STATUS,
+              STATE_JSON, LAST_UPDATED_AT)
+      VALUES (
+        :sessionId,
+        src.COMMAND_KEY,
+        src.OWNER_USER_ID,
+        src.CHANNEL_ID,
+        src.GUILD_ID,
+        'ACTIVE',
+        src.STATE_JSON,
+        src.LAST_UPDATED_AT
+      )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteHistorical: {
+    oracle: `DELETE FROM RPG_CLUB_ADMIN_WIZARD_SESSIONS
+        WHERE COMMAND_KEY = :commandKey
+          AND OWNER_USER_ID = :ownerUserId
+          AND CHANNEL_ID = :channelId
+          AND STATUS = :status`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateStatus: {
+    oracle: `UPDATE RPG_CLUB_ADMIN_WIZARD_SESSIONS
+          SET STATUS = :status,
+              LAST_UPDATED_AT = :lastUpdatedAt
+        WHERE COMMAND_KEY = :commandKey
+          AND OWNER_USER_ID = :ownerUserId
+          AND CHANNEL_ID = :channelId
+          AND STATUS = 'ACTIVE'`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/botVotingInfo.sql.ts
+++ b/src/db/sql/botVotingInfo.sql.ts
@@ -1,0 +1,85 @@
+import type { SqlEntry } from "./types.js";
+
+const VOTING_COLS = `ROUND_NUMBER,
+                NOMINATION_LIST_ID,
+                NEXT_VOTE_AT,
+                FIVE_DAY_REMINDER_SENT,
+                ONE_DAY_REMINDER_SENT`;
+
+export const BotVotingInfoSql = {
+  getAll: {
+    oracle: `SELECT ${VOTING_COLS}
+         FROM BOT_VOTING_INFO
+        ORDER BY ROUND_NUMBER`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getByRound: {
+    oracle: `SELECT ${VOTING_COLS}
+         FROM BOT_VOTING_INFO
+        WHERE ROUND_NUMBER = :round`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getCurrentRound: {
+    oracle: `SELECT ${VOTING_COLS}
+         FROM BOT_VOTING_INFO
+        WHERE ROUND_NUMBER = (
+          SELECT MAX(ROUND_NUMBER) FROM BOT_VOTING_INFO
+        )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateRoundInfo: {
+    oracle: `UPDATE BOT_VOTING_INFO
+            SET NOMINATION_LIST_ID = :nominationListId,
+                NEXT_VOTE_AT = :nextVoteAt
+          WHERE ROUND_NUMBER = :round`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertRoundInfo: {
+    oracle: `INSERT INTO BOT_VOTING_INFO (
+           ROUND_NUMBER,
+           NOMINATION_LIST_ID,
+           NEXT_VOTE_AT,
+           FIVE_DAY_REMINDER_SENT,
+           ONE_DAY_REMINDER_SENT
+         ) VALUES (
+           :round,
+           :nominationListId,
+           :nextVoteAt,
+           0,
+           0
+         )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  markReminderSent: (column: string) =>
+    ({
+      oracle: `UPDATE BOT_VOTING_INFO
+          SET ${column} = 1
+        WHERE ROUND_NUMBER = :round`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  updateNextVoteAt: {
+    oracle: `UPDATE BOT_VOTING_INFO
+          SET NEXT_VOTE_AT = :nextVoteAt
+        WHERE ROUND_NUMBER = :round`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateNominationListId: {
+    oracle: `UPDATE BOT_VOTING_INFO
+          SET NOMINATION_LIST_ID = :nominationListId
+        WHERE ROUND_NUMBER = :round`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteRound: {
+    oracle: `DELETE FROM BOT_VOTING_INFO
+        WHERE ROUND_NUMBER = :round`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/collectionCsvImport.sql.ts
+++ b/src/db/sql/collectionCsvImport.sql.ts
@@ -1,0 +1,166 @@
+import type { SqlEntry } from "./types.js";
+
+const ITEM_COLS = `ITEM_ID,
+            IMPORT_ID,
+            ROW_INDEX,
+            RAW_TITLE,
+            RAW_PLATFORM,
+            RAW_OWNERSHIP_TYPE,
+            RAW_NOTE,
+            RAW_GAMEDB_ID,
+            RAW_IGDB_ID,
+            PLATFORM_ID,
+            OWNERSHIP_TYPE,
+            NOTE,
+            STATUS,
+            MATCH_CONFIDENCE,
+            MATCH_CANDIDATE_JSON,
+            GAMEDB_GAME_ID,
+            COLLECTION_ENTRY_ID,
+            RESULT_REASON,
+            ERROR_TEXT`;
+
+export const CollectionCsvImportSql = {
+  createImport: {
+    oracle: `INSERT INTO RPG_CLUB_COLLECTION_CSV_IMPORTS (
+         USER_ID,
+         STATUS,
+         CURRENT_INDEX,
+         TOTAL_COUNT,
+         SOURCE_FILE_NAME,
+         SOURCE_FILE_SIZE,
+         TEMPLATE_VERSION
+       ) VALUES (
+         :userId,
+         'ACTIVE',
+         0,
+         :totalCount,
+         :sourceFileName,
+         :sourceFileSize,
+         :templateVersion
+       ) RETURNING IMPORT_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertItem: {
+    oracle: `INSERT INTO RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS (
+           IMPORT_ID,
+           ROW_INDEX,
+           RAW_TITLE,
+           RAW_PLATFORM,
+           RAW_OWNERSHIP_TYPE,
+           RAW_NOTE,
+           RAW_GAMEDB_ID,
+           RAW_IGDB_ID,
+           PLATFORM_ID,
+           OWNERSHIP_TYPE,
+           NOTE,
+           STATUS
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :rawTitle,
+           :rawPlatform,
+           :rawOwnershipType,
+           :rawNote,
+           :rawGameDbId,
+           :rawIgdbId,
+           :platformId,
+           :ownershipType,
+           :note,
+           'PENDING'
+         )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getImportById: {
+    oracle: `SELECT IMPORT_ID,
+            USER_ID,
+            STATUS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            SOURCE_FILE_NAME,
+            SOURCE_FILE_SIZE,
+            TEMPLATE_VERSION,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_COLLECTION_CSV_IMPORTS
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getActiveForUser: {
+    oracle: `SELECT IMPORT_ID,
+            USER_ID,
+            STATUS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            SOURCE_FILE_NAME,
+            SOURCE_FILE_SIZE,
+            TEMPLATE_VERSION,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_COLLECTION_CSV_IMPORTS
+      WHERE USER_ID = :userId
+        AND STATUS IN ('ACTIVE', 'PAUSED')
+      ORDER BY CREATED_AT DESC, IMPORT_ID DESC
+      FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  setStatus: {
+    oracle: `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORTS
+        SET STATUS = :status
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateIndex: {
+    oracle: `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORTS
+        SET CURRENT_INDEX = :currentIndex
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getItemById: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
+      WHERE ITEM_ID = :itemId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNextPendingItem: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+        AND STATUS = 'PENDING'
+      ORDER BY ROW_INDEX ASC, ITEM_ID ASC
+      FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateItem: (setParts: string[]) =>
+    ({
+      oracle: `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
+        SET ${setParts.join(", ")}
+      WHERE ITEM_ID = :itemId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  countItemsByStatus: {
+    oracle: `SELECT STATUS, COUNT(*) AS TOTAL
+       FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY STATUS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countItemsByReason: {
+    oracle: `SELECT RESULT_REASON, COUNT(*) AS TOTAL
+       FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+        AND RESULT_REASON IS NOT NULL
+      GROUP BY RESULT_REASON`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/completionatorImport.sql.ts
+++ b/src/db/sql/completionatorImport.sql.ts
@@ -1,0 +1,135 @@
+import type { SqlEntry } from "./types.js";
+
+const ITEM_COLS = `ITEM_ID,
+            IMPORT_ID,
+            ROW_INDEX,
+            GAME_TITLE,
+            PLATFORM_NAME,
+            REGION_NAME,
+            SOURCE_TYPE,
+            TIME_TEXT,
+            COMPLETED_AT,
+            COMPLETION_TYPE,
+            PLAYTIME_HRS,
+            STATUS,
+            GAMEDB_GAME_ID,
+            COMPLETION_ID,
+            ERROR_TEXT`;
+
+export const CompletionatorImportSql = {
+  createImport: {
+    oracle: `INSERT INTO RPG_CLUB_COMPLETIONATOR_IMPORTS (
+         USER_ID, STATUS, CURRENT_INDEX, TOTAL_COUNT, SOURCE_FILENAME
+       ) VALUES (
+         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
+       ) RETURNING IMPORT_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertItem: {
+    oracle: `INSERT INTO RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS (
+           IMPORT_ID,
+           ROW_INDEX,
+           GAME_TITLE,
+           PLATFORM_NAME,
+           REGION_NAME,
+           SOURCE_TYPE,
+           TIME_TEXT,
+           COMPLETED_AT,
+           COMPLETION_TYPE,
+           PLAYTIME_HRS,
+           STATUS
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :gameTitle,
+           :platformName,
+           :regionName,
+           :sourceType,
+           :timeText,
+           :completedAt,
+           :completionType,
+           :playtimeHours,
+           'PENDING'
+         )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getImportById: {
+    oracle: `SELECT IMPORT_ID,
+            USER_ID,
+            STATUS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            SOURCE_FILENAME,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_COMPLETIONATOR_IMPORTS
+      WHERE IMPORT_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getActiveForUser: {
+    oracle: `SELECT IMPORT_ID,
+            USER_ID,
+            STATUS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            SOURCE_FILENAME,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_COMPLETIONATOR_IMPORTS
+      WHERE USER_ID = :userId
+        AND STATUS IN ('ACTIVE', 'PAUSED')
+      ORDER BY CREATED_AT DESC, IMPORT_ID DESC
+      FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  setStatus: {
+    oracle: `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORTS
+        SET STATUS = :status
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateIndex: {
+    oracle: `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORTS
+        SET CURRENT_INDEX = :currentIndex
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getItemById: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
+      WHERE ITEM_ID = :itemId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNextPendingItem: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+        AND STATUS = 'PENDING'
+      ORDER BY ROW_INDEX ASC
+      FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateItem: (fields: string[]) =>
+    ({
+      oracle: `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
+        SET ${fields.join(", ")}
+      WHERE ITEM_ID = :itemId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  countItemsByStatus: {
+    oracle: `SELECT STATUS, COUNT(*) AS CNT
+       FROM RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY STATUS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/game.sql.ts
+++ b/src/db/sql/game.sql.ts
@@ -1,0 +1,583 @@
+import type { SqlEntry } from "./types.js";
+
+const GAME_COLS = `GAME_ID, TITLE, DESCRIPTION, IMAGE_DATA, THUMBNAIL_BAD,
+              THUMBNAIL_APPROVED, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL,
+              FEATURED_VIDEO_URL, INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT`;
+
+const PLATFORM_COLS = `PLATFORM_ID,
+              PLATFORM_CODE,
+              PLATFORM_NAME,
+              PLATFORM_ABBREVIATION,
+              IGDB_PLATFORM_ID`;
+
+const REGION_COLS = `REGION_ID, REGION_CODE, REGION_NAME, IGDB_REGION_ID`;
+
+export const GameSql = {
+  createGame: {
+    oracle: `INSERT INTO GAMEDB_GAMES (
+           TITLE,
+           DESCRIPTION,
+           IMAGE_DATA,
+           IGDB_ID,
+           SLUG,
+           TOTAL_RATING,
+           IGDB_URL,
+           FEATURED_VIDEO_URL
+         ) VALUES (
+           :title,
+           :description,
+           :imageData,
+           :igdbId,
+           :slug,
+           :totalRating,
+           :igdbUrl,
+           :featuredVideoUrl
+         )
+         RETURNING GAME_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGameById: {
+    oracle: `SELECT GAME_ID, TITLE, DESCRIPTION, IMAGE_DATA, THUMBNAIL_BAD,
+                THUMBNAIL_APPROVED, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL, FEATURED_VIDEO_URL,
+                INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
+           FROM GAMEDB_GAMES
+          WHERE GAME_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGamesByIds: (placeholders: string) =>
+    ({
+      oracle: `SELECT ${GAME_COLS}
+           FROM GAMEDB_GAMES
+          WHERE GAME_ID IN (${placeholders})`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getAlternateVersions: {
+    oracle: `SELECT ${GAME_COLS}
+           FROM GAMEDB_GAMES
+          WHERE GAME_ID IN (
+            SELECT CASE
+                     WHEN GAME_ID = :id THEN ALT_GAME_ID
+                     ELSE GAME_ID
+                   END
+              FROM GAMEDB_GAME_ALTERNATES
+             WHERE GAME_ID = :id OR ALT_GAME_ID = :id
+          )
+          ORDER BY UPPER(TITLE)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  linkAlternateVersions: {
+    oracle: `MERGE INTO GAMEDB_GAME_ALTERNATES t
+         USING (
+           SELECT :gameId AS GAME_ID,
+                  :altGameId AS ALT_GAME_ID,
+                  :createdBy AS CREATED_BY
+             FROM dual
+         ) s
+            ON (t.GAME_ID = s.GAME_ID AND t.ALT_GAME_ID = s.ALT_GAME_ID)
+         WHEN NOT MATCHED THEN
+           INSERT (GAME_ID, ALT_GAME_ID, CREATED_BY)
+           VALUES (s.GAME_ID, s.ALT_GAME_ID, s.CREATED_BY)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGameByIgdbId: {
+    oracle: `SELECT ${GAME_COLS}
+           FROM GAMEDB_GAMES
+          WHERE IGDB_ID = :igdbId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getOrInsertMetadataSelect: (
+    idCol: string,
+    table: string,
+    igdbIdCol: string,
+  ) =>
+    ({
+      oracle: `SELECT ${idCol} FROM ${table} WHERE ${igdbIdCol} = :igdbId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getOrInsertMetadataInsert: (
+    table: string,
+    nameCol: string,
+    idCol: string,
+    igdbIdCol: string,
+  ) =>
+    ({
+      oracle: `INSERT INTO ${table} (${nameCol}, ${igdbIdCol})
+         VALUES (:name, :igdbId)
+         RETURNING ${idCol} INTO :id`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  insertGameCompany: {
+    oracle: `INSERT INTO GAMEDB_GAME_COMPANIES (GAME_ID, COMPANY_ID, ROLE)
+             VALUES (:gameId, :companyId, :role)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertGameGenre: {
+    oracle: `INSERT INTO GAMEDB_GAME_GENRES (GAME_ID, GENRE_ID) VALUES (:gameId, :genreId)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertGameTheme: {
+    oracle: `INSERT INTO GAMEDB_GAME_THEMES (GAME_ID, THEME_ID) VALUES (:gameId, :themeId)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertGameMode: {
+    oracle: `INSERT INTO GAMEDB_GAME_MODES (GAME_ID, MODE_ID) VALUES (:gameId, :modeId)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertGamePerspective: {
+    oracle: `INSERT INTO GAMEDB_GAME_PERSPECTIVES (GAME_ID, PERSPECTIVE_ID)
+             VALUES (:gameId, :persId)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertGameEngine: {
+    oracle: `INSERT INTO GAMEDB_GAME_ENGINES (GAME_ID, ENGINE_ID) VALUES (:gameId, :engineId)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertGameFranchise: {
+    oracle: `INSERT INTO GAMEDB_GAME_FRANCHISES (GAME_ID, FRANCHISE_ID)
+             VALUES (:gameId, :franchiseId)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateCollectionId: {
+    oracle: `UPDATE GAMEDB_GAMES SET COLLECTION_ID = :collectionId WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateParentIgdbId: {
+    oracle: `UPDATE GAMEDB_GAMES
+               SET PARENT_IGDB_ID = :parentId,
+                   PARENT_GAME_NAME = :parentName
+             WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateInitialReleaseDateSelect: {
+    oracle: `SELECT MIN(RELEASE_DATE) AS MIN_DATE
+         FROM GAMEDB_RELEASES
+        WHERE GAME_ID = :gameId
+          AND RELEASE_DATE IS NOT NULL`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateInitialReleaseDateUpdate: {
+    oracle: `UPDATE GAMEDB_GAMES
+          SET INITIAL_RELEASE_DATE = :releaseDate
+        WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertPlatform: {
+    oracle: `INSERT INTO GAMEDB_PLATFORMS (PLATFORM_CODE, PLATFORM_NAME, IGDB_PLATFORM_ID)
+         VALUES (:code, :name, :igdbId)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertRegion: {
+    oracle: `INSERT INTO GAMEDB_REGIONS (REGION_CODE, REGION_NAME, IGDB_REGION_ID)
+         VALUES (:code, :name, :igdbId)
+         RETURNING REGION_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGameCompanies: {
+    oracle: `SELECT c.NAME FROM GAMEDB_COMPANIES c
+       JOIN GAMEDB_GAME_COMPANIES gc ON c.COMPANY_ID = gc.COMPANY_ID
+       WHERE gc.GAME_ID = :gameId AND gc.ROLE = :role`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getSimpleList: (defTable: string, mapTable: string, idCol: string) =>
+    ({
+      oracle: `SELECT t.NAME FROM ${defTable} t
+       JOIN ${mapTable} m ON t.${idCol} = m.${idCol}
+       WHERE m.GAME_ID = :gameId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getGameSeries: {
+    oracle: `SELECT c.NAME FROM GAMEDB_COLLECTIONS c
+       JOIN GAMEDB_GAMES g ON c.COLLECTION_ID = g.COLLECTION_ID
+       WHERE g.GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertRelease: {
+    oracle: `INSERT INTO GAMEDB_RELEASES
+       (GAME_ID, PLATFORM_ID, REGION_ID, FORMAT, RELEASE_DATE, NOTES)
+       VALUES (:gameId, :platformId, :regionId, :format, :releaseDate, :notes)
+       RETURNING RELEASE_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getReleaseById: {
+    oracle: `SELECT RELEASE_ID, GAME_ID, PLATFORM_ID, REGION_ID, FORMAT, RELEASE_DATE, NOTES
+         FROM GAMEDB_RELEASES
+        WHERE RELEASE_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGameReleases: {
+    oracle: `SELECT RELEASE_ID, GAME_ID, PLATFORM_ID, REGION_ID, FORMAT, RELEASE_DATE, NOTES
+         FROM GAMEDB_RELEASES
+        WHERE GAME_ID = :gameId
+        ORDER BY RELEASE_DATE ASC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getPlatformsForGame: {
+    oracle: `SELECT DISTINCT p.PLATFORM_ID,
+              p.PLATFORM_CODE,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              p.IGDB_PLATFORM_ID
+         FROM GAMEDB_RELEASES r
+         JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = r.PLATFORM_ID
+        WHERE r.GAME_ID = :gameId
+        ORDER BY p.PLATFORM_NAME ASC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAllPlatforms: {
+    oracle: `SELECT ${PLATFORM_COLS}
+         FROM GAMEDB_PLATFORMS
+        ORDER BY PLATFORM_NAME ASC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getPlatformsByIgdbIds: (placeholders: string) =>
+    ({
+      oracle: `SELECT ${PLATFORM_COLS}
+         FROM GAMEDB_PLATFORMS
+        WHERE IGDB_PLATFORM_ID IN (${placeholders})`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  attachPlatformsToGames: (placeholders: string) =>
+    ({
+      oracle: `SELECT gp.GAME_ID,
+              gp.PLATFORM_ID,
+              p.PLATFORM_CODE,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              p.IGDB_PLATFORM_ID
+         FROM GAMEDB_GAME_PLATFORMS gp
+         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = gp.PLATFORM_ID
+        WHERE gp.GAME_ID IN (${placeholders})`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getPlatformByIgdbId: {
+    oracle: `SELECT ${PLATFORM_COLS}
+         FROM GAMEDB_PLATFORMS
+        WHERE IGDB_PLATFORM_ID = :igdbId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAllRegions: {
+    oracle: `SELECT ${REGION_COLS}
+         FROM GAMEDB_REGIONS
+        ORDER BY REGION_NAME ASC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getRegionByCode: {
+    oracle: `SELECT ${REGION_COLS}
+         FROM GAMEDB_REGIONS
+        WHERE REGION_CODE = :code`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getRegionById: {
+    oracle: `SELECT ${REGION_COLS}
+         FROM GAMEDB_REGIONS
+        WHERE REGION_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getRegionByIgdbId: {
+    oracle: `SELECT ${REGION_COLS}
+         FROM GAMEDB_REGIONS
+        WHERE IGDB_REGION_ID = :igdbId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  searchGamesAutocomplete: (
+    titleFoldExpr: string,
+    titleNormExpr: string,
+  ) =>
+    ({
+      oracle: `SELECT GAME_ID, TITLE, INITIAL_RELEASE_DATE
+           FROM GAMEDB_GAMES
+          WHERE ${titleFoldExpr} LIKE :rawContains
+             OR (
+               :exactNorm IS NOT NULL AND
+               ${titleNormExpr} LIKE :normContains
+             )
+          ORDER BY CASE
+                     WHEN ${titleFoldExpr} = :exactRaw THEN 0
+                     WHEN ${titleFoldExpr} LIKE :rawPrefix THEN 1
+                     WHEN :exactNorm IS NOT NULL AND
+                          ${titleNormExpr} = :exactNorm THEN 2
+                     WHEN :exactNorm IS NOT NULL AND
+                          ${titleNormExpr} LIKE :normPrefix THEN 3
+                     ELSE 4
+                   END,
+                   TITLE ASC
+          FETCH FIRST :limit ROWS ONLY`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getAllCompanies: {
+    oracle: `SELECT COMPANY_ID, NAME, IGDB_COMPANY_ID
+       FROM GAMEDB_COMPANIES
+       ORDER BY NAME ASC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getCompanyById: {
+    oracle: `SELECT COMPANY_ID, NAME, IGDB_COMPANY_ID
+       FROM GAMEDB_COMPANIES
+       WHERE COMPANY_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  searchGames: (whereClause: string, orderPrefix: string) =>
+    ({
+      oracle: `WITH upcoming AS (
+           SELECT GAME_ID, MIN(RELEASE_DATE) AS UPCOMING_DATE
+             FROM GAMEDB_RELEASES
+            WHERE RELEASE_DATE > SYSDATE
+            GROUP BY GAME_ID
+         )
+         SELECT g.GAME_ID, g.TITLE, g.DESCRIPTION, g.IGDB_ID, g.SLUG, g.TOTAL_RATING,
+                g.IGDB_URL, g.FEATURED_VIDEO_URL, g.INITIAL_RELEASE_DATE,
+                g.CREATED_AT, g.UPDATED_AT,
+                u.UPCOMING_DATE AS UPCOMING_RELEASE_DATE,
+                (SELECT LISTAGG(COALESCE(p.PLATFORM_ABBREVIATION, p.PLATFORM_NAME), ',')
+                        WITHIN GROUP (ORDER BY p.PLATFORM_NAME)
+                   FROM GAMEDB_RELEASES r
+                   JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = r.PLATFORM_ID
+                  WHERE r.GAME_ID = g.GAME_ID AND r.RELEASE_DATE = u.UPCOMING_DATE
+                ) AS UPCOMING_PLATFORMS
+           FROM GAMEDB_GAMES g
+           LEFT JOIN upcoming u ON u.GAME_ID = g.GAME_ID
+          WHERE ${whereClause}
+          ORDER BY ${orderPrefix}g.TITLE ASC`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  addGamePlatformMerge: {
+    oracle: `MERGE INTO GAMEDB_GAME_PLATFORMS gp
+           USING (SELECT :gameId AS GAME_ID, :platformId AS PLATFORM_ID FROM dual) src
+           ON (gp.GAME_ID = src.GAME_ID AND gp.PLATFORM_ID = src.PLATFORM_ID)
+           WHEN NOT MATCHED THEN
+             INSERT (GAME_ID, PLATFORM_ID) VALUES (src.GAME_ID, src.PLATFORM_ID)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGamesForAudit: (combinedClause: string) =>
+    ({
+      oracle: `SELECT g.GAME_ID, g.TITLE, g.DESCRIPTION, g.IMAGE_DATA, g.IGDB_ID, g.SLUG,
+                g.TOTAL_RATING, g.IGDB_URL, g.FEATURED_VIDEO_URL,
+                g.INITIAL_RELEASE_DATE, g.CREATED_AT, g.UPDATED_AT
+           FROM GAMEDB_GAMES g
+          WHERE ${combinedClause}
+          ORDER BY g.TITLE ASC`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  updateGameImage: {
+    oracle: `UPDATE GAMEDB_GAMES
+         SET IMAGE_DATA = :imageData,
+             UPDATED_AT = SYSTIMESTAMP
+       WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateGameThumbnailBad: {
+    oracle: `UPDATE GAMEDB_GAMES
+          SET THUMBNAIL_BAD = :thumbnailBad,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateGameThumbnailApproved: {
+    oracle: `UPDATE GAMEDB_GAMES
+          SET THUMBNAIL_APPROVED = :thumbnailApproved,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getThreadStatusForGameIds: (placeholders: string) =>
+    ({
+      oracle: `SELECT DISTINCT g.GAME_ID
+         FROM GAMEDB_GAMES g
+        WHERE g.GAME_ID IN (${placeholders})
+          AND (
+            EXISTS (SELECT 1 FROM THREAD_GAME_LINKS tgl WHERE tgl.GAMEDB_GAME_ID = g.GAME_ID)
+            OR EXISTS (SELECT 1 FROM THREADS th WHERE th.GAMEDB_GAME_ID = g.GAME_ID)
+          )`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  updateFeaturedVideoUrl: {
+    oracle: `UPDATE GAMEDB_GAMES
+          SET FEATURED_VIDEO_URL = :featuredVideoUrl,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateGameDescription: {
+    oracle: `UPDATE GAMEDB_GAMES
+          SET DESCRIPTION = :description,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  clearReleaseAnnouncements: {
+    oracle: `DELETE FROM GAMEDB_RELEASE_ANNOUNCEMENTS
+          WHERE RELEASE_ID IN (
+            SELECT RELEASE_ID FROM GAMEDB_RELEASES WHERE GAME_ID = :gameId
+          )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  clearReleases: {
+    oracle: `DELETE FROM GAMEDB_RELEASES WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  clearInitialReleaseDate: {
+    oracle: `UPDATE GAMEDB_GAMES
+            SET INITIAL_RELEASE_DATE = NULL, UPDATED_AT = SYSTIMESTAMP
+          WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  touchGameUpdatedAt: {
+    oracle: `UPDATE GAMEDB_GAMES SET UPDATED_AT = SYSTIMESTAMP WHERE GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGotmWins: {
+    oracle: `SELECT ge.ROUND_NUMBER,
+                COALESCE(
+                  (SELECT MIN(tgl.THREAD_ID)
+                     FROM THREAD_GAME_LINKS tgl
+                    WHERE tgl.GAMEDB_GAME_ID = ge.GAMEDB_GAME_ID),
+                  (SELECT MIN(th.THREAD_ID)
+                     FROM THREADS th
+                    WHERE th.GAMEDB_GAME_ID = ge.GAMEDB_GAME_ID)
+                ) AS THREAD_ID,
+                ge.REDDIT_URL, ge.MONTH_YEAR
+           FROM GOTM_ENTRIES ge
+          WHERE ge.GAMEDB_GAME_ID = :gameId
+          ORDER BY ge.ROUND_NUMBER`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNrGotmWins: {
+    oracle: `SELECT nge.ROUND_NUMBER,
+                COALESCE(
+                  (SELECT MIN(tgl.THREAD_ID)
+                     FROM THREAD_GAME_LINKS tgl
+                    WHERE tgl.GAMEDB_GAME_ID = nge.GAMEDB_GAME_ID),
+                  (SELECT MIN(th.THREAD_ID)
+                     FROM THREADS th
+                    WHERE th.GAMEDB_GAME_ID = nge.GAMEDB_GAME_ID)
+                ) AS THREAD_ID,
+                nge.REDDIT_URL, nge.MONTH_YEAR
+           FROM NR_GOTM_ENTRIES nge
+          WHERE nge.GAMEDB_GAME_ID = :gameId
+          ORDER BY nge.ROUND_NUMBER`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGotmNominations: {
+    oracle: `SELECT n.ROUND_NUMBER, n.USER_ID, u.USERNAME, u.GLOBAL_NAME
+           FROM GOTM_NOMINATIONS n
+           LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = n.USER_ID
+          WHERE n.GAMEDB_GAME_ID = :gameId
+          ORDER BY n.ROUND_NUMBER`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNrGotmNominations: {
+    oracle: `SELECT n.ROUND_NUMBER, n.USER_ID, u.USERNAME, u.GLOBAL_NAME
+           FROM NR_GOTM_NOMINATIONS n
+           LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = n.USER_ID
+          WHERE n.GAMEDB_GAME_ID = :gameId
+          ORDER BY n.ROUND_NUMBER`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNowPlayingMembers: {
+    oracle: `SELECT u.USER_ID,
+              ru.USERNAME,
+              ru.GLOBAL_NAME,
+              COALESCE(
+                (SELECT MIN(tgl.THREAD_ID) FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID),
+                (SELECT MIN(th.THREAD_ID) FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID)
+              ) AS THREAD_ID,
+              u.ADDED_AT
+         FROM USER_NOW_PLAYING u
+         JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
+        WHERE u.GAMEDB_GAME_ID = :gameId
+        ORDER BY u.ADDED_AT DESC, u.ENTRY_ID DESC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGameCompletions: {
+    oracle: `SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME,
+              c.COMPLETION_TYPE, c.COMPLETED_AT, c.FINAL_PLAYTIME_HRS
+         FROM USER_GAME_COMPLETIONS c
+         LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
+        WHERE c.GAMEDB_GAME_ID = :gameId
+        ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.CREATED_AT DESC, c.COMPLETION_ID DESC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGameCollectionOwners: {
+    oracle: `SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME
+         FROM USER_GAME_COLLECTIONS c
+         LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
+        WHERE c.GAMEDB_GAME_ID = :gameId
+        GROUP BY c.USER_ID, u.USERNAME, u.GLOBAL_NAME
+        ORDER BY LOWER(COALESCE(u.GLOBAL_NAME, u.USERNAME, c.USER_ID))`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getPlatformByCode: {
+    oracle: `SELECT ${PLATFORM_COLS}
+         FROM GAMEDB_PLATFORMS
+        WHERE PLATFORM_CODE = :code`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getPlatformById: {
+    oracle: `SELECT ${PLATFORM_COLS}
+         FROM GAMEDB_PLATFORMS
+        WHERE PLATFORM_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/gameDbCsvImport.sql.ts
+++ b/src/db/sql/gameDbCsvImport.sql.ts
@@ -1,0 +1,125 @@
+import type { SqlEntry } from "./types.js";
+
+const ITEM_COLS = `ITEM_ID,
+            IMPORT_ID,
+            ROW_INDEX,
+            GAME_TITLE,
+            RAW_GAME_TITLE,
+            PLATFORM_NAME,
+            REGION_NAME,
+            INITIAL_RELEASE_DATE,
+            STATUS,
+            GAMEDB_GAME_ID,
+            ERROR_TEXT`;
+
+export const GameDbCsvImportSql = {
+  createImport: {
+    oracle: `INSERT INTO RPG_CLUB_GAMEDB_IMPORTS (
+         USER_ID, STATUS, CURRENT_INDEX, TOTAL_COUNT, SOURCE_FILENAME
+       ) VALUES (
+         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
+       ) RETURNING IMPORT_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertItem: {
+    oracle: `INSERT INTO RPG_CLUB_GAMEDB_IMPORT_ITEMS (
+           IMPORT_ID,
+           ROW_INDEX,
+           GAME_TITLE,
+           RAW_GAME_TITLE,
+           PLATFORM_NAME,
+           REGION_NAME,
+           INITIAL_RELEASE_DATE,
+           STATUS
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :gameTitle,
+           :rawGameTitle,
+           :platformName,
+           :regionName,
+           :initialReleaseDate,
+           'PENDING'
+         )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getImportById: {
+    oracle: `SELECT IMPORT_ID,
+            USER_ID,
+            STATUS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            SOURCE_FILENAME,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_GAMEDB_IMPORTS
+      WHERE IMPORT_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getActiveForUser: {
+    oracle: `SELECT IMPORT_ID,
+            USER_ID,
+            STATUS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            SOURCE_FILENAME,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_GAMEDB_IMPORTS
+      WHERE USER_ID = :userId
+        AND STATUS IN ('ACTIVE', 'PAUSED')
+      ORDER BY CREATED_AT DESC, IMPORT_ID DESC
+      FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  setStatus: {
+    oracle: `UPDATE RPG_CLUB_GAMEDB_IMPORTS
+        SET STATUS = :status
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateIndex: {
+    oracle: `UPDATE RPG_CLUB_GAMEDB_IMPORTS
+        SET CURRENT_INDEX = :currentIndex
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNextPendingItem: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_GAMEDB_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+        AND STATUS = 'PENDING'
+      ORDER BY ROW_INDEX ASC
+      FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getItemById: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_GAMEDB_IMPORT_ITEMS
+      WHERE ITEM_ID = :itemId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateItem: (fields: string[]) =>
+    ({
+      oracle: `UPDATE RPG_CLUB_GAMEDB_IMPORT_ITEMS
+        SET ${fields.join(", ")}
+      WHERE ITEM_ID = :itemId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  countItems: {
+    oracle: `SELECT STATUS, COUNT(*) AS CNT
+       FROM RPG_CLUB_GAMEDB_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY STATUS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/gameKey.sql.ts
+++ b/src/db/sql/gameKey.sql.ts
@@ -1,0 +1,65 @@
+import type { SqlEntry } from "./types.js";
+
+const GAME_KEY_COLS = `KEY_ID,
+        GAME_TITLE,
+        PLATFORM,
+        KEY_VALUE,
+        DONOR_USER_ID,
+        CLAIMED_BY_USER_ID,
+        CLAIMED_AT,
+        CREATED_AT,
+        UPDATED_AT`;
+
+export const GameKeySql = {
+  create: {
+    oracle: `INSERT INTO RPG_CLUB_GAME_KEYS (GAME_TITLE, PLATFORM, KEY_VALUE, DONOR_USER_ID)
+     VALUES (:title, :platform, :keyValue, :donorUserId)
+     RETURNING KEY_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getById: {
+    oracle: `SELECT ${GAME_KEY_COLS}
+       FROM RPG_CLUB_GAME_KEYS
+      WHERE KEY_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countAvailable: {
+    oracle: `SELECT COUNT(*) AS TOTAL
+       FROM RPG_CLUB_GAME_KEYS
+      WHERE CLAIMED_BY_USER_ID IS NULL`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  listAvailable: {
+    oracle: `SELECT ${GAME_KEY_COLS}
+       FROM RPG_CLUB_GAME_KEYS
+      WHERE CLAIMED_BY_USER_ID IS NULL
+      ORDER BY UPPER(GAME_TITLE), KEY_ID
+      OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  listByDonor: {
+    oracle: `SELECT ${GAME_KEY_COLS}
+       FROM RPG_CLUB_GAME_KEYS
+      WHERE DONOR_USER_ID = :userId
+      ORDER BY CREATED_AT DESC, KEY_ID DESC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  claim: {
+    oracle: `UPDATE RPG_CLUB_GAME_KEYS
+        SET CLAIMED_BY_USER_ID = :userId,
+            CLAIMED_AT = SYSTIMESTAMP
+      WHERE KEY_ID = :keyId
+        AND CLAIMED_BY_USER_ID IS NULL`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  revoke: {
+    oracle: `DELETE FROM RPG_CLUB_GAME_KEYS WHERE KEY_ID = :keyId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/gameReleaseAnnouncement.sql.ts
+++ b/src/db/sql/gameReleaseAnnouncement.sql.ts
@@ -1,0 +1,165 @@
+import type { SqlEntry } from "./types.js";
+
+export const GameReleaseAnnouncementSql = {
+  syncReleaseAnnouncements: {
+    oracle: `MERGE INTO GAMEDB_RELEASE_ANNOUNCEMENTS a
+         USING (
+           SELECT r.RELEASE_ID, r.RELEASE_DATE - 7 AS ANNOUNCE_AT
+           FROM GAMEDB_RELEASES r
+           WHERE r.RELEASE_DATE IS NOT NULL
+         ) src
+         ON (a.RELEASE_ID = src.RELEASE_ID)
+         WHEN MATCHED THEN
+           UPDATE SET
+             a.ANNOUNCE_AT = src.ANNOUNCE_AT,
+             a.UPDATED_AT = CURRENT_TIMESTAMP
+           WHERE a.SENT_AT IS NULL
+             AND a.SKIPPED_AT IS NULL
+             AND a.ANNOUNCE_AT <> src.ANNOUNCE_AT
+         WHEN NOT MATCHED THEN
+           INSERT (
+             RELEASE_ID, ANNOUNCE_AT, SENT_AT, SKIPPED_AT,
+             SKIP_REASON, CREATED_AT, UPDATED_AT
+           )
+           VALUES (
+             src.RELEASE_ID, src.ANNOUNCE_AT, NULL, NULL, NULL,
+             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+           )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  restoreNonCanonical: {
+    oracle: `UPDATE GAMEDB_RELEASE_ANNOUNCEMENTS a
+            SET a.SKIPPED_AT = NULL,
+                a.SKIP_REASON = NULL,
+                a.UPDATED_AT = CURRENT_TIMESTAMP
+          WHERE a.SENT_AT IS NULL
+            AND a.SKIP_REASON IN (:portOnlyReason, :sameDayReason)
+            AND NOT EXISTS (
+              SELECT 1
+              FROM (
+                SELECT ranked.RELEASE_ID
+                FROM (
+                  SELECT r.RELEASE_ID,
+                         r.RELEASE_DATE,
+                         MIN(r.RELEASE_DATE) OVER (PARTITION BY r.GAME_ID) AS FIRST_RELEASE_DATE,
+                         ROW_NUMBER() OVER (
+                           PARTITION BY r.GAME_ID, r.RELEASE_DATE
+                           ORDER BY r.RELEASE_ID ASC
+                         ) AS SAME_DAY_RANK
+                  FROM GAMEDB_RELEASES r
+                  WHERE r.RELEASE_DATE IS NOT NULL
+                ) ranked
+                WHERE ranked.RELEASE_DATE > ranked.FIRST_RELEASE_DATE
+                   OR (
+                     ranked.RELEASE_DATE = ranked.FIRST_RELEASE_DATE
+                     AND ranked.SAME_DAY_RANK > 1
+                   )
+              ) non_canonical
+              WHERE non_canonical.RELEASE_ID = a.RELEASE_ID
+            )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  markNonCanonical: {
+    oracle: `MERGE INTO GAMEDB_RELEASE_ANNOUNCEMENTS a
+       USING (
+         SELECT ranked.RELEASE_ID,
+                CASE
+                  WHEN ranked.RELEASE_DATE > ranked.FIRST_RELEASE_DATE THEN :portOnlyReason
+                  ELSE :sameDayReason
+                END AS SKIP_REASON
+         FROM (
+           SELECT r.RELEASE_ID,
+                  r.RELEASE_DATE,
+                  MIN(r.RELEASE_DATE) OVER (PARTITION BY r.GAME_ID) AS FIRST_RELEASE_DATE,
+                  ROW_NUMBER() OVER (
+                    PARTITION BY r.GAME_ID, r.RELEASE_DATE
+                    ORDER BY r.RELEASE_ID ASC
+                  ) AS SAME_DAY_RANK
+           FROM GAMEDB_RELEASES r
+           WHERE r.RELEASE_DATE IS NOT NULL
+         ) ranked
+         WHERE ranked.RELEASE_DATE > ranked.FIRST_RELEASE_DATE
+            OR (
+              ranked.RELEASE_DATE = ranked.FIRST_RELEASE_DATE
+              AND ranked.SAME_DAY_RANK > 1
+            )
+       ) src
+       ON (a.RELEASE_ID = src.RELEASE_ID)
+       WHEN MATCHED THEN
+         UPDATE SET
+           a.SKIPPED_AT = CURRENT_TIMESTAMP,
+           a.SKIP_REASON = src.SKIP_REASON,
+           a.UPDATED_AT = CURRENT_TIMESTAMP
+         WHERE a.SENT_AT IS NULL
+           AND a.SKIPPED_AT IS NULL`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  listDueAnnouncements: {
+    oracle: `SELECT a.RELEASE_ID,
+              r.GAME_ID,
+              g.TITLE,
+              r.RELEASE_DATE,
+              a.ANNOUNCE_AT,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              g.IGDB_URL
+         FROM GAMEDB_RELEASE_ANNOUNCEMENTS a
+         JOIN GAMEDB_RELEASES r ON r.RELEASE_ID = a.RELEASE_ID
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = r.GAME_ID
+         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = r.PLATFORM_ID
+         JOIN (
+           SELECT canonical.RELEASE_ID
+           FROM (
+             SELECT r.RELEASE_ID,
+                    r.RELEASE_DATE,
+                    MIN(r.RELEASE_DATE) OVER (PARTITION BY r.GAME_ID) AS FIRST_RELEASE_DATE,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY r.GAME_ID, r.RELEASE_DATE
+                      ORDER BY r.RELEASE_ID ASC
+                    ) AS SAME_DAY_RANK
+             FROM GAMEDB_RELEASES r
+             WHERE r.RELEASE_DATE IS NOT NULL
+           ) canonical
+           WHERE canonical.RELEASE_DATE = canonical.FIRST_RELEASE_DATE
+             AND canonical.SAME_DAY_RANK = 1
+         ) c ON c.RELEASE_ID = a.RELEASE_ID
+        WHERE a.SENT_AT IS NULL
+          AND a.SKIPPED_AT IS NULL
+          AND a.ANNOUNCE_AT <= :referenceTime
+          AND r.RELEASE_DATE > :referenceTime
+        ORDER BY a.ANNOUNCE_AT ASC, r.RELEASE_DATE ASC, r.GAME_ID ASC, a.RELEASE_ID ASC
+        FETCH FIRST :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  markSent: {
+    oracle: `UPDATE GAMEDB_RELEASE_ANNOUNCEMENTS
+          SET SENT_AT = :sentAt,
+              SKIP_REASON = NULL,
+              UPDATED_AT = CURRENT_TIMESTAMP
+        WHERE RELEASE_ID = :releaseId
+          AND SENT_AT IS NULL
+          AND SKIPPED_AT IS NULL`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  markMissed: {
+    oracle: `UPDATE GAMEDB_RELEASE_ANNOUNCEMENTS a
+          SET a.SKIPPED_AT = :referenceTime,
+              a.SKIP_REASON = :reason,
+              a.UPDATED_AT = CURRENT_TIMESTAMP
+        WHERE a.SENT_AT IS NULL
+          AND a.SKIPPED_AT IS NULL
+          AND a.ANNOUNCE_AT <= :referenceTime
+          AND EXISTS (
+            SELECT 1
+            FROM GAMEDB_RELEASES r
+            WHERE r.RELEASE_ID = a.RELEASE_ID
+              AND r.RELEASE_DATE <= :referenceTime
+          )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/gameSearchSynonym.sql.ts
+++ b/src/db/sql/gameSearchSynonym.sql.ts
@@ -1,0 +1,163 @@
+import type { SqlEntry } from "./types.js";
+
+const SYNONYM_COLS = `TERM_ID, GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_AT, CREATED_BY`;
+
+export const GameSearchSynonymSql = {
+  getGroupIdsForTerm: {
+    oracle: `SELECT GROUP_ID
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE TERM_NORM = :termNorm`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  listGroupTerms: {
+    oracle: `SELECT ${SYNONYM_COLS}
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE GROUP_ID = :groupId
+        ORDER BY TERM_TEXT ASC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getTermsForQuery: (placeholders: string) =>
+    ({
+      oracle: `SELECT DISTINCT TERM_TEXT
+           FROM GAMEDB_SEARCH_SYNONYMS
+          WHERE GROUP_ID IN (${placeholders})
+          ORDER BY TERM_TEXT ASC`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  listSynonyms: {
+    oracle: `SELECT ${SYNONYM_COLS}
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE (:searchQuery IS NULL
+           OR LOWER(TERM_TEXT) LIKE :searchQuery
+           OR TERM_NORM LIKE :normalizedQuery)
+        ORDER BY GROUP_ID ASC, TERM_TEXT ASC
+        FETCH FIRST :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countSynonymGroups: {
+    oracle: `SELECT COUNT(DISTINCT GROUP_ID) AS CNT
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE (:searchQuery IS NULL
+           OR LOWER(TERM_TEXT) LIKE :searchQuery
+           OR TERM_NORM LIKE :normalizedQuery)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  listGroupIdsForSearch: {
+    oracle: `SELECT DISTINCT GROUP_ID
+           FROM GAMEDB_SEARCH_SYNONYMS
+          WHERE (:searchQuery IS NULL
+             OR LOWER(TERM_TEXT) LIKE :searchQuery
+             OR TERM_NORM LIKE :normalizedQuery)
+          ORDER BY GROUP_ID ASC
+          OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  listTermsInGroups: (placeholders: string) =>
+    ({
+      oracle: `SELECT ${SYNONYM_COLS}
+           FROM GAMEDB_SEARCH_SYNONYMS
+          WHERE GROUP_ID IN (${placeholders})
+          ORDER BY GROUP_ID ASC, TERM_TEXT ASC`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  insertSynonymGroup: {
+    oracle: `INSERT INTO GAMEDB_SEARCH_SYNONYM_GROUPS (CREATED_BY)
+           VALUES (:createdBy)
+           RETURNING GROUP_ID INTO :groupId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertSynonymTerm: {
+    oracle: `INSERT INTO GAMEDB_SEARCH_SYNONYMS
+               (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
+             VALUES (:groupId, :termText, :termNorm, :createdBy)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateSynonymTerm: {
+    oracle: `UPDATE GAMEDB_SEARCH_SYNONYMS
+            SET TERM_TEXT = :termText,
+                TERM_NORM = :termNorm
+          WHERE TERM_ID = :termId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  checkGroupExists: {
+    oracle: `SELECT COUNT(*) AS CNT
+           FROM GAMEDB_SEARCH_SYNONYM_GROUPS
+          WHERE GROUP_ID = :groupId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteSynonymsByGroup: {
+    oracle: `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE GROUP_ID = :groupId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getSynonymById: {
+    oracle: `SELECT ${SYNONYM_COLS}
+         FROM GAMEDB_SEARCH_SYNONYMS
+        WHERE TERM_ID = :termId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteGroup: {
+    oracle: `DELETE FROM GAMEDB_SEARCH_SYNONYM_GROUPS WHERE GROUP_ID = :groupId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getSynonymGroupId: {
+    oracle: `SELECT GROUP_ID
+           FROM GAMEDB_SEARCH_SYNONYMS
+          WHERE TERM_ID = :termId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countSynonymsInGroup: {
+    oracle: `SELECT COUNT(*) AS CNT
+             FROM GAMEDB_SEARCH_SYNONYMS
+            WHERE GROUP_ID = :groupId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteSynonymById: {
+    oracle: `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE TERM_ID = :termId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};
+
+export const GameSearchSynonymDraftSql = {
+  createDraft: {
+    oracle: `INSERT INTO GAMEDB_SEARCH_SYNONYM_DRAFTS (USER_ID, PAIRS_JSON)
+       VALUES (:userId, :pairsJson)
+       RETURNING DRAFT_ID INTO :draftId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getDraft: {
+    oracle: `SELECT DRAFT_ID, USER_ID, PAIRS_JSON, CREATED_AT, UPDATED_AT
+         FROM GAMEDB_SEARCH_SYNONYM_DRAFTS
+        WHERE DRAFT_ID = :draftId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateDraft: {
+    oracle: `UPDATE GAMEDB_SEARCH_SYNONYM_DRAFTS
+            SET PAIRS_JSON = :pairsJson,
+                UPDATED_AT = CURRENT_TIMESTAMP
+          WHERE DRAFT_ID = :draftId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteDraft: {
+    oracle: `DELETE FROM GAMEDB_SEARCH_SYNONYM_DRAFTS WHERE DRAFT_ID = :draftId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/gotm.sql.ts
+++ b/src/db/sql/gotm.sql.ts
@@ -1,0 +1,152 @@
+import type { SqlEntry } from "./types.js";
+
+export const GotmSql = {
+  loadAll: {
+    oracle: `SELECT ROUND_NUMBER,
+            MONTH_YEAR,
+            GAME_INDEX,
+            REDDIT_URL,
+            VOTING_RESULTS_MESSAGE_ID,
+            GAMEDB_GAME_ID
+       FROM GOTM_ENTRIES
+      ORDER BY ROUND_NUMBER, GAME_INDEX`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getRowsByRound: {
+    oracle: `SELECT ROUND_NUMBER,
+              GAME_INDEX
+         FROM GOTM_ENTRIES
+        WHERE ROUND_NUMBER = :round
+        ORDER BY GAME_INDEX`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateField: (columnName: string) =>
+    ({
+      oracle: `UPDATE GOTM_ENTRIES
+          SET ${columnName} = :value
+        WHERE ROUND_NUMBER = :round
+          AND GAME_INDEX = :gameIndex`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  updateVotingResults: {
+    oracle: `UPDATE GOTM_ENTRIES
+        SET VOTING_RESULTS_MESSAGE_ID = :value
+      WHERE ROUND_NUMBER = :round`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  checkRoundExists: {
+    oracle: `SELECT COUNT(*) AS CNT
+       FROM GOTM_ENTRIES
+      WHERE ROUND_NUMBER = :round`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertRound: {
+    oracle: `INSERT INTO GOTM_ENTRIES (
+           ROUND_NUMBER,
+           MONTH_YEAR,
+           GAME_INDEX,
+           REDDIT_URL,
+           VOTING_RESULTS_MESSAGE_ID,
+           GAMEDB_GAME_ID
+         ) VALUES (
+           :round,
+           :monthYear,
+           :gameIndex,
+           :redditUrl,
+           NULL,
+           :gamedbGameId
+         )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteRound: {
+    oracle: `DELETE FROM GOTM_ENTRIES
+      WHERE ROUND_NUMBER = :round`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};
+
+export const NrGotmSql = {
+  loadAll: {
+    oracle: `SELECT ROUND_NUMBER,
+            MONTH_YEAR,
+            GAME_INDEX,
+            REDDIT_URL,
+            VOTING_RESULTS_MESSAGE_ID,
+            GAMEDB_GAME_ID
+       FROM NR_GOTM_ENTRIES
+      ORDER BY ROUND_NUMBER, GAME_INDEX`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getRowsByRound: {
+    oracle: `SELECT NR_GOTM_ID,
+              ROUND_NUMBER,
+              GAME_INDEX
+         FROM NR_GOTM_ENTRIES
+        WHERE ROUND_NUMBER = :roundNumber
+        ORDER BY GAME_INDEX`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateByRowId: (columnName: string) =>
+    ({
+      oracle: `UPDATE NR_GOTM_ENTRIES
+            SET ${columnName} = :bindValue
+          WHERE NR_GOTM_ID = :rowIdValue`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  updateByRound: (columnName: string) =>
+    ({
+      oracle: `UPDATE NR_GOTM_ENTRIES
+          SET ${columnName} = :bindValue
+        WHERE NR_GOTM_ID = :rowIdValue`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  updateVotingResults: {
+    oracle: `UPDATE NR_GOTM_ENTRIES
+        SET VOTING_RESULTS_MESSAGE_ID = :bindValue
+      WHERE ROUND_NUMBER = :roundNumber`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  checkRoundExists: {
+    oracle: `SELECT COUNT(*) AS CNT
+       FROM NR_GOTM_ENTRIES
+      WHERE ROUND_NUMBER = :roundNumber`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertRound: {
+    oracle: `INSERT INTO NR_GOTM_ENTRIES (
+           ROUND_NUMBER,
+           MONTH_YEAR,
+           GAME_INDEX,
+           REDDIT_URL,
+           VOTING_RESULTS_MESSAGE_ID,
+           GAMEDB_GAME_ID
+         ) VALUES (
+           :roundNumber,
+           :monthYear,
+           :gameIndex,
+           :redditUrl,
+           NULL,
+           :gamedbGameId
+         )
+         RETURNING NR_GOTM_ID INTO :outId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteRound: {
+    oracle: `DELETE FROM NR_GOTM_ENTRIES
+      WHERE ROUND_NUMBER = :roundNumber`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/gotmAuditImport.sql.ts
+++ b/src/db/sql/gotmAuditImport.sql.ts
@@ -1,0 +1,142 @@
+import type { SqlEntry } from "./types.js";
+
+const ITEM_COLS = `ITEM_ID,
+            IMPORT_ID,
+            ROW_INDEX,
+            KIND,
+            ROUND_NUMBER,
+            MONTH_YEAR,
+            GAME_INDEX,
+            GAME_TITLE,
+            THREAD_ID,
+            REDDIT_URL,
+            STATUS,
+            GAMEDB_GAME_ID,
+            ERROR_TEXT`;
+
+export const GotmAuditImportSql = {
+  createSession: {
+    oracle: `INSERT INTO RPG_CLUB_GOTM_AUDIT_IMPORTS (
+         USER_ID, STATUS, CURRENT_INDEX, TOTAL_COUNT, SOURCE_FILENAME
+       ) VALUES (
+         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
+       ) RETURNING IMPORT_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertItems: {
+    oracle: `INSERT INTO RPG_CLUB_GOTM_AUDIT_ITEMS (
+           IMPORT_ID,
+           ROW_INDEX,
+           KIND,
+           ROUND_NUMBER,
+           MONTH_YEAR,
+           GAME_INDEX,
+           GAME_TITLE,
+           THREAD_ID,
+           REDDIT_URL,
+           STATUS,
+           GAMEDB_GAME_ID
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :kind,
+           :roundNumber,
+           :monthYear,
+           :gameIndex,
+           :gameTitle,
+           :threadId,
+           :redditUrl,
+           'PENDING',
+           :gameDbGameId
+         )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getById: {
+    oracle: `SELECT IMPORT_ID,
+            USER_ID,
+            STATUS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            SOURCE_FILENAME,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_GOTM_AUDIT_IMPORTS
+      WHERE IMPORT_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getActiveForUser: {
+    oracle: `SELECT IMPORT_ID,
+            USER_ID,
+            STATUS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            SOURCE_FILENAME,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_GOTM_AUDIT_IMPORTS
+      WHERE USER_ID = :userId
+        AND STATUS IN ('ACTIVE', 'PAUSED')
+      ORDER BY IMPORT_ID DESC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  setStatus: {
+    oracle: `UPDATE RPG_CLUB_GOTM_AUDIT_IMPORTS
+        SET STATUS = :status
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateIndex: {
+    oracle: `UPDATE RPG_CLUB_GOTM_AUDIT_IMPORTS
+        SET CURRENT_INDEX = :currentIndex
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNextPendingItem: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_GOTM_AUDIT_ITEMS
+      WHERE IMPORT_ID = :importId
+        AND STATUS = 'PENDING'
+      ORDER BY ROW_INDEX
+      FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getItemById: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_GOTM_AUDIT_ITEMS
+      WHERE ITEM_ID = :itemId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateItem: (fields: string[]) =>
+    ({
+      oracle: `UPDATE RPG_CLUB_GOTM_AUDIT_ITEMS
+        SET ${fields.join(", ")}
+      WHERE ITEM_ID = :itemId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getItemsForRound: {
+    oracle: `SELECT ${ITEM_COLS}
+       FROM RPG_CLUB_GOTM_AUDIT_ITEMS
+      WHERE IMPORT_ID = :importId
+        AND KIND = :kind
+        AND ROUND_NUMBER = :roundNumber
+      ORDER BY GAME_INDEX`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countItems: {
+    oracle: `SELECT STATUS, COUNT(*) AS CNT
+       FROM RPG_CLUB_GOTM_AUDIT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY STATUS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/hltbCache.sql.ts
+++ b/src/db/sql/hltbCache.sql.ts
@@ -1,0 +1,73 @@
+import type { SqlEntry } from "./types.js";
+
+export const HltbCacheSql = {
+  getByGameId: {
+    oracle: `SELECT GAMEDB_GAME_ID,
+            HLTB_NAME,
+            HLTB_URL,
+            HLTB_IMAGE_URL,
+            MAIN,
+            MAIN_SIDES,
+            COMPLETIONIST,
+            SINGLE_PLAYER,
+            CO_OP,
+            VS,
+            SOURCE_QUERY,
+            SCRAPED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_HLTB_CACHE
+      WHERE GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  upsertCache: {
+    oracle: `MERGE INTO RPG_CLUB_HLTB_CACHE t
+     USING (SELECT :gameId AS GAME_ID FROM dual) s
+        ON (t.GAMEDB_GAME_ID = s.GAME_ID)
+     WHEN MATCHED THEN
+       UPDATE SET
+         HLTB_NAME = :name,
+         HLTB_URL = :url,
+         HLTB_IMAGE_URL = :imageUrl,
+         MAIN = :main,
+         MAIN_SIDES = :mainSides,
+         COMPLETIONIST = :completionist,
+         SINGLE_PLAYER = :singlePlayer,
+         CO_OP = :coOp,
+         VS = :vs,
+         SOURCE_QUERY = :sourceQuery,
+         SCRAPED_AT = SYSTIMESTAMP,
+         UPDATED_AT = SYSTIMESTAMP
+     WHEN NOT MATCHED THEN
+       INSERT (
+         GAMEDB_GAME_ID,
+         HLTB_NAME,
+         HLTB_URL,
+         HLTB_IMAGE_URL,
+         MAIN,
+         MAIN_SIDES,
+         COMPLETIONIST,
+         SINGLE_PLAYER,
+         CO_OP,
+         VS,
+         SOURCE_QUERY,
+         SCRAPED_AT,
+         UPDATED_AT
+       ) VALUES (
+         :gameId,
+         :name,
+         :url,
+         :imageUrl,
+         :main,
+         :mainSides,
+         :completionist,
+         :singlePlayer,
+         :coOp,
+         :vs,
+         :sourceQuery,
+         SYSTIMESTAMP,
+         SYSTIMESTAMP
+       )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/index.ts
+++ b/src/db/sql/index.ts
@@ -1,0 +1,52 @@
+import type { Dialect, SqlEntry } from "./types.js";
+
+export type { Dialect, SqlEntry };
+
+export { AdminWizardSessionSql } from "./adminWizardSession.sql.js";
+export { BotVotingInfoSql } from "./botVotingInfo.sql.js";
+export { CollectionCsvImportSql } from "./collectionCsvImport.sql.js";
+export { CompletionatorImportSql } from "./completionatorImport.sql.js";
+export { GameSql } from "./game.sql.js";
+export { GameDbCsvImportSql } from "./gameDbCsvImport.sql.js";
+export { GameKeySql } from "./gameKey.sql.js";
+export { GameReleaseAnnouncementSql } from "./gameReleaseAnnouncement.sql.js";
+export {
+  GameSearchSynonymSql,
+  GameSearchSynonymDraftSql,
+} from "./gameSearchSynonym.sql.js";
+export { GotmSql, NrGotmSql } from "./gotm.sql.js";
+export { GotmAuditImportSql } from "./gotmAuditImport.sql.js";
+export { HltbCacheSql } from "./hltbCache.sql.js";
+export { MemberSql } from "./member.sql.js";
+export { NominationSql } from "./nomination.sql.js";
+export {
+  PresencePromptHistorySql,
+  PresencePromptOptOutSql,
+} from "./presencePrompt.sql.js";
+export { ReminderSql, PublicReminderSql } from "./reminder.sql.js";
+export { RssFeedSql } from "./rssFeed.sql.js";
+export { StarboardSql } from "./starboard.sql.js";
+export { SteamCollectionImportSql } from "./steamCollectionImport.sql.js";
+export { SuggestionSql, SuggestionReviewSessionSql } from "./suggestion.sql.js";
+export { ThreadSql } from "./thread.sql.js";
+export { TodoSql } from "./todo.sql.js";
+export {
+  UserActivityIconSql,
+  UserChannelMessageCountSql,
+} from "./userActivity.sql.js";
+export { UserGameCollectionSql } from "./userGameCollection.sql.js";
+export { XboxCollectionImportSql } from "./xboxCollectionImport.sql.js";
+
+/**
+ * Selects the SQL string for the active dialect from a static SqlEntry.
+ */
+export function getSql(entry: SqlEntry, dialect: Dialect): string {
+  return entry[dialect];
+}
+
+/**
+ * Selects the SQL string for the active dialect from a factory-produced SqlEntry.
+ */
+export function getSqlDynamic(entry: SqlEntry, dialect: Dialect): string {
+  return entry[dialect];
+}

--- a/src/db/sql/member.sql.ts
+++ b/src/db/sql/member.sql.ts
@@ -1,0 +1,768 @@
+import type { SqlEntry } from "./types.js";
+
+const COMPLETION_SELECT_SQL = `SELECT c.COMPLETION_ID,
+             g.GAME_ID,
+             g.TITLE,
+             c.COMPLETION_TYPE,
+             c.PLATFORM_ID,
+             c.COMPLETED_AT,
+             c.FINAL_PLAYTIME_HRS,
+             c.CREATED_AT,
+             c.NOTE,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.THREAD_ID)
+                  FROM THREAD_GAME_LINKS tgl
+                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                ),
+                (
+                  SELECT MIN(th.THREAD_ID)
+                  FROM THREADS th
+                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
+                )
+              ) AS THREAD_ID
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID`;
+
+export const MemberSql = {
+  touchLastSeen: {
+    oracle: `UPDATE RPG_CLUB_USERS
+            SET LAST_SEEN_AT = :lastSeen,
+                UPDATED_AT = SYSTIMESTAMP
+          WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNowPlaying: (threadIdSql: string) =>
+    ({
+      oracle: `SELECT g.GAME_ID,
+                g.TITLE,
+                u.PLATFORM_ID,
+                p.PLATFORM_NAME,
+                p.PLATFORM_ABBREVIATION,
+                ${threadIdSql} AS THREAD_ID,
+                u.NOTE,
+                u.ADDED_AT,
+                u.NOTE_UPDATED_AT,
+                u.SORT_ORDER,
+                NVL(jp.IS_ENABLED, 1) AS JOURNAL_ENABLED,
+                CASE
+                  WHEN EXISTS (
+                    SELECT 1
+                    FROM USER_GAME_JOURNAL_ENTRIES je
+                    WHERE je.USER_ID = u.USER_ID
+                      AND je.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
+                  ) THEN 1
+                  ELSE 0
+                END AS HAS_JOURNAL_ENTRY,
+                (SELECT COUNT(*)
+                   FROM USER_GAME_JOURNAL_ENTRIES je2
+                  WHERE je2.USER_ID = u.USER_ID
+                    AND je2.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID) AS JOURNAL_COUNT,
+                (SELECT MAX(je3.CREATED_AT)
+                   FROM USER_GAME_JOURNAL_ENTRIES je3
+                  WHERE je3.USER_ID = u.USER_ID
+                    AND je3.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID) AS LAST_JOURNAL_AT
+           FROM USER_NOW_PLAYING u
+           JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
+           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
+           LEFT JOIN USER_GAME_JOURNAL_PREFS jp
+             ON jp.USER_ID = u.USER_ID
+            AND jp.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
+          WHERE u.USER_ID = :userId
+            AND u.GAMEDB_GAME_ID IS NOT NULL
+          ORDER BY u.SORT_ORDER NULLS LAST, u.ADDED_AT DESC, u.ENTRY_ID DESC`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getAllNowPlaying: (threadIdSql: string) =>
+    ({
+      oracle: `SELECT u.USER_ID,
+                ru.USERNAME,
+                ru.GLOBAL_NAME,
+                g.GAME_ID,
+                g.TITLE,
+                u.PLATFORM_ID,
+                p.PLATFORM_NAME,
+                p.PLATFORM_ABBREVIATION,
+                ${threadIdSql} AS THREAD_ID,
+                u.NOTE,
+                u.ADDED_AT,
+                u.NOTE_UPDATED_AT,
+                u.ENTRY_ID
+           FROM USER_NOW_PLAYING u
+           JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
+           JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
+           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
+          WHERE NVL(ru.IS_BOT, 0) = 0
+            AND ru.SERVER_LEFT_AT IS NULL
+          ORDER BY COALESCE(ru.GLOBAL_NAME, ru.USERNAME, ru.USER_ID),
+                   u.ADDED_AT DESC,
+                   u.ENTRY_ID DESC`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getNowPlayingByGameIds: (placeholders: string) =>
+    ({
+      oracle: `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
+              g.TITLE,
+              u.USER_ID
+         FROM USER_NOW_PLAYING u
+         JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
+        WHERE u.GAMEDB_GAME_ID IN (${placeholders})
+          AND NVL(ru.IS_BOT, 0) = 0
+          AND ru.SERVER_LEFT_AT IS NULL
+        ORDER BY g.TITLE, u.USER_ID`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getNowPlayingByTitleSearch: {
+    oracle: `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
+              g.TITLE,
+              u.USER_ID
+         FROM USER_NOW_PLAYING u
+         JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
+        WHERE (LOWER(g.TITLE) LIKE :searchQuery
+            OR REGEXP_REPLACE(LOWER(g.TITLE), '[^a-z0-9]', '') LIKE :normalizedQuery)
+          AND NVL(ru.IS_BOT, 0) = 0
+          AND ru.SERVER_LEFT_AT IS NULL
+        ORDER BY g.TITLE, u.USER_ID`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNowPlayingEntries: {
+    oracle: `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
+              g.TITLE,
+              u.PLATFORM_ID,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              u.NOTE,
+              u.ADDED_AT,
+              u.NOTE_UPDATED_AT,
+              u.SORT_ORDER,
+              jp.IS_ENABLED AS JOURNAL_ENABLED
+         FROM USER_NOW_PLAYING u
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
+         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
+         LEFT JOIN USER_GAME_JOURNAL_PREFS jp
+           ON jp.USER_ID = u.USER_ID
+          AND jp.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
+        WHERE u.USER_ID = :userId
+          AND u.GAMEDB_GAME_ID IS NOT NULL
+        ORDER BY u.SORT_ORDER NULLS LAST, u.ADDED_AT DESC, u.ENTRY_ID DESC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNowPlayingEntryMeta: {
+    oracle: `SELECT ADDED_AT
+         FROM USER_NOW_PLAYING
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateNowPlayingNote: {
+    oracle: `UPDATE USER_NOW_PLAYING
+          SET NOTE = :note,
+              NOTE_UPDATED_AT = :noteUpdatedAt
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countNowPlaying: {
+    oracle: `SELECT COUNT(*) AS CNT FROM USER_NOW_PLAYING WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNowPlayingMaxSort: {
+    oracle: `SELECT MAX(SORT_ORDER) AS MAX_SORT
+             FROM USER_NOW_PLAYING
+            WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertNowPlaying: {
+    oracle: `INSERT INTO USER_NOW_PLAYING
+            (USER_ID, GAMEDB_GAME_ID, PLATFORM_ID, NOTE, NOTE_UPDATED_AT, SORT_ORDER)
+           VALUES (:userId, :gameId, :platformId, :note, :noteUpdatedAt, :sortOrder)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  mergeJournalPrefs: {
+    oracle: `MERGE INTO USER_GAME_JOURNAL_PREFS p
+           USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
+              ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
+           WHEN MATCHED THEN
+             UPDATE SET IS_ENABLED = 1, UPDATED_AT = SYSTIMESTAMP
+           WHEN NOT MATCHED THEN
+             INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
+             VALUES (:userId, :gameId, 1, 0)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGameJournalPreference: {
+    oracle: `SELECT USER_ID,
+              GAMEDB_GAME_ID,
+              IS_ENABLED
+         FROM USER_GAME_JOURNAL_PREFS
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  upsertGameJournalPreference: {
+    oracle: `MERGE INTO USER_GAME_JOURNAL_PREFS p
+       USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
+          ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
+        WHEN MATCHED THEN
+          UPDATE SET IS_ENABLED = :isEnabled,
+                     DEFAULT_IS_PUBLIC = 1,
+                     UPDATED_AT = SYSTIMESTAMP
+        WHEN NOT MATCHED THEN
+          INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
+          VALUES (:userId, :gameId, :isEnabled, 1)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getJournalStatusForGames: (inlineTable: string) =>
+    ({
+      oracle: `SELECT gids.GAME_ID,
+              COUNT(*) AS JOURNAL_COUNT,
+              MAX(je.CREATED_AT) AS LAST_JOURNAL_AT
+         FROM (${inlineTable}) gids
+         LEFT JOIN USER_GAME_JOURNAL_ENTRIES je
+           ON je.USER_ID = :userId
+          AND je.GAMEDB_GAME_ID = gids.GAME_ID
+        GROUP BY gids.GAME_ID`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getGameJournalEntries: {
+    oracle: `WITH all_entries AS (
+         SELECT ENTRY_ID,
+                USER_ID,
+                GAMEDB_GAME_ID,
+                ENTRY_TITLE,
+                ENTRY_BODY,
+                CREATED_AT,
+                UPDATED_AT,
+                ROW_NUMBER() OVER (ORDER BY CREATED_AT ASC, ENTRY_ID ASC) AS ENTRY_NUMBER
+           FROM USER_GAME_JOURNAL_ENTRIES
+          WHERE USER_ID = :userId
+            AND GAMEDB_GAME_ID = :gameId
+       )
+       SELECT ENTRY_ID,
+              USER_ID,
+              GAMEDB_GAME_ID,
+              ENTRY_TITLE,
+              ENTRY_BODY,
+              CREATED_AT,
+              UPDATED_AT,
+              ENTRY_NUMBER
+         FROM all_entries
+        ORDER BY CREATED_AT DESC, ENTRY_ID DESC
+        OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countGameJournalEntries: {
+    oracle: `SELECT COUNT(*) AS CNT
+         FROM USER_GAME_JOURNAL_ENTRIES
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  addGameJournalEntry: {
+    oracle: `INSERT INTO USER_GAME_JOURNAL_ENTRIES
+        (USER_ID, GAMEDB_GAME_ID, ENTRY_TITLE, ENTRY_BODY, IS_PUBLIC)
+       VALUES
+        (:userId, :gameId, :title, :body, 1)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGameJournalEntryForUser: {
+    oracle: `SELECT e.ENTRY_ID,
+              e.USER_ID,
+              e.GAMEDB_GAME_ID,
+              e.ENTRY_TITLE,
+              e.ENTRY_BODY,
+              e.CREATED_AT,
+              e.UPDATED_AT,
+              (SELECT COUNT(*) + 1
+                 FROM USER_GAME_JOURNAL_ENTRIES e2
+                WHERE e2.USER_ID = e.USER_ID
+                  AND e2.GAMEDB_GAME_ID = e.GAMEDB_GAME_ID
+                  AND (e2.CREATED_AT < e.CREATED_AT
+                       OR (e2.CREATED_AT = e.CREATED_AT AND e2.ENTRY_ID < e.ENTRY_ID))
+              ) AS ENTRY_NUMBER
+         FROM USER_GAME_JOURNAL_ENTRIES e
+        WHERE e.USER_ID = :userId
+          AND e.ENTRY_ID = :entryId
+        FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateGameJournalEntry: (fields: string[]) =>
+    ({
+      oracle: `UPDATE USER_GAME_JOURNAL_ENTRIES
+          SET ${fields.join(", ")}
+        WHERE USER_ID = :userId
+          AND ENTRY_ID = :entryId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  deleteGameJournalEntry: {
+    oracle: `DELETE FROM USER_GAME_JOURNAL_ENTRIES
+        WHERE USER_ID = :userId
+          AND ENTRY_ID = :entryId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateNowPlayingSort: {
+    oracle: `UPDATE USER_NOW_PLAYING
+            SET SORT_ORDER = :sortOrder
+          WHERE USER_ID = :userId
+            AND GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  removeNowPlaying: {
+    oracle: `DELETE FROM USER_NOW_PLAYING WHERE USER_ID = :userId AND GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  addCompletion: {
+    oracle: `INSERT INTO USER_GAME_COMPLETIONS (
+          USER_ID, GAMEDB_GAME_ID, COMPLETION_TYPE, PLATFORM_ID,
+          COMPLETED_AT, FINAL_PLAYTIME_HRS, NOTE
+        ) VALUES (
+          :userId, :gameId, :type, :platformId, :completedAt, :playtime, :note
+        )
+        RETURNING COMPLETION_ID INTO :completionId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  verifyCompletion: {
+    oracle: `SELECT COUNT(*) AS CNT FROM USER_GAME_COMPLETIONS
+          WHERE COMPLETION_ID = :id AND USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getCompletion: {
+    oracle: `${COMPLETION_SELECT_SQL}
+       WHERE c.COMPLETION_ID = :completionId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getCompletionForUser: {
+    oracle: `${COMPLETION_SELECT_SQL}
+       WHERE c.USER_ID = :userId
+         AND c.COMPLETION_ID = :completionId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getCompletionByGameId: {
+    oracle: `${COMPLETION_SELECT_SQL}
+       WHERE c.USER_ID = :userId
+         AND c.GAMEDB_GAME_ID = :gameId
+       FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getCompletions: (whereClause: string) =>
+    ({
+      oracle: `${COMPLETION_SELECT_SQL}
+       WHERE ${whereClause}
+       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC
+       OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getAllCompletions: {
+    oracle: `${COMPLETION_SELECT_SQL}
+       WHERE c.USER_ID = :userId
+       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.CREATED_AT DESC, c.COMPLETION_ID DESC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countCompletions: (whereClause: string) =>
+    ({
+      oracle: `SELECT COUNT(*) AS CNT
+        FROM USER_GAME_COMPLETIONS c
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE ${whereClause}`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  updateCompletion: (fields: string[]) =>
+    ({
+      oracle: `UPDATE USER_GAME_COMPLETIONS
+         SET ${fields.join(", ")}
+       WHERE COMPLETION_ID = :completionId
+         AND USER_ID = :userId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  deleteCompletion: {
+    oracle: `DELETE FROM USER_GAME_COMPLETIONS
+       WHERE COMPLETION_ID = :completionId
+         AND USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getCompletionsForGame: {
+    oracle: `${COMPLETION_SELECT_SQL}
+       WHERE c.USER_ID = :userId
+         AND c.GAMEDB_GAME_ID = :gameId
+       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getRecentCompletionForGame: {
+    oracle: `${COMPLETION_SELECT_SQL}
+       WHERE c.USER_ID = :userId
+         AND c.GAMEDB_GAME_ID = :gameId
+         AND COALESCE(c.COMPLETED_AT, c.CREATED_AT) BETWEEN :startDate AND :endDate
+       ORDER BY COALESCE(c.COMPLETED_AT, c.CREATED_AT) DESC
+       FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getRecentNickHistory: {
+    oracle: `SELECT OLD_NICK, NEW_NICK, CHANGED_AT
+           FROM RPG_CLUB_USER_NICK_HISTORY
+          WHERE USER_ID = :userId
+          ORDER BY CHANGED_AT DESC
+          FETCH FIRST :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getCompletionLeaderboard: (whereClause: string) =>
+    ({
+      oracle: `SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME, COUNT(*) AS CNT
+        FROM USER_GAME_COMPLETIONS c
+        JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
+        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+       WHERE ${whereClause}
+       GROUP BY c.USER_ID, u.USERNAME, u.GLOBAL_NAME
+       ORDER BY CNT DESC
+       FETCH FIRST :limit ROWS ONLY`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  searchMembers: (where: string) =>
+    ({
+      oracle: `SELECT USER_ID,
+              USERNAME,
+              GLOBAL_NAME,
+              IS_BOT,
+              COMPLETIONATOR_URL,
+              STEAM_URL,
+              PSN_USERNAME,
+              XBL_USERNAME,
+              NSW_FRIEND_CODE,
+              ROLE_ADMIN,
+              ROLE_MODERATOR,
+              ROLE_REGULAR,
+              ROLE_MEMBER,
+              ROLE_NEWCOMER,
+              SERVER_LEFT_AT,
+              SERVER_JOINED_AT,
+              LAST_SEEN_AT
+         FROM RPG_CLUB_USERS
+        WHERE ${where}
+        ORDER BY COALESCE(UPPER(GLOBAL_NAME), UPPER(USERNAME), USER_ID)
+        FETCH FIRST :limit ROWS ONLY`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getByUserId: {
+    oracle: `SELECT USER_ID,
+                IS_BOT,
+                USERNAME,
+                GLOBAL_NAME,
+               AVATAR_BLOB,
+               SERVER_JOINED_AT,
+                SERVER_LEFT_AT,
+                LAST_SEEN_AT,
+                ROLE_ADMIN,
+                ROLE_MODERATOR,
+                ROLE_REGULAR,
+                ROLE_MEMBER,
+                ROLE_NEWCOMER,
+                MESSAGE_COUNT,
+                COMPLETIONATOR_URL,
+                PSN_USERNAME,
+                XBL_USERNAME,
+                NSW_FRIEND_CODE,
+                STEAM_URL,
+                PROFILE_IMAGE,
+                PROFILE_IMAGE_AT
+           FROM RPG_CLUB_USERS
+          WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateNowPlayingPlatform: {
+    oracle: `UPDATE USER_NOW_PLAYING
+          SET PLATFORM_ID = :platformId
+        WHERE USER_ID = :userId
+          AND GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAvatarHistory: {
+    oracle: `SELECT EVENT_ID,
+                USER_ID,
+                AVATAR_HASH,
+                AVATAR_URL,
+                AVATAR_BLOB,
+                CHANGED_AT
+           FROM RPG_CLUB_USER_AVATAR_HISTORY
+          WHERE USER_ID = :userId
+          ORDER BY CHANGED_AT DESC, EVENT_ID DESC
+          OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateMember: {
+    oracle: `UPDATE RPG_CLUB_USERS
+            SET IS_BOT = :isBot,
+                USERNAME = :username,
+                GLOBAL_NAME = :globalName,
+                AVATAR_BLOB = :avatarBlob,
+                SERVER_JOINED_AT = :joinedAt,
+                SERVER_LEFT_AT = :leftAt,
+                LAST_SEEN_AT = :lastSeenAt,
+                LAST_FETCHED_AT = SYSTIMESTAMP,
+                ROLE_ADMIN = :roleAdmin,
+                ROLE_MODERATOR = :roleModerator,
+                ROLE_REGULAR = :roleRegular,
+                ROLE_MEMBER = :roleMember,
+                ROLE_NEWCOMER = :roleNewcomer,
+                COMPLETIONATOR_URL = :completionatorUrl,
+                PSN_USERNAME = :psnUsername,
+                XBL_USERNAME = :xblUsername,
+                NSW_FRIEND_CODE = :nswFriendCode,
+                STEAM_URL = :steamUrl,
+                UPDATED_AT = SYSTIMESTAMP
+          WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertMember: {
+    oracle: `INSERT INTO RPG_CLUB_USERS (
+             USER_ID, IS_BOT, USERNAME, GLOBAL_NAME, AVATAR_BLOB,
+             SERVER_JOINED_AT, SERVER_LEFT_AT, LAST_SEEN_AT, LAST_FETCHED_AT,
+             ROLE_ADMIN, ROLE_MODERATOR, ROLE_REGULAR, ROLE_MEMBER, ROLE_NEWCOMER,
+             COMPLETIONATOR_URL, PSN_USERNAME, XBL_USERNAME, NSW_FRIEND_CODE,
+             STEAM_URL,
+             CREATED_AT, UPDATED_AT
+           ) VALUES (
+             :userId, :isBot, :username, :globalName, :avatarBlob,
+             :joinedAt, :leftAt, :lastSeenAt, SYSTIMESTAMP,
+             :roleAdmin, :roleModerator, :roleRegular, :roleMember, :roleNewcomer,
+             :completionatorUrl, :psnUsername, :xblUsername,
+             :nswFriendCode, :steamUrl,
+             SYSTIMESTAMP, SYSTIMESTAMP
+           )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  markDepartedNotIn: (placeholders: string) =>
+    ({
+      oracle: `UPDATE RPG_CLUB_USERS
+             SET SERVER_LEFT_AT = SYSTIMESTAMP,
+                 UPDATED_AT = SYSTIMESTAMP
+           WHERE SERVER_LEFT_AT IS NULL
+             AND USER_ID NOT IN (${placeholders})`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getGameJournalList: {
+    oracle: `SELECT g.GAME_ID,
+              g.TITLE,
+              COUNT(e.ENTRY_ID) AS TOTAL_ENTRIES
+         FROM USER_GAME_JOURNAL_PREFS jp
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = jp.GAMEDB_GAME_ID
+         LEFT JOIN USER_GAME_JOURNAL_ENTRIES e
+           ON e.USER_ID = jp.USER_ID
+          AND e.GAMEDB_GAME_ID = jp.GAMEDB_GAME_ID
+        WHERE jp.USER_ID = :userId
+          AND jp.IS_ENABLED = 1
+        GROUP BY g.GAME_ID, g.TITLE
+       HAVING COUNT(e.ENTRY_ID) > 0
+        ORDER BY g.TITLE`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAllJournalUsers: {
+    oracle: `SELECT u.USER_ID,
+              u.USERNAME,
+              u.GLOBAL_NAME,
+              COUNT(DISTINCT je.GAMEDB_GAME_ID) AS GAME_COUNT,
+              COUNT(je.ENTRY_ID) AS ENTRY_COUNT
+         FROM USER_GAME_JOURNAL_ENTRIES je
+         JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
+        WHERE NVL(u.IS_BOT, 0) = 0
+          AND u.SERVER_LEFT_AT IS NULL
+        GROUP BY u.USER_ID, u.USERNAME, u.GLOBAL_NAME
+        ORDER BY COUNT(DISTINCT je.GAMEDB_GAME_ID) DESC,
+                 u.GLOBAL_NAME NULLS LAST,
+                 u.USERNAME NULLS LAST`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  searchJournalEntries: {
+    oracle: `SELECT COUNT(*) OVER () AS TOTAL_COUNT,
+              je.ENTRY_ID,
+              je.USER_ID,
+              u.GLOBAL_NAME,
+              u.USERNAME,
+              je.GAMEDB_GAME_ID,
+              g.TITLE         AS GAME_TITLE,
+              je.ENTRY_TITLE,
+              je.ENTRY_BODY,
+              je.CREATED_AT
+         FROM USER_GAME_JOURNAL_ENTRIES je
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = je.GAMEDB_GAME_ID
+         JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
+        WHERE (
+                UPPER(je.ENTRY_TITLE) LIKE '%' || UPPER(:searchTerm) || '%'
+             OR UPPER(je.ENTRY_BODY)  LIKE '%' || UPPER(:searchTerm) || '%'
+              )
+          AND (:userId IS NULL OR je.USER_ID = :userId)
+          AND (:gameId IS NULL OR je.GAMEDB_GAME_ID = :gameId)
+        ORDER BY je.CREATED_AT DESC, je.ENTRY_ID DESC
+        OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateEmojiName: {
+    oracle: `UPDATE RPG_CLUB_USERS
+          SET EMOJI_NAME = :emojiName,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAllWithEmojiName: {
+    oracle: `SELECT USER_ID, EMOJI_NAME
+         FROM RPG_CLUB_USERS
+        WHERE EMOJI_NAME IS NOT NULL`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  upsertJournalMessageContext: {
+    oracle: `MERGE INTO JOURNAL_MESSAGE_CONTEXTS dst
+       USING (SELECT :channelId AS CHANNEL_ID, :messageId AS MESSAGE_ID FROM DUAL) src
+          ON (dst.CHANNEL_ID = src.CHANNEL_ID AND dst.MESSAGE_ID = src.MESSAGE_ID)
+        WHEN MATCHED THEN
+          UPDATE SET CREATED_AT_MS = :createdAtMs,
+                     OWNER_USER_ID = :ownerUserId,
+                     GAME_ID       = :gameId
+        WHEN NOT MATCHED THEN
+          INSERT (CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID)
+          VALUES (:channelId, :messageId, :createdAtMs, :ownerUserId, :gameId)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteJournalMessageContext: {
+    oracle: `DELETE FROM JOURNAL_MESSAGE_CONTEXTS
+        WHERE CHANNEL_ID = :channelId
+          AND MESSAGE_ID = :messageId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  loadActiveJournalMessageContexts: {
+    oracle: `SELECT CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID
+         FROM JOURNAL_MESSAGE_CONTEXTS
+        WHERE CREATED_AT_MS >= :cutoffMs`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  pruneExpiredJournalMessageContexts: {
+    oracle: `DELETE FROM JOURNAL_MESSAGE_CONTEXTS WHERE CREATED_AT_MS < :cutoffMs`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getGiveawayDonorNotifySetting: {
+    oracle: `SELECT DONOR_NOTIFY_ON_CLAIM
+         FROM RPG_CLUB_USERS
+        WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateGiveawayDonorNotifySetting: {
+    oracle: `UPDATE RPG_CLUB_USERS
+            SET DONOR_NOTIFY_ON_CLAIM = :enabled
+          WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertGiveawayDonorNotifySetting: {
+    oracle: `INSERT INTO RPG_CLUB_USERS (USER_ID, DONOR_NOTIFY_ON_CLAIM)
+           VALUES (:userId, :enabled)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countAvatarHistory: {
+    oracle: `SELECT COUNT(*) AS TOTAL
+         FROM RPG_CLUB_USER_AVATAR_HISTORY
+        WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertAvatarHistoryRecord: {
+    oracle: `INSERT INTO RPG_CLUB_USER_AVATAR_HISTORY
+       (USER_ID, AVATAR_HASH, AVATAR_URL, AVATAR_BLOB)
+       VALUES (:userId, :avatarHash, :avatarUrl, :avatarBlob)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAllMembersAvatarHistoryCounts: {
+    oracle: `SELECT h.USER_ID,
+              u.USERNAME,
+              u.GLOBAL_NAME,
+              COUNT(*) AS TOTAL
+         FROM RPG_CLUB_USER_AVATAR_HISTORY h
+         JOIN RPG_CLUB_USERS u ON u.USER_ID = h.USER_ID
+        WHERE NVL(u.IS_BOT, 0) = 0
+          AND u.SERVER_LEFT_AT IS NULL
+        GROUP BY h.USER_ID, u.USERNAME, u.GLOBAL_NAME
+        ORDER BY COALESCE(u.GLOBAL_NAME, u.USERNAME, h.USER_ID)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getMembersWithPlatforms: {
+    oracle: `SELECT USER_ID,
+              USERNAME,
+              GLOBAL_NAME,
+              STEAM_URL,
+              PSN_USERNAME,
+              XBL_USERNAME,
+              NSW_FRIEND_CODE,
+              SERVER_LEFT_AT
+         FROM RPG_CLUB_USERS
+        WHERE (STEAM_URL IS NOT NULL
+               OR PSN_USERNAME IS NOT NULL
+               OR XBL_USERNAME IS NOT NULL
+               OR NSW_FRIEND_CODE IS NOT NULL)
+          AND NVL(IS_BOT, 0) = 0
+          AND SERVER_LEFT_AT IS NULL`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  checkLinkedThreadColumn: {
+    oracle: `SELECT COUNT(*) AS CNT
+           FROM ALL_TAB_COLUMNS
+          WHERE OWNER = SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')
+            AND TABLE_NAME = 'GAMEDB_GAMES'
+            AND COLUMN_NAME = 'LINKED_THREAD_ID'`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/nomination.sql.ts
+++ b/src/db/sql/nomination.sql.ts
@@ -1,0 +1,65 @@
+import type { SqlEntry } from "./types.js";
+
+export const NominationSql = {
+  getNominationForUser: (table: string) =>
+    ({
+      oracle: `SELECT n.NOMINATION_ID,
+            n.ROUND_NUMBER,
+            n.USER_ID,
+            n.GAMEDB_GAME_ID,
+            g.TITLE AS GAMEDB_TITLE,
+            n.NOMINATED_AT,
+            n.REASON
+       FROM ${table} n
+       LEFT JOIN GAMEDB_GAMES g ON g.GAME_ID = n.GAMEDB_GAME_ID
+      WHERE n.ROUND_NUMBER = :roundNumber
+        AND n.USER_ID = :userId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  upsertNomination: (table: string) =>
+    ({
+      oracle: `MERGE INTO ${table} t
+      USING (
+        SELECT :roundNumber AS ROUND_NUMBER,
+               :userId AS USER_ID,
+               :gamedbGameId AS GAMEDB_GAME_ID,
+               CAST(:nominatedAt AS TIMESTAMP) AS NOMINATED_AT,
+               :reason AS REASON
+          FROM dual
+      ) src
+         ON (t.ROUND_NUMBER = src.ROUND_NUMBER AND t.USER_ID = src.USER_ID)
+    WHEN MATCHED THEN
+      UPDATE SET t.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID,
+                 t.NOMINATED_AT = src.NOMINATED_AT,
+                 t.REASON = src.REASON
+    WHEN NOT MATCHED THEN
+      INSERT (ROUND_NUMBER, USER_ID, GAMEDB_GAME_ID, NOMINATED_AT, REASON)
+      VALUES (src.ROUND_NUMBER, src.USER_ID, src.GAMEDB_GAME_ID, src.NOMINATED_AT, src.REASON)`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  deleteNomination: (table: string) =>
+    ({
+      oracle: `DELETE FROM ${table}
+      WHERE ROUND_NUMBER = :roundNumber
+        AND USER_ID = :userId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  listNominationsForRound: (table: string) =>
+    ({
+      oracle: `SELECT n.NOMINATION_ID,
+            n.ROUND_NUMBER,
+            n.USER_ID,
+            n.GAMEDB_GAME_ID,
+            g.TITLE AS GAMEDB_TITLE,
+            n.NOMINATED_AT,
+            n.REASON
+       FROM ${table} n
+       LEFT JOIN GAMEDB_GAMES g ON g.GAME_ID = n.GAMEDB_GAME_ID
+      WHERE n.ROUND_NUMBER = :roundNumber
+      ORDER BY g.TITLE ASC`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+};

--- a/src/db/sql/presencePrompt.sql.ts
+++ b/src/db/sql/presencePrompt.sql.ts
@@ -1,0 +1,72 @@
+import type { SqlEntry } from "./types.js";
+
+export const PresencePromptHistorySql = {
+  createPrompt: {
+    oracle: `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_HISTORY
+        (PROMPT_ID, USER_ID, GAME_TITLE, GAME_TITLE_NORM, STATUS)
+       VALUES (:promptId, :userId, :gameTitle, :gameTitleNorm, 'PENDING')`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  markResolved: {
+    oracle: `UPDATE RPG_CLUB_PRESENCE_PROMPT_HISTORY
+          SET STATUS = :status,
+              RESOLVED_AT = SYSTIMESTAMP
+        WHERE PROMPT_ID = :promptId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getLastPromptDate: {
+    oracle: `SELECT CREATED_AT
+         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
+        WHERE USER_ID = :userId
+          AND GAME_TITLE_NORM = :gameTitleNorm
+        ORDER BY CREATED_AT DESC
+        FETCH NEXT 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countPendingForGame: {
+    oracle: `SELECT COUNT(*) AS CNT
+         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
+        WHERE USER_ID = :userId
+          AND GAME_TITLE_NORM = :gameTitleNorm
+          AND STATUS = 'PENDING'`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countPendingForUser: {
+    oracle: `SELECT COUNT(*) AS CNT
+         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
+        WHERE USER_ID = :userId
+          AND STATUS = 'PENDING'`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};
+
+export const PresencePromptOptOutSql = {
+  isOptedOutAll: {
+    oracle: `SELECT COUNT(*) AS CNT
+         FROM RPG_CLUB_PRESENCE_PROMPT_OPTS
+        WHERE USER_ID = :userId
+          AND SCOPE = 'ALL'
+          AND GAME_TITLE_NORM = :token`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  isOptedOutGame: {
+    oracle: `SELECT COUNT(*) AS CNT
+         FROM RPG_CLUB_PRESENCE_PROMPT_OPTS
+        WHERE USER_ID = :userId
+          AND SCOPE = 'GAME'
+          AND GAME_TITLE_NORM = :gameTitleNorm`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertOptOut: {
+    oracle: `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_OPTS
+          (USER_ID, SCOPE, GAME_TITLE, GAME_TITLE_NORM)
+         VALUES (:userId, :scope, :gameTitle, :gameTitleNorm)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/reminder.sql.ts
+++ b/src/db/sql/reminder.sql.ts
@@ -1,0 +1,153 @@
+import type { SqlEntry } from "./types.js";
+
+const REMINDER_COLS =
+  "REMINDER_ID, USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT," +
+  " FAILURE_COUNT, FAILED_AT, CREATED_AT, UPDATED_AT";
+
+export const ReminderSql = {
+  create: {
+    oracle: `INSERT INTO USER_REMINDERS (
+         USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT, FAILURE_COUNT,
+         FAILED_AT, CREATED_AT, UPDATED_AT
+       ) VALUES (
+         :userId, :remindAt, :content, :noisyVal, NULL, 0, NULL,
+         SYSTIMESTAMP, SYSTIMESTAMP
+       )
+       RETURNING REMINDER_ID INTO :reminderId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  listByUser: {
+    oracle: `SELECT ${REMINDER_COLS}
+         FROM USER_REMINDERS
+        WHERE USER_ID = :userId
+        ORDER BY REMIND_AT`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getById: {
+    oracle: `SELECT ${REMINDER_COLS}
+         FROM USER_REMINDERS
+        WHERE REMINDER_ID = :reminderId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  delete: {
+    oracle: `DELETE FROM USER_REMINDERS
+        WHERE REMINDER_ID = :reminderId
+          AND USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  snooze: {
+    oracle: `UPDATE USER_REMINDERS
+          SET REMIND_AT = :remindAt,
+              SENT_AT = NULL,
+              FAILURE_COUNT = 0,
+              FAILED_AT = NULL,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE REMINDER_ID = :reminderId
+          AND USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  markSent: {
+    oracle: `UPDATE USER_REMINDERS
+          SET SENT_AT = SYSTIMESTAMP,
+              FAILURE_COUNT = 0,
+              FAILED_AT = NULL,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE REMINDER_ID = :reminderId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  recordFailure: {
+    oracle: `UPDATE USER_REMINDERS
+          SET FAILURE_COUNT = FAILURE_COUNT + 1,
+              FAILED_AT = SYSTIMESTAMP,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE REMINDER_ID = :reminderId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  markFailedPermanently: {
+    oracle: `UPDATE USER_REMINDERS
+          SET SENT_AT = SYSTIMESTAMP,
+              UPDATED_AT = SYSTIMESTAMP
+        WHERE REMINDER_ID = :reminderId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getDueUndelivered: {
+    oracle: `SELECT ${REMINDER_COLS}
+         FROM (
+           SELECT ${REMINDER_COLS}
+             FROM USER_REMINDERS
+            WHERE REMIND_AT <= :cutoff
+              AND SENT_AT IS NULL
+              AND FAILURE_COUNT < 5
+            ORDER BY REMIND_AT
+         )
+        WHERE ROWNUM <= :limit`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};
+
+export const PublicReminderSql = {
+  create: {
+    oracle: `INSERT INTO RPG_CLUB_PUBLIC_REMINDERS (
+       CHANNEL_ID,
+       MESSAGE,
+       DUE_AT,
+       RECUR_EVERY,
+       RECUR_UNIT,
+       ENABLED,
+       CREATED_BY
+     ) VALUES (
+       :channelId,
+       :message,
+       :dueAt,
+       :recurEvery,
+       :recurUnit,
+       1,
+       :createdBy
+     )
+     RETURNING REMINDER_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  listUpcoming: {
+    oracle: `SELECT REMINDER_ID,
+            CHANNEL_ID,
+            MESSAGE,
+            DUE_AT,
+            RECUR_EVERY,
+            RECUR_UNIT,
+            ENABLED,
+            CREATED_BY
+       FROM RPG_CLUB_PUBLIC_REMINDERS
+      WHERE ENABLED = 1
+      ORDER BY DUE_AT ASC
+      FETCH FIRST :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  delete: {
+    oracle: `DELETE FROM RPG_CLUB_PUBLIC_REMINDERS WHERE REMINDER_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateDueDate: {
+    oracle: `UPDATE RPG_CLUB_PUBLIC_REMINDERS
+        SET DUE_AT = :nextDue
+      WHERE REMINDER_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  disable: {
+    oracle: `UPDATE RPG_CLUB_PUBLIC_REMINDERS
+        SET ENABLED = 0
+      WHERE REMINDER_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/rssFeed.sql.ts
+++ b/src/db/sql/rssFeed.sql.ts
@@ -1,0 +1,80 @@
+import type { SqlEntry } from "./types.js";
+
+export const RssFeedSql = {
+  listFeeds: {
+    oracle: `SELECT FEED_ID,
+            FEED_NAME,
+            FEED_URL,
+            CHANNEL_ID,
+            INCLUDE_KEYWORDS,
+            EXCLUDE_KEYWORDS
+       FROM RPG_CLUB_RSS_FEEDS
+      ORDER BY FEED_ID`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  addFeed: {
+    oracle: `INSERT INTO RPG_CLUB_RSS_FEEDS (
+       FEED_NAME,
+       FEED_URL,
+       CHANNEL_ID,
+       INCLUDE_KEYWORDS,
+       EXCLUDE_KEYWORDS
+     ) VALUES (
+       :feedName,
+       :feedUrl,
+       :channelId,
+       :includes,
+       :excludes
+     )
+     RETURNING FEED_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  removeFeed: {
+    oracle: `DELETE FROM RPG_CLUB_RSS_FEEDS WHERE FEED_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateFeed: (sets: string[]) =>
+    ({
+      oracle: `UPDATE RPG_CLUB_RSS_FEEDS
+        SET ${sets.join(", ")}
+      WHERE FEED_ID = :feedId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  markItemsSeen: {
+    oracle: `MERGE INTO RPG_CLUB_RSS_FEED_ITEMS t
+    USING (
+      SELECT :feedId AS feed_id,
+             :itemIdHash AS item_id_hash,
+             :itemGuid AS item_guid,
+             :itemLink AS item_link,
+             :publishedAt AS published_at
+        FROM dual
+    ) s
+       ON (t.FEED_ID = s.feed_id AND t.ITEM_ID_HASH = s.item_id_hash)
+     WHEN NOT MATCHED THEN
+       INSERT (FEED_ID, ITEM_ID_HASH, ITEM_GUID, ITEM_LINK, PUBLISHED_AT, FIRST_SEEN_AT)
+       VALUES (s.feed_id, s.item_id_hash, s.item_guid, s.item_link, s.published_at, SYSTIMESTAMP)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  isItemSeen: {
+    oracle: `SELECT 1 AS FOUND
+       FROM RPG_CLUB_RSS_FEED_ITEMS
+      WHERE FEED_ID = :feedId
+        AND ITEM_ID_HASH = :hash`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getSeenItemHashes: (bindPlaceholders: string) =>
+    ({
+      oracle: `SELECT ITEM_ID_HASH
+           FROM RPG_CLUB_RSS_FEED_ITEMS
+          WHERE FEED_ID = :feedId
+            AND ITEM_ID_HASH IN (${bindPlaceholders})`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+};

--- a/src/db/sql/starboard.sql.ts
+++ b/src/db/sql/starboard.sql.ts
@@ -1,0 +1,22 @@
+import type { SqlEntry } from "./types.js";
+
+export const StarboardSql = {
+  getByMessageId: {
+    oracle: `SELECT MESSAGE_ID,
+              CHANNEL_ID,
+              STARBOARD_MESSAGE_ID,
+              AUTHOR_ID,
+              STAR_COUNT,
+              CREATED_AT
+         FROM RPG_CLUB_STARBOARD
+        WHERE MESSAGE_ID = :messageId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insert: {
+    oracle: `INSERT INTO RPG_CLUB_STARBOARD
+        (MESSAGE_ID, CHANNEL_ID, STARBOARD_MESSAGE_ID, AUTHOR_ID, STAR_COUNT)
+       VALUES (:messageId, :channelId, :starboardMessageId, :authorId, :starCount)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/steamCollectionImport.sql.ts
+++ b/src/db/sql/steamCollectionImport.sql.ts
@@ -1,0 +1,215 @@
+import type { SqlEntry } from "./types.js";
+
+const IMPORT_COLS = `IMPORT_ID,
+       USER_ID,
+       STATUS,
+       CURRENT_INDEX,
+       TOTAL_COUNT,
+       STEAM_ID64,
+       STEAM_PROFILE_REF,
+       SOURCE_PROFILE_NAME,
+       CREATED_AT,
+       UPDATED_AT`;
+
+const ITEM_COLS = `ITEM_ID,
+       IMPORT_ID,
+       ROW_INDEX,
+       STEAM_APP_ID,
+       STEAM_APP_NAME,
+       PLAYTIME_FOREVER_MIN,
+       PLAYTIME_WINDOWS_MIN,
+       PLAYTIME_MAC_MIN,
+       PLAYTIME_LINUX_MIN,
+       PLAYTIME_DECK_MIN,
+       LAST_PLAYED_AT,
+       STATUS,
+       MATCH_CONFIDENCE,
+       MATCH_CANDIDATE_JSON,
+       GAMEDB_GAME_ID,
+       COLLECTION_ENTRY_ID,
+       RESULT_REASON,
+       ERROR_TEXT`;
+
+export const SteamCollectionImportSql = {
+  createImport: {
+    oracle: `INSERT INTO RPG_CLUB_STEAM_COLLECTION_IMPORTS (
+         USER_ID,
+         STATUS,
+         CURRENT_INDEX,
+         TOTAL_COUNT,
+         STEAM_ID64,
+         STEAM_PROFILE_REF,
+         SOURCE_PROFILE_NAME
+       ) VALUES (
+         :userId,
+         'ACTIVE',
+         0,
+         :totalCount,
+         :steamId64,
+         :steamProfileRef,
+         :sourceProfileName
+       ) RETURNING IMPORT_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertItem: {
+    oracle: `INSERT INTO RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS (
+           IMPORT_ID,
+           ROW_INDEX,
+           STEAM_APP_ID,
+           STEAM_APP_NAME,
+           PLAYTIME_FOREVER_MIN,
+           PLAYTIME_WINDOWS_MIN,
+           PLAYTIME_MAC_MIN,
+           PLAYTIME_LINUX_MIN,
+           PLAYTIME_DECK_MIN,
+           LAST_PLAYED_AT,
+           STATUS
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :steamAppId,
+           :steamAppName,
+           :playtimeForeverMin,
+           :playtimeWindowsMin,
+           :playtimeMacMin,
+           :playtimeLinuxMin,
+           :playtimeDeckMin,
+           :lastPlayedAt,
+           'PENDING'
+         )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getImportById: {
+    oracle: `SELECT ${IMPORT_COLS}
+  FROM RPG_CLUB_STEAM_COLLECTION_IMPORTS WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getActiveForUser: {
+    oracle: `SELECT ${IMPORT_COLS}
+  FROM RPG_CLUB_STEAM_COLLECTION_IMPORTS
+     WHERE USER_ID = :userId
+       AND STATUS IN ('ACTIVE', 'PAUSED')
+     ORDER BY CREATED_AT DESC, IMPORT_ID DESC
+     FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  setStatus: {
+    oracle: `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
+        SET STATUS = :status
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateIndex: {
+    oracle: `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
+        SET CURRENT_INDEX = :currentIndex
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getItemById: {
+    oracle: `SELECT ${ITEM_COLS}
+  FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS WHERE ITEM_ID = :itemId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNextPendingItem: {
+    oracle: `SELECT ${ITEM_COLS}
+  FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
+     WHERE IMPORT_ID = :importId
+       AND STATUS = 'PENDING'
+     ORDER BY ROW_INDEX ASC
+     FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateItem: (setParts: string[]) =>
+    ({
+      oracle: `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
+        SET ${setParts.join(", ")}
+      WHERE ITEM_ID = :itemId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  countItemsByStatus: {
+    oracle: `SELECT STATUS, COUNT(*) AS CNT
+       FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY STATUS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countItemsByReason: {
+    oracle: `SELECT RESULT_REASON, COUNT(*) AS CNT
+       FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+        AND RESULT_REASON IS NOT NULL
+      GROUP BY RESULT_REASON`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAppMap: {
+    oracle: `SELECT MAP_ID,
+            STEAM_APP_ID,
+            GAMEDB_GAME_ID,
+            STATUS,
+            CREATED_BY,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_STEAM_APP_GAMEDB_MAP
+      WHERE STEAM_APP_ID = :steamAppId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  upsertAppMap: {
+    oracle: `MERGE INTO RPG_CLUB_STEAM_APP_GAMEDB_MAP m
+       USING (
+         SELECT :steamAppId AS steamAppId,
+                :gameDbGameId AS gameDbGameId,
+                :status AS status,
+                :createdBy AS createdBy
+           FROM dual
+       ) src
+          ON (m.STEAM_APP_ID = src.steamAppId)
+       WHEN MATCHED THEN UPDATE SET
+         m.GAMEDB_GAME_ID = src.gameDbGameId,
+         m.STATUS = src.status,
+         m.CREATED_BY = src.createdBy
+       WHEN NOT MATCHED THEN INSERT (
+         STEAM_APP_ID,
+         GAMEDB_GAME_ID,
+         STATUS,
+         CREATED_BY
+       ) VALUES (
+         src.steamAppId,
+         src.gameDbGameId,
+         src.status,
+         src.createdBy
+       )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getHistoricalMappedIds: {
+    oracle: `SELECT t.GAMEDB_GAME_ID
+       FROM (
+         SELECT ii.GAMEDB_GAME_ID,
+                COUNT(*) AS CNT,
+                MAX(ii.ITEM_ID) AS LAST_ITEM_ID
+           FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS ii
+           JOIN RPG_CLUB_STEAM_COLLECTION_IMPORTS i
+             ON i.IMPORT_ID = ii.IMPORT_ID
+          WHERE ii.STEAM_APP_ID = :steamAppId
+            AND ii.GAMEDB_GAME_ID IS NOT NULL
+            AND ii.RESULT_REASON = 'MANUAL_REMAP'
+            AND (:excludeUserId IS NULL OR i.USER_ID <> :excludeUserId)
+          GROUP BY ii.GAMEDB_GAME_ID
+          ORDER BY CNT DESC, LAST_ITEM_ID DESC
+       ) t
+      WHERE ROWNUM <= :limit`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/suggestion.sql.ts
+++ b/src/db/sql/suggestion.sql.ts
@@ -1,0 +1,96 @@
+import type { SqlEntry } from "./types.js";
+
+export const SuggestionSql = {
+  create: {
+    oracle: `INSERT INTO RPG_CLUB_SUGGESTIONS (TITLE, DETAILS, LABELS, CREATED_BY, CREATED_BY_NAME)
+       VALUES (:title, :details, :labels, :createdBy, :createdByName)
+       RETURNING SUGGESTION_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  list: {
+    oracle: `SELECT SUGGESTION_ID,
+            TITLE,
+            DETAILS,
+            LABELS,
+            CREATED_BY,
+            CREATED_BY_NAME,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_SUGGESTIONS
+      ORDER BY CREATED_AT DESC, SUGGESTION_ID DESC
+      FETCH FIRST :limit ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  count: {
+    oracle: `SELECT COUNT(*) AS TOTAL FROM RPG_CLUB_SUGGESTIONS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getById: {
+    oracle: `SELECT SUGGESTION_ID,
+            TITLE,
+            DETAILS,
+            LABELS,
+            CREATED_BY,
+            CREATED_BY_NAME,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_SUGGESTIONS
+      WHERE SUGGESTION_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  delete: {
+    oracle: `DELETE FROM RPG_CLUB_SUGGESTIONS WHERE SUGGESTION_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};
+
+export const SuggestionReviewSessionSql = {
+  create: {
+    oracle: `INSERT INTO RPG_CLUB_SUGGESTION_REVIEW_SESSIONS
+         (SESSION_ID, REVIEWER_ID, SUGGESTION_IDS, CURRENT_INDEX, TOTAL_COUNT)
+       VALUES (:sessionId, :reviewerId, :suggestionIds, :currentIndex, :totalCount)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getById: {
+    oracle: `SELECT SESSION_ID,
+            REVIEWER_ID,
+            SUGGESTION_IDS,
+            CURRENT_INDEX,
+            TOTAL_COUNT,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS
+      WHERE SESSION_ID = :sessionId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  update: {
+    oracle: `UPDATE RPG_CLUB_SUGGESTION_REVIEW_SESSIONS
+        SET REVIEWER_ID = :reviewerId,
+            SUGGESTION_IDS = :suggestionIds,
+            CURRENT_INDEX = :currentIndex,
+            TOTAL_COUNT = :totalCount
+      WHERE SESSION_ID = :sessionId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  delete: {
+    oracle: `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE SESSION_ID = :sessionId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteForReviewer: {
+    oracle: `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE REVIEWER_ID = :reviewerId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteExpired: {
+    oracle: `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE CREATED_AT < :cutoff`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/thread.sql.ts
+++ b/src/db/sql/thread.sql.ts
@@ -1,0 +1,100 @@
+import type { SqlEntry } from "./types.js";
+
+export const ThreadSql = {
+  upsertThread: {
+    oracle: `MERGE INTO THREADS t
+     USING (
+       SELECT
+         :threadId       AS THREAD_ID,
+         :forumChannelId AS FORUM_CHANNEL_ID,
+         :threadName     AS THREAD_NAME,
+         :isArchived     AS IS_ARCHIVED,
+         :createdAt      AS CREATED_AT,
+         :lastSeenAt     AS LAST_SEEN_AT,
+         :skipLinking    AS SKIP_LINKING
+       FROM DUAL
+     ) s
+     ON (t.THREAD_ID = s.THREAD_ID)
+     WHEN MATCHED THEN UPDATE SET
+       t.THREAD_NAME      = s.THREAD_NAME,
+       t.FORUM_CHANNEL_ID = s.FORUM_CHANNEL_ID,
+       t.IS_ARCHIVED      = s.IS_ARCHIVED,
+       t.LAST_SEEN_AT     = s.LAST_SEEN_AT
+     WHEN NOT MATCHED THEN INSERT (
+       THREAD_ID, FORUM_CHANNEL_ID, THREAD_NAME, IS_ARCHIVED,
+       CREATED_AT, LAST_SEEN_AT, SKIP_LINKING
+     ) VALUES (
+       s.THREAD_ID, s.FORUM_CHANNEL_ID, s.THREAD_NAME, s.IS_ARCHIVED,
+       s.CREATED_AT, s.LAST_SEEN_AT, s.SKIP_LINKING
+     )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  deleteThreadGameLink: {
+    oracle: `DELETE FROM THREAD_GAME_LINKS WHERE THREAD_ID = :threadId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  mergeThreadGameLink: {
+    oracle: `MERGE INTO THREAD_GAME_LINKS tgt
+         USING (
+           SELECT :threadId AS THREAD_ID, :gameId AS GAMEDB_GAME_ID FROM DUAL
+         ) src
+         ON (tgt.THREAD_ID = src.THREAD_ID AND tgt.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
+         WHEN NOT MATCHED THEN
+           INSERT (THREAD_ID, GAMEDB_GAME_ID, LINKED_AT)
+           VALUES (src.THREAD_ID, src.GAMEDB_GAME_ID, SYSTIMESTAMP)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateThreadsGameId: {
+    oracle: `UPDATE THREADS t
+       SET GAMEDB_GAME_ID = (
+         SELECT MIN(g.GAMEDB_GAME_ID)
+           FROM THREAD_GAME_LINKS g
+          WHERE g.THREAD_ID = t.THREAD_ID
+       )
+       WHERE t.THREAD_ID = :threadId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  removeThreadGameLinks: (withGameId: boolean) =>
+    ({
+      oracle: `DELETE FROM THREAD_GAME_LINKS
+       WHERE THREAD_ID = :threadId
+       ${withGameId ? "AND GAMEDB_GAME_ID = :gameId" : ""}`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  setSkipLinking: {
+    oracle: `UPDATE THREADS
+        SET SKIP_LINKING = :skip
+      WHERE THREAD_ID = :threadId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getSkipLinking: {
+    oracle: `SELECT SKIP_LINKING FROM THREADS WHERE THREAD_ID = :threadId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getThreadLinksForGame: {
+    oracle: `SELECT THREAD_ID FROM THREAD_GAME_LINKS WHERE GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getLegacyGameId: {
+    oracle: `SELECT GAMEDB_GAME_ID FROM THREADS WHERE THREAD_ID = :threadId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getThreadGameLinks: {
+    oracle: `SELECT GAMEDB_GAME_ID FROM THREAD_GAME_LINKS WHERE THREAD_ID = :threadId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getLegacyThreadIdForGame: {
+    oracle: `SELECT THREAD_ID FROM THREADS WHERE GAMEDB_GAME_ID = :gameId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/todo.sql.ts
+++ b/src/db/sql/todo.sql.ts
@@ -1,0 +1,114 @@
+import type { SqlEntry } from "./types.js";
+
+const TODO_COLS = `TODO_ID,
+              TITLE,
+              DETAILS,
+              TODO_CATEGORY,
+              TODO_SIZE,
+              CREATED_BY,
+              CREATED_AT,
+              UPDATED_AT,
+              COMPLETED_AT,
+              COMPLETED_BY,
+              IS_COMPLETED`;
+
+export const TodoSql = {
+  getById: {
+    oracle: `SELECT ${TODO_COLS}
+       FROM RPG_CLUB_TODOS
+      WHERE TODO_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  create: {
+    oracle: `INSERT INTO RPG_CLUB_TODOS (TITLE, DETAILS, TODO_CATEGORY, TODO_SIZE, CREATED_BY)
+     VALUES (:title, :details, :todoCategory, :todoSize, :createdBy)
+     RETURNING TODO_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  list: (whereClause: string) =>
+    ({
+      oracle: `SELECT ${TODO_COLS}
+       FROM RPG_CLUB_TODOS
+       ${whereClause}
+      ORDER BY IS_COMPLETED ASC, CREATED_AT ASC
+      FETCH FIRST :limit ROWS ONLY`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  update: {
+    oracle: `UPDATE RPG_CLUB_TODOS
+        SET TITLE = CASE WHEN :titleProvided = 1 THEN :title ELSE TITLE END,
+            DETAILS = CASE WHEN :detailsProvided = 1 THEN :details ELSE DETAILS END,
+            TODO_CATEGORY = CASE
+              WHEN :categoryProvided = 1 THEN :todoCategory
+              ELSE TODO_CATEGORY
+            END,
+            TODO_SIZE = CASE
+              WHEN :sizeProvided = 1 THEN :todoSize
+              ELSE TODO_SIZE
+            END
+      WHERE TODO_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  delete: {
+    oracle: `DELETE FROM RPG_CLUB_TODOS WHERE TODO_ID = :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  complete: {
+    oracle: `UPDATE RPG_CLUB_TODOS
+        SET IS_COMPLETED = 1,
+            COMPLETED_AT = SYSTIMESTAMP,
+            COMPLETED_BY = :completedBy
+      WHERE TODO_ID = :id
+        AND IS_COMPLETED = 0`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countTodos: {
+    oracle: `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
+            SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT
+       FROM RPG_CLUB_TODOS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countTodoSummary: {
+    oracle: `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
+            SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'New Features' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_NEW_FEATURES,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Improvements' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_IMPROVEMENTS,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Defects' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_DEFECTS,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Blocked' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_BLOCKED,
+            SUM(
+              CASE
+                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Refactoring' THEN 1
+                ELSE 0
+              END
+            ) AS OPEN_REFACTORING
+       FROM RPG_CLUB_TODOS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/types.ts
+++ b/src/db/sql/types.ts
@@ -1,0 +1,6 @@
+export type Dialect = "oracle" | "postgres";
+
+export interface SqlEntry {
+  oracle: string;
+  postgres: string;
+}

--- a/src/db/sql/userActivity.sql.ts
+++ b/src/db/sql/userActivity.sql.ts
@@ -1,0 +1,94 @@
+import type { SqlEntry } from "./types.js";
+
+export const UserActivityIconSql = {
+  mergeActivity: {
+    oracle: `MERGE INTO RPG_CLUB_USER_ACTIVITY_ICONS t
+USING (
+  SELECT
+    :userId AS USER_ID,
+    :username AS USERNAME,
+    :activityName AS ACTIVITY_NAME,
+    :activityNameNorm AS ACTIVITY_NAME_NORM,
+    :iconType AS ICON_TYPE,
+    :sourceRef AS SOURCE_REF,
+    :iconUrl AS ICON_URL
+  FROM dual
+) s
+ON (
+  t.USER_ID = s.USER_ID
+  AND t.ACTIVITY_NAME_NORM = s.ACTIVITY_NAME_NORM
+  AND t.ICON_TYPE = s.ICON_TYPE
+  AND t.SOURCE_REF = s.SOURCE_REF
+)
+WHEN MATCHED THEN
+  UPDATE SET
+    t.USERNAME = s.USERNAME,
+    t.ICON_URL = s.ICON_URL,
+    t.LAST_SEEN_AT = SYSTIMESTAMP,
+    t.SEEN_COUNT = t.SEEN_COUNT + 1
+WHEN NOT MATCHED THEN
+  INSERT (
+    USER_ID, USERNAME, ACTIVITY_NAME, ACTIVITY_NAME_NORM,
+    ICON_TYPE, SOURCE_REF, ICON_URL,
+    FIRST_SEEN_AT, LAST_SEEN_AT, SEEN_COUNT
+  )
+  VALUES (
+    s.USER_ID, s.USERNAME, s.ACTIVITY_NAME, s.ACTIVITY_NAME_NORM,
+    s.ICON_TYPE, s.SOURCE_REF, s.ICON_URL,
+    SYSTIMESTAMP, SYSTIMESTAMP, 1
+  )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getRecentForUsers: (userGroupClauses: string) =>
+    ({
+      oracle: `SELECT
+         USER_ID,
+         ACTIVITY_NAME,
+         ICON_TYPE,
+         SOURCE_REF,
+         ICON_URL,
+         LAST_SEEN_AT
+       FROM RPG_CLUB_USER_ACTIVITY_ICONS
+       WHERE (${userGroupClauses})
+         AND LAST_SEEN_AT >= SYSTIMESTAMP - NUMTODSINTERVAL(:days, 'DAY')
+         AND (:activityNameNorm IS NULL OR ACTIVITY_NAME_NORM = :activityNameNorm)
+         AND (:iconType IS NULL OR ICON_TYPE = :iconType)
+       ORDER BY LAST_SEEN_AT DESC`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+};
+
+export const UserChannelMessageCountSql = {
+  upsertChannelCounts: {
+    oracle: `MERGE INTO RPG_CLUB_USER_CHANNEL_COUNTS t
+            USING (
+              SELECT :userId AS user_id,
+                     :channelId AS channel_id,
+                     :count AS message_count,
+                     :scanned AS scanned
+                FROM dual
+            ) s
+               ON (t.USER_ID = s.user_id AND t.CHANNEL_ID = s.channel_id)
+             WHEN MATCHED THEN
+               UPDATE SET t.MESSAGE_COUNT = NVL(t.MESSAGE_COUNT, 0) + s.message_count,
+                          t.LAST_SCANNED_AT = s.scanned,
+                          t.UPDATED_AT = SYSTIMESTAMP
+             WHEN NOT MATCHED THEN
+               INSERT (USER_ID, CHANNEL_ID, MESSAGE_COUNT, LAST_SCANNED_AT,
+                       CREATED_AT, UPDATED_AT)
+               VALUES (s.user_id, s.channel_id, s.message_count, s.scanned,
+                       SYSTIMESTAMP, SYSTIMESTAMP)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getScannedChannelIds: {
+    oracle: `SELECT DISTINCT CHANNEL_ID FROM RPG_CLUB_USER_CHANNEL_COUNTS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getChannelScanMeta: {
+    oracle: `SELECT CHANNEL_ID, LAST_SCANNED_AT FROM RPG_CLUB_USER_CHANNEL_COUNTS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/userGameCollection.sql.ts
+++ b/src/db/sql/userGameCollection.sql.ts
@@ -1,0 +1,183 @@
+import type { SqlEntry } from "./types.js";
+
+const ENTRY_SELECT_SQL = `SELECT c.ENTRY_ID,
+       c.USER_ID,
+       c.GAMEDB_GAME_ID,
+       g.TITLE,
+       c.PLATFORM_ID,
+       p.PLATFORM_NAME,
+       p.PLATFORM_ABBREVIATION,
+       c.OWNERSHIP_TYPE,
+       c.NOTE,
+       c.IS_SHARED,
+       c.CREATED_AT,
+       c.UPDATED_AT
+  FROM USER_GAME_COLLECTIONS c
+  JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+  LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID`;
+
+export const UserGameCollectionSql = {
+  addEntry: {
+    oracle: `INSERT INTO USER_GAME_COLLECTIONS (
+             USER_ID,
+             GAMEDB_GAME_ID,
+             PLATFORM_ID,
+             OWNERSHIP_TYPE,
+             NOTE,
+             IS_SHARED
+           ) VALUES (
+             :userId,
+             :gameId,
+             :platformId,
+             :ownershipType,
+             :note,
+             :isShared
+           )
+           RETURNING ENTRY_ID INTO :entryId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getEntryById: {
+    oracle: `${ENTRY_SELECT_SQL}
+     WHERE c.ENTRY_ID = :entryId
+       AND c.USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getEntryForUser: {
+    oracle: `${ENTRY_SELECT_SQL}
+       WHERE c.ENTRY_ID = :entryId
+         AND c.USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateEntry: (updateParts: string[]) =>
+    ({
+      oracle: `UPDATE USER_GAME_COLLECTIONS
+              SET ${updateParts.join(", ")}
+            WHERE ENTRY_ID = :entryId
+              AND USER_ID = :userId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  removeEntry: {
+    oracle: `DELETE FROM USER_GAME_COLLECTIONS
+        WHERE ENTRY_ID = :entryId
+          AND USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  searchEntries: (whereClause: string, fetchClause: string) =>
+    ({
+      oracle: `SELECT c.ENTRY_ID,
+              c.USER_ID,
+              c.GAMEDB_GAME_ID,
+              g.TITLE,
+              c.PLATFORM_ID,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              c.OWNERSHIP_TYPE,
+              c.NOTE,
+              c.IS_SHARED,
+              c.CREATED_AT,
+              c.UPDATED_AT
+         FROM USER_GAME_COLLECTIONS c
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+        LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
+        WHERE ${whereClause}
+        ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
+        ${fetchClause}`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  getTotalCount: {
+    oracle: `SELECT COUNT(*) AS TOTAL_COUNT
+           FROM USER_GAME_COLLECTIONS
+          WHERE USER_ID = :userId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getPlatformCounts: {
+    oracle: `SELECT c.PLATFORM_ID,
+                p.PLATFORM_NAME,
+                p.PLATFORM_ABBREVIATION,
+                COUNT(*) AS TOTAL_COUNT
+           FROM USER_GAME_COLLECTIONS c
+           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
+          WHERE c.USER_ID = :userId
+          GROUP BY c.PLATFORM_ID, p.PLATFORM_NAME, p.PLATFORM_ABBREVIATION
+          ORDER BY COUNT(*) DESC,
+                   LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
+                   c.PLATFORM_ID`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAllPlatformCounts: {
+    oracle: `SELECT c.PLATFORM_ID,
+                p.PLATFORM_NAME,
+                p.PLATFORM_ABBREVIATION,
+                COUNT(*) AS TOTAL_COUNT
+           FROM USER_GAME_COLLECTIONS c
+           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
+          GROUP BY c.PLATFORM_ID, p.PLATFORM_NAME, p.PLATFORM_ABBREVIATION
+          ORDER BY COUNT(*) DESC,
+                   LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
+                   c.PLATFORM_ID`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getAllUserRows: {
+    oracle: `SELECT c.USER_ID,
+                u.USERNAME,
+                u.GLOBAL_NAME,
+                c.PLATFORM_ID,
+                p.PLATFORM_NAME,
+                p.PLATFORM_ABBREVIATION,
+                COUNT(*) AS TOTAL_COUNT
+           FROM USER_GAME_COLLECTIONS c
+           LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
+           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
+          WHERE NVL(u.IS_BOT, 0) = 0
+          GROUP BY c.USER_ID,
+                   u.USERNAME,
+                   u.GLOBAL_NAME,
+                   c.PLATFORM_ID,
+                   p.PLATFORM_NAME,
+                   p.PLATFORM_ABBREVIATION
+          ORDER BY LOWER(COALESCE(u.GLOBAL_NAME, u.USERNAME, c.USER_ID)),
+                   c.USER_ID,
+                   COUNT(*) DESC,
+                   LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
+                   c.PLATFORM_ID`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getTotalAllCount: {
+    oracle: `SELECT COUNT(*) AS TOTAL_COUNT FROM USER_GAME_COLLECTIONS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  autocompleteEntries: (titleWhere: string) =>
+    ({
+      oracle: `SELECT c.ENTRY_ID,
+              c.USER_ID,
+              c.GAMEDB_GAME_ID,
+              g.TITLE,
+              c.PLATFORM_ID,
+              p.PLATFORM_NAME,
+              p.PLATFORM_ABBREVIATION,
+              c.OWNERSHIP_TYPE,
+              c.NOTE,
+              c.IS_SHARED,
+              c.CREATED_AT,
+              c.UPDATED_AT
+         FROM USER_GAME_COLLECTIONS c
+         JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
+         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
+        WHERE c.USER_ID = :userId
+          ${titleWhere}
+        ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
+        FETCH FIRST :limit ROWS ONLY`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+};

--- a/src/db/sql/xboxCollectionImport.sql.ts
+++ b/src/db/sql/xboxCollectionImport.sql.ts
@@ -1,0 +1,231 @@
+import type { SqlEntry } from "./types.js";
+
+const IMPORT_COLS = `IMPORT_ID,
+       USER_ID,
+       STATUS,
+       CURRENT_INDEX,
+       TOTAL_COUNT,
+       XUID,
+       GAMERTAG,
+       SOURCE_TYPE,
+       SOURCE_FILE_NAME,
+       SOURCE_FILE_SIZE,
+       TEMPLATE_VERSION,
+       CREATED_AT,
+       UPDATED_AT`;
+
+const ITEM_COLS = `ITEM_ID,
+       IMPORT_ID,
+       ROW_INDEX,
+       XBOX_TITLE_ID,
+       XBOX_PRODUCT_ID,
+       XBOX_TITLE_NAME,
+       RAW_PLATFORM,
+       RAW_OWNERSHIP_TYPE,
+       RAW_NOTE,
+       RAW_GAMEDB_ID,
+       RAW_IGDB_ID,
+       PLATFORM_ID,
+       OWNERSHIP_TYPE,
+       NOTE,
+       STATUS,
+       MATCH_CONFIDENCE,
+       MATCH_CANDIDATE_JSON,
+       GAMEDB_GAME_ID,
+       COLLECTION_ENTRY_ID,
+       RESULT_REASON,
+       ERROR_TEXT`;
+
+export const XboxCollectionImportSql = {
+  createImport: {
+    oracle: `INSERT INTO RPG_CLUB_XBOX_COLLECTION_IMPORTS (
+         USER_ID,
+         STATUS,
+         CURRENT_INDEX,
+         TOTAL_COUNT,
+         XUID,
+         GAMERTAG,
+         SOURCE_TYPE,
+         SOURCE_FILE_NAME,
+         SOURCE_FILE_SIZE,
+         TEMPLATE_VERSION
+       ) VALUES (
+         :userId,
+         'ACTIVE',
+         0,
+         :totalCount,
+         :xuid,
+         :gamertag,
+         :sourceType,
+         :sourceFileName,
+         :sourceFileSize,
+         :templateVersion
+       ) RETURNING IMPORT_ID INTO :id`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  insertItem: {
+    oracle: `INSERT INTO RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS (
+           IMPORT_ID,
+           ROW_INDEX,
+           XBOX_TITLE_ID,
+           XBOX_PRODUCT_ID,
+           XBOX_TITLE_NAME,
+           RAW_PLATFORM,
+           RAW_OWNERSHIP_TYPE,
+           RAW_NOTE,
+           RAW_GAMEDB_ID,
+           RAW_IGDB_ID,
+           PLATFORM_ID,
+           OWNERSHIP_TYPE,
+           NOTE,
+           STATUS
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :xboxTitleId,
+           :xboxProductId,
+           :xboxTitleName,
+           :rawPlatform,
+           :rawOwnershipType,
+           :rawNote,
+           :rawGameDbId,
+           :rawIgdbId,
+           :platformId,
+           :ownershipType,
+           :note,
+           'PENDING'
+         )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getImportById: {
+    oracle: `SELECT ${IMPORT_COLS}
+  FROM RPG_CLUB_XBOX_COLLECTION_IMPORTS WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getActiveForUser: {
+    oracle: `SELECT ${IMPORT_COLS}
+  FROM RPG_CLUB_XBOX_COLLECTION_IMPORTS
+     WHERE USER_ID = :userId
+       AND STATUS IN ('ACTIVE', 'PAUSED')
+     ORDER BY IMPORT_ID DESC`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  setStatus: {
+    oracle: `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
+        SET STATUS = :status
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateIndex: {
+    oracle: `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
+        SET CURRENT_INDEX = :currentIndex
+      WHERE IMPORT_ID = :importId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getItemById: {
+    oracle: `SELECT ${ITEM_COLS}
+  FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS WHERE ITEM_ID = :itemId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getNextPendingItem: {
+    oracle: `SELECT ${ITEM_COLS}
+  FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
+     WHERE IMPORT_ID = :importId
+       AND STATUS = 'PENDING'
+     ORDER BY ROW_INDEX ASC
+     FETCH FIRST 1 ROWS ONLY`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  updateItem: (fields: string[]) =>
+    ({
+      oracle: `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
+        SET ${fields.join(", ")}
+      WHERE ITEM_ID = :itemId`,
+      postgres: ``,
+    }) satisfies SqlEntry,
+
+  countItemsByStatus: {
+    oracle: `SELECT STATUS, COUNT(*) AS CNT
+       FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY STATUS`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  countItemsByReason: {
+    oracle: `SELECT RESULT_REASON, COUNT(*) AS CNT
+       FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
+      WHERE IMPORT_ID = :importId
+      GROUP BY RESULT_REASON`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getTitleMap: {
+    oracle: `SELECT MAP_ID,
+            XBOX_TITLE_ID,
+            GAMEDB_GAME_ID,
+            STATUS,
+            CREATED_BY,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_XBOX_TITLE_GAMEDB_MAP
+      WHERE XBOX_TITLE_ID = :xboxTitleId`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  upsertTitleMap: {
+    oracle: `MERGE INTO RPG_CLUB_XBOX_TITLE_GAMEDB_MAP m
+       USING (
+         SELECT :xboxTitleId AS xboxTitleId,
+                :gameDbGameId AS gameDbGameId,
+                :status AS status,
+                :createdBy AS createdBy
+           FROM dual
+       ) src
+          ON (m.XBOX_TITLE_ID = src.xboxTitleId)
+       WHEN MATCHED THEN UPDATE SET
+         m.GAMEDB_GAME_ID = src.gameDbGameId,
+         m.STATUS = src.status,
+         m.CREATED_BY = src.createdBy
+       WHEN NOT MATCHED THEN INSERT (
+         XBOX_TITLE_ID,
+         GAMEDB_GAME_ID,
+         STATUS,
+         CREATED_BY
+       ) VALUES (
+         src.xboxTitleId,
+         src.gameDbGameId,
+         src.status,
+         src.createdBy
+       )`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  getHistoricalMappedIds: {
+    oracle: `SELECT t.GAMEDB_GAME_ID
+       FROM (
+         SELECT ii.GAMEDB_GAME_ID,
+                COUNT(*) AS CNT,
+                MAX(ii.ITEM_ID) AS LAST_ITEM_ID
+           FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS ii
+           JOIN RPG_CLUB_XBOX_COLLECTION_IMPORTS i
+             ON i.IMPORT_ID = ii.IMPORT_ID
+          WHERE ii.XBOX_TITLE_ID = :xboxTitleId
+            AND ii.GAMEDB_GAME_ID IS NOT NULL
+            AND ii.RESULT_REASON = 'MANUAL_REMAP'
+            AND (:excludeUserId IS NULL OR i.USER_ID <> :excludeUserId)
+          GROUP BY ii.GAMEDB_GAME_ID
+          ORDER BY CNT DESC, LAST_ITEM_ID DESC
+       ) t
+      WHERE ROWNUM <= :limit`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};


### PR DESCRIPTION
## Summary
- Creates `src/db/sql/` containing typed `SqlEntry` registries extracted verbatim from every domain class (26 files total)
- Adds `src/db/sql/types.ts` defining `Dialect` and `SqlEntry`, plus `src/db/dialect.ts` for reading `DB_DIALECT`
- Adds `src/db/sql/index.ts` barrel exporting all registries plus `getSql`/`getSqlDynamic` helpers
- Updates `src/db/SqlManager.ts` to re-export `Dialect`, `SqlEntry`, `getSql`, and `getSqlDynamic`
- All Oracle SQL extracted verbatim; all postgres values are empty string placeholders
- Dynamic SQL (runtime WHERE clauses, IN lists, dynamic column/table names) captured as factory functions

## Covered domain registries
`GameSql`, `MemberSql`, `ReminderSql`, `PublicReminderSql`, `GotmSql`, `NrGotmSql`, `NominationSql`, `ThreadSql`, `StarboardSql`, `HltbCacheSql`, `AdminWizardSessionSql`, `GameKeySql`, `PresencePromptHistorySql`, `PresencePromptOptOutSql`, `BotVotingInfoSql`, `GameReleaseAnnouncementSql`, `GotmAuditImportSql`, `CompletionatorImportSql`, `CollectionCsvImportSql`, `GameDbCsvImportSql`, `GameSearchSynonymSql`, `GameSearchSynonymDraftSql`, `RssFeedSql`, `UserActivityIconSql`, `UserChannelMessageCountSql`, `TodoSql`, `UserGameCollectionSql`, `XboxCollectionImportSql`, `SteamCollectionImportSql`

## Test plan
- [x] `tsc --noEmit` passes with zero errors
- [ ] Verify bot runs normally on desktop environment (no domain class files were modified)
- [ ] Spot-check a few SQL strings in the registries against their source class counterparts

🤖 Generated with [Claude Code](https://claude.com/claude-code)