### PR TITLE
feat: finish wiring Game.ts to centralized SQL registry

### DIFF
--- a/SQL_MIGRATION_PLAN.md
+++ b/SQL_MIGRATION_PLAN.md
@@ -251,71 +251,52 @@ End-to-end (requires both DBs running):
 
 ### Fully Migrated (no inline SQL remaining)
 
+All domain classes now hold zero raw standalone SQL. Every class uses `getSql(XxxSql.key, dialect)`
+or `XxxSql.factory(args)[dialect]` for all database calls.
+
+Note: `Member.ts` and `Game.ts` retain a small number of code-generated SQL fragment strings
+(dynamic WHERE clause builders, IN-list expanders) that are constructed at runtime and are not
+standalone queries -- these are intentionally left inline.
+
+Previously fully migrated:
 - `GameSearchSynonym.ts`
 - `Gotm.ts`
 - `NrGotm.ts`
-- `PublicReminder.ts` (SQL lives in `reminder.sql.ts` as `PublicReminderSql`)
+- `PublicReminder.ts`
 - `RssFeed.ts`
 - `Starboard.ts`
 - `Thread.ts`
 - `UserActivityIcon.ts`
 - `UserChannelMessageCount.ts`
 
----
-
-### Phase A: SQL file exists, class not yet wired (zero `getSql` calls)
-
-Wire each class to its already-created `.sql.ts` file. Sorted by approximate SQL hit count (descending).
-
-| Class | Approx. raw SQL hits | SQL file |
-|---|---|---|
-| `GameReleaseAnnouncement.ts` | 24 | `gameReleaseAnnouncement.sql.ts` |
-| `AdminWizardSession.ts` | 19 | `adminWizardSession.sql.ts` |
-| `CollectionCsvImport.ts` | 18 | `collectionCsvImport.sql.ts` |
-| `CompletionatorImport.ts` | 16 | `completionatorImport.sql.ts` |
-| `GotmAuditImport.ts` | 15 | `gotmAuditImport.sql.ts` |
-| `GameDbCsvImport.ts` | 14 | `gameDbCsvImport.sql.ts` |
-| `GameKey.ts` | 10 | `gameKey.sql.ts` |
-| `BotVotingInfo.ts` | 10 | `botVotingInfo.sql.ts` |
-| `Nomination.ts` | 7 | `nomination.sql.ts` |
-| `PresencePromptHistory.ts` | 5 | `presencePrompt.sql.ts` |
-| `PresencePromptOptOut.ts` | 3 | `presencePrompt.sql.ts` |
-
----
-
-### Phase B: Partially wired (SQL file exists, but raw SQL still remains inline)
-
-| Class | Approx. remaining raw SQL hits | SQL file |
-|---|---|---|
-| `Member.ts` | 114 | `member.sql.ts` |
-| `Game.ts` | 25 | `game.sql.ts` |
-| `XboxCollectionImport.ts` | 6 | `xboxCollectionImport.sql.ts` |
-| `SteamCollectionImport.ts` | 6 | `steamCollectionImport.sql.ts` |
-| `Reminder.ts` | 3 | `reminder.sql.ts` |
-| `UserGameCollection.ts` | 2 | `userGameCollection.sql.ts` |
-| `Todo.ts` | 2 | `todo.sql.ts` |
-| `SuggestionReviewSession.ts` | 2 | `suggestion.sql.ts` |
-| `Suggestion.ts` | 2 | `suggestion.sql.ts` |
-| `HltbCache.ts` | 2 | `hltbCache.sql.ts` |
-| `GameSearchSynonymDraft.ts` | 1 | `gameSearchSynonym.sql.ts` |
+Migrated in this phase (Phases A/B/C):
+- `AdminWizardSession.ts`
+- `BotVotingInfo.ts`
+- `CollectionCsvImport.ts`
+- `CompletionatorImport.ts`
+- `Game.ts`
+- `GameDbCsvImport.ts`
+- `GameDbCsvImportMapping.ts` (new sql file: `gameDbCsvImportMapping.sql.ts`)
+- `GameKey.ts`
+- `GameReleaseAnnouncement.ts`
+- `GameSearchSynonymDraft.ts`
+- `GotmAuditImport.ts`
+- `HltbCache.ts`
+- `Member.ts`
+- `Nomination.ts`
+- `PresencePromptHistory.ts`
+- `PresencePromptOptOut.ts`
+- `Reminder.ts`
+- `Suggestion.ts`
+- `SuggestionReviewSession.ts`
+- `Todo.ts`
+- `UserGameCollection.ts`
+- `XboxCollectionImport.ts`
+- `SteamCollectionImport.ts`
 
 ---
 
-### Phase C: SQL file missing -- extract first, then wire
-
-| Class | Approx. raw SQL hits | Action |
-|---|---|---|
-| `GameDbCsvImportMapping.ts` | 8 | Create `gameDbCsvImportMapping.sql.ts` (or extend `gameDbCsvImport.sql.ts`), then wire the class |
-
----
-
-### Suggested Completion Order
-
-1. **Phase C first** -- `GameDbCsvImportMapping.ts` has no sql file yet; create it before wiring.
-2. **Phase B `Member.ts` and `Game.ts`** -- largest backlogs; finish these to clear the biggest debt.
-3. **Phase A batch** -- all sql files already exist; wire the remaining 11 classes in one pass.
-4. **Phase B tail** -- finish the 9 smaller partially-wired classes.
-5. **Phase D (below)** -- make the execution wrappers dialect-agnostic.
+### Next Step: Phase D -- Dialect-agnostic execution wrappers
 
 ---
 

