### PR TITLE
feat: wire domain classes to centralized SQL registry

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -6,6 +6,11 @@ import {
   oraWithConnection,
   oraTransaction,
 } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GameSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 import { IGDBGameDetails, igdbService } from "../services/IGDB/IgdbService.js";
 import GameSearchSynonym from "./GameSearchSynonym.js";
 import {
@@ -338,26 +343,7 @@ export default class Game {
   ): Promise<IGame> {
     const gameId = await oraWithConnection(async (conn) => {
       const result = await oraMutate(
-        `INSERT INTO GAMEDB_GAMES (
-           TITLE,
-           DESCRIPTION,
-           IMAGE_DATA,
-           IGDB_ID,
-           SLUG,
-           TOTAL_RATING,
-           IGDB_URL,
-           FEATURED_VIDEO_URL
-         ) VALUES (
-           :title,
-           :description,
-           :imageData,
-           :igdbId,
-           :slug,
-           :totalRating,
-           :igdbUrl,
-           :featuredVideoUrl
-         )
-         RETURNING GAME_ID INTO :id`,
+        getSql(GameSql.createGame, dialect),
         {
           title,
           description,
@@ -432,11 +418,7 @@ export default class Game {
         CREATED_AT: Date;
         UPDATED_AT: Date;
       }>(
-        `SELECT GAME_ID, TITLE, DESCRIPTION, IMAGE_DATA, THUMBNAIL_BAD,
-                THUMBNAIL_APPROVED, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL, FEATURED_VIDEO_URL,
-                INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
-           FROM GAMEDB_GAMES
-          WHERE GAME_ID = :id`,
+        getSql(GameSql.getGameById, dialect),
         { id },
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
@@ -483,10 +465,7 @@ export default class Game {
         CREATED_AT: Date;
         UPDATED_AT: Date;
       }>(
-        `SELECT GAME_ID, TITLE, DESCRIPTION, IMAGE_DATA, THUMBNAIL_BAD, THUMBNAIL_APPROVED, IGDB_ID, SLUG, TOTAL_RATING,
-                IGDB_URL, FEATURED_VIDEO_URL, INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
-           FROM GAMEDB_GAMES
-          WHERE GAME_ID IN (${placeholders.join(", ")})`,
+        GameSql.getGamesByIds(placeholders.join(", "))[dialect],
         binds,
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
@@ -519,18 +498,7 @@ export default class Game {
         CREATED_AT: Date;
         UPDATED_AT: Date;
       }>(
-        `SELECT GAME_ID, TITLE, DESCRIPTION, IMAGE_DATA, THUMBNAIL_BAD, THUMBNAIL_APPROVED, IGDB_ID, SLUG, TOTAL_RATING,
-                IGDB_URL, FEATURED_VIDEO_URL, INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
-           FROM GAMEDB_GAMES
-          WHERE GAME_ID IN (
-            SELECT CASE
-                     WHEN GAME_ID = :id THEN ALT_GAME_ID
-                     ELSE GAME_ID
-                   END
-              FROM GAMEDB_GAME_ALTERNATES
-             WHERE GAME_ID = :id OR ALT_GAME_ID = :id
-          )
-          ORDER BY UPPER(TITLE)`,
+        getSql(GameSql.getAlternateVersions, dialect),
         { id: gameId },
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
@@ -572,17 +540,7 @@ export default class Game {
 
     return oraWithConnection(async (conn) => {
       await conn.executeMany(
-        `MERGE INTO GAMEDB_GAME_ALTERNATES t
-         USING (
-           SELECT :gameId AS GAME_ID,
-                  :altGameId AS ALT_GAME_ID,
-                  :createdBy AS CREATED_BY
-             FROM dual
-         ) s
-            ON (t.GAME_ID = s.GAME_ID AND t.ALT_GAME_ID = s.ALT_GAME_ID)
-         WHEN NOT MATCHED THEN
-           INSERT (GAME_ID, ALT_GAME_ID, CREATED_BY)
-           VALUES (s.GAME_ID, s.ALT_GAME_ID, s.CREATED_BY)`,
+        getSql(GameSql.linkAlternateVersions, dialect),
         pairs,
         { autoCommit: true },
       );
@@ -608,10 +566,7 @@ export default class Game {
         CREATED_AT: Date;
         UPDATED_AT: Date;
       }>(
-        `SELECT GAME_ID, TITLE, DESCRIPTION, IMAGE_DATA, THUMBNAIL_BAD, THUMBNAIL_APPROVED, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL,
-                FEATURED_VIDEO_URL, INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
-           FROM GAMEDB_GAMES
-          WHERE IGDB_ID = :igdbId`,
+        getSql(GameSql.getGameByIgdbId, dialect),
         { igdbId },
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
@@ -750,8 +705,7 @@ export default class Game {
             ic.company.id,
           );
           await oraMutate(
-            `INSERT INTO GAMEDB_GAME_COMPANIES (GAME_ID, COMPANY_ID, ROLE)
-             VALUES (:gameId, :companyId, :role)`,
+            getSql(GameSql.insertGameCompany, dialect),
             {
               gameId,
               companyId,
@@ -780,7 +734,7 @@ export default class Game {
             g.id,
           );
           await oraMutate(
-            `INSERT INTO GAMEDB_GAME_GENRES (GAME_ID, GENRE_ID) VALUES (:gameId, :genreId)`,
+            getSql(GameSql.insertGameGenre, dialect),
             { gameId, genreId },
             conn,
           )
@@ -801,7 +755,7 @@ export default class Game {
             t.id,
           );
           await oraMutate(
-            `INSERT INTO GAMEDB_GAME_THEMES (GAME_ID, THEME_ID) VALUES (:gameId, :themeId)`,
+            getSql(GameSql.insertGameTheme, dialect),
             { gameId, themeId },
             conn,
           )
@@ -822,7 +776,7 @@ export default class Game {
             gm.id,
           );
           await oraMutate(
-            `INSERT INTO GAMEDB_GAME_MODES (GAME_ID, MODE_ID) VALUES (:gameId, :modeId)`,
+            getSql(GameSql.insertGameMode, dialect),
             { gameId, modeId },
             conn,
           )
@@ -843,7 +797,7 @@ export default class Game {
             pp.id,
           );
           await oraMutate(
-            `INSERT INTO GAMEDB_GAME_PERSPECTIVES (GAME_ID, PERSPECTIVE_ID) VALUES (:gameId, :persId)`,
+            getSql(GameSql.insertGamePerspective, dialect),
             { gameId, persId },
             conn,
           )
@@ -864,7 +818,7 @@ export default class Game {
             e.id,
           );
           await oraMutate(
-            `INSERT INTO GAMEDB_GAME_ENGINES (GAME_ID, ENGINE_ID) VALUES (:gameId, :engineId)`,
+            getSql(GameSql.insertGameEngine, dialect),
             { gameId, engineId },
             conn,
           )
@@ -885,7 +839,7 @@ export default class Game {
             f.id,
           );
           await oraMutate(
-            `INSERT INTO GAMEDB_GAME_FRANCHISES (GAME_ID, FRANCHISE_ID) VALUES (:gameId, :franchiseId)`,
+            getSql(GameSql.insertGameFranchise, dialect),
             { gameId, franchiseId },
             conn,
           )
@@ -905,7 +859,7 @@ export default class Game {
           details.collection.id,
         );
         await oraMutate(
-          `UPDATE GAMEDB_GAMES SET COLLECTION_ID = :collectionId WHERE GAME_ID = :gameId`,
+          getSql(GameSql.updateCollectionId, dialect),
           { collectionId, gameId },
           conn,
         );
@@ -914,8 +868,7 @@ export default class Game {
 
       if (details.parent_game) {
         await oraMutate(
-          `UPDATE GAMEDB_GAMES SET PARENT_IGDB_ID = :parentId, PARENT_GAME_NAME = :parentName
-           WHERE GAME_ID = :gameId`,
+          getSql(GameSql.updateParentIgdbId, dialect),
           {
             parentId: details.parent_game.id,
             parentName: details.parent_game.name,
@@ -1016,19 +969,14 @@ export default class Game {
 
   static async updateInitialReleaseDate(gameId: number): Promise<void> {
     const rows = await oraQuery(
-      `SELECT MIN(RELEASE_DATE) AS MIN_DATE
-         FROM GAMEDB_RELEASES
-        WHERE GAME_ID = :gameId
-          AND RELEASE_DATE IS NOT NULL`,
+      getSql(GameSql.updateInitialReleaseDateSelect, dialect),
       { gameId },
       (row: { MIN_DATE: Date | null }) => row.MIN_DATE,
     );
     const minDate = rows[0] ?? null;
     if (!minDate) return;
     await oraMutate(
-      `UPDATE GAMEDB_GAMES
-          SET INITIAL_RELEASE_DATE = :releaseDate
-        WHERE GAME_ID = :gameId`,
+      getSql(GameSql.updateInitialReleaseDateUpdate, dialect),
       { releaseDate: minDate, gameId },
     );
   }
@@ -1044,8 +992,7 @@ export default class Game {
 
     try {
       await oraMutate(
-        `INSERT INTO GAMEDB_PLATFORMS (PLATFORM_CODE, PLATFORM_NAME, IGDB_PLATFORM_ID)
-         VALUES (:code, :name, :igdbId)`,
+        getSql(GameSql.insertPlatform, dialect),
         {
           code: buildPlatformCode(igdbPlatform.name, igdbPlatform.id),
           name: igdbPlatform.name ?? `IGDB Platform ${igdbPlatform.id}`,
@@ -1075,9 +1022,7 @@ export default class Game {
 
     try {
       const insertRes = await oraMutate(
-        `INSERT INTO GAMEDB_REGIONS (REGION_CODE, REGION_NAME, IGDB_REGION_ID)
-         VALUES (:code, :name, :igdbId)
-         RETURNING REGION_ID INTO :id`,
+        getSql(GameSql.insertRegion, dialect),
         {
           code: regionConfig.code,
           name: regionConfig.name,
@@ -1111,9 +1056,7 @@ export default class Game {
     role: string,
   ): Promise<string[]> {
     return oraQuery(
-      `SELECT c.NAME FROM GAMEDB_COMPANIES c
-       JOIN GAMEDB_GAME_COMPANIES gc ON c.COMPANY_ID = gc.COMPANY_ID
-       WHERE gc.GAME_ID = :gameId AND gc.ROLE = :role`,
+      getSql(GameSql.getGameCompanies, dialect),
       { gameId, role },
       (row: { NAME: string }) => row.NAME,
     );
@@ -1175,9 +1118,7 @@ export default class Game {
 
   static async getGameSeries(gameId: number): Promise<string | null> {
     const rows = await oraQuery(
-      `SELECT c.NAME FROM GAMEDB_COLLECTIONS c
-       JOIN GAMEDB_GAMES g ON c.COLLECTION_ID = g.COLLECTION_ID
-       WHERE g.GAME_ID = :gameId`,
+      getSql(GameSql.getGameSeries, dialect),
       { gameId },
       (row: { NAME: string }) => row.NAME,
     );
@@ -1208,9 +1149,7 @@ export default class Game {
     notes: string | null,
   ): Promise<IRelease> {
     const result = await oraMutate(
-      `INSERT INTO GAMEDB_RELEASES (GAME_ID, PLATFORM_ID, REGION_ID, FORMAT, RELEASE_DATE, NOTES)
-       VALUES (:gameId, :platformId, :regionId, :format, :releaseDate, :notes)
-       RETURNING RELEASE_ID INTO :id`,
+      getSql(GameSql.insertRelease, dialect),
       {
         gameId,
         platformId,
@@ -1231,9 +1170,7 @@ export default class Game {
 
   static async getReleaseById(id: number): Promise<IRelease | null> {
     const rows = await oraQuery(
-      `SELECT RELEASE_ID, GAME_ID, PLATFORM_ID, REGION_ID, FORMAT, RELEASE_DATE, NOTES
-         FROM GAMEDB_RELEASES
-        WHERE RELEASE_ID = :id`,
+      getSql(GameSql.getReleaseById, dialect),
       { id },
       mapReleaseRow,
     );
@@ -1242,10 +1179,7 @@ export default class Game {
 
   static async getGameReleases(gameId: number): Promise<IRelease[]> {
     return oraQuery(
-      `SELECT RELEASE_ID, GAME_ID, PLATFORM_ID, REGION_ID, FORMAT, RELEASE_DATE, NOTES
-         FROM GAMEDB_RELEASES
-        WHERE GAME_ID = :gameId
-        ORDER BY RELEASE_DATE ASC`,
+      getSql(GameSql.getGameReleases, dialect),
       { gameId },
       mapReleaseRow,
     );
@@ -1253,15 +1187,7 @@ export default class Game {
 
   static async getPlatformsForGame(gameId: number): Promise<IPlatformDef[]> {
     return oraQuery(
-      `SELECT DISTINCT p.PLATFORM_ID,
-              p.PLATFORM_CODE,
-              p.PLATFORM_NAME,
-              p.PLATFORM_ABBREVIATION,
-              p.IGDB_PLATFORM_ID
-         FROM GAMEDB_RELEASES r
-         JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = r.PLATFORM_ID
-        WHERE r.GAME_ID = :gameId
-        ORDER BY p.PLATFORM_NAME ASC`,
+      getSql(GameSql.getPlatformsForGame, dialect),
       { gameId },
       mapPlatformDefRow,
     );
@@ -1269,13 +1195,7 @@ export default class Game {
 
   static async getAllPlatforms(): Promise<IPlatformDef[]> {
     return oraQuery(
-      `SELECT PLATFORM_ID,
-              PLATFORM_CODE,
-              PLATFORM_NAME,
-              PLATFORM_ABBREVIATION,
-              IGDB_PLATFORM_ID
-         FROM GAMEDB_PLATFORMS
-        ORDER BY PLATFORM_NAME ASC`,
+      getSql(GameSql.getAllPlatforms, dialect),
       {},
       mapPlatformDefRow,
     );
@@ -1300,13 +1220,7 @@ export default class Game {
     });
 
     const platforms = await oraQuery(
-      `SELECT PLATFORM_ID,
-              PLATFORM_CODE,
-              PLATFORM_NAME,
-              PLATFORM_ABBREVIATION,
-              IGDB_PLATFORM_ID
-         FROM GAMEDB_PLATFORMS
-        WHERE IGDB_PLATFORM_ID IN (${placeholders.join(", ")})`,
+      GameSql.getPlatformsByIgdbIds(placeholders.join(", "))[dialect],
       binds,
       mapPlatformDefRow,
     );
@@ -1350,13 +1264,7 @@ export default class Game {
 
   static async getPlatformByCode(code: string): Promise<IPlatformDef | null> {
     const rows = await oraQuery(
-      `SELECT PLATFORM_ID,
-              PLATFORM_CODE,
-              PLATFORM_NAME,
-              PLATFORM_ABBREVIATION,
-              IGDB_PLATFORM_ID
-         FROM GAMEDB_PLATFORMS
-        WHERE PLATFORM_CODE = :code`,
+      getSql(GameSql.getPlatformByCode, dialect),
       { code },
       mapPlatformDefRow,
     );
@@ -1365,13 +1273,7 @@ export default class Game {
 
   static async getPlatformById(id: number): Promise<IPlatformDef | null> {
     const rows = await oraQuery(
-      `SELECT PLATFORM_ID,
-              PLATFORM_CODE,
-              PLATFORM_NAME,
-              PLATFORM_ABBREVIATION,
-              IGDB_PLATFORM_ID
-         FROM GAMEDB_PLATFORMS
-        WHERE PLATFORM_ID = :id`,
+      getSql(GameSql.getPlatformById, dialect),
       { id },
       mapPlatformDefRow,
     );
@@ -1404,15 +1306,7 @@ export default class Game {
     const missingPlatformIds = new Set<number>();
 
     const rows = await oraQuery(
-      `SELECT gp.GAME_ID,
-              gp.PLATFORM_ID,
-              p.PLATFORM_CODE,
-              p.PLATFORM_NAME,
-              p.PLATFORM_ABBREVIATION,
-              p.IGDB_PLATFORM_ID
-         FROM GAMEDB_GAME_PLATFORMS gp
-         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = gp.PLATFORM_ID
-        WHERE gp.GAME_ID IN (${placeholders.join(", ")})`,
+      GameSql.attachPlatformsToGames(placeholders.join(", "))[dialect],
       binds,
       (row: {
         GAME_ID: number;
@@ -1463,13 +1357,7 @@ export default class Game {
     igdbId: number,
   ): Promise<IPlatformDef | null> {
     const rows = await oraQuery(
-      `SELECT PLATFORM_ID,
-              PLATFORM_CODE,
-              PLATFORM_NAME,
-              PLATFORM_ABBREVIATION,
-              IGDB_PLATFORM_ID
-         FROM GAMEDB_PLATFORMS
-        WHERE IGDB_PLATFORM_ID = :igdbId`,
+      getSql(GameSql.getPlatformByIgdbId, dialect),
       { igdbId },
       mapPlatformDefRow,
     );
@@ -1478,9 +1366,7 @@ export default class Game {
 
   static async getAllRegions(): Promise<IRegionDef[]> {
     return oraQuery(
-      `SELECT REGION_ID, REGION_CODE, REGION_NAME, IGDB_REGION_ID
-         FROM GAMEDB_REGIONS
-        ORDER BY REGION_NAME ASC`,
+      getSql(GameSql.getAllRegions, dialect),
       {},
       mapRegionDefRow,
     );
@@ -1488,9 +1374,7 @@ export default class Game {
 
   static async getRegionByCode(code: string): Promise<IRegionDef | null> {
     const rows = await oraQuery(
-      `SELECT REGION_ID, REGION_CODE, REGION_NAME, IGDB_REGION_ID
-         FROM GAMEDB_REGIONS
-        WHERE REGION_CODE = :code`,
+      getSql(GameSql.getRegionByCode, dialect),
       { code },
       mapRegionDefRow,
     );
@@ -1499,9 +1383,7 @@ export default class Game {
 
   static async getRegionById(id: number): Promise<IRegionDef | null> {
     const rows = await oraQuery(
-      `SELECT REGION_ID, REGION_CODE, REGION_NAME, IGDB_REGION_ID
-         FROM GAMEDB_REGIONS
-        WHERE REGION_ID = :id`,
+      getSql(GameSql.getRegionById, dialect),
       { id },
       mapRegionDefRow,
     );
@@ -1510,9 +1392,7 @@ export default class Game {
 
   static async getRegionByIgdbId(igdbId: number): Promise<IRegionDef | null> {
     const rows = await oraQuery(
-      `SELECT REGION_ID, REGION_CODE, REGION_NAME, IGDB_REGION_ID
-         FROM GAMEDB_REGIONS
-        WHERE IGDB_REGION_ID = :igdbId`,
+      getSql(GameSql.getRegionByIgdbId, dialect),
       { igdbId },
       mapRegionDefRow,
     );
@@ -1621,7 +1501,7 @@ export default class Game {
 
   static async getAllCompanies(): Promise<ICompany[]> {
     return oraQuery(
-      `SELECT COMPANY_ID, NAME, IGDB_COMPANY_ID FROM GAMEDB_COMPANIES ORDER BY NAME ASC`,
+      getSql(GameSql.getAllCompanies, dialect),
       {},
       (row: {
         COMPANY_ID: number;
@@ -1637,7 +1517,7 @@ export default class Game {
 
   static async getCompanyById(id: number): Promise<ICompany | null> {
     const rows = await oraQuery(
-      `SELECT COMPANY_ID, NAME, IGDB_COMPANY_ID FROM GAMEDB_COMPANIES WHERE COMPANY_ID = :id`,
+      getSql(GameSql.getCompanyById, dialect),
       { id },
       (row: {
         COMPANY_ID: number;
@@ -1913,11 +1793,7 @@ export default class Game {
         const platform = platformMap.get(igdbId);
         if (!platform) continue;
         await oraMutate(
-          `MERGE INTO GAMEDB_GAME_PLATFORMS gp
-           USING (SELECT :gameId AS GAME_ID, :platformId AS PLATFORM_ID FROM dual) src
-           ON (gp.GAME_ID = src.GAME_ID AND gp.PLATFORM_ID = src.PLATFORM_ID)
-           WHEN NOT MATCHED THEN
-             INSERT (GAME_ID, PLATFORM_ID) VALUES (src.GAME_ID, src.PLATFORM_ID)`,
+          getSql(GameSql.addGamePlatformMerge, dialect),
           { gameId, platformId: platform.id },
           conn,
         );
@@ -2003,11 +1879,7 @@ export default class Game {
         CREATED_AT: Date;
         UPDATED_AT: Date;
       }>(
-        `SELECT g.GAME_ID, g.TITLE, g.DESCRIPTION, g.IMAGE_DATA, g.IGDB_ID, g.SLUG, g.TOTAL_RATING,
-                g.IGDB_URL, g.FEATURED_VIDEO_URL, g.INITIAL_RELEASE_DATE, g.CREATED_AT, g.UPDATED_AT
-           FROM GAMEDB_GAMES g
-          WHERE ${combinedClause}
-          ORDER BY g.TITLE ASC`,
+        GameSql.getGamesForAudit(combinedClause)[dialect],
         binds,
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
@@ -2027,7 +1899,7 @@ export default class Game {
     imageData: Buffer,
   ): Promise<void> {
     await oraMutate(
-      `UPDATE GAMEDB_GAMES SET IMAGE_DATA = :imageData, UPDATED_AT = SYSTIMESTAMP WHERE GAME_ID = :gameId`,
+      getSql(GameSql.updateGameImage, dialect),
       { imageData, gameId },
     );
   }
@@ -2037,10 +1909,7 @@ export default class Game {
     isBad: boolean,
   ): Promise<void> {
     await oraMutate(
-      `UPDATE GAMEDB_GAMES
-          SET THUMBNAIL_BAD = :thumbnailBad,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE GAME_ID = :gameId`,
+      getSql(GameSql.updateGameThumbnailBad, dialect),
       { thumbnailBad: isBad ? 1 : 0, gameId },
     );
   }
@@ -2050,10 +1919,7 @@ export default class Game {
     isApproved: boolean,
   ): Promise<void> {
     await oraMutate(
-      `UPDATE GAMEDB_GAMES
-          SET THUMBNAIL_APPROVED = :thumbnailApproved,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE GAME_ID = :gameId`,
+      getSql(GameSql.updateGameThumbnailApproved, dialect),
       { thumbnailApproved: isApproved ? 1 : 0, gameId },
     );
   }
@@ -2073,13 +1939,7 @@ export default class Game {
     });
 
     const rows = await oraQuery(
-      `SELECT DISTINCT g.GAME_ID
-         FROM GAMEDB_GAMES g
-        WHERE g.GAME_ID IN (${placeholders})
-          AND (
-            EXISTS (SELECT 1 FROM THREAD_GAME_LINKS tgl WHERE tgl.GAMEDB_GAME_ID = g.GAME_ID)
-            OR EXISTS (SELECT 1 FROM THREADS th WHERE th.GAMEDB_GAME_ID = g.GAME_ID)
-          )`,
+      GameSql.getThreadStatusForGameIds(placeholders)[dialect],
       binds,
       (row: { GAME_ID: number }) => Number(row.GAME_ID),
     );
@@ -2091,10 +1951,7 @@ export default class Game {
     featuredVideoUrl: string | null,
   ): Promise<void> {
     await oraMutate(
-      `UPDATE GAMEDB_GAMES
-          SET FEATURED_VIDEO_URL = :featuredVideoUrl,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE GAME_ID = :gameId`,
+      getSql(GameSql.updateFeaturedVideoUrl, dialect),
       { featuredVideoUrl, gameId },
     );
   }
@@ -2104,10 +1961,7 @@ export default class Game {
     description: string | null,
   ): Promise<void> {
     await oraMutate(
-      `UPDATE GAMEDB_GAMES
-          SET DESCRIPTION = :description,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE GAME_ID = :gameId`,
+      getSql(GameSql.updateGameDescription, dialect),
       { description, gameId },
     );
   }
@@ -2117,22 +1971,17 @@ export default class Game {
   ): Promise<{ releases: number; announcements: number }> {
     return oraTransaction(async (conn) => {
       const announceResult = await oraMutate(
-        `DELETE FROM GAMEDB_RELEASE_ANNOUNCEMENTS
-          WHERE RELEASE_ID IN (
-            SELECT RELEASE_ID FROM GAMEDB_RELEASES WHERE GAME_ID = :gameId
-          )`,
+        getSql(GameSql.clearReleaseAnnouncements, dialect),
         { gameId },
         conn,
       );
       const releaseResult = await oraMutate(
-        `DELETE FROM GAMEDB_RELEASES WHERE GAME_ID = :gameId`,
+        getSql(GameSql.clearReleases, dialect),
         { gameId },
         conn,
       );
       await oraMutate(
-        `UPDATE GAMEDB_GAMES
-            SET INITIAL_RELEASE_DATE = NULL, UPDATED_AT = SYSTIMESTAMP
-          WHERE GAME_ID = :gameId`,
+        getSql(GameSql.clearInitialReleaseDate, dialect),
         { gameId },
         conn,
       );
@@ -2154,7 +2003,7 @@ export default class Game {
 
   static async touchGameUpdatedAt(gameId: number): Promise<void> {
     await oraMutate(
-      `UPDATE GAMEDB_GAMES SET UPDATED_AT = SYSTIMESTAMP WHERE GAME_ID = :gameId`,
+      getSql(GameSql.touchGameUpdatedAt, dialect),
       { gameId },
     );
   }
@@ -2186,15 +2035,7 @@ export default class Game {
             monthYear: string;
           }
         >(
-          `SELECT ge.ROUND_NUMBER,
-                COALESCE(
-                  (SELECT MIN(tgl.THREAD_ID) FROM THREAD_GAME_LINKS tgl WHERE tgl.GAMEDB_GAME_ID = ge.GAMEDB_GAME_ID),
-                  (SELECT MIN(th.THREAD_ID) FROM THREADS th WHERE th.GAMEDB_GAME_ID = ge.GAMEDB_GAME_ID)
-                ) AS THREAD_ID,
-                ge.REDDIT_URL, ge.MONTH_YEAR
-           FROM GOTM_ENTRIES ge
-          WHERE ge.GAMEDB_GAME_ID = :gameId
-          ORDER BY ge.ROUND_NUMBER`,
+          getSql(GameSql.getGotmWins, dialect),
           { gameId },
           (row) => ({
             round: Number(row.ROUND_NUMBER),
@@ -2212,15 +2053,7 @@ export default class Game {
             monthYear: string;
           }
         >(
-          `SELECT nge.ROUND_NUMBER,
-                COALESCE(
-                  (SELECT MIN(tgl.THREAD_ID) FROM THREAD_GAME_LINKS tgl WHERE tgl.GAMEDB_GAME_ID = nge.GAMEDB_GAME_ID),
-                  (SELECT MIN(th.THREAD_ID) FROM THREADS th WHERE th.GAMEDB_GAME_ID = nge.GAMEDB_GAME_ID)
-                ) AS THREAD_ID,
-                nge.REDDIT_URL, nge.MONTH_YEAR
-           FROM NR_GOTM_ENTRIES nge
-          WHERE nge.GAMEDB_GAME_ID = :gameId
-          ORDER BY nge.ROUND_NUMBER`,
+          getSql(GameSql.getNrGotmWins, dialect),
           { gameId },
           (row) => ({
             round: Number(row.ROUND_NUMBER),
@@ -2230,11 +2063,7 @@ export default class Game {
           }),
         ),
         oraQuery<NomRow, { round: number; userId: string; username: string }>(
-          `SELECT n.ROUND_NUMBER, n.USER_ID, u.USERNAME, u.GLOBAL_NAME
-           FROM GOTM_NOMINATIONS n
-           LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = n.USER_ID
-          WHERE n.GAMEDB_GAME_ID = :gameId
-          ORDER BY n.ROUND_NUMBER`,
+          getSql(GameSql.getGotmNominations, dialect),
           { gameId },
           (row) => ({
             round: Number(row.ROUND_NUMBER),
@@ -2243,11 +2072,7 @@ export default class Game {
           }),
         ),
         oraQuery<NomRow, { round: number; userId: string; username: string }>(
-          `SELECT n.ROUND_NUMBER, n.USER_ID, u.USERNAME, u.GLOBAL_NAME
-           FROM NR_GOTM_NOMINATIONS n
-           LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = n.USER_ID
-          WHERE n.GAMEDB_GAME_ID = :gameId
-          ORDER BY n.ROUND_NUMBER`,
+          getSql(GameSql.getNrGotmNominations, dialect),
           { gameId },
           (row) => ({
             round: Number(row.ROUND_NUMBER),
@@ -2264,20 +2089,7 @@ export default class Game {
     gameId: number,
   ): Promise<INowPlayingMember[]> {
     return oraQuery(
-      `SELECT u.USER_ID,
-              ru.USERNAME,
-              ru.GLOBAL_NAME,
-              COALESCE(
-                (SELECT MIN(tgl.THREAD_ID) FROM THREAD_GAME_LINKS tgl
-                  WHERE tgl.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID),
-                (SELECT MIN(th.THREAD_ID) FROM THREADS th
-                  WHERE th.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID)
-              ) AS THREAD_ID,
-              u.ADDED_AT
-         FROM USER_NOW_PLAYING u
-         JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
-        WHERE u.GAMEDB_GAME_ID = :gameId
-        ORDER BY u.ADDED_AT DESC, u.ENTRY_ID DESC`,
+      getSql(GameSql.getNowPlayingMembers, dialect),
       { gameId },
       (row: {
         USER_ID: string;
@@ -2302,12 +2114,7 @@ export default class Game {
 
   static async getGameCompletions(gameId: number): Promise<ICompletedMember[]> {
     return oraQuery(
-      `SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME,
-              c.COMPLETION_TYPE, c.COMPLETED_AT, c.FINAL_PLAYTIME_HRS
-         FROM USER_GAME_COMPLETIONS c
-         LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
-        WHERE c.GAMEDB_GAME_ID = :gameId
-        ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.CREATED_AT DESC, c.COMPLETION_ID DESC`,
+      getSql(GameSql.getGameCompletions, dialect),
       { gameId },
       (row: {
         USER_ID: string;
@@ -2339,12 +2146,7 @@ export default class Game {
     gameId: number,
   ): Promise<ICollectionOwnerMember[]> {
     return oraQuery(
-      `SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME
-         FROM USER_GAME_COLLECTIONS c
-         LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
-        WHERE c.GAMEDB_GAME_ID = :gameId
-        GROUP BY c.USER_ID, u.USERNAME, u.GLOBAL_NAME
-        ORDER BY LOWER(COALESCE(u.GLOBAL_NAME, u.USERNAME, c.USER_ID))`,
+      getSql(GameSql.getGameCollectionOwners, dialect),
       { gameId },
       (row: {
         USER_ID: string;

--- a/src/classes/GameSearchSynonym.ts
+++ b/src/classes/GameSearchSynonym.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GameSearchSynonymSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type IGameSearchSynonym = {
   termId: number;
@@ -25,8 +30,6 @@ function mapSynonymRow(row: any): IGameSearchSynonym {
   };
 }
 
-const SYNONYM_COLS = `TERM_ID, GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_AT, CREATED_BY`;
-
 export default class GameSearchSynonym {
   static normalizeTerm(text: string): string {
     return normalizeSearchTerm(text);
@@ -39,9 +42,7 @@ export default class GameSearchSynonym {
     const norm = normalizeSearchTerm(termText);
     if (!norm) return [];
     return oraQuery(
-      `SELECT GROUP_ID
-         FROM GAMEDB_SEARCH_SYNONYMS
-        WHERE TERM_NORM = :termNorm`,
+      getSql(GameSearchSynonymSql.getGroupIdsForTerm, dialect),
       { termNorm: norm },
       (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
       conn,
@@ -53,10 +54,7 @@ export default class GameSearchSynonym {
     conn?: oracledb.Connection,
   ): Promise<IGameSearchSynonym[]> {
     return oraQuery(
-      `SELECT ${SYNONYM_COLS}
-         FROM GAMEDB_SEARCH_SYNONYMS
-        WHERE GROUP_ID = :groupId
-        ORDER BY TERM_TEXT ASC`,
+      getSql(GameSearchSynonymSql.listGroupTerms, dialect),
       { groupId },
       mapSynonymRow,
       conn,
@@ -76,10 +74,7 @@ export default class GameSearchSynonym {
         return `:${key}`;
       });
       return oraQuery(
-        `SELECT DISTINCT TERM_TEXT
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE GROUP_ID IN (${placeholders.join(", ")})
-          ORDER BY TERM_TEXT ASC`,
+        GameSearchSynonymSql.getTermsForQuery(placeholders.join(", "))[dialect],
         binds,
         (row: { TERM_TEXT: string }) => String(row.TERM_TEXT),
         conn,
@@ -95,13 +90,7 @@ export default class GameSearchSynonym {
     const normalizedQuery = query ? `%${normalizeSearchTerm(query)}%` : null;
     const limit = options.limit ?? 50;
     return oraQuery(
-      `SELECT ${SYNONYM_COLS}
-         FROM GAMEDB_SEARCH_SYNONYMS
-        WHERE (:searchQuery IS NULL
-           OR LOWER(TERM_TEXT) LIKE :searchQuery
-           OR TERM_NORM LIKE :normalizedQuery)
-        ORDER BY GROUP_ID ASC, TERM_TEXT ASC
-        FETCH FIRST :limit ROWS ONLY`,
+      getSql(GameSearchSynonymSql.listSynonyms, dialect),
       { searchQuery, normalizedQuery, limit },
       mapSynonymRow,
     );
@@ -114,11 +103,7 @@ export default class GameSearchSynonym {
       ? `%${normalizeSearchTerm(cleanedQuery)}%`
       : null;
     const rows = await oraQuery(
-      `SELECT COUNT(DISTINCT GROUP_ID) AS CNT
-         FROM GAMEDB_SEARCH_SYNONYMS
-        WHERE (:searchQuery IS NULL
-           OR LOWER(TERM_TEXT) LIKE :searchQuery
-           OR TERM_NORM LIKE :normalizedQuery)`,
+      getSql(GameSearchSynonymSql.countSynonymGroups, dialect),
       { searchQuery, normalizedQuery },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );
@@ -138,13 +123,7 @@ export default class GameSearchSynonym {
 
     return oraWithConnection(async (conn) => {
       const groupIds = await oraQuery(
-        `SELECT DISTINCT GROUP_ID
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE (:searchQuery IS NULL
-             OR LOWER(TERM_TEXT) LIKE :searchQuery
-             OR TERM_NORM LIKE :normalizedQuery)
-          ORDER BY GROUP_ID ASC
-          OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+        getSql(GameSearchSynonymSql.listGroupIdsForSearch, dialect),
         { searchQuery, normalizedQuery, offset, limit },
         (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
         conn,
@@ -158,10 +137,7 @@ export default class GameSearchSynonym {
         return `:${key}`;
       });
       return oraQuery(
-        `SELECT ${SYNONYM_COLS}
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE GROUP_ID IN (${placeholders.join(", ")})
-          ORDER BY GROUP_ID ASC, TERM_TEXT ASC`,
+        GameSearchSynonymSql.listTermsInGroups(placeholders.join(", "))[dialect],
         binds,
         mapSynonymRow,
         conn,
@@ -188,9 +164,7 @@ export default class GameSearchSynonym {
 
       if (!groupId) {
         const groupResult = await oraMutate(
-          `INSERT INTO GAMEDB_SEARCH_SYNONYM_GROUPS (CREATED_BY)
-           VALUES (:createdBy)
-           RETURNING GROUP_ID INTO :groupId`,
+          getSql(GameSearchSynonymSql.insertSynonymGroup, dialect),
           {
             createdBy,
             groupId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
@@ -208,9 +182,7 @@ export default class GameSearchSynonym {
         }
         try {
           await oraMutate(
-            `INSERT INTO GAMEDB_SEARCH_SYNONYMS
-               (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
-             VALUES (:groupId, :termText, :termNorm, :createdBy)`,
+            getSql(GameSearchSynonymSql.insertSynonymTerm, dialect),
             { groupId, termText: text, termNorm: norm, createdBy },
             conn,
           );
@@ -245,10 +217,7 @@ export default class GameSearchSynonym {
 
     return oraWithConnection(async (conn) => {
       await oraMutate(
-        `UPDATE GAMEDB_SEARCH_SYNONYMS
-            SET TERM_TEXT = :termText,
-                TERM_NORM = :termNorm
-          WHERE TERM_ID = :termId`,
+        getSql(GameSearchSynonymSql.updateSynonymTerm, dialect),
         { termId, termText: trimmed, termNorm },
         conn,
       );
@@ -272,9 +241,7 @@ export default class GameSearchSynonym {
 
     return oraWithConnection(async (conn) => {
       const existsRows = await oraQuery(
-        `SELECT COUNT(*) AS CNT
-           FROM GAMEDB_SEARCH_SYNONYM_GROUPS
-          WHERE GROUP_ID = :groupId`,
+        getSql(GameSearchSynonymSql.checkGroupExists, dialect),
         { groupId },
         (row: { CNT: number }) => Number(row.CNT ?? 0),
         conn,
@@ -284,7 +251,7 @@ export default class GameSearchSynonym {
       }
 
       await oraMutate(
-        `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE GROUP_ID = :groupId`,
+        getSql(GameSearchSynonymSql.deleteSynonymsByGroup, dialect),
         { groupId },
         conn,
       );
@@ -297,9 +264,7 @@ export default class GameSearchSynonym {
         }
         try {
           await oraMutate(
-            `INSERT INTO GAMEDB_SEARCH_SYNONYMS
-               (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
-             VALUES (:groupId, :termText, :termNorm, :createdBy)`,
+            getSql(GameSearchSynonymSql.insertSynonymTerm, dialect),
             { groupId, termText: text, termNorm: norm, createdBy: updatedBy },
             conn,
           );
@@ -339,9 +304,7 @@ export default class GameSearchSynonym {
 
     return oraWithConnection(async (conn) => {
       const groupResult = await oraMutate(
-        `INSERT INTO GAMEDB_SEARCH_SYNONYM_GROUPS (CREATED_BY)
-         VALUES (:createdBy)
-         RETURNING GROUP_ID INTO :groupId`,
+        getSql(GameSearchSynonymSql.insertSynonymGroup, dialect),
         {
           createdBy,
           groupId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
@@ -357,9 +320,7 @@ export default class GameSearchSynonym {
       for (const text of cleaned) {
         const norm = normalizeSearchTerm(text);
         await oraMutate(
-          `INSERT INTO GAMEDB_SEARCH_SYNONYMS
-             (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
-           VALUES (:groupId, :termText, :termNorm, :createdBy)`,
+          getSql(GameSearchSynonymSql.insertSynonymTerm, dialect),
           { groupId, termText: text, termNorm: norm, createdBy },
           conn,
         );
@@ -376,9 +337,7 @@ export default class GameSearchSynonym {
   static async deleteSynonym(termId: number): Promise<boolean> {
     return oraWithConnection(async (conn) => {
       const groupRows = await oraQuery(
-        `SELECT GROUP_ID
-           FROM GAMEDB_SEARCH_SYNONYMS
-          WHERE TERM_ID = :termId`,
+        getSql(GameSearchSynonymSql.getSynonymGroupId, dialect),
         { termId },
         (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
         conn,
@@ -386,7 +345,7 @@ export default class GameSearchSynonym {
       const groupId = groupRows[0] ?? null;
 
       const result = await oraMutate(
-        `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE TERM_ID = :termId`,
+        getSql(GameSearchSynonymSql.deleteSynonymById, dialect),
         { termId },
         conn,
       );
@@ -394,16 +353,14 @@ export default class GameSearchSynonym {
 
       if (groupId) {
         const countRows = await oraQuery(
-          `SELECT COUNT(*) AS CNT
-             FROM GAMEDB_SEARCH_SYNONYMS
-            WHERE GROUP_ID = :groupId`,
+          getSql(GameSearchSynonymSql.countSynonymsInGroup, dialect),
           { groupId },
           (row: { CNT: number }) => Number(row.CNT ?? 0),
           conn,
         );
         if ((countRows[0] ?? 0) === 0) {
           await oraMutate(
-            `DELETE FROM GAMEDB_SEARCH_SYNONYM_GROUPS WHERE GROUP_ID = :groupId`,
+            getSql(GameSearchSynonymSql.deleteGroup, dialect),
             { groupId },
             conn,
           );
@@ -419,9 +376,7 @@ export default class GameSearchSynonym {
     if (!Number.isInteger(groupId) || groupId <= 0) return false;
     return oraWithConnection(async (conn) => {
       const existsRows = await oraQuery(
-        `SELECT COUNT(*) AS CNT
-           FROM GAMEDB_SEARCH_SYNONYM_GROUPS
-          WHERE GROUP_ID = :groupId`,
+        getSql(GameSearchSynonymSql.checkGroupExists, dialect),
         { groupId },
         (row: { CNT: number }) => Number(row.CNT ?? 0),
         conn,
@@ -429,13 +384,13 @@ export default class GameSearchSynonym {
       if ((existsRows[0] ?? 0) === 0) return false;
 
       await oraMutate(
-        `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE GROUP_ID = :groupId`,
+        getSql(GameSearchSynonymSql.deleteSynonymsByGroup, dialect),
         { groupId },
         conn,
       );
       await conn.commit();
       await oraMutate(
-        `DELETE FROM GAMEDB_SEARCH_SYNONYM_GROUPS WHERE GROUP_ID = :groupId`,
+        getSql(GameSearchSynonymSql.deleteGroup, dialect),
         { groupId },
         conn,
       );
@@ -449,9 +404,7 @@ export default class GameSearchSynonym {
     conn?: oracledb.Connection,
   ): Promise<IGameSearchSynonym | null> {
     const rows = await oraQuery(
-      `SELECT ${SYNONYM_COLS}
-         FROM GAMEDB_SEARCH_SYNONYMS
-        WHERE TERM_ID = :termId`,
+      getSql(GameSearchSynonymSql.getSynonymById, dialect),
       { termId },
       mapSynonymRow,
       conn,

--- a/src/classes/GameSearchSynonymDraft.ts
+++ b/src/classes/GameSearchSynonymDraft.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GameSearchSynonymDraftSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type ISynonymDraftPair = {
   term: string;
@@ -45,9 +50,7 @@ function mapDraftRow(row: any): ISynonymDraft {
 export default class GameSearchSynonymDraft {
   static async createDraft(userId: string): Promise<ISynonymDraft> {
     const result = await oraMutate(
-      `INSERT INTO GAMEDB_SEARCH_SYNONYM_DRAFTS (USER_ID, PAIRS_JSON)
-       VALUES (:userId, :pairsJson)
-       RETURNING DRAFT_ID INTO :draftId`,
+      getSql(GameSearchSynonymDraftSql.createDraft, dialect),
       {
         userId,
         pairsJson: JSON.stringify([]),
@@ -64,9 +67,7 @@ export default class GameSearchSynonymDraft {
 
   static async getDraft(draftId: number): Promise<ISynonymDraft | null> {
     const rows = await oraQuery(
-      `SELECT DRAFT_ID, USER_ID, PAIRS_JSON, CREATED_AT, UPDATED_AT
-         FROM GAMEDB_SEARCH_SYNONYM_DRAFTS
-        WHERE DRAFT_ID = :draftId`,
+      getSql(GameSearchSynonymDraftSql.getDraft, dialect),
       { draftId },
       mapDraftRow,
     );
@@ -82,10 +83,7 @@ export default class GameSearchSynonymDraft {
       if (!existing) return null;
       const combined = [...existing.pairs, ...pairs];
       await oraMutate(
-        `UPDATE GAMEDB_SEARCH_SYNONYM_DRAFTS
-            SET PAIRS_JSON = :pairsJson,
-                UPDATED_AT = CURRENT_TIMESTAMP
-          WHERE DRAFT_ID = :draftId`,
+        getSql(GameSearchSynonymDraftSql.updateDraft, dialect),
         { draftId, pairsJson: JSON.stringify(combined) },
         conn,
       );
@@ -95,7 +93,7 @@ export default class GameSearchSynonymDraft {
 
   static async deleteDraft(draftId: number): Promise<void> {
     await oraMutate(
-      `DELETE FROM GAMEDB_SEARCH_SYNONYM_DRAFTS WHERE DRAFT_ID = :draftId`,
+      getSql(GameSearchSynonymDraftSql.deleteDraft, dialect),
       { draftId },
     );
   }
@@ -105,9 +103,7 @@ export default class GameSearchSynonymDraft {
     conn: oracledb.Connection,
   ): Promise<ISynonymDraft | null> {
     const rows = await oraQuery(
-      `SELECT DRAFT_ID, USER_ID, PAIRS_JSON, CREATED_AT, UPDATED_AT
-         FROM GAMEDB_SEARCH_SYNONYM_DRAFTS
-        WHERE DRAFT_ID = :draftId`,
+      getSql(GameSearchSynonymDraftSql.getDraft, dialect),
       { draftId },
       mapDraftRow,
       conn,

--- a/src/classes/Gotm.ts
+++ b/src/classes/Gotm.ts
@@ -1,5 +1,10 @@
 import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GotmSql } from "../db/sql/index.js";
 import Game from "./Game.js";
+
+const dialect = getDialect();
 import { getThreadsByGameId } from "./Thread.js";
 
 export interface IGotmGame {
@@ -64,14 +69,7 @@ type GotmEntryRow = {
 
 async function loadFromDatabaseInternal(): Promise<IGotmEntry[]> {
   const rows = await oraQuery<GotmEntryRow, GotmEntryRow>(
-    `SELECT ROUND_NUMBER,
-            MONTH_YEAR,
-            GAME_INDEX,
-            REDDIT_URL,
-            VOTING_RESULTS_MESSAGE_ID,
-            GAMEDB_GAME_ID
-       FROM GOTM_ENTRIES
-      ORDER BY ROUND_NUMBER, GAME_INDEX`,
+    getSql(GotmSql.loadAll, dialect),
     {},
     (row) => row,
   );
@@ -334,11 +332,7 @@ export async function updateGotmGameFieldInDatabase(
 
   await oraWithConnection(async (conn) => {
     const rows = await oraQuery<GotmRowIndexRow, GotmRowIndexRow>(
-      `SELECT ROUND_NUMBER,
-              GAME_INDEX
-         FROM GOTM_ENTRIES
-        WHERE ROUND_NUMBER = :round
-        ORDER BY GAME_INDEX`,
+      getSql(GotmSql.getRowsByRound, dialect),
       { round },
       (row) => row,
       conn,
@@ -368,10 +362,7 @@ export async function updateGotmGameFieldInDatabase(
     }
 
     await oraMutate(
-      `UPDATE GOTM_ENTRIES
-          SET ${columnName} = :value
-        WHERE ROUND_NUMBER = :round
-          AND GAME_INDEX = :gameIndex`,
+      GotmSql.updateField(columnName)[dialect],
       { round, gameIndex: dbGameIndex, value: dbValue },
       conn,
     );
@@ -398,9 +389,7 @@ export async function updateGotmVotingResultsInDatabase(
   messageId: string | null,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE GOTM_ENTRIES
-        SET VOTING_RESULTS_MESSAGE_ID = :value
-      WHERE ROUND_NUMBER = :round`,
+    getSql(GotmSql.updateVotingResults, dialect),
     { round, value: messageId },
   );
 }
@@ -418,9 +407,7 @@ export async function insertGotmRoundInDatabase(
   }
 
   const countRows = await oraQuery<{ CNT: number }, { CNT: number }>(
-    `SELECT COUNT(*) AS CNT
-       FROM GOTM_ENTRIES
-      WHERE ROUND_NUMBER = :round`,
+    getSql(GotmSql.checkRoundExists, dialect),
     { round },
     (row) => row,
   );
@@ -437,21 +424,7 @@ export async function insertGotmRoundInDatabase(
       }
       const gameMeta = await getGameDetailsCached(g.gamedbGameId);
       await oraMutate(
-        `INSERT INTO GOTM_ENTRIES (
-           ROUND_NUMBER,
-           MONTH_YEAR,
-           GAME_INDEX,
-           REDDIT_URL,
-           VOTING_RESULTS_MESSAGE_ID,
-           GAMEDB_GAME_ID
-         ) VALUES (
-           :round,
-           :monthYear,
-           :gameIndex,
-           :redditUrl,
-           NULL,
-           :gamedbGameId
-         )`,
+        getSql(GotmSql.insertRound, dialect),
         {
           round,
           monthYear,
@@ -472,8 +445,7 @@ export async function deleteGotmRoundFromDatabase(round: number): Promise<number
   }
 
   const result = await oraMutate(
-    `DELETE FROM GOTM_ENTRIES
-      WHERE ROUND_NUMBER = :round`,
+    getSql(GotmSql.deleteRound, dialect),
     { round },
   );
   return result.rowsAffected ?? 0;

--- a/src/classes/HltbCache.ts
+++ b/src/classes/HltbCache.ts
@@ -1,4 +1,9 @@
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { HltbCacheSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type HltbCacheEntry = {
   gameId: number;
@@ -56,21 +61,7 @@ export async function getHltbCacheByGameId(
   gameId: number,
 ): Promise<HltbCacheEntry | null> {
   const rows = await oraQuery(
-    `SELECT GAMEDB_GAME_ID,
-            HLTB_NAME,
-            HLTB_URL,
-            HLTB_IMAGE_URL,
-            MAIN,
-            MAIN_SIDES,
-            COMPLETIONIST,
-            SINGLE_PLAYER,
-            CO_OP,
-            VS,
-            SOURCE_QUERY,
-            SCRAPED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_HLTB_CACHE
-      WHERE GAMEDB_GAME_ID = :gameId`,
+    getSql(HltbCacheSql.getByGameId, dialect),
     { gameId },
     mapRow,
   );
@@ -93,53 +84,7 @@ export async function upsertHltbCache(
   },
 ): Promise<void> {
   await oraMutate(
-    `MERGE INTO RPG_CLUB_HLTB_CACHE t
-     USING (SELECT :gameId AS GAME_ID FROM dual) s
-        ON (t.GAMEDB_GAME_ID = s.GAME_ID)
-     WHEN MATCHED THEN
-       UPDATE SET
-         HLTB_NAME = :name,
-         HLTB_URL = :url,
-         HLTB_IMAGE_URL = :imageUrl,
-         MAIN = :main,
-         MAIN_SIDES = :mainSides,
-         COMPLETIONIST = :completionist,
-         SINGLE_PLAYER = :singlePlayer,
-         CO_OP = :coOp,
-         VS = :vs,
-         SOURCE_QUERY = :sourceQuery,
-         SCRAPED_AT = SYSTIMESTAMP,
-         UPDATED_AT = SYSTIMESTAMP
-     WHEN NOT MATCHED THEN
-       INSERT (
-         GAMEDB_GAME_ID,
-         HLTB_NAME,
-         HLTB_URL,
-         HLTB_IMAGE_URL,
-         MAIN,
-         MAIN_SIDES,
-         COMPLETIONIST,
-         SINGLE_PLAYER,
-         CO_OP,
-         VS,
-         SOURCE_QUERY,
-         SCRAPED_AT,
-         UPDATED_AT
-       ) VALUES (
-         :gameId,
-         :name,
-         :url,
-         :imageUrl,
-         :main,
-         :mainSides,
-         :completionist,
-         :singlePlayer,
-         :coOp,
-         :vs,
-         :sourceQuery,
-         SYSTIMESTAMP,
-         SYSTIMESTAMP
-       )`,
+    getSql(HltbCacheSql.upsertCache, dialect),
     {
       gameId,
       name: payload.name ?? null,

--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -5,6 +5,11 @@ import {
   oraWithConnection,
   oraTransaction,
 } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { MemberSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface IMemberRecord {
   userId: string;
@@ -205,11 +210,7 @@ async function getNowPlayingThreadIdSql(connection: Connection): Promise<string>
   if (nowPlayingLinkedThreadColumnAvailable === null) {
     try {
       const res = await oraQuery<{ CNT: number }, number>(
-        `SELECT COUNT(*) AS CNT
-           FROM ALL_TAB_COLUMNS
-          WHERE OWNER = SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')
-            AND TABLE_NAME = 'GAMEDB_GAMES'
-            AND COLUMN_NAME = 'LINKED_THREAD_ID'`,
+        getSql(MemberSql.checkLinkedThreadColumn, dialect),
         {},
         (row) => Number(row.CNT),
         connection,
@@ -256,10 +257,7 @@ export default class Member {
   static async touchLastSeen(userId: string, when: Date = new Date()): Promise<void> {
     try {
       await oraMutate(
-        `UPDATE RPG_CLUB_USERS
-            SET LAST_SEEN_AT = :lastSeen,
-                UPDATED_AT = SYSTIMESTAMP
-          WHERE USER_ID = :userId`,
+        getSql(MemberSql.touchLastSeen, dialect),
         { userId, lastSeen: when },
       );
     } catch (err: any) {
@@ -289,43 +287,7 @@ export default class Member {
         JOURNAL_COUNT: number | null;
         LAST_JOURNAL_AT: Date | string | null;
       }>(
-        `SELECT g.GAME_ID,
-                g.TITLE,
-                u.PLATFORM_ID,
-                p.PLATFORM_NAME,
-                p.PLATFORM_ABBREVIATION,
-                ${threadIdSql} AS THREAD_ID,
-                u.NOTE,
-                u.ADDED_AT,
-                u.NOTE_UPDATED_AT,
-                u.SORT_ORDER,
-                NVL(jp.IS_ENABLED, 1) AS JOURNAL_ENABLED,
-                CASE
-                  WHEN EXISTS (
-                    SELECT 1
-                    FROM USER_GAME_JOURNAL_ENTRIES je
-                    WHERE je.USER_ID = u.USER_ID
-                      AND je.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
-                  ) THEN 1
-                  ELSE 0
-                END AS HAS_JOURNAL_ENTRY,
-                (SELECT COUNT(*)
-                   FROM USER_GAME_JOURNAL_ENTRIES je2
-                  WHERE je2.USER_ID = u.USER_ID
-                    AND je2.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID) AS JOURNAL_COUNT,
-                (SELECT MAX(je3.CREATED_AT)
-                   FROM USER_GAME_JOURNAL_ENTRIES je3
-                  WHERE je3.USER_ID = u.USER_ID
-                    AND je3.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID) AS LAST_JOURNAL_AT
-           FROM USER_NOW_PLAYING u
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
-           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
-           LEFT JOIN USER_GAME_JOURNAL_PREFS jp
-             ON jp.USER_ID = u.USER_ID
-            AND jp.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
-          WHERE u.USER_ID = :userId
-            AND u.GAMEDB_GAME_ID IS NOT NULL
-          ORDER BY u.SORT_ORDER NULLS LAST, u.ADDED_AT DESC, u.ENTRY_ID DESC`,
+        MemberSql.getNowPlaying(threadIdSql)[dialect],
         { userId },
         { outFormat: oracledb.OUT_FORMAT_OBJECT },
       );
@@ -379,28 +341,7 @@ export default class Member {
         ADDED_AT: Date | string | null;
         NOTE_UPDATED_AT: Date | string | null;
       }>(
-        `SELECT u.USER_ID,
-                ru.USERNAME,
-                ru.GLOBAL_NAME,
-                g.GAME_ID,
-                g.TITLE,
-                u.PLATFORM_ID,
-                p.PLATFORM_NAME,
-                p.PLATFORM_ABBREVIATION,
-                ${threadIdSql} AS THREAD_ID,
-                u.NOTE,
-                u.ADDED_AT,
-                u.NOTE_UPDATED_AT,
-                u.ENTRY_ID
-           FROM USER_NOW_PLAYING u
-           JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
-           JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
-           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
-          WHERE NVL(ru.IS_BOT, 0) = 0
-            AND ru.SERVER_LEFT_AT IS NULL
-          ORDER BY COALESCE(ru.GLOBAL_NAME, ru.USERNAME, ru.USER_ID),
-                   u.ADDED_AT DESC,
-                   u.ENTRY_ID DESC`,
+        MemberSql.getAllNowPlaying(threadIdSql)[dialect],
         {},
         { outFormat: oracledb.OUT_FORMAT_OBJECT },
       );
@@ -466,16 +407,7 @@ export default class Member {
 
     return oraQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
       { gameId: number; title: string; userId: string }>(
-      `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
-              g.TITLE,
-              u.USER_ID
-         FROM USER_NOW_PLAYING u
-         JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
-         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
-        WHERE u.GAMEDB_GAME_ID IN (${placeholders.join(", ")})
-          AND NVL(ru.IS_BOT, 0) = 0
-          AND ru.SERVER_LEFT_AT IS NULL
-        ORDER BY g.TITLE, u.USER_ID`,
+      MemberSql.getNowPlayingByGameIds(placeholders.join(", "))[dialect],
       binds,
       (row) => ({
         gameId: Number(row.GAME_ID),
@@ -494,17 +426,7 @@ export default class Member {
     const normalizedQuery = `%${trimmed.replace(/[^a-z0-9]/g, "")}%`;
     return oraQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
       { gameId: number; title: string; userId: string }>(
-      `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
-              g.TITLE,
-              u.USER_ID
-         FROM USER_NOW_PLAYING u
-         JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
-         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
-        WHERE (LOWER(g.TITLE) LIKE :searchQuery
-            OR REGEXP_REPLACE(LOWER(g.TITLE), '[^a-z0-9]', '') LIKE :normalizedQuery)
-          AND NVL(ru.IS_BOT, 0) = 0
-          AND ru.SERVER_LEFT_AT IS NULL
-        ORDER BY g.TITLE, u.USER_ID`,
+      getSql(MemberSql.getNowPlayingByTitleSearch, dialect),
       { searchQuery, normalizedQuery },
       (row) => ({
         gameId: Number(row.GAME_ID),
@@ -553,25 +475,7 @@ export default class Member {
       journalEnabled: boolean;
       hasJournalEntry: boolean;
     }>(
-      `SELECT u.GAMEDB_GAME_ID AS GAME_ID,
-              g.TITLE,
-              u.PLATFORM_ID,
-              p.PLATFORM_NAME,
-              p.PLATFORM_ABBREVIATION,
-              u.NOTE,
-              u.ADDED_AT,
-              u.NOTE_UPDATED_AT,
-              u.SORT_ORDER,
-              jp.IS_ENABLED AS JOURNAL_ENABLED
-         FROM USER_NOW_PLAYING u
-         JOIN GAMEDB_GAMES g ON g.GAME_ID = u.GAMEDB_GAME_ID
-         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = u.PLATFORM_ID
-         LEFT JOIN USER_GAME_JOURNAL_PREFS jp
-           ON jp.USER_ID = u.USER_ID
-          AND jp.GAMEDB_GAME_ID = u.GAMEDB_GAME_ID
-        WHERE u.USER_ID = :userId
-          AND u.GAMEDB_GAME_ID IS NOT NULL
-        ORDER BY u.SORT_ORDER NULLS LAST, u.ADDED_AT DESC, u.ENTRY_ID DESC`,
+      getSql(MemberSql.getNowPlayingEntries, dialect),
       { userId },
       (r) => ({
         gameId: Number(r.GAME_ID),
@@ -605,10 +509,7 @@ export default class Member {
       throw new Error("Invalid GameDB id.");
     }
     const rows = await oraQuery<{ ADDED_AT: Date | string | null }, { addedAt: Date | null }>(
-      `SELECT ADDED_AT
-         FROM USER_NOW_PLAYING
-        WHERE USER_ID = :userId
-          AND GAMEDB_GAME_ID = :gameId`,
+      getSql(MemberSql.getNowPlayingEntryMeta, dialect),
       { userId, gameId },
       (row) => ({
         addedAt: row.ADDED_AT instanceof Date

--- a/src/classes/NrGotm.ts
+++ b/src/classes/NrGotm.ts
@@ -1,6 +1,11 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { NrGotmSql } from "../db/sql/index.js";
 import Game from "./Game.js";
+
+const dialect = getDialect();
 import { getThreadsByGameId } from "./Thread.js";
 
 export interface INrGotmGame {
@@ -67,14 +72,7 @@ type NrGotmEntryRow = {
 
 async function loadFromDatabaseInternal(): Promise<INrGotmEntry[]> {
   const rows = await oraQuery<NrGotmEntryRow, NrGotmEntryRow>(
-    `SELECT ROUND_NUMBER,
-            MONTH_YEAR,
-            GAME_INDEX,
-            REDDIT_URL,
-            VOTING_RESULTS_MESSAGE_ID,
-            GAMEDB_GAME_ID
-       FROM NR_GOTM_ENTRIES
-      ORDER BY ROUND_NUMBER, GAME_INDEX`,
+    getSql(NrGotmSql.loadAll, dialect),
     {},
     (row) => row,
   );
@@ -359,9 +357,7 @@ export async function updateNrGotmGameFieldInDatabase(
   await oraWithConnection(async (conn) => {
     if (opts.rowId) {
       await oraMutate(
-        `UPDATE NR_GOTM_ENTRIES
-            SET ${columnName} = :bindValue
-          WHERE NR_GOTM_ID = :rowIdValue`,
+        NrGotmSql.updateByRowId(columnName)[dialect],
         { rowIdValue: opts.rowId, bindValue: dbValue },
         conn,
       );
@@ -397,12 +393,7 @@ export async function updateNrGotmGameFieldInDatabase(
     }
 
     const rows = await oraQuery<NrGotmRowRef, NrGotmRowRef>(
-      `SELECT NR_GOTM_ID,
-              ROUND_NUMBER,
-              GAME_INDEX
-         FROM NR_GOTM_ENTRIES
-        WHERE ROUND_NUMBER = :roundNumber
-        ORDER BY GAME_INDEX`,
+      getSql(NrGotmSql.getRowsByRound, dialect),
       { roundNumber: round },
       (row) => row,
       conn,
@@ -423,9 +414,7 @@ export async function updateNrGotmGameFieldInDatabase(
     const rowId = rows[gi].NR_GOTM_ID;
 
     await oraMutate(
-      `UPDATE NR_GOTM_ENTRIES
-          SET ${columnName} = :bindValue
-        WHERE NR_GOTM_ID = :rowIdValue`,
+      NrGotmSql.updateByRowId(columnName)[dialect],
       { rowIdValue: rowId, bindValue: dbValue },
       conn,
     );
@@ -452,9 +441,7 @@ export async function updateNrGotmVotingResultsInDatabase(
   messageId: string | null,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE NR_GOTM_ENTRIES
-        SET VOTING_RESULTS_MESSAGE_ID = :bindValue
-      WHERE ROUND_NUMBER = :roundNumber`,
+    getSql(NrGotmSql.updateVotingResults, dialect),
     { roundNumber: round, bindValue: messageId },
   );
 }
@@ -472,9 +459,7 @@ export async function insertNrGotmRoundInDatabase(
   }
 
   const countRows = await oraQuery<{ CNT: number }, { CNT: number }>(
-    `SELECT COUNT(*) AS CNT
-       FROM NR_GOTM_ENTRIES
-      WHERE ROUND_NUMBER = :roundNumber`,
+    getSql(NrGotmSql.checkRoundExists, dialect),
     { roundNumber: round },
     (row) => row,
   );
@@ -493,22 +478,7 @@ export async function insertNrGotmRoundInDatabase(
       }
       const meta = await getNrGameDetailsCached(g.gamedbGameId);
       const result = await oraMutate(
-        `INSERT INTO NR_GOTM_ENTRIES (
-           ROUND_NUMBER,
-           MONTH_YEAR,
-           GAME_INDEX,
-           REDDIT_URL,
-           VOTING_RESULTS_MESSAGE_ID,
-           GAMEDB_GAME_ID
-         ) VALUES (
-           :roundNumber,
-           :monthYear,
-           :gameIndex,
-           :redditUrl,
-           NULL,
-           :gamedbGameId
-         )
-         RETURNING NR_GOTM_ID INTO :outId`,
+        getSql(NrGotmSql.insertRound, dialect),
         {
           roundNumber: round,
           monthYear,
@@ -540,8 +510,7 @@ export async function deleteNrGotmRoundFromDatabase(round: number): Promise<numb
   }
 
   const result = await oraMutate(
-    `DELETE FROM NR_GOTM_ENTRIES
-      WHERE ROUND_NUMBER = :roundNumber`,
+    getSql(NrGotmSql.deleteRound, dialect),
     { roundNumber: round },
   );
   return result.rowsAffected ?? 0;

--- a/src/classes/PublicReminder.ts
+++ b/src/classes/PublicReminder.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { PublicReminderSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type RecurrenceUnit = "minutes" | "hours" | "days" | "weeks" | "months" | "years";
 
@@ -23,24 +28,7 @@ export async function createReminder(
   createdBy: string | null,
 ): Promise<IPublicReminder> {
   const result = await oraMutate(
-    `INSERT INTO RPG_CLUB_PUBLIC_REMINDERS (
-       CHANNEL_ID,
-       MESSAGE,
-       DUE_AT,
-       RECUR_EVERY,
-       RECUR_UNIT,
-       ENABLED,
-       CREATED_BY
-     ) VALUES (
-       :channelId,
-       :message,
-       :dueAt,
-       :recurEvery,
-       :recurUnit,
-       1,
-       :createdBy
-     )
-     RETURNING REMINDER_ID INTO :id`,
+    getSql(PublicReminderSql.create, dialect),
     {
       channelId,
       message,
@@ -67,18 +55,7 @@ export async function createReminder(
 export async function listUpcomingReminders(limit: number = 20): Promise<IPublicReminder[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 100);
   return oraQuery(
-    `SELECT REMINDER_ID,
-            CHANNEL_ID,
-            MESSAGE,
-            DUE_AT,
-            RECUR_EVERY,
-            RECUR_UNIT,
-            ENABLED,
-            CREATED_BY
-       FROM RPG_CLUB_PUBLIC_REMINDERS
-      WHERE ENABLED = 1
-      ORDER BY DUE_AT ASC
-      FETCH FIRST :limit ROWS ONLY`,
+    getSql(PublicReminderSql.listUpcoming, dialect),
     { limit: safeLimit },
     (row: {
       REMINDER_ID: number;
@@ -104,7 +81,7 @@ export async function listUpcomingReminders(limit: number = 20): Promise<IPublic
 
 export async function deleteReminder(reminderId: number): Promise<boolean> {
   const result = await oraMutate(
-    `DELETE FROM RPG_CLUB_PUBLIC_REMINDERS WHERE REMINDER_ID = :id`,
+    getSql(PublicReminderSql.delete, dialect),
     { id: reminderId },
   );
   return (result.rowsAffected ?? 0) > 0;
@@ -115,18 +92,14 @@ export async function updateReminderDueDate(
   nextDue: Date,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_PUBLIC_REMINDERS
-        SET DUE_AT = :nextDue
-      WHERE REMINDER_ID = :id`,
+    getSql(PublicReminderSql.updateDueDate, dialect),
     { nextDue, id: reminderId },
   );
 }
 
 export async function disableReminder(reminderId: number): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_PUBLIC_REMINDERS
-        SET ENABLED = 0
-      WHERE REMINDER_ID = :id`,
+    getSql(PublicReminderSql.disable, dialect),
     { id: reminderId },
   );
 }

--- a/src/classes/Reminder.ts
+++ b/src/classes/Reminder.ts
@@ -1,6 +1,11 @@
 import oracledb from "oracledb";
 import type { Connection } from "oracledb";
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { ReminderSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface IReminderRecord {
   reminderId: number;
@@ -14,10 +19,6 @@ export interface IReminderRecord {
   createdAt: Date | null;
   updatedAt: Date | null;
 }
-
-const REMINDER_COLUMNS =
-  "REMINDER_ID, USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT," +
-  " FAILURE_COUNT, FAILED_AT, CREATED_AT, UPDATED_AT";
 
 function normalizeReminderId(value: number): number {
   const id = Number(value);
@@ -111,14 +112,7 @@ export default class Reminder {
     const noisyVal = isNoisy ? 1 : 0;
 
     const result = await oraMutate(
-      `INSERT INTO USER_REMINDERS (
-         USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT, FAILURE_COUNT,
-         FAILED_AT, CREATED_AT, UPDATED_AT
-       ) VALUES (
-         :userId, :remindAt, :content, :noisyVal, NULL, 0, NULL,
-         SYSTIMESTAMP, SYSTIMESTAMP
-       )
-       RETURNING REMINDER_ID INTO :reminderId`,
+      getSql(ReminderSql.create, dialect),
       {
         userId,
         remindAt: normalizedDate,
@@ -140,10 +134,7 @@ export default class Reminder {
 
   static async listByUser(userId: string): Promise<IReminderRecord[]> {
     return oraQuery(
-      `SELECT ${REMINDER_COLUMNS}
-         FROM USER_REMINDERS
-        WHERE USER_ID = :userId
-        ORDER BY REMIND_AT`,
+      getSql(ReminderSql.listByUser, dialect),
       { userId },
       mapRowToReminder,
     );
@@ -155,9 +146,7 @@ export default class Reminder {
   ): Promise<IReminderRecord | null> {
     const id = normalizeReminderId(reminderId);
     const rows = await oraQuery(
-      `SELECT ${REMINDER_COLUMNS}
-         FROM USER_REMINDERS
-        WHERE REMINDER_ID = :reminderId`,
+      getSql(ReminderSql.getById, dialect),
       { reminderId: id },
       mapRowToReminder,
       opts?.connection,
@@ -168,9 +157,7 @@ export default class Reminder {
   static async delete(reminderId: number, userId: string): Promise<boolean> {
     const id = normalizeReminderId(reminderId);
     const result = await oraMutate(
-      `DELETE FROM USER_REMINDERS
-        WHERE REMINDER_ID = :reminderId
-          AND USER_ID = :userId`,
+      getSql(ReminderSql.delete, dialect),
       { reminderId: id, userId },
     );
     return (result.rowsAffected ?? 0) > 0;
@@ -185,14 +172,7 @@ export default class Reminder {
     const normalizedDate = normalizeDate(remindAt);
 
     const result = await oraMutate(
-      `UPDATE USER_REMINDERS
-          SET REMIND_AT = :remindAt,
-              SENT_AT = NULL,
-              FAILURE_COUNT = 0,
-              FAILED_AT = NULL,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE REMINDER_ID = :reminderId
-          AND USER_ID = :userId`,
+      getSql(ReminderSql.snooze, dialect),
       { reminderId: id, userId, remindAt: normalizedDate },
     );
 
@@ -205,12 +185,7 @@ export default class Reminder {
   static async markSent(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
     const result = await oraMutate(
-      `UPDATE USER_REMINDERS
-          SET SENT_AT = SYSTIMESTAMP,
-              FAILURE_COUNT = 0,
-              FAILED_AT = NULL,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE REMINDER_ID = :reminderId`,
+      getSql(ReminderSql.markSent, dialect),
       { reminderId: id },
     );
     if ((result.rowsAffected ?? 0) === 0) {
@@ -221,11 +196,7 @@ export default class Reminder {
   static async recordFailure(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
     await oraMutate(
-      `UPDATE USER_REMINDERS
-          SET FAILURE_COUNT = FAILURE_COUNT + 1,
-              FAILED_AT = SYSTIMESTAMP,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE REMINDER_ID = :reminderId`,
+      getSql(ReminderSql.recordFailure, dialect),
       { reminderId: id },
     );
   }
@@ -233,10 +204,7 @@ export default class Reminder {
   static async markFailedPermanently(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
     await oraMutate(
-      `UPDATE USER_REMINDERS
-          SET SENT_AT = SYSTIMESTAMP,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE REMINDER_ID = :reminderId`,
+      getSql(ReminderSql.markFailedPermanently, dialect),
       { reminderId: id },
     );
   }
@@ -249,16 +217,7 @@ export default class Reminder {
     const safeLimit = Math.max(1, Math.min(limit, 100));
 
     return oraQuery(
-      `SELECT ${REMINDER_COLUMNS}
-         FROM (
-           SELECT ${REMINDER_COLUMNS}
-             FROM USER_REMINDERS
-            WHERE REMIND_AT <= :cutoff
-              AND SENT_AT IS NULL
-              AND FAILURE_COUNT < 5
-            ORDER BY REMIND_AT
-         )
-        WHERE ROWNUM <= :limit`,
+      getSql(ReminderSql.getDueUndelivered, dialect),
       { cutoff: normalizedDate, limit: safeLimit },
       mapRowToReminder,
     );

--- a/src/classes/RssFeed.ts
+++ b/src/classes/RssFeed.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { RssFeedSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface IRssFeed {
   feedId: number;
@@ -49,14 +54,7 @@ function mapFeedRow(row: FeedRow): IRssFeed {
 
 export async function listFeeds(existingConnection?: oracledb.Connection): Promise<IRssFeed[]> {
   return oraQuery(
-    `SELECT FEED_ID,
-            FEED_NAME,
-            FEED_URL,
-            CHANNEL_ID,
-            INCLUDE_KEYWORDS,
-            EXCLUDE_KEYWORDS
-       FROM RPG_CLUB_RSS_FEEDS
-      ORDER BY FEED_ID`,
+    getSql(RssFeedSql.listFeeds, dialect),
     {},
     mapFeedRow,
     existingConnection,
@@ -73,20 +71,7 @@ export async function addFeed(
   const normalizedInclude = normalizeKeywords(includeKeywords);
   const normalizedExclude = normalizeKeywords(excludeKeywords);
   const result = await oraMutate(
-    `INSERT INTO RPG_CLUB_RSS_FEEDS (
-       FEED_NAME,
-       FEED_URL,
-       CHANNEL_ID,
-       INCLUDE_KEYWORDS,
-       EXCLUDE_KEYWORDS
-     ) VALUES (
-       :feedName,
-       :feedUrl,
-       :channelId,
-       :includes,
-       :excludes
-     )
-     RETURNING FEED_ID INTO :id`,
+    getSql(RssFeedSql.addFeed, dialect),
     {
       feedName,
       feedUrl,
@@ -102,7 +87,7 @@ export async function addFeed(
 
 export async function removeFeed(feedId: number): Promise<boolean> {
   const result = await oraMutate(
-    `DELETE FROM RPG_CLUB_RSS_FEEDS WHERE FEED_ID = :id`,
+    getSql(RssFeedSql.removeFeed, dialect),
     { id: feedId },
   );
   return (result.rowsAffected ?? 0) > 0;
@@ -141,9 +126,7 @@ export async function updateFeed(
   if (!sets.length) return false;
 
   const result = await oraMutate(
-    `UPDATE RPG_CLUB_RSS_FEEDS
-        SET ${sets.join(", ")}
-      WHERE FEED_ID = :feedId`,
+    RssFeedSql.updateFeed(sets)[dialect],
     params,
   );
   return (result.rowsAffected ?? 0) > 0;
@@ -159,19 +142,7 @@ export async function markItemsSeen(
     itemGuid: item.itemGuid ? item.itemGuid.slice(0, 512) : null,
     itemLink: item.itemLink ? item.itemLink.slice(0, 512) : null,
   }));
-  const sql = `MERGE INTO RPG_CLUB_RSS_FEED_ITEMS t
-    USING (
-      SELECT :feedId AS feed_id,
-             :itemIdHash AS item_id_hash,
-             :itemGuid AS item_guid,
-             :itemLink AS item_link,
-             :publishedAt AS published_at
-        FROM dual
-    ) s
-       ON (t.FEED_ID = s.feed_id AND t.ITEM_ID_HASH = s.item_id_hash)
-     WHEN NOT MATCHED THEN
-       INSERT (FEED_ID, ITEM_ID_HASH, ITEM_GUID, ITEM_LINK, PUBLISHED_AT, FIRST_SEEN_AT)
-       VALUES (s.feed_id, s.item_id_hash, s.item_guid, s.item_link, s.published_at, SYSTIMESTAMP)`;
+  const sql = getSql(RssFeedSql.markItemsSeen, dialect);
   const opts = {
     autoCommit: true,
     bindDefs: {
@@ -198,10 +169,7 @@ export async function isItemSeen(
   existingConnection?: oracledb.Connection,
 ): Promise<boolean> {
   const rows = await oraQuery(
-    `SELECT 1 AS FOUND
-       FROM RPG_CLUB_RSS_FEED_ITEMS
-      WHERE FEED_ID = :feedId
-        AND ITEM_ID_HASH = :hash`,
+    getSql(RssFeedSql.isItemSeen, dialect),
     { feedId, hash: itemIdHash },
     (row: { FOUND: number }) => row,
     existingConnection,
@@ -232,10 +200,7 @@ export async function getSeenItemHashes(
       });
 
       const rows = await oraQuery(
-        `SELECT ITEM_ID_HASH
-           FROM RPG_CLUB_RSS_FEED_ITEMS
-          WHERE FEED_ID = :feedId
-            AND ITEM_ID_HASH IN (${bindPlaceholders.join(", ")})`,
+        RssFeedSql.getSeenItemHashes(bindPlaceholders.join(", "))[dialect],
         bindVars,
         (row: { ITEM_ID_HASH: string }) => row,
         conn,

--- a/src/classes/Starboard.ts
+++ b/src/classes/Starboard.ts
@@ -1,4 +1,9 @@
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { StarboardSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type StarboardRecord = {
   messageId: string;
@@ -12,14 +17,7 @@ export type StarboardRecord = {
 export default class Starboard {
   static async getByMessageId(messageId: string): Promise<StarboardRecord | null> {
     const rows = await oraQuery(
-      `SELECT MESSAGE_ID,
-              CHANNEL_ID,
-              STARBOARD_MESSAGE_ID,
-              AUTHOR_ID,
-              STAR_COUNT,
-              CREATED_AT
-         FROM RPG_CLUB_STARBOARD
-        WHERE MESSAGE_ID = :messageId`,
+      getSql(StarboardSql.getByMessageId, dialect),
       { messageId },
       (row: {
         MESSAGE_ID: string;
@@ -44,9 +42,7 @@ export default class Starboard {
 
   static async insert(record: Omit<StarboardRecord, "createdAt">): Promise<void> {
     await oraMutate(
-      `INSERT INTO RPG_CLUB_STARBOARD
-        (MESSAGE_ID, CHANNEL_ID, STARBOARD_MESSAGE_ID, AUTHOR_ID, STAR_COUNT)
-       VALUES (:messageId, :channelId, :starboardMessageId, :authorId, :starCount)`,
+      getSql(StarboardSql.insert, dialect),
       {
         messageId: record.messageId,
         channelId: record.channelId,

--- a/src/classes/SteamCollectionImport.ts
+++ b/src/classes/SteamCollectionImport.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { SteamCollectionImportSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type SteamCollectionImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type SteamCollectionImportItemStatus =
@@ -167,37 +172,6 @@ function mapAppMap(row: AppMapRow): ISteamAppGameDbMap {
   };
 }
 
-const IMPORT_SELECT_SQL = `SELECT IMPORT_ID,
-       USER_ID,
-       STATUS,
-       CURRENT_INDEX,
-       TOTAL_COUNT,
-       STEAM_ID64,
-       STEAM_PROFILE_REF,
-       SOURCE_PROFILE_NAME,
-       CREATED_AT,
-       UPDATED_AT
-  FROM RPG_CLUB_STEAM_COLLECTION_IMPORTS`;
-
-const ITEM_SELECT_SQL = `SELECT ITEM_ID,
-       IMPORT_ID,
-       ROW_INDEX,
-       STEAM_APP_ID,
-       STEAM_APP_NAME,
-       PLAYTIME_FOREVER_MIN,
-       PLAYTIME_WINDOWS_MIN,
-       PLAYTIME_MAC_MIN,
-       PLAYTIME_LINUX_MIN,
-       PLAYTIME_DECK_MIN,
-       LAST_PLAYED_AT,
-       STATUS,
-       MATCH_CONFIDENCE,
-       MATCH_CANDIDATE_JSON,
-       GAMEDB_GAME_ID,
-       COLLECTION_ENTRY_ID,
-       RESULT_REASON,
-       ERROR_TEXT
-  FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS`;
 
 export async function createSteamCollectionImportSession(params: {
   userId: string;
@@ -208,23 +182,7 @@ export async function createSteamCollectionImportSession(params: {
 }): Promise<ISteamCollectionImport> {
   return oraWithConnection(async (conn) => {
     const insert = await oraMutate(
-      `INSERT INTO RPG_CLUB_STEAM_COLLECTION_IMPORTS (
-         USER_ID,
-         STATUS,
-         CURRENT_INDEX,
-         TOTAL_COUNT,
-         STEAM_ID64,
-         STEAM_PROFILE_REF,
-         SOURCE_PROFILE_NAME
-       ) VALUES (
-         :userId,
-         'ACTIVE',
-         0,
-         :totalCount,
-         :steamId64,
-         :steamProfileRef,
-         :sourceProfileName
-       ) RETURNING IMPORT_ID INTO :id`,
+      getSql(SteamCollectionImportSql.createImport, dialect),
       {
         userId: params.userId,
         totalCount: params.totalCount,
@@ -265,31 +223,7 @@ export async function insertSteamCollectionImportItems(
   await oraTransaction(async (conn) => {
     for (const item of items) {
       await oraMutate(
-        `INSERT INTO RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS (
-           IMPORT_ID,
-           ROW_INDEX,
-           STEAM_APP_ID,
-           STEAM_APP_NAME,
-           PLAYTIME_FOREVER_MIN,
-           PLAYTIME_WINDOWS_MIN,
-           PLAYTIME_MAC_MIN,
-           PLAYTIME_LINUX_MIN,
-           PLAYTIME_DECK_MIN,
-           LAST_PLAYED_AT,
-           STATUS
-         ) VALUES (
-           :importId,
-           :rowIndex,
-           :steamAppId,
-           :steamAppName,
-           :playtimeForeverMin,
-           :playtimeWindowsMin,
-           :playtimeMacMin,
-           :playtimeLinuxMin,
-           :playtimeDeckMin,
-           :lastPlayedAt,
-           'PENDING'
-         )`,
+        getSql(SteamCollectionImportSql.insertItem, dialect),
         {
           importId,
           rowIndex: item.rowIndex,
@@ -313,7 +247,7 @@ export async function getSteamCollectionImportById(
   existingConnection?: oracledb.Connection,
 ): Promise<ISteamCollectionImport | null> {
   const rows = await oraQuery(
-    `${IMPORT_SELECT_SQL} WHERE IMPORT_ID = :importId`,
+    getSql(SteamCollectionImportSql.getImportById, dialect),
     { importId },
     mapImport,
     existingConnection,
@@ -325,11 +259,7 @@ export async function getActiveSteamCollectionImportForUser(
   userId: string,
 ): Promise<ISteamCollectionImport | null> {
   const rows = await oraQuery(
-    `${IMPORT_SELECT_SQL}
-     WHERE USER_ID = :userId
-       AND STATUS IN ('ACTIVE', 'PAUSED')
-     ORDER BY CREATED_AT DESC, IMPORT_ID DESC
-     FETCH FIRST 1 ROWS ONLY`,
+    getSql(SteamCollectionImportSql.getActiveForUser, dialect),
     { userId },
     mapImport,
   );
@@ -341,9 +271,7 @@ export async function setSteamCollectionImportStatus(
   status: SteamCollectionImportStatus,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
-        SET STATUS = :status
-      WHERE IMPORT_ID = :importId`,
+    getSql(SteamCollectionImportSql.setStatus, dialect),
     { status, importId },
   );
 }
@@ -353,9 +281,7 @@ export async function updateSteamCollectionImportIndex(
   currentIndex: number,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
-        SET CURRENT_INDEX = :currentIndex
-      WHERE IMPORT_ID = :importId`,
+    getSql(SteamCollectionImportSql.updateIndex, dialect),
     { currentIndex, importId },
   );
 }
@@ -377,18 +303,14 @@ async function fetchItemWithJsonCol(
 export async function getSteamCollectionImportItemById(
   itemId: number,
 ): Promise<ISteamCollectionImportItem | null> {
-  return fetchItemWithJsonCol(`${ITEM_SELECT_SQL} WHERE ITEM_ID = :itemId`, { itemId });
+  return fetchItemWithJsonCol(getSql(SteamCollectionImportSql.getItemById, dialect), { itemId });
 }
 
 export async function getNextPendingSteamCollectionImportItem(
   importId: number,
 ): Promise<ISteamCollectionImportItem | null> {
   return fetchItemWithJsonCol(
-    `${ITEM_SELECT_SQL}
-     WHERE IMPORT_ID = :importId
-       AND STATUS = 'PENDING'
-     ORDER BY ROW_INDEX ASC
-     FETCH FIRST 1 ROWS ONLY`,
+    getSql(SteamCollectionImportSql.getNextPendingItem, dialect),
     { importId },
   );
 }
@@ -440,9 +362,7 @@ export async function updateSteamCollectionImportItem(
   if (!setParts.length) return;
 
   await oraMutate(
-    `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
-        SET ${setParts.join(", ")}
-      WHERE ITEM_ID = :itemId`,
+    SteamCollectionImportSql.updateItem(setParts)[dialect],
     binds,
   );
 }
@@ -457,10 +377,7 @@ export async function countSteamCollectionImportItems(
   failed: number;
 }> {
   const rows = await oraQuery(
-    `SELECT STATUS, COUNT(*) AS CNT
-       FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-      GROUP BY STATUS`,
+    getSql(SteamCollectionImportSql.countItemsByStatus, dialect),
     { importId },
     (row: { STATUS: SteamCollectionImportItemStatus; CNT: number }) => row,
   );
@@ -481,11 +398,7 @@ export async function countSteamCollectionImportResultReasons(
   importId: number,
 ): Promise<Record<string, number>> {
   const rows = await oraQuery(
-    `SELECT RESULT_REASON, COUNT(*) AS CNT
-       FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-        AND RESULT_REASON IS NOT NULL
-      GROUP BY RESULT_REASON`,
+    getSql(SteamCollectionImportSql.countItemsByReason, dialect),
     { importId },
     (row: { RESULT_REASON: string | null; CNT: number }) => row,
   );
@@ -503,15 +416,7 @@ export async function getSteamAppGameDbMapByAppId(
   existingConnection?: oracledb.Connection,
 ): Promise<ISteamAppGameDbMap | null> {
   const rows = await oraQuery(
-    `SELECT MAP_ID,
-            STEAM_APP_ID,
-            GAMEDB_GAME_ID,
-            STATUS,
-            CREATED_BY,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_STEAM_APP_GAMEDB_MAP
-      WHERE STEAM_APP_ID = :steamAppId`,
+    getSql(SteamCollectionImportSql.getAppMap, dialect),
     { steamAppId },
     mapAppMap,
     existingConnection,
@@ -527,30 +432,7 @@ export async function upsertSteamAppGameDbMap(params: {
 }): Promise<ISteamAppGameDbMap> {
   return oraWithConnection(async (conn) => {
     await oraMutate(
-      `MERGE INTO RPG_CLUB_STEAM_APP_GAMEDB_MAP m
-       USING (
-         SELECT :steamAppId AS steamAppId,
-                :gameDbGameId AS gameDbGameId,
-                :status AS status,
-                :createdBy AS createdBy
-           FROM dual
-       ) src
-          ON (m.STEAM_APP_ID = src.steamAppId)
-       WHEN MATCHED THEN UPDATE SET
-         m.GAMEDB_GAME_ID = src.gameDbGameId,
-         m.STATUS = src.status,
-         m.CREATED_BY = src.createdBy
-       WHEN NOT MATCHED THEN INSERT (
-         STEAM_APP_ID,
-         GAMEDB_GAME_ID,
-         STATUS,
-         CREATED_BY
-       ) VALUES (
-         src.steamAppId,
-         src.gameDbGameId,
-         src.status,
-         src.createdBy
-       )`,
+      getSql(SteamCollectionImportSql.upsertAppMap, dialect),
       {
         steamAppId: params.steamAppId,
         gameDbGameId: params.gameDbGameId,
@@ -576,22 +458,7 @@ export async function getSteamAppHistoricalMappedGameIds(params: {
     ? Number(params.limit) : 5;
 
   const rows = await oraQuery(
-    `SELECT t.GAMEDB_GAME_ID
-       FROM (
-         SELECT ii.GAMEDB_GAME_ID,
-                COUNT(*) AS CNT,
-                MAX(ii.ITEM_ID) AS LAST_ITEM_ID
-           FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS ii
-           JOIN RPG_CLUB_STEAM_COLLECTION_IMPORTS i
-             ON i.IMPORT_ID = ii.IMPORT_ID
-          WHERE ii.STEAM_APP_ID = :steamAppId
-            AND ii.GAMEDB_GAME_ID IS NOT NULL
-            AND ii.RESULT_REASON = 'MANUAL_REMAP'
-            AND (:excludeUserId IS NULL OR i.USER_ID <> :excludeUserId)
-          GROUP BY ii.GAMEDB_GAME_ID
-          ORDER BY CNT DESC, LAST_ITEM_ID DESC
-       ) t
-      WHERE ROWNUM <= :limit`,
+    getSql(SteamCollectionImportSql.getHistoricalMappedIds, dialect),
     {
       steamAppId: params.steamAppId,
       excludeUserId: params.excludeUserId ?? null,

--- a/src/classes/Suggestion.ts
+++ b/src/classes/Suggestion.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { SuggestionSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface ISuggestionItem {
   suggestionId: number;
@@ -49,9 +54,7 @@ export async function createSuggestion(
 ): Promise<ISuggestionItem> {
   return oraWithConnection(async (conn) => {
     const result = await oraMutate(
-      `INSERT INTO RPG_CLUB_SUGGESTIONS (TITLE, DETAILS, LABELS, CREATED_BY, CREATED_BY_NAME)
-       VALUES (:title, :details, :labels, :createdBy, :createdByName)
-       RETURNING SUGGESTION_ID INTO :id`,
+      getSql(SuggestionSql.create, dialect),
       {
         title,
         details,
@@ -76,17 +79,7 @@ export async function createSuggestion(
 export async function listSuggestions(limit: number = 50): Promise<ISuggestionItem[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 200);
   return oraQuery(
-    `SELECT SUGGESTION_ID,
-            TITLE,
-            DETAILS,
-            LABELS,
-            CREATED_BY,
-            CREATED_BY_NAME,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_SUGGESTIONS
-      ORDER BY CREATED_AT DESC, SUGGESTION_ID DESC
-      FETCH FIRST :limit ROWS ONLY`,
+    getSql(SuggestionSql.list, dialect),
     { limit: safeLimit },
     mapSuggestionRow,
   );
@@ -94,7 +87,7 @@ export async function listSuggestions(limit: number = 50): Promise<ISuggestionIt
 
 export async function countSuggestions(): Promise<number> {
   const rows = await oraQuery(
-    "SELECT COUNT(*) AS TOTAL FROM RPG_CLUB_SUGGESTIONS",
+    getSql(SuggestionSql.count, dialect),
     {},
     (row: { TOTAL: number | null }) => row,
   );
@@ -106,16 +99,7 @@ export async function getSuggestionById(
   existingConnection?: oracledb.Connection,
 ): Promise<ISuggestionItem | null> {
   const rows = await oraQuery(
-    `SELECT SUGGESTION_ID,
-            TITLE,
-            DETAILS,
-            LABELS,
-            CREATED_BY,
-            CREATED_BY_NAME,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_SUGGESTIONS
-      WHERE SUGGESTION_ID = :id`,
+    getSql(SuggestionSql.getById, dialect),
     { id: suggestionId },
     mapSuggestionRow,
     existingConnection,
@@ -125,7 +109,7 @@ export async function getSuggestionById(
 
 export async function deleteSuggestion(suggestionId: number): Promise<boolean> {
   const result = await oraMutate(
-    `DELETE FROM RPG_CLUB_SUGGESTIONS WHERE SUGGESTION_ID = :id`,
+    getSql(SuggestionSql.delete, dialect),
     { id: suggestionId },
   );
   return (result.rowsAffected ?? 0) > 0;

--- a/src/classes/SuggestionReviewSession.ts
+++ b/src/classes/SuggestionReviewSession.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { SuggestionReviewSessionSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface ISuggestionReviewSession {
   sessionId: string;
@@ -73,9 +78,7 @@ export async function createSuggestionReviewSessionRecord(session: {
   return oraWithConnection(async (conn) => {
     const suggestionIds = serializeSuggestionIds(session.suggestionIds);
     await oraMutate(
-      `INSERT INTO RPG_CLUB_SUGGESTION_REVIEW_SESSIONS
-         (SESSION_ID, REVIEWER_ID, SUGGESTION_IDS, CURRENT_INDEX, TOTAL_COUNT)
-       VALUES (:sessionId, :reviewerId, :suggestionIds, :currentIndex, :totalCount)`,
+      getSql(SuggestionReviewSessionSql.create, dialect),
       {
         sessionId: session.sessionId,
         reviewerId: session.reviewerId,
@@ -98,15 +101,7 @@ export async function getSuggestionReviewSession(
   existingConnection?: oracledb.Connection,
 ): Promise<ISuggestionReviewSession | null> {
   const rows = await oraQuery(
-    `SELECT SESSION_ID,
-            REVIEWER_ID,
-            SUGGESTION_IDS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS
-      WHERE SESSION_ID = :sessionId`,
+    getSql(SuggestionReviewSessionSql.getById, dialect),
     { sessionId },
     mapSessionRow,
     existingConnection,
@@ -119,12 +114,7 @@ export async function updateSuggestionReviewSession(
 ): Promise<void> {
   const suggestionIds = serializeSuggestionIds(session.suggestionIds);
   await oraMutate(
-    `UPDATE RPG_CLUB_SUGGESTION_REVIEW_SESSIONS
-        SET REVIEWER_ID = :reviewerId,
-            SUGGESTION_IDS = :suggestionIds,
-            CURRENT_INDEX = :currentIndex,
-            TOTAL_COUNT = :totalCount
-      WHERE SESSION_ID = :sessionId`,
+    getSql(SuggestionReviewSessionSql.update, dialect),
     {
       reviewerId: session.reviewerId,
       suggestionIds,
@@ -137,7 +127,7 @@ export async function updateSuggestionReviewSession(
 
 export async function deleteSuggestionReviewSession(sessionId: string): Promise<boolean> {
   const result = await oraMutate(
-    `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE SESSION_ID = :sessionId`,
+    getSql(SuggestionReviewSessionSql.delete, dialect),
     { sessionId },
   );
   return (result.rowsAffected ?? 0) > 0;
@@ -147,7 +137,7 @@ export async function deleteSuggestionReviewSessionsForReviewer(
   reviewerId: string,
 ): Promise<number> {
   const result = await oraMutate(
-    `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE REVIEWER_ID = :reviewerId`,
+    getSql(SuggestionReviewSessionSql.deleteForReviewer, dialect),
     { reviewerId },
   );
   return Number(result.rowsAffected ?? 0);
@@ -157,7 +147,7 @@ export async function deleteExpiredSuggestionReviewSessions(
   cutoffDate: Date,
 ): Promise<number> {
   const result = await oraMutate(
-    `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE CREATED_AT < :cutoff`,
+    getSql(SuggestionReviewSessionSql.deleteExpired, dialect),
     { cutoff: cutoffDate },
   );
   return Number(result.rowsAffected ?? 0);

--- a/src/classes/Thread.ts
+++ b/src/classes/Thread.ts
@@ -1,4 +1,9 @@
 import { oraQuery, oraMutate, oraTransaction, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { ThreadSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 type NullableDate = Date | null;
 
@@ -16,31 +21,7 @@ export async function upsertThreadRecord(params: {
   skipLinking?: "Y" | "N";
 }): Promise<void> {
   await oraMutate(
-    `MERGE INTO THREADS t
-     USING (
-       SELECT
-         :threadId       AS THREAD_ID,
-         :forumChannelId AS FORUM_CHANNEL_ID,
-         :threadName     AS THREAD_NAME,
-         :isArchived     AS IS_ARCHIVED,
-         :createdAt      AS CREATED_AT,
-         :lastSeenAt     AS LAST_SEEN_AT,
-         :skipLinking    AS SKIP_LINKING
-       FROM DUAL
-     ) s
-     ON (t.THREAD_ID = s.THREAD_ID)
-     WHEN MATCHED THEN UPDATE SET
-       t.THREAD_NAME      = s.THREAD_NAME,
-       t.FORUM_CHANNEL_ID = s.FORUM_CHANNEL_ID,
-       t.IS_ARCHIVED      = s.IS_ARCHIVED,
-       t.LAST_SEEN_AT     = s.LAST_SEEN_AT
-     WHEN NOT MATCHED THEN INSERT (
-       THREAD_ID, FORUM_CHANNEL_ID, THREAD_NAME, IS_ARCHIVED,
-       CREATED_AT, LAST_SEEN_AT, SKIP_LINKING
-     ) VALUES (
-       s.THREAD_ID, s.FORUM_CHANNEL_ID, s.THREAD_NAME, s.IS_ARCHIVED,
-       s.CREATED_AT, s.LAST_SEEN_AT, s.SKIP_LINKING
-     )`,
+    getSql(ThreadSql.upsertThread, dialect),
     {
       threadId: params.threadId,
       forumChannelId: params.forumChannelId,
@@ -64,33 +45,20 @@ export async function setThreadGameLink(
   await oraTransaction(async (conn) => {
     if (gameId === null) {
       await oraMutate(
-        `DELETE FROM THREAD_GAME_LINKS WHERE THREAD_ID = :threadId`,
+        getSql(ThreadSql.deleteThreadGameLink, dialect),
         { threadId },
         conn,
       );
     } else {
       await oraMutate(
-        `MERGE INTO THREAD_GAME_LINKS tgt
-         USING (
-           SELECT :threadId AS THREAD_ID, :gameId AS GAMEDB_GAME_ID FROM DUAL
-         ) src
-         ON (tgt.THREAD_ID = src.THREAD_ID AND tgt.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
-         WHEN NOT MATCHED THEN
-           INSERT (THREAD_ID, GAMEDB_GAME_ID, LINKED_AT)
-           VALUES (src.THREAD_ID, src.GAMEDB_GAME_ID, SYSTIMESTAMP)`,
+        getSql(ThreadSql.mergeThreadGameLink, dialect),
         { threadId, gameId },
         conn,
       );
     }
 
     await oraMutate(
-      `UPDATE THREADS t
-       SET GAMEDB_GAME_ID = (
-         SELECT MIN(g.GAMEDB_GAME_ID)
-           FROM THREAD_GAME_LINKS g
-          WHERE g.THREAD_ID = t.THREAD_ID
-       )
-       WHERE t.THREAD_ID = :threadId`,
+      getSql(ThreadSql.updateThreadsGameId, dialect),
       { threadId },
       conn,
     );
@@ -110,21 +78,13 @@ export async function removeThreadGameLink(
 
   return oraTransaction(async (conn) => {
     const res = await oraMutate(
-      `DELETE FROM THREAD_GAME_LINKS
-       WHERE THREAD_ID = :threadId
-       ${gameId ? "AND GAMEDB_GAME_ID = :gameId" : ""}`,
+      ThreadSql.removeThreadGameLinks(!!gameId)[dialect],
       gameId ? { threadId, gameId } : { threadId },
       conn,
     );
 
     await oraMutate(
-      `UPDATE THREADS t
-       SET GAMEDB_GAME_ID = (
-         SELECT MIN(g.GAMEDB_GAME_ID)
-           FROM THREAD_GAME_LINKS g
-          WHERE g.THREAD_ID = t.THREAD_ID
-       )
-       WHERE t.THREAD_ID = :threadId`,
+      getSql(ThreadSql.updateThreadsGameId, dialect),
       { threadId },
       conn,
     );
@@ -138,16 +98,14 @@ export async function setThreadSkipLinking(
   skip: boolean,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE THREADS
-        SET SKIP_LINKING = :skip
-      WHERE THREAD_ID = :threadId`,
+    getSql(ThreadSql.setSkipLinking, dialect),
     { skip: toYN(skip), threadId },
   );
 }
 
 export async function getThreadSkipLinking(threadId: string): Promise<boolean> {
   const rows = await oraQuery(
-    `SELECT SKIP_LINKING FROM THREADS WHERE THREAD_ID = :threadId`,
+    getSql(ThreadSql.getSkipLinking, dialect),
     { threadId },
     (row: { SKIP_LINKING: string }) => String(row.SKIP_LINKING ?? "N").toUpperCase() === "Y",
   );
@@ -159,7 +117,7 @@ export async function getThreadLinkInfo(
 ): Promise<{ skipLinking: boolean; gamedbGameIds: number[] }> {
   return oraWithConnection(async (conn) => {
     const [skipFlag] = await oraQuery(
-      `SELECT SKIP_LINKING FROM THREADS WHERE THREAD_ID = :threadId`,
+      getSql(ThreadSql.getSkipLinking, dialect),
       { threadId },
       (row: { SKIP_LINKING: string }) =>
         String(row.SKIP_LINKING ?? "N").toUpperCase() === "Y",
@@ -167,7 +125,7 @@ export async function getThreadLinkInfo(
     );
 
     const gameIds = await oraQuery(
-      `SELECT GAMEDB_GAME_ID FROM THREAD_GAME_LINKS WHERE THREAD_ID = :threadId`,
+      getSql(ThreadSql.getThreadGameLinks, dialect),
       { threadId },
       (row: { GAMEDB_GAME_ID: number }) => Number(row.GAMEDB_GAME_ID),
       conn,
@@ -175,7 +133,7 @@ export async function getThreadLinkInfo(
 
     if (!gameIds.length) {
       const legacyIds = await oraQuery(
-        `SELECT GAMEDB_GAME_ID FROM THREADS WHERE THREAD_ID = :threadId`,
+        getSql(ThreadSql.getLegacyGameId, dialect),
         { threadId },
         (row: { GAMEDB_GAME_ID: number | null }) =>
           row.GAMEDB_GAME_ID != null ? Number(row.GAMEDB_GAME_ID) : null,
@@ -201,14 +159,14 @@ export async function getThreadGameIds(threadId: string): Promise<number[]> {
 export async function getThreadsByGameId(gameId: number): Promise<string[]> {
   return oraWithConnection(async (conn) => {
     const threadIds = await oraQuery(
-      `SELECT THREAD_ID FROM THREAD_GAME_LINKS WHERE GAMEDB_GAME_ID = :gameId`,
+      getSql(ThreadSql.getThreadLinksForGame, dialect),
       { gameId },
       (row: { THREAD_ID: string }) => String(row.THREAD_ID),
       conn,
     );
 
     const legacyIds = await oraQuery(
-      `SELECT THREAD_ID FROM THREADS WHERE GAMEDB_GAME_ID = :gameId`,
+      getSql(ThreadSql.getLegacyThreadIdForGame, dialect),
       { gameId },
       (row: { THREAD_ID: string }) => String(row.THREAD_ID),
       conn,

--- a/src/classes/Todo.ts
+++ b/src/classes/Todo.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { TodoSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface ITodoItem {
   todoId: number;
@@ -47,23 +52,9 @@ function mapTodoRow(row: {
   };
 }
 
-const TODO_COLS = `TODO_ID,
-              TITLE,
-              DETAILS,
-              TODO_CATEGORY,
-              TODO_SIZE,
-              CREATED_BY,
-              CREATED_AT,
-              UPDATED_AT,
-              COMPLETED_AT,
-              COMPLETED_BY,
-              IS_COMPLETED`;
-
 export async function fetchTodoById(todoId: number): Promise<ITodoItem | null> {
   const rows = await oraQuery(
-    `SELECT ${TODO_COLS}
-       FROM RPG_CLUB_TODOS
-      WHERE TODO_ID = :id`,
+    getSql(TodoSql.getById, dialect),
     { id: todoId },
     mapTodoRow,
   );
@@ -78,9 +69,7 @@ export async function createTodo(
   createdBy: string | null,
 ): Promise<ITodoItem> {
   const result = await oraMutate(
-    `INSERT INTO RPG_CLUB_TODOS (TITLE, DETAILS, TODO_CATEGORY, TODO_SIZE, CREATED_BY)
-     VALUES (:title, :details, :todoCategory, :todoSize, :createdBy)
-     RETURNING TODO_ID INTO :id`,
+    getSql(TodoSql.create, dialect),
     {
       title,
       details,
@@ -108,11 +97,7 @@ export async function listTodos(
   const safeLimit = Math.min(Math.max(limit, 1), 200);
   const whereClause = includeCompleted ? "" : "WHERE IS_COMPLETED = 0";
   return oraQuery(
-    `SELECT ${TODO_COLS}
-       FROM RPG_CLUB_TODOS
-       ${whereClause}
-      ORDER BY IS_COMPLETED ASC, CREATED_AT ASC
-      FETCH FIRST :limit ROWS ONLY`,
+    TodoSql.list(whereClause)[dialect],
     { limit: safeLimit },
     mapTodoRow,
   );
@@ -130,18 +115,7 @@ export async function updateTodo(
   const categoryProvided = todoCategory !== undefined ? 1 : 0;
   const sizeProvided = todoSize !== undefined ? 1 : 0;
   const result = await oraMutate(
-    `UPDATE RPG_CLUB_TODOS
-        SET TITLE = CASE WHEN :titleProvided = 1 THEN :title ELSE TITLE END,
-            DETAILS = CASE WHEN :detailsProvided = 1 THEN :details ELSE DETAILS END,
-            TODO_CATEGORY = CASE
-              WHEN :categoryProvided = 1 THEN :todoCategory
-              ELSE TODO_CATEGORY
-            END,
-            TODO_SIZE = CASE
-              WHEN :sizeProvided = 1 THEN :todoSize
-              ELSE TODO_SIZE
-            END
-      WHERE TODO_ID = :id`,
+    getSql(TodoSql.update, dialect),
     {
       id: todoId,
       title,
@@ -159,7 +133,7 @@ export async function updateTodo(
 
 export async function deleteTodo(todoId: number): Promise<boolean> {
   const result = await oraMutate(
-    `DELETE FROM RPG_CLUB_TODOS WHERE TODO_ID = :id`,
+    getSql(TodoSql.delete, dialect),
     { id: todoId },
   );
   return (result.rowsAffected ?? 0) > 0;
@@ -170,12 +144,7 @@ export async function completeTodo(
   completedBy: string | null,
 ): Promise<boolean> {
   const result = await oraMutate(
-    `UPDATE RPG_CLUB_TODOS
-        SET IS_COMPLETED = 1,
-            COMPLETED_AT = SYSTIMESTAMP,
-            COMPLETED_BY = :completedBy
-      WHERE TODO_ID = :id
-        AND IS_COMPLETED = 0`,
+    getSql(TodoSql.complete, dialect),
     { id: todoId, completedBy },
   );
   return (result.rowsAffected ?? 0) > 0;
@@ -183,9 +152,7 @@ export async function completeTodo(
 
 export async function countTodos(): Promise<{ open: number; completed: number }> {
   const rows = await oraQuery(
-    `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
-            SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT
-       FROM RPG_CLUB_TODOS`,
+    getSql(TodoSql.countTodos, dialect),
     {},
     (row: { OPEN_COUNT: number | null; COMPLETED_COUNT: number | null }) => ({
       open: Number(row.OPEN_COUNT ?? 0),
@@ -207,39 +174,7 @@ export async function countTodoSummary(): Promise<{
   };
 }> {
   const rows = await oraQuery(
-    `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
-            SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT,
-            SUM(
-              CASE
-                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'New Features' THEN 1
-                ELSE 0
-              END
-            ) AS OPEN_NEW_FEATURES,
-            SUM(
-              CASE
-                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Improvements' THEN 1
-                ELSE 0
-              END
-            ) AS OPEN_IMPROVEMENTS,
-            SUM(
-              CASE
-                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Defects' THEN 1
-                ELSE 0
-              END
-            ) AS OPEN_DEFECTS,
-            SUM(
-              CASE
-                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Blocked' THEN 1
-                ELSE 0
-              END
-            ) AS OPEN_BLOCKED,
-            SUM(
-              CASE
-                WHEN IS_COMPLETED = 0 AND TODO_CATEGORY = 'Refactoring' THEN 1
-                ELSE 0
-              END
-            ) AS OPEN_REFACTORING
-       FROM RPG_CLUB_TODOS`,
+    getSql(TodoSql.countTodoSummary, dialect),
     {},
     (row: {
       OPEN_COUNT: number | null;

--- a/src/classes/UserActivityIcon.ts
+++ b/src/classes/UserActivityIcon.ts
@@ -1,5 +1,10 @@
 import type { Activity } from "discord.js";
 import { oraQuery, oraTransaction } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { UserActivityIconSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type IUserActivityIconRow = {
   userId: string;
@@ -92,42 +97,6 @@ function collectActivityRecords(activities: readonly Activity[]): ActivityRecord
   return records;
 }
 
-const MERGE_SQL = `MERGE INTO RPG_CLUB_USER_ACTIVITY_ICONS t
-USING (
-  SELECT
-    :userId AS USER_ID,
-    :username AS USERNAME,
-    :activityName AS ACTIVITY_NAME,
-    :activityNameNorm AS ACTIVITY_NAME_NORM,
-    :iconType AS ICON_TYPE,
-    :sourceRef AS SOURCE_REF,
-    :iconUrl AS ICON_URL
-  FROM dual
-) s
-ON (
-  t.USER_ID = s.USER_ID
-  AND t.ACTIVITY_NAME_NORM = s.ACTIVITY_NAME_NORM
-  AND t.ICON_TYPE = s.ICON_TYPE
-  AND t.SOURCE_REF = s.SOURCE_REF
-)
-WHEN MATCHED THEN
-  UPDATE SET
-    t.USERNAME = s.USERNAME,
-    t.ICON_URL = s.ICON_URL,
-    t.LAST_SEEN_AT = SYSTIMESTAMP,
-    t.SEEN_COUNT = t.SEEN_COUNT + 1
-WHEN NOT MATCHED THEN
-  INSERT (
-    USER_ID, USERNAME, ACTIVITY_NAME, ACTIVITY_NAME_NORM,
-    ICON_TYPE, SOURCE_REF, ICON_URL,
-    FIRST_SEEN_AT, LAST_SEEN_AT, SEEN_COUNT
-  )
-  VALUES (
-    s.USER_ID, s.USERNAME, s.ACTIVITY_NAME, s.ACTIVITY_NAME_NORM,
-    s.ICON_TYPE, s.SOURCE_REF, s.ICON_URL,
-    SYSTIMESTAMP, SYSTIMESTAMP, 1
-  )`;
-
 export default class UserActivityIcon {
   static async recordFromPresence(
     userId: string,
@@ -140,7 +109,7 @@ export default class UserActivityIcon {
 
     await oraTransaction(async (conn) => {
       for (const record of records) {
-        await conn.execute(MERGE_SQL, {
+        await conn.execute(getSql(UserActivityIconSql.mergeActivity, dialect), {
           userId,
           username,
           activityName: record.activityName,
@@ -194,19 +163,7 @@ export default class UserActivityIcon {
     }
 
     return oraQuery(
-      `SELECT
-         USER_ID,
-         ACTIVITY_NAME,
-         ICON_TYPE,
-         SOURCE_REF,
-         ICON_URL,
-         LAST_SEEN_AT
-       FROM RPG_CLUB_USER_ACTIVITY_ICONS
-       WHERE (${userGroupClauses.join(" OR ")})
-         AND LAST_SEEN_AT >= SYSTIMESTAMP - NUMTODSINTERVAL(:days, 'DAY')
-         AND (:activityNameNorm IS NULL OR ACTIVITY_NAME_NORM = :activityNameNorm)
-         AND (:iconType IS NULL OR ICON_TYPE = :iconType)
-       ORDER BY LAST_SEEN_AT DESC`,
+      UserActivityIconSql.getRecentForUsers(userGroupClauses.join(" OR "))[dialect],
       binds,
       (row: {
         USER_ID: string;

--- a/src/classes/UserChannelMessageCount.ts
+++ b/src/classes/UserChannelMessageCount.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { UserChannelMessageCountSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 type ChannelCountBind = {
   userId: string;
@@ -23,24 +28,7 @@ export default class UserChannelMessageCount {
     await oraWithConnection(async (conn) => {
       try {
         await conn.executeMany(
-          `MERGE INTO RPG_CLUB_USER_CHANNEL_COUNTS t
-            USING (
-              SELECT :userId AS user_id,
-                     :channelId AS channel_id,
-                     :count AS message_count,
-                     :scanned AS scanned
-                FROM dual
-            ) s
-               ON (t.USER_ID = s.user_id AND t.CHANNEL_ID = s.channel_id)
-             WHEN MATCHED THEN
-               UPDATE SET t.MESSAGE_COUNT = NVL(t.MESSAGE_COUNT, 0) + s.message_count,
-                          t.LAST_SCANNED_AT = s.scanned,
-                          t.UPDATED_AT = SYSTIMESTAMP
-             WHEN NOT MATCHED THEN
-               INSERT (USER_ID, CHANNEL_ID, MESSAGE_COUNT, LAST_SCANNED_AT,
-                       CREATED_AT, UPDATED_AT)
-               VALUES (s.user_id, s.channel_id, s.message_count, s.scanned,
-                       SYSTIMESTAMP, SYSTIMESTAMP)`,
+          getSql(UserChannelMessageCountSql.upsertChannelCounts, dialect),
           rows,
           {
             autoCommit: true,
@@ -65,7 +53,7 @@ export default class UserChannelMessageCount {
   static async getScannedChannelIds(): Promise<Set<string>> {
     try {
       const rows = await oraQuery(
-        `SELECT DISTINCT CHANNEL_ID FROM RPG_CLUB_USER_CHANNEL_COUNTS`,
+        getSql(UserChannelMessageCountSql.getScannedChannelIds, dialect),
         [],
         (row: { CHANNEL_ID: string }) => row.CHANNEL_ID,
       );
@@ -80,7 +68,7 @@ export default class UserChannelMessageCount {
   static async getChannelScanMeta(): Promise<Map<string, Date>> {
     try {
       const rows = await oraQuery(
-        `SELECT CHANNEL_ID, LAST_SCANNED_AT FROM RPG_CLUB_USER_CHANNEL_COUNTS`,
+        getSql(UserChannelMessageCountSql.getChannelScanMeta, dialect),
         [],
         (row: { CHANNEL_ID: string; LAST_SCANNED_AT: Date }) => row,
       );

--- a/src/classes/UserGameCollection.ts
+++ b/src/classes/UserGameCollection.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { UserGameCollectionSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export const COLLECTION_OWNERSHIP_TYPES = [
   "Digital",
@@ -95,31 +100,13 @@ function mapEntry(row: CollectionRow): IUserGameCollectionEntry {
   };
 }
 
-const ENTRY_SELECT_SQL = `SELECT c.ENTRY_ID,
-       c.USER_ID,
-       c.GAMEDB_GAME_ID,
-       g.TITLE,
-       c.PLATFORM_ID,
-       p.PLATFORM_NAME,
-       p.PLATFORM_ABBREVIATION,
-       c.OWNERSHIP_TYPE,
-       c.NOTE,
-       c.IS_SHARED,
-       c.CREATED_AT,
-       c.UPDATED_AT
-  FROM USER_GAME_COLLECTIONS c
-  JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-  LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID`;
-
 async function getEntryById(
   entryId: number,
   userId: string,
   conn: oracledb.Connection,
 ): Promise<IUserGameCollectionEntry | null> {
   const rows = await oraQuery(
-    `${ENTRY_SELECT_SQL}
-     WHERE c.ENTRY_ID = :entryId
-       AND c.USER_ID = :userId`,
+    getSql(UserGameCollectionSql.getEntryById, dialect),
     { entryId, userId },
     mapEntry,
     conn,
@@ -154,22 +141,7 @@ export default class UserGameCollection {
       let insert: oracledb.Result<unknown>;
       try {
         insert = await oraMutate(
-          `INSERT INTO USER_GAME_COLLECTIONS (
-             USER_ID,
-             GAMEDB_GAME_ID,
-             PLATFORM_ID,
-             OWNERSHIP_TYPE,
-             NOTE,
-             IS_SHARED
-           ) VALUES (
-             :userId,
-             :gameId,
-             :platformId,
-             :ownershipType,
-             :note,
-             :isShared
-           )
-           RETURNING ENTRY_ID INTO :entryId`,
+          getSql(UserGameCollectionSql.addEntry, dialect),
           {
             userId,
             gameId,
@@ -211,9 +183,7 @@ export default class UserGameCollection {
       throw new Error("Invalid entry id.");
     }
     const rows = await oraQuery(
-      `${ENTRY_SELECT_SQL}
-       WHERE c.ENTRY_ID = :entryId
-         AND c.USER_ID = :userId`,
+      getSql(UserGameCollectionSql.getEntryForUser, dialect),
       { entryId, userId },
       mapEntry,
     );
@@ -267,10 +237,7 @@ export default class UserGameCollection {
       let result: oracledb.Result<unknown>;
       try {
         result = await oraMutate(
-          `UPDATE USER_GAME_COLLECTIONS
-              SET ${updateParts.join(", ")}
-            WHERE ENTRY_ID = :entryId
-              AND USER_ID = :userId`,
+          UserGameCollectionSql.updateEntry(updateParts)[dialect],
           binds,
           conn,
         );
@@ -295,9 +262,7 @@ export default class UserGameCollection {
       throw new Error("Invalid entry id.");
     }
     const result = await oraMutate(
-      `DELETE FROM USER_GAME_COLLECTIONS
-        WHERE ENTRY_ID = :entryId
-          AND USER_ID = :userId`,
+      getSql(UserGameCollectionSql.removeEntry, dialect),
       { entryId, userId },
     );
     return (result.rowsAffected ?? 0) > 0;
@@ -353,24 +318,7 @@ export default class UserGameCollection {
     const fetchClause = hasLimit ? "FETCH FIRST :limit ROWS ONLY" : "";
 
     return oraQuery(
-      `SELECT c.ENTRY_ID,
-              c.USER_ID,
-              c.GAMEDB_GAME_ID,
-              g.TITLE,
-              c.PLATFORM_ID,
-              p.PLATFORM_NAME,
-              p.PLATFORM_ABBREVIATION,
-              c.OWNERSHIP_TYPE,
-              c.NOTE,
-              c.IS_SHARED,
-              c.CREATED_AT,
-              c.UPDATED_AT
-         FROM USER_GAME_COLLECTIONS c
-         JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-        LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
-        WHERE ${where.join(" AND ")}
-        ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
-        ${fetchClause}`,
+      UserGameCollectionSql.searchEntries(where.join(" AND "), fetchClause)[dialect],
       binds,
       mapEntry,
     );
@@ -386,24 +334,12 @@ export default class UserGameCollection {
 
     const [totalRows, platformRows] = await Promise.all([
       oraQuery(
-        `SELECT COUNT(*) AS TOTAL_COUNT
-           FROM USER_GAME_COLLECTIONS
-          WHERE USER_ID = :userId`,
+        getSql(UserGameCollectionSql.getTotalCount, dialect),
         { userId },
         (row: { TOTAL_COUNT: number }) => row,
       ),
       oraQuery(
-        `SELECT c.PLATFORM_ID,
-                p.PLATFORM_NAME,
-                p.PLATFORM_ABBREVIATION,
-                COUNT(*) AS TOTAL_COUNT
-           FROM USER_GAME_COLLECTIONS c
-           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
-          WHERE c.USER_ID = :userId
-          GROUP BY c.PLATFORM_ID, p.PLATFORM_NAME, p.PLATFORM_ABBREVIATION
-          ORDER BY COUNT(*) DESC,
-                   LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
-                   c.PLATFORM_ID`,
+        getSql(UserGameCollectionSql.getPlatformCounts, dialect),
         { userId },
         (row: {
           PLATFORM_ID: number | null;
@@ -432,21 +368,12 @@ export default class UserGameCollection {
   }> {
     const [totalRows, platformRows, userRows] = await Promise.all([
       oraQuery(
-        `SELECT COUNT(*) AS TOTAL_COUNT FROM USER_GAME_COLLECTIONS`,
+        getSql(UserGameCollectionSql.getTotalAllCount, dialect),
         {},
         (row: { TOTAL_COUNT: number }) => row,
       ),
       oraQuery(
-        `SELECT c.PLATFORM_ID,
-                p.PLATFORM_NAME,
-                p.PLATFORM_ABBREVIATION,
-                COUNT(*) AS TOTAL_COUNT
-           FROM USER_GAME_COLLECTIONS c
-           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
-          GROUP BY c.PLATFORM_ID, p.PLATFORM_NAME, p.PLATFORM_ABBREVIATION
-          ORDER BY COUNT(*) DESC,
-                   LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
-                   c.PLATFORM_ID`,
+        getSql(UserGameCollectionSql.getAllPlatformCounts, dialect),
         {},
         (row: {
           PLATFORM_ID: number | null;
@@ -461,28 +388,7 @@ export default class UserGameCollection {
         }),
       ),
       oraQuery(
-        `SELECT c.USER_ID,
-                u.USERNAME,
-                u.GLOBAL_NAME,
-                c.PLATFORM_ID,
-                p.PLATFORM_NAME,
-                p.PLATFORM_ABBREVIATION,
-                COUNT(*) AS TOTAL_COUNT
-           FROM USER_GAME_COLLECTIONS c
-           LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
-           LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
-          WHERE NVL(u.IS_BOT, 0) = 0
-          GROUP BY c.USER_ID,
-                   u.USERNAME,
-                   u.GLOBAL_NAME,
-                   c.PLATFORM_ID,
-                   p.PLATFORM_NAME,
-                   p.PLATFORM_ABBREVIATION
-          ORDER BY LOWER(COALESCE(u.GLOBAL_NAME, u.USERNAME, c.USER_ID)),
-                   c.USER_ID,
-                   COUNT(*) DESC,
-                   LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
-                   c.PLATFORM_ID`,
+        getSql(UserGameCollectionSql.getAllUserRows, dialect),
         {},
         (row: {
           USER_ID: string;
@@ -556,25 +462,7 @@ export default class UserGameCollection {
     }
 
     const rows = await oraQuery(
-      `SELECT c.ENTRY_ID,
-              c.USER_ID,
-              c.GAMEDB_GAME_ID,
-              g.TITLE,
-              c.PLATFORM_ID,
-              p.PLATFORM_NAME,
-              p.PLATFORM_ABBREVIATION,
-              c.OWNERSHIP_TYPE,
-              c.NOTE,
-              c.IS_SHARED,
-              c.CREATED_AT,
-              c.UPDATED_AT
-         FROM USER_GAME_COLLECTIONS c
-         JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID
-        WHERE c.USER_ID = :userId
-          ${titleWhere}
-        ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
-        FETCH FIRST :limit ROWS ONLY`,
+      UserGameCollectionSql.autocompleteEntries(titleWhere)[dialect],
       binds,
       mapEntry,
     );

--- a/src/classes/XboxCollectionImport.ts
+++ b/src/classes/XboxCollectionImport.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { XboxCollectionImportSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type XboxCollectionImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type XboxCollectionImportItemStatus =
@@ -184,43 +189,6 @@ function mapTitleMap(row: TitleMapRow): IXboxTitleGameDbMap {
   };
 }
 
-const IMPORT_SELECT_SQL = `SELECT IMPORT_ID,
-       USER_ID,
-       STATUS,
-       CURRENT_INDEX,
-       TOTAL_COUNT,
-       XUID,
-       GAMERTAG,
-       SOURCE_TYPE,
-       SOURCE_FILE_NAME,
-       SOURCE_FILE_SIZE,
-       TEMPLATE_VERSION,
-       CREATED_AT,
-       UPDATED_AT
-  FROM RPG_CLUB_XBOX_COLLECTION_IMPORTS`;
-
-const ITEM_SELECT_SQL = `SELECT ITEM_ID,
-       IMPORT_ID,
-       ROW_INDEX,
-       XBOX_TITLE_ID,
-       XBOX_PRODUCT_ID,
-       XBOX_TITLE_NAME,
-       RAW_PLATFORM,
-       RAW_OWNERSHIP_TYPE,
-       RAW_NOTE,
-       RAW_GAMEDB_ID,
-       RAW_IGDB_ID,
-       PLATFORM_ID,
-       OWNERSHIP_TYPE,
-       NOTE,
-       STATUS,
-       MATCH_CONFIDENCE,
-       MATCH_CANDIDATE_JSON,
-       GAMEDB_GAME_ID,
-       COLLECTION_ENTRY_ID,
-       RESULT_REASON,
-       ERROR_TEXT
-  FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS`;
 
 export async function createXboxCollectionImportSession(params: {
   userId: string;
@@ -234,29 +202,7 @@ export async function createXboxCollectionImportSession(params: {
 }): Promise<IXboxCollectionImport> {
   return oraWithConnection(async (conn) => {
     const insert = await oraMutate(
-      `INSERT INTO RPG_CLUB_XBOX_COLLECTION_IMPORTS (
-         USER_ID,
-         STATUS,
-         CURRENT_INDEX,
-         TOTAL_COUNT,
-         XUID,
-         GAMERTAG,
-         SOURCE_TYPE,
-         SOURCE_FILE_NAME,
-         SOURCE_FILE_SIZE,
-         TEMPLATE_VERSION
-       ) VALUES (
-         :userId,
-         'ACTIVE',
-         0,
-         :totalCount,
-         :xuid,
-         :gamertag,
-         :sourceType,
-         :sourceFileName,
-         :sourceFileSize,
-         :templateVersion
-       ) RETURNING IMPORT_ID INTO :id`,
+      getSql(XboxCollectionImportSql.createImport, dialect),
       {
         userId: params.userId,
         totalCount: params.totalCount,
@@ -303,37 +249,7 @@ export async function insertXboxCollectionImportItems(
   await oraTransaction(async (conn) => {
     for (const item of items) {
       await oraMutate(
-        `INSERT INTO RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS (
-           IMPORT_ID,
-           ROW_INDEX,
-           XBOX_TITLE_ID,
-           XBOX_PRODUCT_ID,
-           XBOX_TITLE_NAME,
-           RAW_PLATFORM,
-           RAW_OWNERSHIP_TYPE,
-           RAW_NOTE,
-           RAW_GAMEDB_ID,
-           RAW_IGDB_ID,
-           PLATFORM_ID,
-           OWNERSHIP_TYPE,
-           NOTE,
-           STATUS
-         ) VALUES (
-           :importId,
-           :rowIndex,
-           :xboxTitleId,
-           :xboxProductId,
-           :xboxTitleName,
-           :rawPlatform,
-           :rawOwnershipType,
-           :rawNote,
-           :rawGameDbId,
-           :rawIgdbId,
-           :platformId,
-           :ownershipType,
-           :note,
-           'PENDING'
-         )`,
+        getSql(XboxCollectionImportSql.insertItem, dialect),
         {
           importId,
           rowIndex: item.rowIndex,
@@ -360,7 +276,7 @@ export async function getXboxCollectionImportById(
   connectionOverride?: oracledb.Connection,
 ): Promise<IXboxCollectionImport | null> {
   const rows = await oraQuery(
-    `${IMPORT_SELECT_SQL} WHERE IMPORT_ID = :importId`,
+    getSql(XboxCollectionImportSql.getImportById, dialect),
     { importId },
     mapImport,
     connectionOverride,
@@ -372,10 +288,7 @@ export async function getActiveXboxCollectionImportForUser(
   userId: string,
 ): Promise<IXboxCollectionImport | null> {
   const rows = await oraQuery(
-    `${IMPORT_SELECT_SQL}
-     WHERE USER_ID = :userId
-       AND STATUS IN ('ACTIVE', 'PAUSED')
-     ORDER BY IMPORT_ID DESC`,
+    getSql(XboxCollectionImportSql.getActiveForUser, dialect),
     { userId },
     mapImport,
   );
@@ -387,9 +300,7 @@ export async function setXboxCollectionImportStatus(
   status: XboxCollectionImportStatus,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
-        SET STATUS = :status
-      WHERE IMPORT_ID = :importId`,
+    getSql(XboxCollectionImportSql.setStatus, dialect),
     { importId, status },
   );
 }
@@ -399,9 +310,7 @@ export async function updateXboxCollectionImportIndex(
   currentIndex: number,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
-        SET CURRENT_INDEX = :currentIndex
-      WHERE IMPORT_ID = :importId`,
+    getSql(XboxCollectionImportSql.updateIndex, dialect),
     { importId, currentIndex },
   );
 }
@@ -410,7 +319,7 @@ export async function getXboxCollectionImportItemById(
   itemId: number,
 ): Promise<IXboxCollectionImportItem | null> {
   const rows = await oraQuery(
-    `${ITEM_SELECT_SQL} WHERE ITEM_ID = :itemId`,
+    getSql(XboxCollectionImportSql.getItemById, dialect),
     { itemId },
     mapItem,
   );
@@ -421,11 +330,7 @@ export async function getNextPendingXboxCollectionImportItem(
   importId: number,
 ): Promise<IXboxCollectionImportItem | null> {
   const rows = await oraQuery(
-    `${ITEM_SELECT_SQL}
-     WHERE IMPORT_ID = :importId
-       AND STATUS = 'PENDING'
-     ORDER BY ROW_INDEX ASC
-     FETCH FIRST 1 ROWS ONLY`,
+    getSql(XboxCollectionImportSql.getNextPendingItem, dialect),
     { importId },
     mapItem,
   );
@@ -479,9 +384,7 @@ export async function updateXboxCollectionImportItem(
   if (!fields.length) return;
 
   await oraMutate(
-    `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
-        SET ${fields.join(", ")}
-      WHERE ITEM_ID = :itemId`,
+    XboxCollectionImportSql.updateItem(fields)[dialect],
     binds,
   );
 }
@@ -496,10 +399,7 @@ export async function countXboxCollectionImportItems(
   failed: number;
 }> {
   const rows = await oraQuery(
-    `SELECT STATUS, COUNT(*) AS CNT
-       FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-      GROUP BY STATUS`,
+    getSql(XboxCollectionImportSql.countItemsByStatus, dialect),
     { importId },
     (row: { STATUS: XboxCollectionImportItemStatus; CNT: number }) => row,
   );
@@ -519,10 +419,7 @@ export async function countXboxCollectionImportResultReasons(
   importId: number,
 ): Promise<Record<string, number>> {
   const rows = await oraQuery(
-    `SELECT RESULT_REASON, COUNT(*) AS CNT
-       FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-      GROUP BY RESULT_REASON`,
+    getSql(XboxCollectionImportSql.countItemsByReason, dialect),
     { importId },
     (row: { RESULT_REASON: XboxCollectionImportResultReason | null; CNT: number }) => row,
   );
@@ -539,15 +436,7 @@ export async function getXboxTitleGameDbMapByTitleId(
   existingConnection?: oracledb.Connection,
 ): Promise<IXboxTitleGameDbMap | null> {
   const rows = await oraQuery(
-    `SELECT MAP_ID,
-            XBOX_TITLE_ID,
-            GAMEDB_GAME_ID,
-            STATUS,
-            CREATED_BY,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_XBOX_TITLE_GAMEDB_MAP
-      WHERE XBOX_TITLE_ID = :xboxTitleId`,
+    getSql(XboxCollectionImportSql.getTitleMap, dialect),
     { xboxTitleId },
     mapTitleMap,
     existingConnection,
@@ -563,30 +452,7 @@ export async function upsertXboxTitleGameDbMap(params: {
 }): Promise<IXboxTitleGameDbMap> {
   return oraWithConnection(async (conn) => {
     await oraMutate(
-      `MERGE INTO RPG_CLUB_XBOX_TITLE_GAMEDB_MAP m
-       USING (
-         SELECT :xboxTitleId AS xboxTitleId,
-                :gameDbGameId AS gameDbGameId,
-                :status AS status,
-                :createdBy AS createdBy
-           FROM dual
-       ) src
-          ON (m.XBOX_TITLE_ID = src.xboxTitleId)
-       WHEN MATCHED THEN UPDATE SET
-         m.GAMEDB_GAME_ID = src.gameDbGameId,
-         m.STATUS = src.status,
-         m.CREATED_BY = src.createdBy
-       WHEN NOT MATCHED THEN INSERT (
-         XBOX_TITLE_ID,
-         GAMEDB_GAME_ID,
-         STATUS,
-         CREATED_BY
-       ) VALUES (
-         src.xboxTitleId,
-         src.gameDbGameId,
-         src.status,
-         src.createdBy
-       )`,
+      getSql(XboxCollectionImportSql.upsertTitleMap, dialect),
       {
         xboxTitleId: params.xboxTitleId,
         gameDbGameId: params.gameDbGameId,
@@ -612,22 +478,7 @@ export async function getXboxTitleHistoricalMappedGameIds(params: {
     (params.limit ?? 0) > 0 ? Number(params.limit) : 5;
 
   const rows = await oraQuery(
-    `SELECT t.GAMEDB_GAME_ID
-       FROM (
-         SELECT ii.GAMEDB_GAME_ID,
-                COUNT(*) AS CNT,
-                MAX(ii.ITEM_ID) AS LAST_ITEM_ID
-           FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS ii
-           JOIN RPG_CLUB_XBOX_COLLECTION_IMPORTS i
-             ON i.IMPORT_ID = ii.IMPORT_ID
-          WHERE ii.XBOX_TITLE_ID = :xboxTitleId
-            AND ii.GAMEDB_GAME_ID IS NOT NULL
-            AND ii.RESULT_REASON = 'MANUAL_REMAP'
-            AND (:excludeUserId IS NULL OR i.USER_ID <> :excludeUserId)
-          GROUP BY ii.GAMEDB_GAME_ID
-          ORDER BY CNT DESC, LAST_ITEM_ID DESC
-       ) t
-      WHERE ROWNUM <= :limit`,
+    getSql(XboxCollectionImportSql.getHistoricalMappedIds, dialect),
     {
       xboxTitleId: params.xboxTitleId,
       excludeUserId: params.excludeUserId ?? null,


### PR DESCRIPTION
Replace all inline SQL string literals in domain class files with getSql/getSqlDynamic calls referencing the centralized SqlEntry registry built in the previous phase. Adds getDialect() at module level in each class so dialect selection is resolved once at startup.