--- a/src/classes/AdminWizardSession.ts
+++ b/src/classes/AdminWizardSession.ts
@@ -1,4 +1,9 @@
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { AdminWizardSessionSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export const ADMIN_WIZARD_COMMANDS = ["nextround-setup"] as const;
 export type AdminWizardCommand = (typeof ADMIN_WIZARD_COMMANDS)[number];
@@ -190,23 +195,7 @@ export async function getActiveAdminWizardSession(
   channelId: string,
 ): Promise<IAdminWizardSession | null> {
   const rows = await oraQuery(
-    `SELECT SESSION_ID,
-            COMMAND_KEY,
-            OWNER_USER_ID,
-            CHANNEL_ID,
-            GUILD_ID,
-            STATUS,
-            STATE_JSON,
-            LAST_UPDATED_AT,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_ADMIN_WIZARD_SESSIONS
-      WHERE COMMAND_KEY = :commandKey
-        AND OWNER_USER_ID = :ownerUserId
-        AND CHANNEL_ID = :channelId
-        AND STATUS = 'ACTIVE'
-      ORDER BY LAST_UPDATED_AT DESC
-      FETCH FIRST 1 ROWS ONLY`,
+    getSql(AdminWizardSessionSql.getActive, dialect),
     { commandKey, ownerUserId, channelId },
     mapAdminWizardSessionRow,
   );
@@ -236,37 +225,7 @@ export async function saveAdminWizardSession(params: {
   ].join("-");
 
   await oraMutate(
-    `MERGE INTO RPG_CLUB_ADMIN_WIZARD_SESSIONS t
-      USING (
-        SELECT :commandKey AS COMMAND_KEY,
-               :ownerUserId AS OWNER_USER_ID,
-               :channelId AS CHANNEL_ID,
-               :guildId AS GUILD_ID,
-               :stateJson AS STATE_JSON,
-               :lastUpdatedAt AS LAST_UPDATED_AT
-          FROM dual
-      ) src
-         ON (t.COMMAND_KEY = src.COMMAND_KEY
-             AND t.OWNER_USER_ID = src.OWNER_USER_ID
-             AND t.CHANNEL_ID = src.CHANNEL_ID
-             AND t.STATUS = 'ACTIVE')
-    WHEN MATCHED THEN
-      UPDATE SET t.STATE_JSON = src.STATE_JSON,
-                 t.GUILD_ID = src.GUILD_ID,
-                 t.LAST_UPDATED_AT = src.LAST_UPDATED_AT
-    WHEN NOT MATCHED THEN
-      INSERT (SESSION_ID, COMMAND_KEY, OWNER_USER_ID, CHANNEL_ID, GUILD_ID, STATUS,
-              STATE_JSON, LAST_UPDATED_AT)
-      VALUES (
-        :sessionId,
-        src.COMMAND_KEY,
-        src.OWNER_USER_ID,
-        src.CHANNEL_ID,
-        src.GUILD_ID,
-        'ACTIVE',
-        src.STATE_JSON,
-        src.LAST_UPDATED_AT
-      )`,
+    getSql(AdminWizardSessionSql.saveSession, dialect),
     {
       commandKey: params.commandKey,
       ownerUserId: params.ownerUserId,
@@ -299,11 +258,7 @@ export async function closeActiveAdminWizardSession(params: {
     // Remove any prior historical row to avoid unique index collision when
     // promoting ACTIVE -> CANCELLED/COMPLETED.
     await conn.execute(
-      `DELETE FROM RPG_CLUB_ADMIN_WIZARD_SESSIONS
-        WHERE COMMAND_KEY = :commandKey
-          AND OWNER_USER_ID = :ownerUserId
-          AND CHANNEL_ID = :channelId
-          AND STATUS = :status`,
+      getSql(AdminWizardSessionSql.deleteHistorical, dialect),
       {
         commandKey: params.commandKey,
         ownerUserId: params.ownerUserId,
@@ -314,13 +269,7 @@ export async function closeActiveAdminWizardSession(params: {
     );
 
     const result = await conn.execute(
-      `UPDATE RPG_CLUB_ADMIN_WIZARD_SESSIONS
-          SET STATUS = :status,
-              LAST_UPDATED_AT = :lastUpdatedAt
-        WHERE COMMAND_KEY = :commandKey
-          AND OWNER_USER_ID = :ownerUserId
-          AND CHANNEL_ID = :channelId
-          AND STATUS = 'ACTIVE'`,
+      getSql(AdminWizardSessionSql.updateStatus, dialect),
       {
         status: toDbStatus(params.status),
         lastUpdatedAt: new Date(),

--- a/src/classes/BotVotingInfo.ts
+++ b/src/classes/BotVotingInfo.ts
@@ -1,4 +1,9 @@
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { BotVotingInfoSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface IBotVotingInfoEntry {
   roundNumber: number;
@@ -61,18 +66,10 @@ function normalizeDate(value: Date | string): Date {
   return d;
 }
 
-const VOTING_COLS = `ROUND_NUMBER,
-                NOMINATION_LIST_ID,
-                NEXT_VOTE_AT,
-                FIVE_DAY_REMINDER_SENT,
-                ONE_DAY_REMINDER_SENT`;
-
 export default class BotVotingInfo {
   static async getAll(): Promise<IBotVotingInfoEntry[]> {
     return oraQuery(
-      `SELECT ${VOTING_COLS}
-         FROM BOT_VOTING_INFO
-        ORDER BY ROUND_NUMBER`,
+      getSql(BotVotingInfoSql.getAll, dialect),
       [],
       mapRowToEntry,
     );
@@ -81,9 +78,7 @@ export default class BotVotingInfo {
   static async getByRound(roundNumber: number): Promise<IBotVotingInfoEntry | null> {
     const round = normalizeRoundNumber(roundNumber);
     const rows = await oraQuery(
-      `SELECT ${VOTING_COLS}
-         FROM BOT_VOTING_INFO
-        WHERE ROUND_NUMBER = :round`,
+      getSql(BotVotingInfoSql.getByRound, dialect),
       { round },
       mapRowToEntry,
     );
@@ -92,11 +87,7 @@ export default class BotVotingInfo {
 
   static async getCurrentRound(): Promise<IBotVotingInfoEntry | null> {
     const rows = await oraQuery(
-      `SELECT ${VOTING_COLS}
-         FROM BOT_VOTING_INFO
-        WHERE ROUND_NUMBER = (
-          SELECT MAX(ROUND_NUMBER) FROM BOT_VOTING_INFO
-        )`,
+      getSql(BotVotingInfoSql.getCurrentRound, dialect),
       [],
       mapRowToEntry,
     );
@@ -113,29 +104,14 @@ export default class BotVotingInfo {
 
     await oraWithConnection(async (conn) => {
       const updateResult = await conn.execute(
-        `UPDATE BOT_VOTING_INFO
-            SET NOMINATION_LIST_ID = :nominationListId,
-                NEXT_VOTE_AT = :nextVoteAt
-          WHERE ROUND_NUMBER = :round`,
+        getSql(BotVotingInfoSql.updateRoundInfo, dialect),
         { round, nominationListId, nextVoteAt: nextVote },
         { autoCommit: true },
       );
       if ((updateResult.rowsAffected ?? 0) > 0) return;
 
       await conn.execute(
-        `INSERT INTO BOT_VOTING_INFO (
-           ROUND_NUMBER,
-           NOMINATION_LIST_ID,
-           NEXT_VOTE_AT,
-           FIVE_DAY_REMINDER_SENT,
-           ONE_DAY_REMINDER_SENT
-         ) VALUES (
-           :round,
-           :nominationListId,
-           :nextVoteAt,
-           0,
-           0
-         )`,
+        getSql(BotVotingInfoSql.insertRoundInfo, dialect),
         { round, nominationListId, nextVoteAt: nextVote },
         { autoCommit: true },
       );
@@ -151,9 +127,7 @@ export default class BotVotingInfo {
       reminder === "fiveDay" ? "FIVE_DAY_REMINDER_SENT" : "ONE_DAY_REMINDER_SENT";
 
     const result = await oraMutate(
-      `UPDATE BOT_VOTING_INFO
-          SET ${column} = 1
-        WHERE ROUND_NUMBER = :round`,
+      BotVotingInfoSql.markReminderSent(column)[dialect],
       { round },
     );
     if ((result.rowsAffected ?? 0) === 0) {
@@ -170,9 +144,7 @@ export default class BotVotingInfo {
     const round = normalizeRoundNumber(roundNumber);
     const nextVote = normalizeDate(nextVoteAt);
     const result = await oraMutate(
-      `UPDATE BOT_VOTING_INFO
-          SET NEXT_VOTE_AT = :nextVoteAt
-        WHERE ROUND_NUMBER = :round`,
+      getSql(BotVotingInfoSql.updateNextVoteAt, dialect),
       { round, nextVoteAt: nextVote },
     );
     if ((result.rowsAffected ?? 0) === 0) {
@@ -188,9 +160,7 @@ export default class BotVotingInfo {
   ): Promise<void> {
     const round = normalizeRoundNumber(roundNumber);
     const result = await oraMutate(
-      `UPDATE BOT_VOTING_INFO
-          SET NOMINATION_LIST_ID = :nominationListId
-        WHERE ROUND_NUMBER = :round`,
+      getSql(BotVotingInfoSql.updateNominationListId, dialect),
       { round, nominationListId },
     );
     if ((result.rowsAffected ?? 0) === 0) {
@@ -204,8 +174,7 @@ export default class BotVotingInfo {
   static async deleteRound(roundNumber: number): Promise<number> {
     const round = normalizeRoundNumber(roundNumber);
     const result = await oraMutate(
-      `DELETE FROM BOT_VOTING_INFO
-        WHERE ROUND_NUMBER = :round`,
+      getSql(BotVotingInfoSql.deleteRound, dialect),
       { round },
     );
     return result.rowsAffected ?? 0;

--- a/src/classes/CollectionCsvImport.ts
+++ b/src/classes/CollectionCsvImport.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { CollectionCsvImportSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type CollectionCsvImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type CollectionCsvImportItemStatus =
@@ -140,23 +145,7 @@ export async function createCollectionCsvImportSession(params: {
 }): Promise<ICollectionCsvImport> {
   return oraWithConnection(async (conn) => {
     const result = await oraMutate(
-      `INSERT INTO RPG_CLUB_COLLECTION_CSV_IMPORTS (
-         USER_ID,
-         STATUS,
-         CURRENT_INDEX,
-         TOTAL_COUNT,
-         SOURCE_FILE_NAME,
-         SOURCE_FILE_SIZE,
-         TEMPLATE_VERSION
-       ) VALUES (
-         :userId,
-         'ACTIVE',
-         0,
-         :totalCount,
-         :sourceFileName,
-         :sourceFileSize,
-         :templateVersion
-       ) RETURNING IMPORT_ID INTO :id`,
+      getSql(CollectionCsvImportSql.createImport, dialect),
       {
         userId: params.userId,
         totalCount: params.totalCount,
@@ -198,33 +187,7 @@ export async function insertCollectionCsvImportItems(
   await oraTransaction(async (conn) => {
     for (const item of items) {
       await oraMutate(
-        `INSERT INTO RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS (
-           IMPORT_ID,
-           ROW_INDEX,
-           RAW_TITLE,
-           RAW_PLATFORM,
-           RAW_OWNERSHIP_TYPE,
-           RAW_NOTE,
-           RAW_GAMEDB_ID,
-           RAW_IGDB_ID,
-           PLATFORM_ID,
-           OWNERSHIP_TYPE,
-           NOTE,
-           STATUS
-         ) VALUES (
-           :importId,
-           :rowIndex,
-           :rawTitle,
-           :rawPlatform,
-           :rawOwnershipType,
-           :rawNote,
-           :rawGameDbId,
-           :rawIgdbId,
-           :platformId,
-           :ownershipType,
-           :note,
-           'PENDING'
-         )`,
+        getSql(CollectionCsvImportSql.insertItem, dialect),
         {
           importId,
           rowIndex: item.rowIndex,
@@ -249,18 +212,7 @@ export async function getCollectionCsvImportById(
   existingConn?: oracledb.Connection,
 ): Promise<ICollectionCsvImport | null> {
   const rows = await oraQuery(
-    `SELECT IMPORT_ID,
-            USER_ID,
-            STATUS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            SOURCE_FILE_NAME,
-            SOURCE_FILE_SIZE,
-            TEMPLATE_VERSION,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_COLLECTION_CSV_IMPORTS
-      WHERE IMPORT_ID = :importId`,
+    getSql(CollectionCsvImportSql.getImportById, dialect),
     { importId },
     mapImport,
     existingConn,
@@ -272,21 +224,7 @@ export async function getActiveCollectionCsvImportForUser(
   userId: string,
 ): Promise<ICollectionCsvImport | null> {
   const rows = await oraQuery(
-    `SELECT IMPORT_ID,
-            USER_ID,
-            STATUS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            SOURCE_FILE_NAME,
-            SOURCE_FILE_SIZE,
-            TEMPLATE_VERSION,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_COLLECTION_CSV_IMPORTS
-      WHERE USER_ID = :userId
-        AND STATUS IN ('ACTIVE', 'PAUSED')
-      ORDER BY CREATED_AT DESC, IMPORT_ID DESC
-      FETCH FIRST 1 ROWS ONLY`,
+    getSql(CollectionCsvImportSql.getActiveForUser, dialect),
     { userId },
     mapImport,
   );
@@ -298,9 +236,7 @@ export async function setCollectionCsvImportStatus(
   status: CollectionCsvImportStatus,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORTS
-        SET STATUS = :status
-      WHERE IMPORT_ID = :importId`,
+    getSql(CollectionCsvImportSql.setStatus, dialect),
     { status, importId },
   );
 }
@@ -310,9 +246,7 @@ export async function updateCollectionCsvImportIndex(
   currentIndex: number,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORTS
-        SET CURRENT_INDEX = :currentIndex
-      WHERE IMPORT_ID = :importId`,
+    getSql(CollectionCsvImportSql.updateIndex, dialect),
     { currentIndex, importId },
   );
 }
@@ -321,27 +255,7 @@ export async function getCollectionCsvImportItemById(
   itemId: number,
 ): Promise<ICollectionCsvImportItem | null> {
   const rows = await oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            RAW_TITLE,
-            RAW_PLATFORM,
-            RAW_OWNERSHIP_TYPE,
-            RAW_NOTE,
-            RAW_GAMEDB_ID,
-            RAW_IGDB_ID,
-            PLATFORM_ID,
-            OWNERSHIP_TYPE,
-            NOTE,
-            STATUS,
-            MATCH_CONFIDENCE,
-            MATCH_CANDIDATE_JSON,
-            GAMEDB_GAME_ID,
-            COLLECTION_ENTRY_ID,
-            RESULT_REASON,
-            ERROR_TEXT
-       FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
-      WHERE ITEM_ID = :itemId`,
+    getSql(CollectionCsvImportSql.getItemById, dialect),
     { itemId },
     mapItem,
   );
@@ -352,30 +266,7 @@ export async function getNextPendingCollectionCsvImportItem(
   importId: number,
 ): Promise<ICollectionCsvImportItem | null> {
   const rows = await oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            RAW_TITLE,
-            RAW_PLATFORM,
-            RAW_OWNERSHIP_TYPE,
-            RAW_NOTE,
-            RAW_GAMEDB_ID,
-            RAW_IGDB_ID,
-            PLATFORM_ID,
-            OWNERSHIP_TYPE,
-            NOTE,
-            STATUS,
-            MATCH_CONFIDENCE,
-            MATCH_CANDIDATE_JSON,
-            GAMEDB_GAME_ID,
-            COLLECTION_ENTRY_ID,
-            RESULT_REASON,
-            ERROR_TEXT
-       FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-        AND STATUS = 'PENDING'
-      ORDER BY ROW_INDEX ASC, ITEM_ID ASC
-      FETCH FIRST 1 ROWS ONLY`,
+    getSql(CollectionCsvImportSql.getNextPendingItem, dialect),
     { importId },
     mapItem,
   );
@@ -429,9 +320,7 @@ export async function updateCollectionCsvImportItem(
   if (!setParts.length) return;
 
   await oraMutate(
-    `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
-        SET ${setParts.join(", ")}
-      WHERE ITEM_ID = :itemId`,
+    CollectionCsvImportSql.updateItem(setParts)[dialect],
     binds,
   );
 }
@@ -453,10 +342,7 @@ export async function countCollectionCsvImportItems(
     FAILED: 0,
   };
   const rows = await oraQuery(
-    `SELECT STATUS, COUNT(*) AS TOTAL
-       FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-      GROUP BY STATUS`,
+    getSql(CollectionCsvImportSql.countItemsByStatus, dialect),
     { importId },
     (row: { STATUS: CollectionCsvImportItemStatus; TOTAL: number }) => row,
   );
@@ -477,11 +363,7 @@ export async function countCollectionCsvImportResultReasons(
 ): Promise<Record<string, number>> {
   const counts: Record<string, number> = {};
   const rows = await oraQuery(
-    `SELECT RESULT_REASON, COUNT(*) AS TOTAL
-       FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-        AND RESULT_REASON IS NOT NULL
-      GROUP BY RESULT_REASON`,
+    getSql(CollectionCsvImportSql.countItemsByReason, dialect),
     { importId },
     (row: { RESULT_REASON: CollectionCsvImportResultReason; TOTAL: number }) => row,
   );

--- a/src/classes/CompletionatorImport.ts
+++ b/src/classes/CompletionatorImport.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { CompletionatorImportSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type ImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type ImportItemStatus =
@@ -111,11 +116,7 @@ export async function createImportSession(params: {
 }): Promise<ICompletionatorImport> {
   return oraWithConnection(async (conn) => {
     const result = await oraMutate(
-      `INSERT INTO RPG_CLUB_COMPLETIONATOR_IMPORTS (
-         USER_ID, STATUS, CURRENT_INDEX, TOTAL_COUNT, SOURCE_FILENAME
-       ) VALUES (
-         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
-       ) RETURNING IMPORT_ID INTO :id`,
+      getSql(CompletionatorImportSql.createImport, dialect),
       {
         userId: params.userId,
         totalCount: params.totalCount,
@@ -153,31 +154,7 @@ export async function insertImportItems(
   await oraTransaction(async (conn) => {
     for (const item of items) {
       await oraMutate(
-        `INSERT INTO RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS (
-           IMPORT_ID,
-           ROW_INDEX,
-           GAME_TITLE,
-           PLATFORM_NAME,
-           REGION_NAME,
-           SOURCE_TYPE,
-           TIME_TEXT,
-           COMPLETED_AT,
-           COMPLETION_TYPE,
-           PLAYTIME_HRS,
-           STATUS
-         ) VALUES (
-           :importId,
-           :rowIndex,
-           :gameTitle,
-           :platformName,
-           :regionName,
-           :sourceType,
-           :timeText,
-           :completedAt,
-           :completionType,
-           :playtimeHours,
-           'PENDING'
-         )`,
+        getSql(CompletionatorImportSql.insertItem, dialect),
         {
           importId,
           rowIndex: item.rowIndex,
@@ -201,16 +178,7 @@ export async function getImportById(
   existingConn?: oracledb.Connection,
 ): Promise<ICompletionatorImport | null> {
   const rows = await oraQuery(
-    `SELECT IMPORT_ID,
-            USER_ID,
-            STATUS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            SOURCE_FILENAME,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_COMPLETIONATOR_IMPORTS
-      WHERE IMPORT_ID = :id`,
+    getSql(CompletionatorImportSql.getImportById, dialect),
     { id: importId },
     mapImport,
     existingConn,
@@ -222,19 +190,7 @@ export async function getActiveImportForUser(
   userId: string,
 ): Promise<ICompletionatorImport | null> {
   const rows = await oraQuery(
-    `SELECT IMPORT_ID,
-            USER_ID,
-            STATUS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            SOURCE_FILENAME,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_COMPLETIONATOR_IMPORTS
-      WHERE USER_ID = :userId
-        AND STATUS IN ('ACTIVE', 'PAUSED')
-      ORDER BY CREATED_AT DESC, IMPORT_ID DESC
-      FETCH FIRST 1 ROWS ONLY`,
+    getSql(CompletionatorImportSql.getActiveForUser, dialect),
     { userId },
     mapImport,
   );
@@ -246,9 +202,7 @@ export async function setImportStatus(
   status: ImportStatus,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORTS
-        SET STATUS = :status
-      WHERE IMPORT_ID = :importId`,
+    getSql(CompletionatorImportSql.setStatus, dialect),
     { status, importId },
   );
 }
@@ -258,9 +212,7 @@ export async function updateImportIndex(
   currentIndex: number,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORTS
-        SET CURRENT_INDEX = :currentIndex
-      WHERE IMPORT_ID = :importId`,
+    getSql(CompletionatorImportSql.updateIndex, dialect),
     { currentIndex, importId },
   );
 }
@@ -269,26 +221,7 @@ export async function getNextPendingItem(
   importId: number,
 ): Promise<ICompletionatorItem | null> {
   const rows = await oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            GAME_TITLE,
-            PLATFORM_NAME,
-            REGION_NAME,
-            SOURCE_TYPE,
-            TIME_TEXT,
-            COMPLETED_AT,
-            COMPLETION_TYPE,
-            PLAYTIME_HRS,
-            STATUS,
-            GAMEDB_GAME_ID,
-            COMPLETION_ID,
-            ERROR_TEXT
-       FROM RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-        AND STATUS = 'PENDING'
-      ORDER BY ROW_INDEX ASC
-      FETCH FIRST 1 ROWS ONLY`,
+    getSql(CompletionatorImportSql.getNextPendingItem, dialect),
     { importId },
     mapItem,
   );
@@ -299,23 +232,7 @@ export async function getImportItemById(
   itemId: number,
 ): Promise<ICompletionatorItem | null> {
   const rows = await oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            GAME_TITLE,
-            PLATFORM_NAME,
-            REGION_NAME,
-            SOURCE_TYPE,
-            TIME_TEXT,
-            COMPLETED_AT,
-            COMPLETION_TYPE,
-            PLAYTIME_HRS,
-            STATUS,
-            GAMEDB_GAME_ID,
-            COMPLETION_ID,
-            ERROR_TEXT
-       FROM RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
-      WHERE ITEM_ID = :itemId`,
+    getSql(CompletionatorImportSql.getItemById, dialect),
     { itemId },
     mapItem,
   );
@@ -354,9 +271,7 @@ export async function updateImportItem(
   if (!fields.length) return;
 
   await oraMutate(
-    `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
-        SET ${fields.join(", ")}
-      WHERE ITEM_ID = :itemId`,
+    CompletionatorImportSql.updateItem(fields)[dialect],
     binds,
   );
 }
@@ -370,10 +285,7 @@ export async function countImportItems(importId: number): Promise<{
 }> {
   const stats = { pending: 0, skipped: 0, imported: 0, updated: 0, error: 0 };
   const rows = await oraQuery(
-    `SELECT STATUS, COUNT(*) AS CNT
-       FROM RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-      GROUP BY STATUS`,
+    getSql(CompletionatorImportSql.countItemsByStatus, dialect),
     { importId },
     (row: { STATUS: string; CNT: number }) => row,
   );

--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -672,7 +672,7 @@ export default class Game {
     igdbId: number,
   ): Promise<number> {
     const rows = await oraQuery(
-      `SELECT ${idCol} FROM ${table} WHERE ${igdbIdCol} = :igdbId`,
+      GameSql.getOrInsertMetadataSelect(idCol, table, igdbIdCol)[dialect],
       { igdbId },
       (row: Record<string, number>) => Number(row[idCol]),
       conn,
@@ -680,7 +680,7 @@ export default class Game {
     if (rows.length > 0) return rows[0];
 
     const insertRes = await oraMutate(
-      `INSERT INTO ${table} (${nameCol}, ${igdbIdCol}) VALUES (:name, :igdbId) RETURNING ${idCol} INTO :id`,
+      GameSql.getOrInsertMetadataInsert(table, nameCol, idCol, igdbIdCol)[dialect],
       { name, igdbId, id: { type: oracledb.NUMBER, dir: oracledb.BIND_OUT } },
       conn,
     );
@@ -1132,9 +1132,7 @@ export default class Game {
     idCol: string,
   ): Promise<string[]> {
     return oraQuery(
-      `SELECT t.NAME FROM ${defTable} t
-       JOIN ${mapTable} m ON t.${idCol} = m.${idCol}
-       WHERE m.GAME_ID = :gameId`,
+      GameSql.getSimpleList(defTable, mapTable, idCol)[dialect],
       { gameId },
       (row: { NAME: string }) => row.NAME,
     );
@@ -1448,24 +1446,7 @@ export default class Game {
         TITLE: string;
         INITIAL_RELEASE_DATE: Date | null;
       }>(
-        `SELECT GAME_ID, TITLE, INITIAL_RELEASE_DATE
-           FROM GAMEDB_GAMES
-          WHERE ${titleFoldExpr} LIKE :rawContains
-             OR (
-               :exactNorm IS NOT NULL AND
-               ${titleNormExpr} LIKE :normContains
-             )
-          ORDER BY CASE
-                     WHEN ${titleFoldExpr} = :exactRaw THEN 0
-                     WHEN ${titleFoldExpr} LIKE :rawPrefix THEN 1
-                     WHEN :exactNorm IS NOT NULL AND
-                          ${titleNormExpr} = :exactNorm THEN 2
-                     WHEN :exactNorm IS NOT NULL AND
-                          ${titleNormExpr} LIKE :normPrefix THEN 3
-                     ELSE 4
-                   END,
-                   TITLE ASC
-          FETCH FIRST :limit ROWS ONLY`,
+        GameSql.searchGamesAutocomplete(titleFoldExpr, titleNormExpr)[dialect],
         binds,
         { outFormat: oracledb.OUT_FORMAT_OBJECT },
       );
@@ -1669,6 +1650,9 @@ export default class Game {
           ? `${titlePart} AND ${filterPart}`
           : titlePart || filterPart || "1=0";
 
+      const orderPrefix = filters.upcomingRelease
+        ? "u.UPCOMING_DATE ASC NULLS LAST, "
+        : "";
       const result = await connection.execute<{
         GAME_ID: number;
         TITLE: string;
@@ -1685,26 +1669,7 @@ export default class Game {
         UPCOMING_RELEASE_DATE: Date | null;
         UPCOMING_PLATFORMS: string | null;
       }>(
-        `WITH upcoming AS (
-           SELECT GAME_ID, MIN(RELEASE_DATE) AS UPCOMING_DATE
-             FROM GAMEDB_RELEASES
-            WHERE RELEASE_DATE > SYSDATE
-            GROUP BY GAME_ID
-         )
-         SELECT g.GAME_ID, g.TITLE, g.DESCRIPTION, g.IGDB_ID, g.SLUG, g.TOTAL_RATING,
-                g.IGDB_URL, g.FEATURED_VIDEO_URL, g.INITIAL_RELEASE_DATE,
-                g.CREATED_AT, g.UPDATED_AT,
-                u.UPCOMING_DATE AS UPCOMING_RELEASE_DATE,
-                (SELECT LISTAGG(COALESCE(p.PLATFORM_ABBREVIATION, p.PLATFORM_NAME), ',')
-                        WITHIN GROUP (ORDER BY p.PLATFORM_NAME)
-                   FROM GAMEDB_RELEASES r
-                   JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = r.PLATFORM_ID
-                  WHERE r.GAME_ID = g.GAME_ID AND r.RELEASE_DATE = u.UPCOMING_DATE
-                ) AS UPCOMING_PLATFORMS
-           FROM GAMEDB_GAMES g
-           LEFT JOIN upcoming u ON u.GAME_ID = g.GAME_ID
-          WHERE ${whereClause}
-          ORDER BY ${filters.upcomingRelease ? "u.UPCOMING_DATE ASC NULLS LAST, " : ""}g.TITLE ASC`,
+        GameSql.searchGames(whereClause, orderPrefix)[dialect],
         binds,
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,

--- a/src/classes/GameDbCsvImport.ts
+++ b/src/classes/GameDbCsvImport.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GameDbCsvImportSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type GameDbCsvImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type GameDbCsvItemStatus = "PENDING" | "SKIPPED" | "IMPORTED" | "ERROR";
@@ -94,11 +99,7 @@ export async function createGameDbCsvImportSession(params: {
 }): Promise<IGameDbCsvImport> {
   return oraWithConnection(async (conn) => {
     const result = await oraMutate(
-      `INSERT INTO RPG_CLUB_GAMEDB_IMPORTS (
-         USER_ID, STATUS, CURRENT_INDEX, TOTAL_COUNT, SOURCE_FILENAME
-       ) VALUES (
-         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
-       ) RETURNING IMPORT_ID INTO :id`,
+      getSql(GameDbCsvImportSql.createImport, dialect),
       {
         userId: params.userId,
         totalCount: params.totalCount,
@@ -133,25 +134,7 @@ export async function insertGameDbCsvImportItems(
   await oraTransaction(async (conn) => {
     for (const item of items) {
       await oraMutate(
-        `INSERT INTO RPG_CLUB_GAMEDB_IMPORT_ITEMS (
-           IMPORT_ID,
-           ROW_INDEX,
-           GAME_TITLE,
-           RAW_GAME_TITLE,
-           PLATFORM_NAME,
-           REGION_NAME,
-           INITIAL_RELEASE_DATE,
-           STATUS
-         ) VALUES (
-           :importId,
-           :rowIndex,
-           :gameTitle,
-           :rawGameTitle,
-           :platformName,
-           :regionName,
-           :initialReleaseDate,
-           'PENDING'
-         )`,
+        getSql(GameDbCsvImportSql.insertItem, dialect),
         {
           importId,
           rowIndex: item.rowIndex,
@@ -172,16 +155,7 @@ export async function getGameDbCsvImportById(
   existingConn?: oracledb.Connection,
 ): Promise<IGameDbCsvImport | null> {
   const rows = await oraQuery(
-    `SELECT IMPORT_ID,
-            USER_ID,
-            STATUS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            SOURCE_FILENAME,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_GAMEDB_IMPORTS
-      WHERE IMPORT_ID = :id`,
+    getSql(GameDbCsvImportSql.getImportById, dialect),
     { id: importId },
     mapImport,
     existingConn,
@@ -193,19 +167,7 @@ export async function getActiveGameDbCsvImportForUser(
   userId: string,
 ): Promise<IGameDbCsvImport | null> {
   const rows = await oraQuery(
-    `SELECT IMPORT_ID,
-            USER_ID,
-            STATUS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            SOURCE_FILENAME,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_GAMEDB_IMPORTS
-      WHERE USER_ID = :userId
-        AND STATUS IN ('ACTIVE', 'PAUSED')
-      ORDER BY CREATED_AT DESC, IMPORT_ID DESC
-      FETCH FIRST 1 ROWS ONLY`,
+    getSql(GameDbCsvImportSql.getActiveForUser, dialect),
     { userId },
     mapImport,
   );
@@ -217,9 +179,7 @@ export async function setGameDbCsvImportStatus(
   status: GameDbCsvImportStatus,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_GAMEDB_IMPORTS
-        SET STATUS = :status
-      WHERE IMPORT_ID = :importId`,
+    getSql(GameDbCsvImportSql.setStatus, dialect),
     { status, importId },
   );
 }
@@ -229,9 +189,7 @@ export async function updateGameDbCsvImportIndex(
   currentIndex: number,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_GAMEDB_IMPORTS
-        SET CURRENT_INDEX = :currentIndex
-      WHERE IMPORT_ID = :importId`,
+    getSql(GameDbCsvImportSql.updateIndex, dialect),
     { currentIndex, importId },
   );
 }
@@ -240,22 +198,7 @@ export async function getNextGameDbCsvImportItem(
   importId: number,
 ): Promise<IGameDbCsvImportItem | null> {
   const rows = await oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            GAME_TITLE,
-            RAW_GAME_TITLE,
-            PLATFORM_NAME,
-            REGION_NAME,
-            INITIAL_RELEASE_DATE,
-            STATUS,
-            GAMEDB_GAME_ID,
-            ERROR_TEXT
-       FROM RPG_CLUB_GAMEDB_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-        AND STATUS = 'PENDING'
-      ORDER BY ROW_INDEX ASC
-      FETCH FIRST 1 ROWS ONLY`,
+    getSql(GameDbCsvImportSql.getNextPendingItem, dialect),
     { importId },
     mapItem,
   );
@@ -266,19 +209,7 @@ export async function getGameDbCsvImportItemById(
   itemId: number,
 ): Promise<IGameDbCsvImportItem | null> {
   const rows = await oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            GAME_TITLE,
-            RAW_GAME_TITLE,
-            PLATFORM_NAME,
-            REGION_NAME,
-            INITIAL_RELEASE_DATE,
-            STATUS,
-            GAMEDB_GAME_ID,
-            ERROR_TEXT
-       FROM RPG_CLUB_GAMEDB_IMPORT_ITEMS
-      WHERE ITEM_ID = :itemId`,
+    getSql(GameDbCsvImportSql.getItemById, dialect),
     { itemId },
     mapItem,
   );
@@ -312,9 +243,7 @@ export async function updateGameDbCsvImportItem(
   if (!fields.length) return;
 
   await oraMutate(
-    `UPDATE RPG_CLUB_GAMEDB_IMPORT_ITEMS
-        SET ${fields.join(", ")}
-      WHERE ITEM_ID = :itemId`,
+    GameDbCsvImportSql.updateItem(fields)[dialect],
     binds,
   );
 }
@@ -327,10 +256,7 @@ export async function countGameDbCsvImportItems(importId: number): Promise<{
 }> {
   const stats = { pending: 0, skipped: 0, imported: 0, error: 0 };
   const rows = await oraQuery(
-    `SELECT STATUS, COUNT(*) AS CNT
-       FROM RPG_CLUB_GAMEDB_IMPORT_ITEMS
-      WHERE IMPORT_ID = :importId
-      GROUP BY STATUS`,
+    getSql(GameDbCsvImportSql.countItems, dialect),
     { importId },
     (row: { STATUS: string; CNT: number }) => row,
   );

--- a/src/classes/GameDbCsvImportMapping.ts
+++ b/src/classes/GameDbCsvImportMapping.ts
@@ -1,4 +1,9 @@
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GameDbCsvImportMappingSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type GameDbCsvTitleMapStatus = "MAPPED" | "SKIPPED";
 
@@ -43,16 +48,7 @@ export async function getGameDbCsvTitleMapByNorm(
   titleNorm: string,
 ): Promise<IGameDbCsvTitleMap | null> {
   const rows = await oraQuery(
-    `SELECT MAP_ID,
-            TITLE_RAW,
-            TITLE_NORM,
-            GAMEDB_GAME_ID,
-            STATUS,
-            CREATED_BY,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP
-      WHERE TITLE_NORM = :titleNorm`,
+    getSql(GameDbCsvImportMappingSql.getByTitleNorm, dialect),
     { titleNorm },
     mapRow,
   );
@@ -67,20 +63,7 @@ export async function upsertGameDbCsvTitleMap(params: {
   createdBy: string | null;
 }): Promise<void> {
   await oraMutate(
-    `MERGE INTO RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP t
-     USING (
-       SELECT :titleNorm AS TITLE_NORM FROM dual
-     ) s
-        ON (t.TITLE_NORM = s.TITLE_NORM)
-     WHEN MATCHED THEN
-       UPDATE SET
-         TITLE_RAW = :titleRaw,
-         GAMEDB_GAME_ID = :gameDbGameId,
-         STATUS = :status,
-         CREATED_BY = :createdBy
-     WHEN NOT MATCHED THEN
-       INSERT (TITLE_RAW, TITLE_NORM, GAMEDB_GAME_ID, STATUS, CREATED_BY)
-       VALUES (:titleRaw, :titleNorm, :gameDbGameId, :status, :createdBy)`,
+    getSql(GameDbCsvImportMappingSql.upsert, dialect),
     {
       titleRaw: params.titleRaw,
       titleNorm: params.titleNorm,

--- a/src/classes/GameKey.ts
+++ b/src/classes/GameKey.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GameKeySql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface IGameKey {
   keyId: number;
@@ -44,16 +49,6 @@ function mapGameKeyRow(row: GameKeyRow): IGameKey {
   };
 }
 
-const GAME_KEY_COLS = `KEY_ID,
-        GAME_TITLE,
-        PLATFORM,
-        KEY_VALUE,
-        DONOR_USER_ID,
-        CLAIMED_BY_USER_ID,
-        CLAIMED_AT,
-        CREATED_AT,
-        UPDATED_AT`;
-
 export async function createGameKey(
   title: string,
   platform: string,
@@ -61,9 +56,7 @@ export async function createGameKey(
   donorUserId: string,
 ): Promise<IGameKey> {
   const result = await oraMutate(
-    `INSERT INTO RPG_CLUB_GAME_KEYS (GAME_TITLE, PLATFORM, KEY_VALUE, DONOR_USER_ID)
-     VALUES (:title, :platform, :keyValue, :donorUserId)
-     RETURNING KEY_ID INTO :id`,
+    getSql(GameKeySql.create, dialect),
     {
       title,
       platform,
@@ -85,9 +78,7 @@ export async function createGameKey(
 
 export async function getGameKeyById(keyId: number): Promise<IGameKey | null> {
   const rows = await oraQuery(
-    `SELECT ${GAME_KEY_COLS}
-       FROM RPG_CLUB_GAME_KEYS
-      WHERE KEY_ID = :id`,
+    getSql(GameKeySql.getById, dialect),
     { id: keyId },
     mapGameKeyRow,
   );
@@ -96,9 +87,7 @@ export async function getGameKeyById(keyId: number): Promise<IGameKey | null> {
 
 export async function countAvailableGameKeys(): Promise<number> {
   const rows = await oraQuery(
-    `SELECT COUNT(*) AS TOTAL
-       FROM RPG_CLUB_GAME_KEYS
-      WHERE CLAIMED_BY_USER_ID IS NULL`,
+    getSql(GameKeySql.countAvailable, dialect),
     {},
     (row: { TOTAL: number | null }) => Number(row.TOTAL ?? 0),
   );
@@ -112,11 +101,7 @@ export async function listAvailableGameKeys(
   const safeLimit = Math.min(Math.max(limit, 1), 50);
   const safeOffset = Math.max(offset, 0);
   return oraQuery(
-    `SELECT ${GAME_KEY_COLS}
-       FROM RPG_CLUB_GAME_KEYS
-      WHERE CLAIMED_BY_USER_ID IS NULL
-      ORDER BY UPPER(GAME_TITLE), KEY_ID
-      OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+    getSql(GameKeySql.listAvailable, dialect),
     { offset: safeOffset, limit: safeLimit },
     mapGameKeyRow,
   );
@@ -124,10 +109,7 @@ export async function listAvailableGameKeys(
 
 export async function listKeysByDonor(userId: string): Promise<IGameKey[]> {
   return oraQuery(
-    `SELECT ${GAME_KEY_COLS}
-       FROM RPG_CLUB_GAME_KEYS
-      WHERE DONOR_USER_ID = :userId
-      ORDER BY CREATED_AT DESC, KEY_ID DESC`,
+    getSql(GameKeySql.listByDonor, dialect),
     { userId },
     mapGameKeyRow,
   );
@@ -138,11 +120,7 @@ export async function claimGameKey(
   userId: string,
 ): Promise<boolean> {
   const result = await oraMutate(
-    `UPDATE RPG_CLUB_GAME_KEYS
-        SET CLAIMED_BY_USER_ID = :userId,
-            CLAIMED_AT = SYSTIMESTAMP
-      WHERE KEY_ID = :keyId
-        AND CLAIMED_BY_USER_ID IS NULL`,
+    getSql(GameKeySql.claim, dialect),
     { keyId, userId },
   );
   return (result.rowsAffected ?? 0) > 0;
@@ -150,7 +128,7 @@ export async function claimGameKey(
 
 export async function revokeGameKey(keyId: number): Promise<boolean> {
   const result = await oraMutate(
-    `DELETE FROM RPG_CLUB_GAME_KEYS WHERE KEY_ID = :keyId`,
+    getSql(GameKeySql.revoke, dialect),
     { keyId },
   );
   return (result.rowsAffected ?? 0) > 0;

--- a/src/classes/GameReleaseAnnouncement.ts
+++ b/src/classes/GameReleaseAnnouncement.ts
@@ -1,4 +1,9 @@
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GameReleaseAnnouncementSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export interface IReleaseAnnouncementCandidate {
   releaseId: number;
@@ -62,59 +67,14 @@ export default class GameReleaseAnnouncement {
   static async syncReleaseAnnouncements(): Promise<void> {
     await oraWithConnection(async (conn) => {
       await oraMutate(
-        `MERGE INTO GAMEDB_RELEASE_ANNOUNCEMENTS a
-         USING (
-           SELECT r.RELEASE_ID, r.RELEASE_DATE - 7 AS ANNOUNCE_AT
-           FROM GAMEDB_RELEASES r
-           WHERE r.RELEASE_DATE IS NOT NULL
-         ) src
-         ON (a.RELEASE_ID = src.RELEASE_ID)
-         WHEN MATCHED THEN
-           UPDATE SET
-             a.ANNOUNCE_AT = src.ANNOUNCE_AT,
-             a.UPDATED_AT = CURRENT_TIMESTAMP
-           WHERE a.SENT_AT IS NULL
-             AND a.SKIPPED_AT IS NULL
-             AND a.ANNOUNCE_AT <> src.ANNOUNCE_AT
-         WHEN NOT MATCHED THEN
-           INSERT (
-             RELEASE_ID, ANNOUNCE_AT, SENT_AT, SKIPPED_AT, SKIP_REASON, CREATED_AT, UPDATED_AT
-           )
-           VALUES (
-             src.RELEASE_ID, src.ANNOUNCE_AT, NULL, NULL, NULL, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
-           )`,
+        getSql(GameReleaseAnnouncementSql.syncReleaseAnnouncements, dialect),
         {},
         conn,
       );
       await conn.commit();
 
       await oraMutate(
-        `UPDATE GAMEDB_RELEASE_ANNOUNCEMENTS a
-            SET a.SKIPPED_AT = NULL,
-                a.SKIP_REASON = NULL,
-                a.UPDATED_AT = CURRENT_TIMESTAMP
-          WHERE a.SENT_AT IS NULL
-            AND a.SKIP_REASON IN (:portOnlyReason, :sameDayReason)
-            AND NOT EXISTS (
-              SELECT 1
-              FROM (
-                SELECT ranked.RELEASE_ID
-                FROM (
-                  SELECT r.RELEASE_ID,
-                         r.RELEASE_DATE,
-                         MIN(r.RELEASE_DATE) OVER (PARTITION BY r.GAME_ID) AS FIRST_RELEASE_DATE,
-                         ROW_NUMBER() OVER (
-                           PARTITION BY r.GAME_ID, r.RELEASE_DATE
-                           ORDER BY r.RELEASE_ID ASC
-                         ) AS SAME_DAY_RANK
-                  FROM GAMEDB_RELEASES r
-                  WHERE r.RELEASE_DATE IS NOT NULL
-                ) ranked
-                WHERE ranked.RELEASE_DATE > ranked.FIRST_RELEASE_DATE
-                   OR (ranked.RELEASE_DATE = ranked.FIRST_RELEASE_DATE AND ranked.SAME_DAY_RANK > 1)
-              ) non_canonical
-              WHERE non_canonical.RELEASE_ID = a.RELEASE_ID
-            )`,
+        getSql(GameReleaseAnnouncementSql.restoreNonCanonical, dialect),
         { portOnlyReason: PORT_ONLY_RELEASE_REASON, sameDayReason: SAME_DAY_DUPLICATE_REASON },
         conn,
       );
@@ -124,35 +84,7 @@ export default class GameReleaseAnnouncement {
 
   static async markNonCanonicalAnnouncements(): Promise<number> {
     const result = await oraMutate(
-      `MERGE INTO GAMEDB_RELEASE_ANNOUNCEMENTS a
-       USING (
-         SELECT ranked.RELEASE_ID,
-                CASE
-                  WHEN ranked.RELEASE_DATE > ranked.FIRST_RELEASE_DATE THEN :portOnlyReason
-                  ELSE :sameDayReason
-                END AS SKIP_REASON
-         FROM (
-           SELECT r.RELEASE_ID,
-                  r.RELEASE_DATE,
-                  MIN(r.RELEASE_DATE) OVER (PARTITION BY r.GAME_ID) AS FIRST_RELEASE_DATE,
-                  ROW_NUMBER() OVER (
-                    PARTITION BY r.GAME_ID, r.RELEASE_DATE
-                    ORDER BY r.RELEASE_ID ASC
-                  ) AS SAME_DAY_RANK
-           FROM GAMEDB_RELEASES r
-           WHERE r.RELEASE_DATE IS NOT NULL
-         ) ranked
-         WHERE ranked.RELEASE_DATE > ranked.FIRST_RELEASE_DATE
-            OR (ranked.RELEASE_DATE = ranked.FIRST_RELEASE_DATE AND ranked.SAME_DAY_RANK > 1)
-       ) src
-       ON (a.RELEASE_ID = src.RELEASE_ID)
-       WHEN MATCHED THEN
-         UPDATE SET
-           a.SKIPPED_AT = CURRENT_TIMESTAMP,
-           a.SKIP_REASON = src.SKIP_REASON,
-           a.UPDATED_AT = CURRENT_TIMESTAMP
-         WHERE a.SENT_AT IS NULL
-           AND a.SKIPPED_AT IS NULL`,
+      getSql(GameReleaseAnnouncementSql.markNonCanonical, dialect),
       { portOnlyReason: PORT_ONLY_RELEASE_REASON, sameDayReason: SAME_DAY_DUPLICATE_REASON },
     );
     return Number(result.rowsAffected ?? 0);
@@ -164,40 +96,7 @@ export default class GameReleaseAnnouncement {
   ): Promise<IReleaseAnnouncementCandidate[]> {
     const safeLimit = clampBatchSize(limit);
     return oraQuery(
-      `SELECT a.RELEASE_ID,
-              r.GAME_ID,
-              g.TITLE,
-              r.RELEASE_DATE,
-              a.ANNOUNCE_AT,
-              p.PLATFORM_NAME,
-              p.PLATFORM_ABBREVIATION,
-              g.IGDB_URL
-         FROM GAMEDB_RELEASE_ANNOUNCEMENTS a
-         JOIN GAMEDB_RELEASES r ON r.RELEASE_ID = a.RELEASE_ID
-         JOIN GAMEDB_GAMES g ON g.GAME_ID = r.GAME_ID
-         LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = r.PLATFORM_ID
-         JOIN (
-           SELECT canonical.RELEASE_ID
-           FROM (
-             SELECT r.RELEASE_ID,
-                    r.RELEASE_DATE,
-                    MIN(r.RELEASE_DATE) OVER (PARTITION BY r.GAME_ID) AS FIRST_RELEASE_DATE,
-                    ROW_NUMBER() OVER (
-                      PARTITION BY r.GAME_ID, r.RELEASE_DATE
-                      ORDER BY r.RELEASE_ID ASC
-                    ) AS SAME_DAY_RANK
-             FROM GAMEDB_RELEASES r
-             WHERE r.RELEASE_DATE IS NOT NULL
-           ) canonical
-           WHERE canonical.RELEASE_DATE = canonical.FIRST_RELEASE_DATE
-             AND canonical.SAME_DAY_RANK = 1
-         ) c ON c.RELEASE_ID = a.RELEASE_ID
-        WHERE a.SENT_AT IS NULL
-          AND a.SKIPPED_AT IS NULL
-          AND a.ANNOUNCE_AT <= :referenceTime
-          AND r.RELEASE_DATE > :referenceTime
-        ORDER BY a.ANNOUNCE_AT ASC, r.RELEASE_DATE ASC, r.GAME_ID ASC, a.RELEASE_ID ASC
-        FETCH FIRST :limit ROWS ONLY`,
+      getSql(GameReleaseAnnouncementSql.listDueAnnouncements, dialect),
       { referenceTime, limit: safeLimit },
       mapCandidateRow,
     );
@@ -205,13 +104,7 @@ export default class GameReleaseAnnouncement {
 
   static async markAnnouncementSent(releaseId: number, sentAt: Date): Promise<boolean> {
     const result = await oraMutate(
-      `UPDATE GAMEDB_RELEASE_ANNOUNCEMENTS
-          SET SENT_AT = :sentAt,
-              SKIP_REASON = NULL,
-              UPDATED_AT = CURRENT_TIMESTAMP
-        WHERE RELEASE_ID = :releaseId
-          AND SENT_AT IS NULL
-          AND SKIPPED_AT IS NULL`,
+      getSql(GameReleaseAnnouncementSql.markSent, dialect),
       { releaseId, sentAt },
     );
     return (result.rowsAffected ?? 0) > 0;
@@ -219,19 +112,7 @@ export default class GameReleaseAnnouncement {
 
   static async markMissedAnnouncements(referenceTime: Date): Promise<number> {
     const result = await oraMutate(
-      `UPDATE GAMEDB_RELEASE_ANNOUNCEMENTS a
-          SET a.SKIPPED_AT = :referenceTime,
-              a.SKIP_REASON = :reason,
-              a.UPDATED_AT = CURRENT_TIMESTAMP
-        WHERE a.SENT_AT IS NULL
-          AND a.SKIPPED_AT IS NULL
-          AND a.ANNOUNCE_AT <= :referenceTime
-          AND EXISTS (
-            SELECT 1
-            FROM GAMEDB_RELEASES r
-            WHERE r.RELEASE_ID = a.RELEASE_ID
-              AND r.RELEASE_DATE <= :referenceTime
-          )`,
+      getSql(GameReleaseAnnouncementSql.markMissed, dialect),
       { referenceTime, reason: MISSED_WINDOW_REASON },
     );
     return Number(result.rowsAffected ?? 0);

--- a/src/classes/GotmAuditImport.ts
+++ b/src/classes/GotmAuditImport.ts
@@ -1,5 +1,10 @@
 import oracledb from "oracledb";
 import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { GotmAuditImportSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type GotmAuditStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type GotmAuditItemStatus = "PENDING" | "SKIPPED" | "IMPORTED" | "ERROR";
@@ -97,11 +102,7 @@ export async function createGotmAuditImportSession(params: {
 }): Promise<IGotmAuditImport> {
   return oraWithConnection(async (conn) => {
     const result = await oraMutate(
-      `INSERT INTO RPG_CLUB_GOTM_AUDIT_IMPORTS (
-         USER_ID, STATUS, CURRENT_INDEX, TOTAL_COUNT, SOURCE_FILENAME
-       ) VALUES (
-         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
-       ) RETURNING IMPORT_ID INTO :id`,
+      getSql(GotmAuditImportSql.createSession, dialect),
       {
         userId: params.userId,
         totalCount: params.totalCount,
@@ -139,31 +140,7 @@ export async function insertGotmAuditImportItems(
   await oraTransaction(async (conn) => {
     for (const item of items) {
       await oraMutate(
-        `INSERT INTO RPG_CLUB_GOTM_AUDIT_ITEMS (
-           IMPORT_ID,
-           ROW_INDEX,
-           KIND,
-           ROUND_NUMBER,
-           MONTH_YEAR,
-           GAME_INDEX,
-           GAME_TITLE,
-           THREAD_ID,
-           REDDIT_URL,
-           STATUS,
-           GAMEDB_GAME_ID
-         ) VALUES (
-           :importId,
-           :rowIndex,
-           :kind,
-           :roundNumber,
-           :monthYear,
-           :gameIndex,
-           :gameTitle,
-           :threadId,
-           :redditUrl,
-           'PENDING',
-           :gameDbGameId
-         )`,
+        getSql(GotmAuditImportSql.insertItems, dialect),
         {
           importId,
           rowIndex: item.rowIndex,
@@ -187,16 +164,7 @@ export async function getGotmAuditImportById(
   existingConn?: oracledb.Connection,
 ): Promise<IGotmAuditImport | null> {
   const rows = await oraQuery(
-    `SELECT IMPORT_ID,
-            USER_ID,
-            STATUS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            SOURCE_FILENAME,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_GOTM_AUDIT_IMPORTS
-      WHERE IMPORT_ID = :id`,
+    getSql(GotmAuditImportSql.getById, dialect),
     { id: importId },
     mapImport,
     existingConn,
@@ -208,18 +176,7 @@ export async function getActiveGotmAuditImportForUser(
   userId: string,
 ): Promise<IGotmAuditImport | null> {
   const rows = await oraQuery(
-    `SELECT IMPORT_ID,
-            USER_ID,
-            STATUS,
-            CURRENT_INDEX,
-            TOTAL_COUNT,
-            SOURCE_FILENAME,
-            CREATED_AT,
-            UPDATED_AT
-       FROM RPG_CLUB_GOTM_AUDIT_IMPORTS
-      WHERE USER_ID = :userId
-        AND STATUS IN ('ACTIVE', 'PAUSED')
-      ORDER BY IMPORT_ID DESC`,
+    getSql(GotmAuditImportSql.getActiveForUser, dialect),
     { userId },
     mapImport,
   );
@@ -231,9 +188,7 @@ export async function setGotmAuditImportStatus(
   status: GotmAuditStatus,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_GOTM_AUDIT_IMPORTS
-        SET STATUS = :status
-      WHERE IMPORT_ID = :importId`,
+    getSql(GotmAuditImportSql.setStatus, dialect),
     { importId, status },
   );
 }
@@ -243,9 +198,7 @@ export async function updateGotmAuditImportIndex(
   currentIndex: number,
 ): Promise<void> {
   await oraMutate(
-    `UPDATE RPG_CLUB_GOTM_AUDIT_IMPORTS
-        SET CURRENT_INDEX = :currentIndex
-      WHERE IMPORT_ID = :importId`,
+    getSql(GotmAuditImportSql.updateIndex, dialect),
     { importId, currentIndex },
   );
 }
@@ -254,24 +207,7 @@ export async function getNextGotmAuditItem(
   importId: number,
 ): Promise<IGotmAuditItem | null> {
   const rows = await oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            KIND,
-            ROUND_NUMBER,
-            MONTH_YEAR,
-            GAME_INDEX,
-            GAME_TITLE,
-            THREAD_ID,
-            REDDIT_URL,
-            STATUS,
-            GAMEDB_GAME_ID,
-            ERROR_TEXT
-       FROM RPG_CLUB_GOTM_AUDIT_ITEMS
-      WHERE IMPORT_ID = :importId
-        AND STATUS = 'PENDING'
-      ORDER BY ROW_INDEX
-      FETCH FIRST 1 ROWS ONLY`,
+    getSql(GotmAuditImportSql.getNextPendingItem, dialect),
     { importId },
     mapItem,
   );
@@ -282,21 +218,7 @@ export async function getGotmAuditItemById(
   itemId: number,
 ): Promise<IGotmAuditItem | null> {
   const rows = await oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            KIND,
-            ROUND_NUMBER,
-            MONTH_YEAR,
-            GAME_INDEX,
-            GAME_TITLE,
-            THREAD_ID,
-            REDDIT_URL,
-            STATUS,
-            GAMEDB_GAME_ID,
-            ERROR_TEXT
-       FROM RPG_CLUB_GOTM_AUDIT_ITEMS
-      WHERE ITEM_ID = :itemId`,
+    getSql(GotmAuditImportSql.getItemById, dialect),
     { itemId },
     mapItem,
   );
@@ -330,9 +252,7 @@ export async function updateGotmAuditItem(
   if (!fields.length) return;
 
   await oraMutate(
-    `UPDATE RPG_CLUB_GOTM_AUDIT_ITEMS
-        SET ${fields.join(", ")}
-      WHERE ITEM_ID = :itemId`,
+    GotmAuditImportSql.updateItem(fields)[dialect],
     binds,
   );
 }
@@ -343,24 +263,7 @@ export async function getGotmAuditItemsForRound(
   roundNumber: number,
 ): Promise<IGotmAuditItem[]> {
   return oraQuery(
-    `SELECT ITEM_ID,
-            IMPORT_ID,
-            ROW_INDEX,
-            KIND,
-            ROUND_NUMBER,
-            MONTH_YEAR,
-            GAME_INDEX,
-            GAME_TITLE,
-            THREAD_ID,
-            REDDIT_URL,
-            STATUS,
-            GAMEDB_GAME_ID,
-            ERROR_TEXT
-       FROM RPG_CLUB_GOTM_AUDIT_ITEMS
-      WHERE IMPORT_ID = :importId
-        AND KIND = :kind
-        AND ROUND_NUMBER = :roundNumber
-      ORDER BY GAME_INDEX`,
+    getSql(GotmAuditImportSql.getItemsForRound, dialect),
     { importId, kind, roundNumber },
     mapItem,
   );
@@ -374,10 +277,7 @@ export async function countGotmAuditItems(importId: number): Promise<{
 }> {
   const stats = { pending: 0, imported: 0, skipped: 0, error: 0 };
   const rows = await oraQuery(
-    `SELECT STATUS, COUNT(*) AS CNT
-       FROM RPG_CLUB_GOTM_AUDIT_ITEMS
-      WHERE IMPORT_ID = :importId
-      GROUP BY STATUS`,
+    getSql(GotmAuditImportSql.countItems, dialect),
     { importId },
     (row: { STATUS: GotmAuditItemStatus; CNT: number }) => row,
   );

--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -539,11 +539,7 @@ export default class Member {
     const noteUpdatedAt = noteValue ? new Date() : null;
 
     const res = await oraMutate(
-      `UPDATE USER_NOW_PLAYING
-          SET NOTE = :note,
-              NOTE_UPDATED_AT = :noteUpdatedAt
-        WHERE USER_ID = :userId
-          AND GAMEDB_GAME_ID = :gameId`,
+      getSql(MemberSql.updateNowPlayingNote, dialect),
       { userId, gameId, note: noteValue, noteUpdatedAt },
     );
     return (res.rowsAffected ?? 0) > 0;
@@ -568,7 +564,7 @@ export default class Member {
     try {
       await oraWithConnection(async (conn) => {
         const countRes = await conn.execute<{ CNT: number }>(
-          `SELECT COUNT(*) AS CNT FROM USER_NOW_PLAYING WHERE USER_ID = :userId`,
+          getSql(MemberSql.countNowPlaying, dialect),
           { userId },
           { outFormat: oracledb.OUT_FORMAT_OBJECT },
         );
@@ -578,9 +574,7 @@ export default class Member {
         }
 
         const sortRes = await conn.execute<{ MAX_SORT: number | null }>(
-          `SELECT MAX(SORT_ORDER) AS MAX_SORT
-             FROM USER_NOW_PLAYING
-            WHERE USER_ID = :userId`,
+          getSql(MemberSql.getNowPlayingMaxSort, dialect),
           { userId },
           { outFormat: oracledb.OUT_FORMAT_OBJECT },
         );
@@ -588,21 +582,12 @@ export default class Member {
         const nextSort = maxSort + 1;
 
         await oraMutate(
-          `INSERT INTO USER_NOW_PLAYING
-            (USER_ID, GAMEDB_GAME_ID, PLATFORM_ID, NOTE, NOTE_UPDATED_AT, SORT_ORDER)
-           VALUES (:userId, :gameId, :platformId, :note, :noteUpdatedAt, :sortOrder)`,
+          getSql(MemberSql.insertNowPlaying, dialect),
           { userId, gameId, platformId, note: noteValue, noteUpdatedAt, sortOrder: nextSort },
           conn,
         );
         await oraMutate(
-          `MERGE INTO USER_GAME_JOURNAL_PREFS p
-           USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
-              ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
-           WHEN MATCHED THEN
-             UPDATE SET IS_ENABLED = 1, UPDATED_AT = SYSTIMESTAMP
-           WHEN NOT MATCHED THEN
-             INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
-             VALUES (:userId, :gameId, 1, 0)`,
+          getSql(MemberSql.mergeJournalPrefs, dialect),
           { userId, gameId },
           conn,
         );
@@ -626,12 +611,7 @@ export default class Member {
       GAMEDB_GAME_ID: number;
       IS_ENABLED: number;
     }, IGameJournalPreference>(
-      `SELECT USER_ID,
-              GAMEDB_GAME_ID,
-              IS_ENABLED
-         FROM USER_GAME_JOURNAL_PREFS
-        WHERE USER_ID = :userId
-          AND GAMEDB_GAME_ID = :gameId`,
+      getSql(MemberSql.getGameJournalPreference, dialect),
       { userId, gameId },
       (row) => ({
         userId: row.USER_ID,
@@ -650,16 +630,7 @@ export default class Member {
     isEnabled: boolean,
   ): Promise<void> {
     await oraMutate(
-      `MERGE INTO USER_GAME_JOURNAL_PREFS p
-       USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
-          ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
-        WHEN MATCHED THEN
-          UPDATE SET IS_ENABLED = :isEnabled,
-                     DEFAULT_IS_PUBLIC = 1,
-                     UPDATED_AT = SYSTIMESTAMP
-        WHEN NOT MATCHED THEN
-          INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
-          VALUES (:userId, :gameId, :isEnabled, 1)`,
+      getSql(MemberSql.upsertGameJournalPreference, dialect),
       {
         userId,
         gameId,
@@ -693,14 +664,7 @@ export default class Member {
       JOURNAL_COUNT: number;
       LAST_JOURNAL_AT: Date | string | null;
     }, { gameId: number; journalCount: number; lastJournalAt: Date | null }>(
-      `SELECT gids.GAME_ID,
-              COUNT(*) AS JOURNAL_COUNT,
-              MAX(je.CREATED_AT) AS LAST_JOURNAL_AT
-         FROM (${inlineTable}) gids
-         LEFT JOIN USER_GAME_JOURNAL_ENTRIES je
-           ON je.USER_ID = :userId
-          AND je.GAMEDB_GAME_ID = gids.GAME_ID
-        GROUP BY gids.GAME_ID`,
+      MemberSql.getJournalStatusForGames(inlineTable)[dialect],
       binds,
       (row) => ({
         gameId: Number(row.GAME_ID),
@@ -732,30 +696,7 @@ export default class Member {
       UPDATED_AT: Date | string;
       ENTRY_NUMBER: number;
     }, IGameJournalEntry>(
-      `WITH all_entries AS (
-         SELECT ENTRY_ID,
-                USER_ID,
-                GAMEDB_GAME_ID,
-                ENTRY_TITLE,
-                ENTRY_BODY,
-                CREATED_AT,
-                UPDATED_AT,
-                ROW_NUMBER() OVER (ORDER BY CREATED_AT ASC, ENTRY_ID ASC) AS ENTRY_NUMBER
-           FROM USER_GAME_JOURNAL_ENTRIES
-          WHERE USER_ID = :userId
-            AND GAMEDB_GAME_ID = :gameId
-       )
-       SELECT ENTRY_ID,
-              USER_ID,
-              GAMEDB_GAME_ID,
-              ENTRY_TITLE,
-              ENTRY_BODY,
-              CREATED_AT,
-              UPDATED_AT,
-              ENTRY_NUMBER
-         FROM all_entries
-        ORDER BY CREATED_AT DESC, ENTRY_ID DESC
-        OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+      getSql(MemberSql.getGameJournalEntries, dialect),
       { userId, gameId, offset: safeOffset, limit: safeLimit },
       (row) => ({
         entryId: Number(row.ENTRY_ID),
@@ -772,10 +713,7 @@ export default class Member {
 
   static async countGameJournalEntries(userId: string, gameId: number): Promise<number> {
     const rows = await oraQuery<{ CNT: number }, number>(
-      `SELECT COUNT(*) AS CNT
-         FROM USER_GAME_JOURNAL_ENTRIES
-        WHERE USER_ID = :userId
-          AND GAMEDB_GAME_ID = :gameId`,
+      getSql(MemberSql.countGameJournalEntries, dialect),
       { userId, gameId },
       (row) => Number(row.CNT),
     );
@@ -794,10 +732,7 @@ export default class Member {
       throw new Error("Journal body cannot be empty.");
     }
     await oraMutate(
-      `INSERT INTO USER_GAME_JOURNAL_ENTRIES
-        (USER_ID, GAMEDB_GAME_ID, ENTRY_TITLE, ENTRY_BODY, IS_PUBLIC)
-       VALUES
-        (:userId, :gameId, :title, :body, 1)`,
+      getSql(MemberSql.addGameJournalEntry, dialect),
       {
         userId: params.userId,
         gameId: params.gameId,
@@ -821,24 +756,7 @@ export default class Member {
       UPDATED_AT: Date | string;
       ENTRY_NUMBER: number;
     }, IGameJournalEntry>(
-      `SELECT e.ENTRY_ID,
-              e.USER_ID,
-              e.GAMEDB_GAME_ID,
-              e.ENTRY_TITLE,
-              e.ENTRY_BODY,
-              e.CREATED_AT,
-              e.UPDATED_AT,
-              (SELECT COUNT(*) + 1
-                 FROM USER_GAME_JOURNAL_ENTRIES e2
-                WHERE e2.USER_ID = e.USER_ID
-                  AND e2.GAMEDB_GAME_ID = e.GAMEDB_GAME_ID
-                  AND (e2.CREATED_AT < e.CREATED_AT
-                       OR (e2.CREATED_AT = e.CREATED_AT AND e2.ENTRY_ID < e.ENTRY_ID))
-              ) AS ENTRY_NUMBER
-         FROM USER_GAME_JOURNAL_ENTRIES e
-        WHERE e.USER_ID = :userId
-          AND e.ENTRY_ID = :entryId
-        FETCH FIRST 1 ROWS ONLY`,
+      getSql(MemberSql.getGameJournalEntryForUser, dialect),
       { userId, entryId },
       (row) => ({
         entryId: Number(row.ENTRY_ID),
@@ -884,10 +802,7 @@ export default class Member {
     fields.push("UPDATED_AT = SYSTIMESTAMP");
 
     const res = await oraMutate(
-      `UPDATE USER_GAME_JOURNAL_ENTRIES
-          SET ${fields.join(", ")}
-        WHERE USER_ID = :userId
-          AND ENTRY_ID = :entryId`,
+      MemberSql.updateGameJournalEntry(fields)[dialect],
       binds as Record<string, any>,
     );
     return Number(res.rowsAffected ?? 0) > 0;
@@ -895,9 +810,7 @@ export default class Member {
 
   static async deleteGameJournalEntry(userId: string, entryId: number): Promise<boolean> {
     const res = await oraMutate(
-      `DELETE FROM USER_GAME_JOURNAL_ENTRIES
-        WHERE USER_ID = :userId
-          AND ENTRY_ID = :entryId`,
+      getSql(MemberSql.deleteGameJournalEntry, dialect),
       { userId, entryId },
     );
     return Number(res.rowsAffected ?? 0) > 0;
@@ -915,10 +828,7 @@ export default class Member {
         sortOrder: idx + 1,
       }));
       const result = await conn.executeMany(
-        `UPDATE USER_NOW_PLAYING
-            SET SORT_ORDER = :sortOrder
-          WHERE USER_ID = :userId
-            AND GAMEDB_GAME_ID = :gameId`,
+        getSql(MemberSql.updateNowPlayingSort, dialect),
         binds,
       );
       await conn.commit();
@@ -932,7 +842,7 @@ export default class Member {
     }
 
     const res = await oraMutate(
-      `DELETE FROM USER_NOW_PLAYING WHERE USER_ID = :userId AND GAMEDB_GAME_ID = :gameId`,
+      getSql(MemberSql.removeNowPlaying, dialect),
       { userId, gameId },
     );
     const rows = (res as any).rowsAffected ?? 0;
@@ -981,15 +891,7 @@ export default class Member {
 
     return oraTransaction(async (conn) => {
       const result = await oraMutate(
-        `
-        INSERT INTO USER_GAME_COMPLETIONS (
-          USER_ID, GAMEDB_GAME_ID, COMPLETION_TYPE, PLATFORM_ID,
-          COMPLETED_AT, FINAL_PLAYTIME_HRS, NOTE
-        ) VALUES (
-          :userId, :gameId, :type, :platformId, :completedAt, :playtime, :note
-        )
-        RETURNING COMPLETION_ID INTO :completionId
-        `,
+        getSql(MemberSql.addCompletion, dialect),
         {
           userId,
           gameId,
@@ -1007,8 +909,7 @@ export default class Member {
       if (!id) throw new Error("Failed to save completion (no id returned).");
 
       const verify = await oraQuery<{ CNT: number }, number>(
-        `SELECT COUNT(*) AS CNT FROM USER_GAME_COMPLETIONS
-          WHERE COMPLETION_ID = :id AND USER_ID = :userId`,
+        getSql(MemberSql.verifyCompletion, dialect),
         { id, userId },
         (row) => Number(row.CNT),
         conn,
@@ -1035,32 +936,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      `
-      SELECT c.COMPLETION_ID,
-             g.GAME_ID,
-             g.TITLE,
-             c.COMPLETION_TYPE,
-             c.PLATFORM_ID,
-             c.COMPLETED_AT,
-             c.FINAL_PLAYTIME_HRS,
-             c.CREATED_AT,
-             c.NOTE,
-             COALESCE(
-                (
-                  SELECT MIN(tgl.THREAD_ID)
-                  FROM THREAD_GAME_LINKS tgl
-                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                ),
-                (
-                  SELECT MIN(th.THREAD_ID)
-                  FROM THREADS th
-                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                )
-              ) AS THREAD_ID
-        FROM USER_GAME_COMPLETIONS c
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE c.COMPLETION_ID = :completionId
-      `,
+      getSql(MemberSql.getCompletion, dialect),
       { completionId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1106,33 +982,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      `
-      SELECT c.COMPLETION_ID,
-             g.GAME_ID,
-             g.TITLE,
-             c.COMPLETION_TYPE,
-             c.PLATFORM_ID,
-             c.COMPLETED_AT,
-             c.FINAL_PLAYTIME_HRS,
-             c.CREATED_AT,
-             c.NOTE,
-             COALESCE(
-                (
-                  SELECT MIN(tgl.THREAD_ID)
-                  FROM THREAD_GAME_LINKS tgl
-                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                ),
-                (
-                  SELECT MIN(th.THREAD_ID)
-                  FROM THREADS th
-                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                )
-              ) AS THREAD_ID
-        FROM USER_GAME_COMPLETIONS c
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE c.USER_ID = :userId
-         AND c.COMPLETION_ID = :completionId
-      `,
+      getSql(MemberSql.getCompletionForUser, dialect),
       { userId, completionId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1181,34 +1031,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      `
-      SELECT c.COMPLETION_ID,
-             g.GAME_ID,
-             g.TITLE,
-             c.COMPLETION_TYPE,
-             c.PLATFORM_ID,
-             c.COMPLETED_AT,
-             c.FINAL_PLAYTIME_HRS,
-             c.CREATED_AT,
-             c.NOTE,
-             COALESCE(
-                (
-                  SELECT MIN(tgl.THREAD_ID)
-                  FROM THREAD_GAME_LINKS tgl
-                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                ),
-                (
-                  SELECT MIN(th.THREAD_ID)
-                  FROM THREADS th
-                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                )
-              ) AS THREAD_ID
-        FROM USER_GAME_COMPLETIONS c
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE c.USER_ID = :userId
-         AND c.GAMEDB_GAME_ID = :gameId
-       FETCH FIRST 1 ROWS ONLY
-      `,
+      getSql(MemberSql.getCompletionByGameId, dialect),
       { userId, gameId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1274,34 +1097,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      `
-      SELECT c.COMPLETION_ID,
-             g.GAME_ID,
-             g.TITLE,
-             c.COMPLETION_TYPE,
-             c.PLATFORM_ID,
-             c.COMPLETED_AT,
-             c.FINAL_PLAYTIME_HRS,
-             c.CREATED_AT,
-             c.NOTE,
-             COALESCE(
-                (
-                  SELECT MIN(tgl.THREAD_ID)
-                  FROM THREAD_GAME_LINKS tgl
-                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                ),
-                (
-                  SELECT MIN(th.THREAD_ID)
-                  FROM THREADS th
-                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                )
-              ) AS THREAD_ID
-        FROM USER_GAME_COMPLETIONS c
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE ${clauses.join(" AND ")}
-       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC
-       OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY
-      `,
+      MemberSql.getCompletions(clauses.join(" AND "))[dialect],
       binds,
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1342,33 +1138,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      `
-      SELECT c.COMPLETION_ID,
-             g.GAME_ID,
-             g.TITLE,
-             c.COMPLETION_TYPE,
-             c.PLATFORM_ID,
-             c.COMPLETED_AT,
-             c.FINAL_PLAYTIME_HRS,
-             c.CREATED_AT,
-             c.NOTE,
-             COALESCE(
-                (
-                  SELECT MIN(tgl.THREAD_ID)
-                  FROM THREAD_GAME_LINKS tgl
-                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                ),
-                (
-                  SELECT MIN(th.THREAD_ID)
-                  FROM THREADS th
-                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                )
-              ) AS THREAD_ID
-        FROM USER_GAME_COMPLETIONS c
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE c.USER_ID = :userId
-       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.CREATED_AT DESC, c.COMPLETION_ID DESC
-      `,
+      getSql(MemberSql.getAllCompletions, dialect),
       { userId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1415,12 +1185,7 @@ export default class Member {
     }
 
     const rows = await oraQuery<{ CNT: number }, number>(
-      `
-      SELECT COUNT(*) AS CNT
-        FROM USER_GAME_COMPLETIONS c
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE ${clauses.join(" AND ")}
-      `,
+      MemberSql.countCompletions(clauses.join(" AND "))[dialect],
       binds,
       (row) => Number(row.CNT),
     );
@@ -1474,12 +1239,7 @@ export default class Member {
     if (!fields.length) return false;
 
     const res = await oraMutate(
-      `
-      UPDATE USER_GAME_COMPLETIONS
-         SET ${fields.join(", ")}
-       WHERE COMPLETION_ID = :completionId
-         AND USER_ID = :userId
-      `,
+      MemberSql.updateCompletion(fields)[dialect],
       binds,
     );
     const rows = (res as any).rowsAffected ?? 0;
@@ -1491,11 +1251,7 @@ export default class Member {
       throw new Error("Invalid completion id.");
     }
     const res = await oraMutate(
-      `
-      DELETE FROM USER_GAME_COMPLETIONS
-       WHERE COMPLETION_ID = :completionId
-         AND USER_ID = :userId
-      `,
+      getSql(MemberSql.deleteCompletion, dialect),
       { completionId, userId },
     );
     const rows = (res as any).rowsAffected ?? 0;
@@ -1513,11 +1269,7 @@ export default class Member {
         NEW_NICK: string | null;
         CHANGED_AT: Date;
       }, IMemberNickHistory>(
-        `SELECT OLD_NICK, NEW_NICK, CHANGED_AT
-           FROM RPG_CLUB_USER_NICK_HISTORY
-          WHERE USER_ID = :userId
-          ORDER BY CHANGED_AT DESC
-          FETCH FIRST :limit ROWS ONLY`,
+        getSql(MemberSql.getRecentNickHistory, dialect),
         { userId, limit: safeLimit },
         (row) => ({
           oldNick: row.OLD_NICK ?? null,
@@ -1555,16 +1307,7 @@ export default class Member {
       GLOBAL_NAME: string | null;
       CNT: number;
     }, { userId: string; username: string | null; globalName: string | null; count: number }>(
-      `
-      SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME, COUNT(*) AS CNT
-        FROM USER_GAME_COMPLETIONS c
-        JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE ${clauses.join(" AND ")}
-       GROUP BY c.USER_ID, u.USERNAME, u.GLOBAL_NAME
-       ORDER BY CNT DESC
-       FETCH FIRST :limit ROWS ONLY
-      `,
+      MemberSql.getCompletionLeaderboard(clauses.join(" AND "))[dialect],
       binds,
       (row) => ({
         userId: row.USER_ID,
@@ -1653,27 +1396,7 @@ export default class Member {
       SERVER_JOINED_AT: Date | null;
       LAST_SEEN_AT: Date | null;
     }, IMemberSearchResult>(
-      `SELECT USER_ID,
-              USERNAME,
-              GLOBAL_NAME,
-              IS_BOT,
-              COMPLETIONATOR_URL,
-              STEAM_URL,
-              PSN_USERNAME,
-              XBL_USERNAME,
-              NSW_FRIEND_CODE,
-              ROLE_ADMIN,
-              ROLE_MODERATOR,
-              ROLE_REGULAR,
-              ROLE_MEMBER,
-              ROLE_NEWCOMER,
-              SERVER_LEFT_AT,
-              SERVER_JOINED_AT,
-              LAST_SEEN_AT
-         FROM RPG_CLUB_USERS
-        WHERE ${where}
-        ORDER BY COALESCE(UPPER(GLOBAL_NAME), UPPER(USERNAME), USER_ID)
-        FETCH FIRST :limit ROWS ONLY`,
+      MemberSql.searchMembers(where)[dialect],
       params,
       (row) => ({
         userId: row.USER_ID,
@@ -1737,29 +1460,7 @@ export default class Member {
         PROFILE_IMAGE: Buffer | null;
         PROFILE_IMAGE_AT: Date | null;
       }>(
-        `SELECT USER_ID,
-                IS_BOT,
-                USERNAME,
-                GLOBAL_NAME,
-               AVATAR_BLOB,
-               SERVER_JOINED_AT,
-                SERVER_LEFT_AT,
-                LAST_SEEN_AT,
-                ROLE_ADMIN,
-                ROLE_MODERATOR,
-                ROLE_REGULAR,
-                ROLE_MEMBER,
-                ROLE_NEWCOMER,
-                MESSAGE_COUNT,
-                COMPLETIONATOR_URL,
-                PSN_USERNAME,
-                XBL_USERNAME,
-                NSW_FRIEND_CODE,
-                STEAM_URL,
-                PROFILE_IMAGE,
-                PROFILE_IMAGE_AT
-           FROM RPG_CLUB_USERS
-          WHERE USER_ID = :userId`,
+        getSql(MemberSql.getByUserId, dialect),
         { userId },
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
@@ -1813,10 +1514,7 @@ export default class Member {
       throw new Error("Invalid platform selection.");
     }
     const res = await oraMutate(
-      `UPDATE USER_NOW_PLAYING
-          SET PLATFORM_ID = :platformId
-        WHERE USER_ID = :userId
-          AND GAMEDB_GAME_ID = :gameId`,
+      getSql(MemberSql.updateNowPlayingPlatform, dialect),
       { userId, gameId, platformId },
     );
     return (res.rowsAffected ?? 0) > 0;
@@ -1838,16 +1536,7 @@ export default class Member {
         AVATAR_BLOB: Buffer | null;
         CHANGED_AT: Date | string;
       }>(
-        `SELECT EVENT_ID,
-                USER_ID,
-                AVATAR_HASH,
-                AVATAR_URL,
-                AVATAR_BLOB,
-                CHANGED_AT
-           FROM RPG_CLUB_USER_AVATAR_HISTORY
-          WHERE USER_ID = :userId
-          ORDER BY CHANGED_AT DESC, EVENT_ID DESC
-          OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+        getSql(MemberSql.getAvatarHistory, dialect),
         { userId, limit: safeLimit, offset: safeOffset },
         {
           outFormat: oracledb.OUT_FORMAT_OBJECT,
@@ -1887,34 +1576,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      `
-      SELECT c.COMPLETION_ID,
-             g.GAME_ID,
-             g.TITLE,
-             c.COMPLETION_TYPE,
-             c.PLATFORM_ID,
-             c.COMPLETED_AT,
-             c.FINAL_PLAYTIME_HRS,
-             c.CREATED_AT,
-             c.NOTE,
-             COALESCE(
-                (
-                  SELECT MIN(tgl.THREAD_ID)
-                  FROM THREAD_GAME_LINKS tgl
-                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                ),
-                (
-                  SELECT MIN(th.THREAD_ID)
-                  FROM THREADS th
-                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                )
-              ) AS THREAD_ID
-        FROM USER_GAME_COMPLETIONS c
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE c.USER_ID = :userId
-         AND c.GAMEDB_GAME_ID = :gameId
-       ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC
-      `,
+      getSql(MemberSql.getCompletionsForGame, dialect),
       { userId, gameId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1968,36 +1630,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      `
-      SELECT c.COMPLETION_ID,
-             g.GAME_ID,
-             g.TITLE,
-             c.COMPLETION_TYPE,
-             c.PLATFORM_ID,
-             c.COMPLETED_AT,
-             c.FINAL_PLAYTIME_HRS,
-             c.CREATED_AT,
-             c.NOTE,
-             COALESCE(
-                (
-                  SELECT MIN(tgl.THREAD_ID)
-                  FROM THREAD_GAME_LINKS tgl
-                  WHERE tgl.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                ),
-                (
-                  SELECT MIN(th.THREAD_ID)
-                  FROM THREADS th
-                  WHERE th.GAMEDB_GAME_ID = c.GAMEDB_GAME_ID
-                )
-              ) AS THREAD_ID
-        FROM USER_GAME_COMPLETIONS c
-        JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
-       WHERE c.USER_ID = :userId
-         AND c.GAMEDB_GAME_ID = :gameId
-         AND COALESCE(c.COMPLETED_AT, c.CREATED_AT) BETWEEN :startDate AND :endDate
-       ORDER BY COALESCE(c.COMPLETED_AT, c.CREATED_AT) DESC
-       FETCH FIRST 1 ROWS ONLY
-      `,
+      getSql(MemberSql.getRecentCompletionForGame, dialect),
       { userId, gameId, startDate, endDate },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -2029,9 +1662,7 @@ export default class Member {
 
   static async getGiveawayDonorNotifySetting(userId: string): Promise<boolean> {
     const rows = await oraQuery<{ DONOR_NOTIFY_ON_CLAIM: number | null }, boolean>(
-      `SELECT DONOR_NOTIFY_ON_CLAIM
-         FROM RPG_CLUB_USERS
-        WHERE USER_ID = :userId`,
+      getSql(MemberSql.getGiveawayDonorNotifySetting, dialect),
       { userId },
       (row) => Boolean(row.DONOR_NOTIFY_ON_CLAIM),
     );
@@ -2044,9 +1675,7 @@ export default class Member {
   ): Promise<void> {
     await oraWithConnection(async (conn) => {
       const result = await oraMutate(
-        `UPDATE RPG_CLUB_USERS
-            SET DONOR_NOTIFY_ON_CLAIM = :enabled
-          WHERE USER_ID = :userId`,
+        getSql(MemberSql.updateGiveawayDonorNotifySetting, dialect),
         { userId, enabled: enabled ? 1 : 0 },
         conn,
       );
@@ -2057,8 +1686,7 @@ export default class Member {
 
       try {
         await oraMutate(
-          `INSERT INTO RPG_CLUB_USERS (USER_ID, DONOR_NOTIFY_ON_CLAIM)
-           VALUES (:userId, :enabled)`,
+          getSql(MemberSql.insertGiveawayDonorNotifySetting, dialect),
           { userId, enabled: enabled ? 1 : 0 },
           conn,
         );
@@ -2067,9 +1695,7 @@ export default class Member {
         const code = err?.code ?? err?.errorNum;
         if (code === "ORA-00001") {
           await oraMutate(
-            `UPDATE RPG_CLUB_USERS
-                SET DONOR_NOTIFY_ON_CLAIM = :enabled
-              WHERE USER_ID = :userId`,
+            getSql(MemberSql.updateGiveawayDonorNotifySetting, dialect),
             { userId, enabled: enabled ? 1 : 0 },
             conn,
           );
@@ -2083,9 +1709,7 @@ export default class Member {
 
   static async countAvatarHistory(userId: string): Promise<number> {
     const rows = await oraQuery<{ TOTAL: number | null }, number>(
-      `SELECT COUNT(*) AS TOTAL
-         FROM RPG_CLUB_USER_AVATAR_HISTORY
-        WHERE USER_ID = :userId`,
+      getSql(MemberSql.countAvatarHistory, dialect),
       { userId },
       (row) => Number(row.TOTAL ?? 0),
     );
@@ -2099,8 +1723,7 @@ export default class Member {
     avatarBlob: Buffer | null,
   ): Promise<void> {
     await oraMutate(
-      `INSERT INTO RPG_CLUB_USER_AVATAR_HISTORY (USER_ID, AVATAR_HASH, AVATAR_URL, AVATAR_BLOB)
-       VALUES (:userId, :avatarHash, :avatarUrl, :avatarBlob)`,
+      getSql(MemberSql.insertAvatarHistoryRecord, dialect),
       { userId, avatarHash, avatarUrl, avatarBlob },
     );
   }
@@ -2112,16 +1735,7 @@ export default class Member {
       GLOBAL_NAME: string | null;
       TOTAL: number;
     }, IMemberAvatarHistoryCount>(
-      `SELECT h.USER_ID,
-              u.USERNAME,
-              u.GLOBAL_NAME,
-              COUNT(*) AS TOTAL
-         FROM RPG_CLUB_USER_AVATAR_HISTORY h
-         JOIN RPG_CLUB_USERS u ON u.USER_ID = h.USER_ID
-        WHERE NVL(u.IS_BOT, 0) = 0
-          AND u.SERVER_LEFT_AT IS NULL
-        GROUP BY h.USER_ID, u.USERNAME, u.GLOBAL_NAME
-        ORDER BY COALESCE(u.GLOBAL_NAME, u.USERNAME, h.USER_ID)`,
+      getSql(MemberSql.getAllMembersAvatarHistoryCounts, dialect),
       {},
       (row) => ({
         userId: String(row.USER_ID),
@@ -2143,21 +1757,7 @@ export default class Member {
       NSW_FRIEND_CODE: string | null;
       SERVER_LEFT_AT: Date | null;
     }, IMemberPlatformRecord>(
-      `SELECT USER_ID,
-              USERNAME,
-              GLOBAL_NAME,
-              STEAM_URL,
-              PSN_USERNAME,
-              XBL_USERNAME,
-              NSW_FRIEND_CODE,
-              SERVER_LEFT_AT
-         FROM RPG_CLUB_USERS
-        WHERE (STEAM_URL IS NOT NULL
-               OR PSN_USERNAME IS NOT NULL
-               OR XBL_USERNAME IS NOT NULL
-               OR NSW_FRIEND_CODE IS NOT NULL)
-          AND NVL(IS_BOT, 0) = 0
-          AND SERVER_LEFT_AT IS NULL`,
+      getSql(MemberSql.getMembersWithPlatforms, dialect),
       {},
       (row) => ({
         userId: row.USER_ID,
@@ -2186,27 +1786,7 @@ export default class Member {
 
     async function doUpsert(conn: oracledb.Connection): Promise<void> {
       const update = await oraMutate(
-        `UPDATE RPG_CLUB_USERS
-            SET IS_BOT = :isBot,
-                USERNAME = :username,
-                GLOBAL_NAME = :globalName,
-                AVATAR_BLOB = :avatarBlob,
-                SERVER_JOINED_AT = :joinedAt,
-                SERVER_LEFT_AT = :leftAt,
-                LAST_SEEN_AT = :lastSeenAt,
-                LAST_FETCHED_AT = SYSTIMESTAMP,
-                ROLE_ADMIN = :roleAdmin,
-                ROLE_MODERATOR = :roleModerator,
-                ROLE_REGULAR = :roleRegular,
-                ROLE_MEMBER = :roleMember,
-                ROLE_NEWCOMER = :roleNewcomer,
-                COMPLETIONATOR_URL = :completionatorUrl,
-                PSN_USERNAME = :psnUsername,
-                XBL_USERNAME = :xblUsername,
-                NSW_FRIEND_CODE = :nswFriendCode,
-                STEAM_URL = :steamUrl,
-                UPDATED_AT = SYSTIMESTAMP
-          WHERE USER_ID = :userId`,
+        getSql(MemberSql.updateMember, dialect),
         params,
         conn,
       );
@@ -2217,21 +1797,7 @@ export default class Member {
 
       try {
         await oraMutate(
-          `INSERT INTO RPG_CLUB_USERS (
-             USER_ID, IS_BOT, USERNAME, GLOBAL_NAME, AVATAR_BLOB,
-             SERVER_JOINED_AT, SERVER_LEFT_AT, LAST_SEEN_AT, LAST_FETCHED_AT,
-             ROLE_ADMIN, ROLE_MODERATOR, ROLE_REGULAR, ROLE_MEMBER, ROLE_NEWCOMER,
-             COMPLETIONATOR_URL, PSN_USERNAME, XBL_USERNAME, NSW_FRIEND_CODE,
-             STEAM_URL,
-             CREATED_AT, UPDATED_AT
-           ) VALUES (
-             :userId, :isBot, :username, :globalName, :avatarBlob,
-             :joinedAt, :leftAt, :lastSeenAt, SYSTIMESTAMP,
-             :roleAdmin, :roleModerator, :roleRegular, :roleMember, :roleNewcomer,
-             :completionatorUrl, :psnUsername, :xblUsername,
-             :nswFriendCode, :steamUrl,
-             SYSTIMESTAMP, SYSTIMESTAMP
-           )`,
+          getSql(MemberSql.insertMember, dialect),
           params,
           conn,
         );
@@ -2240,27 +1806,7 @@ export default class Member {
         const code = insErr?.code ?? insErr?.errorNum;
         if (code === "ORA-00001") {
           await oraMutate(
-            `UPDATE RPG_CLUB_USERS
-                SET IS_BOT = :isBot,
-                    USERNAME = :username,
-                    GLOBAL_NAME = :globalName,
-                    AVATAR_BLOB = :avatarBlob,
-                    SERVER_JOINED_AT = :joinedAt,
-                    SERVER_LEFT_AT = :leftAt,
-                    LAST_SEEN_AT = :lastSeenAt,
-                    LAST_FETCHED_AT = SYSTIMESTAMP,
-                    ROLE_ADMIN = :roleAdmin,
-                    ROLE_MODERATOR = :roleModerator,
-                    ROLE_REGULAR = :roleRegular,
-                    ROLE_MEMBER = :roleMember,
-                    ROLE_NEWCOMER = :roleNewcomer,
-                    COMPLETIONATOR_URL = :completionatorUrl,
-                    PSN_USERNAME = :psnUsername,
-                    XBL_USERNAME = :xblUsername,
-                    NSW_FRIEND_CODE = :nswFriendCode,
-                    STEAM_URL = :steamUrl,
-                    UPDATED_AT = SYSTIMESTAMP
-              WHERE USER_ID = :userId`,
+            getSql(MemberSql.updateMember, dialect),
             params,
             conn,
           );
@@ -2294,15 +1840,11 @@ export default class Member {
           return `:${key}`;
         });
 
-        const sql = `
-          UPDATE RPG_CLUB_USERS
-             SET SERVER_LEFT_AT = SYSTIMESTAMP,
-                 UPDATED_AT = SYSTIMESTAMP
-           WHERE SERVER_LEFT_AT IS NULL
-             AND USER_ID NOT IN (${placeholders.join(", ")})
-        `;
-
-        const result = await oraMutate(sql, binds, conn);
+        const result = await oraMutate(
+          MemberSql.markDepartedNotIn(placeholders.join(", "))[dialect],
+          binds,
+          conn,
+        );
         totalUpdated += result.rowsAffected ?? 0;
         await conn.commit();
       }
@@ -2317,19 +1859,7 @@ export default class Member {
       TITLE: string;
       TOTAL_ENTRIES: number;
     }, IGameJournalListEntry>(
-      `SELECT g.GAME_ID,
-              g.TITLE,
-              COUNT(e.ENTRY_ID) AS TOTAL_ENTRIES
-         FROM USER_GAME_JOURNAL_PREFS jp
-         JOIN GAMEDB_GAMES g ON g.GAME_ID = jp.GAMEDB_GAME_ID
-         LEFT JOIN USER_GAME_JOURNAL_ENTRIES e
-           ON e.USER_ID = jp.USER_ID
-          AND e.GAMEDB_GAME_ID = jp.GAMEDB_GAME_ID
-        WHERE jp.USER_ID = :userId
-          AND jp.IS_ENABLED = 1
-        GROUP BY g.GAME_ID, g.TITLE
-       HAVING COUNT(e.ENTRY_ID) > 0
-        ORDER BY g.TITLE`,
+      getSql(MemberSql.getGameJournalList, dialect),
       { userId },
       (row) => ({
         gameId: Number(row.GAME_ID),
@@ -2347,19 +1877,7 @@ export default class Member {
       GAME_COUNT: number;
       ENTRY_COUNT: number;
     }, IJournalUserSummary>(
-      `SELECT u.USER_ID,
-              u.USERNAME,
-              u.GLOBAL_NAME,
-              COUNT(DISTINCT je.GAMEDB_GAME_ID) AS GAME_COUNT,
-              COUNT(je.ENTRY_ID) AS ENTRY_COUNT
-         FROM USER_GAME_JOURNAL_ENTRIES je
-         JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
-        WHERE NVL(u.IS_BOT, 0) = 0
-          AND u.SERVER_LEFT_AT IS NULL
-        GROUP BY u.USER_ID, u.USERNAME, u.GLOBAL_NAME
-        ORDER BY COUNT(DISTINCT je.GAMEDB_GAME_ID) DESC,
-                 u.GLOBAL_NAME NULLS LAST,
-                 u.USERNAME NULLS LAST`,
+      getSql(MemberSql.getAllJournalUsers, dialect),
       {},
       (row) => ({
         userId: row.USER_ID,
@@ -2393,27 +1911,7 @@ export default class Member {
       ENTRY_BODY: string;
       CREATED_AT: Date | string;
     }, IJournalSearchResult & { totalCount: number }>(
-      `SELECT COUNT(*) OVER () AS TOTAL_COUNT,
-              je.ENTRY_ID,
-              je.USER_ID,
-              u.GLOBAL_NAME,
-              u.USERNAME,
-              je.GAMEDB_GAME_ID,
-              g.TITLE         AS GAME_TITLE,
-              je.ENTRY_TITLE,
-              je.ENTRY_BODY,
-              je.CREATED_AT
-         FROM USER_GAME_JOURNAL_ENTRIES je
-         JOIN GAMEDB_GAMES g ON g.GAME_ID = je.GAMEDB_GAME_ID
-         JOIN RPG_CLUB_USERS u ON u.USER_ID = je.USER_ID
-        WHERE (
-                UPPER(je.ENTRY_TITLE) LIKE '%' || UPPER(:searchTerm) || '%'
-             OR UPPER(je.ENTRY_BODY)  LIKE '%' || UPPER(:searchTerm) || '%'
-              )
-          AND (:userId IS NULL OR je.USER_ID = :userId)
-          AND (:gameId IS NULL OR je.GAMEDB_GAME_ID = :gameId)
-        ORDER BY je.CREATED_AT DESC, je.ENTRY_ID DESC
-        OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
+      getSql(MemberSql.searchJournalEntries, dialect),
       {
         searchTerm,
         userId: params.userId ?? null,
@@ -2455,10 +1953,7 @@ export default class Member {
 
   static async updateEmojiName(userId: string, emojiName: string | null): Promise<void> {
     await oraMutate(
-      `UPDATE RPG_CLUB_USERS
-          SET EMOJI_NAME = :emojiName,
-              UPDATED_AT = SYSTIMESTAMP
-        WHERE USER_ID = :userId`,
+      getSql(MemberSql.updateEmojiName, dialect),
       { userId, emojiName },
     );
   }
@@ -2466,9 +1961,7 @@ export default class Member {
   static async getAllWithEmojiName(): Promise<Array<{ userId: string; emojiName: string }>> {
     return oraQuery<{ USER_ID: string; EMOJI_NAME: string },
       { userId: string; emojiName: string }>(
-      `SELECT USER_ID, EMOJI_NAME
-         FROM RPG_CLUB_USERS
-        WHERE EMOJI_NAME IS NOT NULL`,
+      getSql(MemberSql.getAllWithEmojiName, dialect),
       {},
       (row) => ({
         userId: row.USER_ID,
@@ -2485,25 +1978,14 @@ export default class Member {
     gameId: number,
   ): Promise<void> {
     await oraMutate(
-      `MERGE INTO JOURNAL_MESSAGE_CONTEXTS dst
-       USING (SELECT :channelId AS CHANNEL_ID, :messageId AS MESSAGE_ID FROM DUAL) src
-          ON (dst.CHANNEL_ID = src.CHANNEL_ID AND dst.MESSAGE_ID = src.MESSAGE_ID)
-        WHEN MATCHED THEN
-          UPDATE SET CREATED_AT_MS = :createdAtMs,
-                     OWNER_USER_ID = :ownerUserId,
-                     GAME_ID       = :gameId
-        WHEN NOT MATCHED THEN
-          INSERT (CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID)
-          VALUES (:channelId, :messageId, :createdAtMs, :ownerUserId, :gameId)`,
+      getSql(MemberSql.upsertJournalMessageContext, dialect),
       { channelId, messageId, createdAtMs, ownerUserId, gameId },
     );
   }
 
   static async deleteJournalMessageContext(channelId: string, messageId: string): Promise<void> {
     await oraMutate(
-      `DELETE FROM JOURNAL_MESSAGE_CONTEXTS
-        WHERE CHANNEL_ID = :channelId
-          AND MESSAGE_ID = :messageId`,
+      getSql(MemberSql.deleteJournalMessageContext, dialect),
       { channelId, messageId },
     );
   }
@@ -2526,9 +2008,7 @@ export default class Member {
       GAME_ID: number;
     }, { channelId: string; messageId: string; createdAt: number;
         ownerUserId: string; gameId: number }>(
-      `SELECT CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID
-         FROM JOURNAL_MESSAGE_CONTEXTS
-        WHERE CREATED_AT_MS >= :cutoffMs`,
+      getSql(MemberSql.loadActiveJournalMessageContexts, dialect),
       { cutoffMs },
       (row) => ({
         channelId: row.CHANNEL_ID,
@@ -2543,7 +2023,7 @@ export default class Member {
   static async pruneExpiredJournalMessageContexts(ttlMs: number): Promise<void> {
     const cutoffMs = Date.now() - ttlMs;
     await oraMutate(
-      `DELETE FROM JOURNAL_MESSAGE_CONTEXTS WHERE CREATED_AT_MS < :cutoffMs`,
+      getSql(MemberSql.pruneExpiredJournalMessageContexts, dialect),
       { cutoffMs },
     );
   }

--- a/src/classes/Nomination.ts
+++ b/src/classes/Nomination.ts
@@ -1,4 +1,8 @@
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { NominationSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 export type NominationKind = "gotm" | "nr-gotm";
 
@@ -57,17 +61,7 @@ export async function getNominationForUser(
   userId: string,
 ): Promise<INominationEntry | null> {
   const rows = await oraQuery(
-    `SELECT n.NOMINATION_ID,
-            n.ROUND_NUMBER,
-            n.USER_ID,
-            n.GAMEDB_GAME_ID,
-            g.TITLE AS GAMEDB_TITLE,
-            n.NOMINATED_AT,
-            n.REASON
-       FROM ${tableName(kind)} n
-       LEFT JOIN GAMEDB_GAMES g ON g.GAME_ID = n.GAMEDB_GAME_ID
-      WHERE n.ROUND_NUMBER = :roundNumber
-        AND n.USER_ID = :userId`,
+    NominationSql.getNominationForUser(tableName(kind))[dialect],
     { roundNumber, userId },
     mapRow,
   );
@@ -86,23 +80,7 @@ export async function upsertNomination(
   }
 
   await oraMutate(
-    `MERGE INTO ${tableName(kind)} t
-      USING (
-        SELECT :roundNumber AS ROUND_NUMBER,
-               :userId AS USER_ID,
-               :gamedbGameId AS GAMEDB_GAME_ID,
-               CAST(:nominatedAt AS TIMESTAMP) AS NOMINATED_AT,
-               :reason AS REASON
-          FROM dual
-      ) src
-         ON (t.ROUND_NUMBER = src.ROUND_NUMBER AND t.USER_ID = src.USER_ID)
-    WHEN MATCHED THEN
-      UPDATE SET t.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID,
-                 t.NOMINATED_AT = src.NOMINATED_AT,
-                 t.REASON = src.REASON
-    WHEN NOT MATCHED THEN
-      INSERT (ROUND_NUMBER, USER_ID, GAMEDB_GAME_ID, NOMINATED_AT, REASON)
-      VALUES (src.ROUND_NUMBER, src.USER_ID, src.GAMEDB_GAME_ID, src.NOMINATED_AT, src.REASON)`,
+    NominationSql.upsertNomination(tableName(kind))[dialect],
     { roundNumber, userId, gamedbGameId, nominatedAt: new Date(), reason },
   );
 
@@ -119,9 +97,7 @@ export async function deleteNominationForUser(
   userId: string,
 ): Promise<boolean> {
   const result = await oraMutate(
-    `DELETE FROM ${tableName(kind)}
-      WHERE ROUND_NUMBER = :roundNumber
-        AND USER_ID = :userId`,
+    NominationSql.deleteNomination(tableName(kind))[dialect],
     { roundNumber, userId },
   );
   return (result.rowsAffected ?? 0) > 0;
@@ -132,17 +108,7 @@ export async function listNominationsForRound(
   roundNumber: number,
 ): Promise<INominationEntry[]> {
   return oraQuery(
-    `SELECT n.NOMINATION_ID,
-            n.ROUND_NUMBER,
-            n.USER_ID,
-            n.GAMEDB_GAME_ID,
-            g.TITLE AS GAMEDB_TITLE,
-            n.NOMINATED_AT,
-            n.REASON
-       FROM ${tableName(kind)} n
-       LEFT JOIN GAMEDB_GAMES g ON g.GAME_ID = n.GAMEDB_GAME_ID
-      WHERE n.ROUND_NUMBER = :roundNumber
-      ORDER BY g.TITLE ASC`,
+    NominationSql.listNominationsForRound(tableName(kind))[dialect],
     { roundNumber },
     mapRow,
   );

--- a/src/classes/PresencePromptHistory.ts
+++ b/src/classes/PresencePromptHistory.ts
@@ -1,5 +1,10 @@
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { PresencePromptHistorySql } from "../db/sql/index.js";
 import { normalizePresenceGameTitle } from "./PresencePromptOptOut.js";
+
+const dialect = getDialect();
 
 export type PresencePromptStatus =
   | "PENDING"
@@ -16,19 +21,14 @@ export default class PresencePromptHistory {
   ): Promise<void> {
     const normalized = normalizePresenceGameTitle(gameTitle);
     await oraMutate(
-      `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_HISTORY
-        (PROMPT_ID, USER_ID, GAME_TITLE, GAME_TITLE_NORM, STATUS)
-       VALUES (:promptId, :userId, :gameTitle, :gameTitleNorm, 'PENDING')`,
+      getSql(PresencePromptHistorySql.createPrompt, dialect),
       { promptId, userId, gameTitle, gameTitleNorm: normalized },
     );
   }
 
   static async markResolved(promptId: string, status: PresencePromptStatus): Promise<void> {
     await oraMutate(
-      `UPDATE RPG_CLUB_PRESENCE_PROMPT_HISTORY
-          SET STATUS = :status,
-              RESOLVED_AT = SYSTIMESTAMP
-        WHERE PROMPT_ID = :promptId`,
+      getSql(PresencePromptHistorySql.markResolved, dialect),
       { status, promptId },
     );
   }
@@ -39,12 +39,7 @@ export default class PresencePromptHistory {
   ): Promise<Date | null> {
     const normalized = normalizePresenceGameTitle(gameTitle);
     const rows = await oraQuery(
-      `SELECT CREATED_AT
-         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
-        WHERE USER_ID = :userId
-          AND GAME_TITLE_NORM = :gameTitleNorm
-        ORDER BY CREATED_AT DESC
-        FETCH NEXT 1 ROWS ONLY`,
+      getSql(PresencePromptHistorySql.getLastPromptDate, dialect),
       { userId, gameTitleNorm: normalized },
       (row: { CREATED_AT: Date | string }) =>
         row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT as string),
@@ -55,11 +50,7 @@ export default class PresencePromptHistory {
   static async countPendingForGame(userId: string, gameTitle: string): Promise<number> {
     const normalized = normalizePresenceGameTitle(gameTitle);
     const rows = await oraQuery(
-      `SELECT COUNT(*) AS CNT
-         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
-        WHERE USER_ID = :userId
-          AND GAME_TITLE_NORM = :gameTitleNorm
-          AND STATUS = 'PENDING'`,
+      getSql(PresencePromptHistorySql.countPendingForGame, dialect),
       { userId, gameTitleNorm: normalized },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );
@@ -68,10 +59,7 @@ export default class PresencePromptHistory {
 
   static async countPendingForUser(userId: string): Promise<number> {
     const rows = await oraQuery(
-      `SELECT COUNT(*) AS CNT
-         FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
-        WHERE USER_ID = :userId
-          AND STATUS = 'PENDING'`,
+      getSql(PresencePromptHistorySql.countPendingForUser, dialect),
       { userId },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );

--- a/src/classes/PresencePromptOptOut.ts
+++ b/src/classes/PresencePromptOptOut.ts
@@ -1,4 +1,9 @@
 import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { getDialect } from "../db/dialect.js";
+import { getSql } from "../db/SqlManager.js";
+import { PresencePromptOptOutSql } from "../db/sql/index.js";
+
+const dialect = getDialect();
 
 const OPT_OUT_ALL_TOKEN = "__ALL__";
 
@@ -9,11 +14,7 @@ export function normalizePresenceGameTitle(title: string): string {
 export default class PresencePromptOptOut {
   static async isOptedOutAll(userId: string): Promise<boolean> {
     const rows = await oraQuery(
-      `SELECT COUNT(*) AS CNT
-         FROM RPG_CLUB_PRESENCE_PROMPT_OPTS
-        WHERE USER_ID = :userId
-          AND SCOPE = 'ALL'
-          AND GAME_TITLE_NORM = :token`,
+      getSql(PresencePromptOptOutSql.isOptedOutAll, dialect),
       { userId, token: OPT_OUT_ALL_TOKEN },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );
@@ -25,11 +26,7 @@ export default class PresencePromptOptOut {
     if (!normalized) return false;
 
     const rows = await oraQuery(
-      `SELECT COUNT(*) AS CNT
-         FROM RPG_CLUB_PRESENCE_PROMPT_OPTS
-        WHERE USER_ID = :userId
-          AND SCOPE = 'GAME'
-          AND GAME_TITLE_NORM = :gameTitleNorm`,
+      getSql(PresencePromptOptOutSql.isOptedOutGame, dialect),
       { userId, gameTitleNorm: normalized },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );
@@ -54,9 +51,7 @@ export default class PresencePromptOptOut {
   ): Promise<void> {
     try {
       await oraMutate(
-        `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_OPTS
-          (USER_ID, SCOPE, GAME_TITLE, GAME_TITLE_NORM)
-         VALUES (:userId, :scope, :gameTitle, :gameTitleNorm)`,
+        getSql(PresencePromptOptOutSql.insertOptOut, dialect),
         { userId, scope, gameTitle, gameTitleNorm: normalizedTitle },
       );
     } catch (err: any) {

--- a/src/db/sql/gameDbCsvImportMapping.sql.ts
+++ b/src/db/sql/gameDbCsvImportMapping.sql.ts
@@ -1,0 +1,35 @@
+import type { SqlEntry } from "./types.js";
+
+export const GameDbCsvImportMappingSql = {
+  getByTitleNorm: {
+    oracle: `SELECT MAP_ID,
+            TITLE_RAW,
+            TITLE_NORM,
+            GAMEDB_GAME_ID,
+            STATUS,
+            CREATED_BY,
+            CREATED_AT,
+            UPDATED_AT
+       FROM RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP
+      WHERE TITLE_NORM = :titleNorm`,
+    postgres: ``,
+  } satisfies SqlEntry,
+
+  upsert: {
+    oracle: `MERGE INTO RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP t
+     USING (
+       SELECT :titleNorm AS TITLE_NORM FROM dual
+     ) s
+        ON (t.TITLE_NORM = s.TITLE_NORM)
+     WHEN MATCHED THEN
+       UPDATE SET
+         TITLE_RAW = :titleRaw,
+         GAMEDB_GAME_ID = :gameDbGameId,
+         STATUS = :status,
+         CREATED_BY = :createdBy
+     WHEN NOT MATCHED THEN
+       INSERT (TITLE_RAW, TITLE_NORM, GAMEDB_GAME_ID, STATUS, CREATED_BY)
+       VALUES (:titleRaw, :titleNorm, :gameDbGameId, :status, :createdBy)`,
+    postgres: ``,
+  } satisfies SqlEntry,
+};

--- a/src/db/sql/index.ts
+++ b/src/db/sql/index.ts
@@ -8,6 +8,7 @@ export { CollectionCsvImportSql } from "./collectionCsvImport.sql.js";
 export { CompletionatorImportSql } from "./completionatorImport.sql.js";
 export { GameSql } from "./game.sql.js";
 export { GameDbCsvImportSql } from "./gameDbCsvImport.sql.js";
+export { GameDbCsvImportMappingSql } from "./gameDbCsvImportMapping.sql.js";
 export { GameKeySql } from "./gameKey.sql.js";
 export { GameReleaseAnnouncementSql } from "./gameReleaseAnnouncement.sql.js";
 export {


### PR DESCRIPTION
## Summary

- Replaces the 5 remaining inline SQL strings in `Game.ts` with `GameSql` registry calls, completing the SQL centralization migration for this domain class
- `getOrInsertMetadata` now uses `GameSql.getOrInsertMetadataSelect` and `GameSql.getOrInsertMetadataInsert` factory entries
- `getSimpleList` now uses `GameSql.getSimpleList` factory entry
- `searchGamesAutocomplete` now uses `GameSql.searchGamesAutocomplete` factory entry
- `searchGames` now uses `GameSql.searchGames` factory entry (orderPrefix extracted into a local variable for clarity)
- `tsc --noEmit` passes with zero errors

## Test plan

- [ ] Verify `tsc --noEmit` still passes after merge
- [ ] Smoke-test autocomplete search to confirm results are unchanged
- [ ] Smoke-test full game search (with and without filters) to confirm results are unchanged
- [ ] Verify game metadata import from IGDB still creates companies/genres/themes/modes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)