### PR TITLE
feat: Phase D -- dialect-agnostic execution wrappers

### DIFF
--- a/SQL_MIGRATION_PLAN.md
+++ b/SQL_MIGRATION_PLAN.md
@@ -296,108 +296,97 @@ Migrated in this phase (Phases A/B/C):
 
 ---
 
-### Next Step: Phase D -- Dialect-agnostic execution wrappers
+### Next Step: Phase D (in progress) -- Dialect-agnostic execution wrappers
 
 ---
 
 ### Phase D: Dialect-agnostic execution wrappers
 
-#### Current state
+#### Completed as of 2026-06-08
 
-`SqlManager.ts` exposes four Oracle-specific helpers and re-exports two Postgres helpers:
+**Infrastructure (done, on branch `feature/phase-d-dialect-agnostic-wrappers`):**
 
-| Wrapper | Dialect | Call sites | Notes |
-|---|---|---|---|
-| `oraQuery(sql, params, mapper)` | Oracle only | 210 | Mapper function inline at call site |
-| `oraMutate(sql, params, conn?)` | Oracle only | 205 | Returns `oracledb.Result<unknown>` |
-| `oraWithConnection(callback)` | Oracle only | 84 | Callback receives `oracledb.Connection` |
-| `oraTransaction(callback)` | Oracle only | 26 | Callback receives `oracledb.Connection` |
-| `pgQuery(text, values?)` | Postgres only | 3 | No mapper -- returns raw rows |
-| `pgTransaction(callback)` | Postgres only | 2 | Callback receives `pg.PoolClient` |
+- `pgMutate` and `pgWithConnection` added to `src/db/postgresClient.ts`
+- `ora*` helpers (`oraQuery`, `oraMutate`, `oraWithConnection`, `oraTransaction`) moved from
+  `SqlManager.ts` to `src/db/oracleClient.ts` -- mirrors `postgresClient.ts` structure
+- `SqlManager.ts` now re-exports everything from both clients and adds four dialect-agnostic
+  wrappers:
+  - `dbQuery(entry, params, mapper)` -- SELECT, picks dialect SQL from `SqlEntry`
+  - `dbMutate(entry, params)` -- DML, returns rows-affected count
+  - `dbWithConnection(callback)` -- single-connection scope
+  - `dbTransaction(callback)` -- atomic transaction
 
-No `pgMutate` or `pgWithConnection` exists. The two sides also have incompatible signatures
-(e.g., `oraQuery` requires a mapper at the call site; `pgQuery` does not).
+**Call sites migrated (simple `oraQuery`/`oraMutate` with no BIND_OUT or conn-passing):**
 
-#### What needs to be built
+| File | Status |
+|---|---|
+| `AdminWizardSession.ts` | Partial -- `getActive` and `saveSession` done; `closeActive` uses `conn.execute` directly (oracle-specific) |
+| `BotVotingInfo.ts` | Partial -- all `get*` and `mark*` done; `setRoundInfo` uses `conn.execute` (oracle-specific) |
+| `CollectionCsvImport.ts` | Partial -- `getImportById` done; `createImport` (BIND_OUT) and `insertItem` (conn-passing) remain |
+| `CompletionatorImport.ts` | Partial -- same pattern as CollectionCsvImport |
+| `GameDbCsvImport.ts` | Partial -- same pattern |
+| `GameDbCsvImportMapping.ts` | Fully migrated |
+| `GameKey.ts` | Partial -- `get*`, `list*`, `claim`, `revoke` done; `create` (BIND_OUT) remains |
+| `GameReleaseAnnouncement.ts` | Partial -- `mark*` and `list*` done; `syncReleaseAnnouncements` (conn-passing) remains |
+| `GameSearchSynonymDraft.ts` | Partial -- `getDraft`, `deleteDraft` done; `createDraft` (BIND_OUT), `appendPairs` (conn-passing) remain |
+| `GameSearchSynonym.ts` | Partial -- standalone `dbQuery` lookups done; all mutation/insert paths use oracle conn-passing and BIND_OUT |
+| `GotmAuditImport.ts` | Partial -- `getById` done; `createSession` (BIND_OUT) and bulk insert (conn-passing) remain |
+| `Gotm.ts` | Partial -- most `get*` done; `updateRowOrder` and `commitRound` use conn-passing |
+| `HltbCache.ts` | Fully migrated |
+| `Member.ts` | Partial -- large file; many `get*` done; connection-passing and BIND_OUT methods remain |
+| `Nomination.ts` | Fully migrated |
+| `PresencePromptHistory.ts` | Fully migrated |
+| `PresencePromptOptOut.ts` | Fully migrated |
+| `PublicReminder.ts` | Partial -- `list*`, `delete`, `update*` done; `create` (BIND_OUT) remains |
+| `Reminder.ts` | Partial -- all done except `create` (BIND_OUT) and `getById` (optional conn) |
+| `RssFeed.ts` | Partial -- `removeFeed`, `updateFeed` done; `addFeed` (BIND_OUT), `markItemsSeen` (executeMany), `getSeenItemHashes` (conn-passing) remain |
+| `Starboard.ts` | Fully migrated |
+| `SuggestionReviewSession.ts` | Partial -- `update`, `delete*` done; `create` (conn-passing) and `getById` (optional conn) remain |
+| `Suggestion.ts` | Partial -- `list`, `count`, `delete` done; `create` (BIND_OUT) and `getById` (optional conn) remain |
+| `Thread.ts` | Partial -- `upsertThread`, `setSkipLinking`, `getThreadSkipLinking` done; transactions and conn-passing remain |
+| `Todo.ts` | Partial -- all done except `create` (BIND_OUT) |
 
-**1. Add missing Postgres helpers to `postgresClient.ts`**
+**Not yet started (oracle-specific throughout):**
 
-```typescript
-/** Runs a DML statement and returns rowCount. */
-export async function pgMutate(
-  text: string,
-  values?: unknown[],
-): Promise<number> {
-  const result = await getPostgresPool().query(text, values);
-  return result.rowCount ?? 0;
-}
+- `Game.ts` (69 remaining ora* calls)
+- `NrGotm.ts` (11)
+- `SteamCollectionImport.ts` (17)
+- `UserActivityIcon.ts` (3)
+- `UserChannelMessageCount.ts` (4)
+- `UserGameCollection.ts` (15)
+- `XboxCollectionImport.ts` (18)
 
-/** Acquires a client, runs callback, then releases it. */
-export async function pgWithConnection<T>(
-  callback: (client: pg.PoolClient) => Promise<T>,
-): Promise<T> {
-  const client = await getPostgresPool().connect();
-  try {
-    return await callback(client);
-  } finally {
-    client.release();
-  }
-}
-```
+---
 
-**2. Add dialect-agnostic wrappers to `SqlManager.ts`**
+#### Remaining work in Phase D
 
-These dispatch to `ora*` or `pg*` based on `getDialect()`. They accept a `SqlEntry` directly so
-`getSql` never needs to be called at the call site.
+**D1 -- Migrate standalone oraQuery/oraMutate in untouched files**
 
-```typescript
-/** SELECT: runs the dialect variant and maps each row. */
-export async function dbQuery<RowT extends object, R>(
-  entry: SqlEntry,
-  params: unknown[],
-  mapper: (row: RowT) => R,
-): Promise<R[]>
+Files above with `ora=N db=0`. For each: replace `oraQuery(getSql(Sql.key, dialect), params, mapper)`
+with `dbQuery(Sql.key, params, mapper)` and `oraMutate(...)` -> `dbMutate(...)` for all calls that
+do not use BIND_OUT or pass a connection argument.
 
-/** DML: runs the dialect variant, returns rows-affected count. */
-export async function dbMutate(
-  entry: SqlEntry,
-  params: unknown[],
-): Promise<number>
+**D2 -- Oracle-only blockers (defer until postgres SQL is written)**
 
-/** Acquire/release a single connection for multiple statements. */
-export async function dbWithConnection<T>(
-  callback: (conn: oracledb.Connection | pg.PoolClient) => Promise<T>,
-): Promise<T>
+Two categories of calls cannot use `db*` wrappers yet:
 
-/** Atomic transaction: commit on success, rollback on throw. */
-export async function dbTransaction<T>(
-  callback: (conn: oracledb.Connection | pg.PoolClient) => Promise<T>,
-): Promise<T>
-```
+1. **BIND_OUT** (`INSERT ... RETURNING x INTO :outVar`): These need postgres SQL filled in as
+   `INSERT ... RETURNING x` and a new `dbInsert(entry, params): Promise<number>` wrapper that
+   returns the generated id (uses `outBinds[0]` on Oracle, `rows[0].id` on Postgres).
 
-**Design notes:**
-- `params` unifies Oracle `BindParameters` and Postgres `unknown[]`. Oracle named binds
-  (`:name`) and Postgres positional (`$1`) are already separated by the `SqlEntry` oracle/postgres
-  keys, so call sites can pass a plain array or object that matches their dialect's SQL.
-- The `dbWithConnection` / `dbTransaction` callback type is a union. Callers that need to issue
-  multiple statements inside one connection will need a small internal helper per dialect, or accept
-  the union and narrow with `instanceof`.
-- Oracle `RETURNING ... INTO :outVar` (bind-out) has no direct Postgres analogue in a shared
-  signature -- those call sites need individual attention when porting.
+2. **Connection-passing** (`oraWithConnection`/`oraTransaction` callbacks that call
+   `oraMutate(sql, params, conn)` or `oraQuery(sql, params, mapper, conn)`): These multi-statement
+   blocks need the postgres SQL filled in and the callback rewritten to accept a union connection
+   type, dispatching to driver-specific calls inside.
 
-**3. Migrate all call sites**
+**D3 -- `executeMany` (RssFeed.markItemsSeen)**
 
-Replace every `oraQuery` / `oraMutate` / `oraWithConnection` / `oraTransaction` call with the
-corresponding `db*` wrapper. Scope: ~525 call sites across 37+ files (see table above for per-file
-counts from the first column of Phase A/B).
+Oracle's `conn.executeMany` has no pg equivalent in the current wrappers. When porting, replace
+with a per-row `pgMutate` loop or a postgres multi-row INSERT ... ON CONFLICT pattern.
 
-**4. Re-export `pgMutate` and `pgWithConnection` from `SqlManager.ts`**
+#### Previously planned approach (still valid)
 
-Keep `SqlManager.ts` as the single import point for all DB helpers.
-
-#### Suggested approach
-
-- Implement and test `dbQuery` / `dbMutate` first (covers 415 of the 525 call sites).
-- Tackle `dbWithConnection` next (84 sites, mostly bulk-import classes).
-- Do `dbTransaction` last (26 sites, already well-isolated in transaction-scoped methods).
+- `dbQuery` / `dbMutate` first (covers the bulk of standalone call sites).
+- `dbWithConnection` / `dbTransaction` next (connection-scoped multi-statement blocks).
+- BIND_OUT cases last (require postgres SQL to be written first).
 - Run `tsc --noEmit` after each batch.

--- a/src/classes/AdminWizardSession.ts
+++ b/src/classes/AdminWizardSession.ts
@@ -1,4 +1,4 @@
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraWithConnection } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { AdminWizardSessionSql } from "../db/sql/index.js";
@@ -194,8 +194,8 @@ export async function getActiveAdminWizardSession(
   ownerUserId: string,
   channelId: string,
 ): Promise<IAdminWizardSession | null> {
-  const rows = await oraQuery(
-    getSql(AdminWizardSessionSql.getActive, dialect),
+  const rows = await dbQuery(
+    AdminWizardSessionSql.getActive,
     { commandKey, ownerUserId, channelId },
     mapAdminWizardSessionRow,
   );
@@ -224,8 +224,8 @@ export async function saveAdminWizardSession(params: {
     Math.floor(Math.random() * 1_000_000).toString(),
   ].join("-");
 
-  await oraMutate(
-    getSql(AdminWizardSessionSql.saveSession, dialect),
+  await dbMutate(
+    AdminWizardSessionSql.saveSession,
     {
       commandKey: params.commandKey,
       ownerUserId: params.ownerUserId,

--- a/src/classes/BotVotingInfo.ts
+++ b/src/classes/BotVotingInfo.ts
@@ -1,4 +1,4 @@
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraWithConnection } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { BotVotingInfoSql } from "../db/sql/index.js";
@@ -68,8 +68,8 @@ function normalizeDate(value: Date | string): Date {
 
 export default class BotVotingInfo {
   static async getAll(): Promise<IBotVotingInfoEntry[]> {
-    return oraQuery(
-      getSql(BotVotingInfoSql.getAll, dialect),
+    return dbQuery(
+      BotVotingInfoSql.getAll,
       [],
       mapRowToEntry,
     );
@@ -77,8 +77,8 @@ export default class BotVotingInfo {
 
   static async getByRound(roundNumber: number): Promise<IBotVotingInfoEntry | null> {
     const round = normalizeRoundNumber(roundNumber);
-    const rows = await oraQuery(
-      getSql(BotVotingInfoSql.getByRound, dialect),
+    const rows = await dbQuery(
+      BotVotingInfoSql.getByRound,
       { round },
       mapRowToEntry,
     );
@@ -86,8 +86,8 @@ export default class BotVotingInfo {
   }
 
   static async getCurrentRound(): Promise<IBotVotingInfoEntry | null> {
-    const rows = await oraQuery(
-      getSql(BotVotingInfoSql.getCurrentRound, dialect),
+    const rows = await dbQuery(
+      BotVotingInfoSql.getCurrentRound,
       [],
       mapRowToEntry,
     );
@@ -126,11 +126,11 @@ export default class BotVotingInfo {
     const column =
       reminder === "fiveDay" ? "FIVE_DAY_REMINDER_SENT" : "ONE_DAY_REMINDER_SENT";
 
-    const result = await oraMutate(
-      BotVotingInfoSql.markReminderSent(column)[dialect],
+    const count = await dbMutate(
+      BotVotingInfoSql.markReminderSent(column),
       { round },
     );
-    if ((result.rowsAffected ?? 0) === 0) {
+    if (count === 0) {
       throw new Error(
         `No BOT_VOTING_INFO row found for round ${round} when updating ${column}.`,
       );
@@ -143,11 +143,11 @@ export default class BotVotingInfo {
   ): Promise<void> {
     const round = normalizeRoundNumber(roundNumber);
     const nextVote = normalizeDate(nextVoteAt);
-    const result = await oraMutate(
-      getSql(BotVotingInfoSql.updateNextVoteAt, dialect),
+    const count = await dbMutate(
+      BotVotingInfoSql.updateNextVoteAt,
       { round, nextVoteAt: nextVote },
     );
-    if ((result.rowsAffected ?? 0) === 0) {
+    if (count === 0) {
       throw new Error(
         `No BOT_VOTING_INFO row found for round ${round} when updating NEXT_VOTE_AT.`,
       );
@@ -159,11 +159,11 @@ export default class BotVotingInfo {
     nominationListId: number | null,
   ): Promise<void> {
     const round = normalizeRoundNumber(roundNumber);
-    const result = await oraMutate(
-      getSql(BotVotingInfoSql.updateNominationListId, dialect),
+    const count = await dbMutate(
+      BotVotingInfoSql.updateNominationListId,
       { round, nominationListId },
     );
-    if ((result.rowsAffected ?? 0) === 0) {
+    if (count === 0) {
       throw new Error(
         `No BOT_VOTING_INFO row found for round ${round}` +
         ` when updating NOMINATION_LIST_ID.`,
@@ -173,10 +173,9 @@ export default class BotVotingInfo {
 
   static async deleteRound(roundNumber: number): Promise<number> {
     const round = normalizeRoundNumber(roundNumber);
-    const result = await oraMutate(
-      getSql(BotVotingInfoSql.deleteRound, dialect),
+    return dbMutate(
+      BotVotingInfoSql.deleteRound,
       { round },
     );
-    return result.rowsAffected ?? 0;
   }
 }

--- a/src/classes/CollectionCsvImport.ts
+++ b/src/classes/CollectionCsvImport.ts
@@ -1,5 +1,12 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import {
+  dbQuery,
+  dbMutate,
+  oraQuery,
+  oraMutate,
+  oraWithConnection,
+  oraTransaction,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { CollectionCsvImportSql } from "../db/sql/index.js";
@@ -223,8 +230,8 @@ export async function getCollectionCsvImportById(
 export async function getActiveCollectionCsvImportForUser(
   userId: string,
 ): Promise<ICollectionCsvImport | null> {
-  const rows = await oraQuery(
-    getSql(CollectionCsvImportSql.getActiveForUser, dialect),
+  const rows = await dbQuery(
+    CollectionCsvImportSql.getActiveForUser,
     { userId },
     mapImport,
   );
@@ -235,8 +242,8 @@ export async function setCollectionCsvImportStatus(
   importId: number,
   status: CollectionCsvImportStatus,
 ): Promise<void> {
-  await oraMutate(
-    getSql(CollectionCsvImportSql.setStatus, dialect),
+  await dbMutate(
+    CollectionCsvImportSql.setStatus,
     { status, importId },
   );
 }
@@ -245,8 +252,8 @@ export async function updateCollectionCsvImportIndex(
   importId: number,
   currentIndex: number,
 ): Promise<void> {
-  await oraMutate(
-    getSql(CollectionCsvImportSql.updateIndex, dialect),
+  await dbMutate(
+    CollectionCsvImportSql.updateIndex,
     { currentIndex, importId },
   );
 }
@@ -254,8 +261,8 @@ export async function updateCollectionCsvImportIndex(
 export async function getCollectionCsvImportItemById(
   itemId: number,
 ): Promise<ICollectionCsvImportItem | null> {
-  const rows = await oraQuery(
-    getSql(CollectionCsvImportSql.getItemById, dialect),
+  const rows = await dbQuery(
+    CollectionCsvImportSql.getItemById,
     { itemId },
     mapItem,
   );
@@ -265,8 +272,8 @@ export async function getCollectionCsvImportItemById(
 export async function getNextPendingCollectionCsvImportItem(
   importId: number,
 ): Promise<ICollectionCsvImportItem | null> {
-  const rows = await oraQuery(
-    getSql(CollectionCsvImportSql.getNextPendingItem, dialect),
+  const rows = await dbQuery(
+    CollectionCsvImportSql.getNextPendingItem,
     { importId },
     mapItem,
   );
@@ -319,8 +326,8 @@ export async function updateCollectionCsvImportItem(
 
   if (!setParts.length) return;
 
-  await oraMutate(
-    CollectionCsvImportSql.updateItem(setParts)[dialect],
+  await dbMutate(
+    CollectionCsvImportSql.updateItem(setParts),
     binds,
   );
 }
@@ -341,8 +348,8 @@ export async function countCollectionCsvImportItems(
     SKIPPED: 0,
     FAILED: 0,
   };
-  const rows = await oraQuery(
-    getSql(CollectionCsvImportSql.countItemsByStatus, dialect),
+  const rows = await dbQuery(
+    CollectionCsvImportSql.countItemsByStatus,
     { importId },
     (row: { STATUS: CollectionCsvImportItemStatus; TOTAL: number }) => row,
   );
@@ -362,8 +369,8 @@ export async function countCollectionCsvImportResultReasons(
   importId: number,
 ): Promise<Record<string, number>> {
   const counts: Record<string, number> = {};
-  const rows = await oraQuery(
-    getSql(CollectionCsvImportSql.countItemsByReason, dialect),
+  const rows = await dbQuery(
+    CollectionCsvImportSql.countItemsByReason,
     { importId },
     (row: { RESULT_REASON: CollectionCsvImportResultReason; TOTAL: number }) => row,
   );

--- a/src/classes/CompletionatorImport.ts
+++ b/src/classes/CompletionatorImport.ts
@@ -1,5 +1,12 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import {
+  dbQuery,
+  dbMutate,
+  oraQuery,
+  oraMutate,
+  oraWithConnection,
+  oraTransaction,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { CompletionatorImportSql } from "../db/sql/index.js";
@@ -189,8 +196,8 @@ export async function getImportById(
 export async function getActiveImportForUser(
   userId: string,
 ): Promise<ICompletionatorImport | null> {
-  const rows = await oraQuery(
-    getSql(CompletionatorImportSql.getActiveForUser, dialect),
+  const rows = await dbQuery(
+    CompletionatorImportSql.getActiveForUser,
     { userId },
     mapImport,
   );
@@ -201,8 +208,8 @@ export async function setImportStatus(
   importId: number,
   status: ImportStatus,
 ): Promise<void> {
-  await oraMutate(
-    getSql(CompletionatorImportSql.setStatus, dialect),
+  await dbMutate(
+    CompletionatorImportSql.setStatus,
     { status, importId },
   );
 }
@@ -211,8 +218,8 @@ export async function updateImportIndex(
   importId: number,
   currentIndex: number,
 ): Promise<void> {
-  await oraMutate(
-    getSql(CompletionatorImportSql.updateIndex, dialect),
+  await dbMutate(
+    CompletionatorImportSql.updateIndex,
     { currentIndex, importId },
   );
 }
@@ -220,8 +227,8 @@ export async function updateImportIndex(
 export async function getNextPendingItem(
   importId: number,
 ): Promise<ICompletionatorItem | null> {
-  const rows = await oraQuery(
-    getSql(CompletionatorImportSql.getNextPendingItem, dialect),
+  const rows = await dbQuery(
+    CompletionatorImportSql.getNextPendingItem,
     { importId },
     mapItem,
   );
@@ -231,8 +238,8 @@ export async function getNextPendingItem(
 export async function getImportItemById(
   itemId: number,
 ): Promise<ICompletionatorItem | null> {
-  const rows = await oraQuery(
-    getSql(CompletionatorImportSql.getItemById, dialect),
+  const rows = await dbQuery(
+    CompletionatorImportSql.getItemById,
     { itemId },
     mapItem,
   );
@@ -270,8 +277,8 @@ export async function updateImportItem(
 
   if (!fields.length) return;
 
-  await oraMutate(
-    CompletionatorImportSql.updateItem(fields)[dialect],
+  await dbMutate(
+    CompletionatorImportSql.updateItem(fields),
     binds,
   );
 }
@@ -284,8 +291,8 @@ export async function countImportItems(importId: number): Promise<{
   error: number;
 }> {
   const stats = { pending: 0, skipped: 0, imported: 0, updated: 0, error: 0 };
-  const rows = await oraQuery(
-    getSql(CompletionatorImportSql.countItemsByStatus, dialect),
+  const rows = await dbQuery(
+    CompletionatorImportSql.countItemsByStatus,
     { importId },
     (row: { STATUS: string; CNT: number }) => row,
   );

--- a/src/classes/GameDbCsvImport.ts
+++ b/src/classes/GameDbCsvImport.ts
@@ -1,5 +1,12 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import {
+  dbQuery,
+  dbMutate,
+  oraQuery,
+  oraMutate,
+  oraWithConnection,
+  oraTransaction,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { GameDbCsvImportSql } from "../db/sql/index.js";
@@ -166,8 +173,8 @@ export async function getGameDbCsvImportById(
 export async function getActiveGameDbCsvImportForUser(
   userId: string,
 ): Promise<IGameDbCsvImport | null> {
-  const rows = await oraQuery(
-    getSql(GameDbCsvImportSql.getActiveForUser, dialect),
+  const rows = await dbQuery(
+    GameDbCsvImportSql.getActiveForUser,
     { userId },
     mapImport,
   );
@@ -178,8 +185,8 @@ export async function setGameDbCsvImportStatus(
   importId: number,
   status: GameDbCsvImportStatus,
 ): Promise<void> {
-  await oraMutate(
-    getSql(GameDbCsvImportSql.setStatus, dialect),
+  await dbMutate(
+    GameDbCsvImportSql.setStatus,
     { status, importId },
   );
 }
@@ -188,8 +195,8 @@ export async function updateGameDbCsvImportIndex(
   importId: number,
   currentIndex: number,
 ): Promise<void> {
-  await oraMutate(
-    getSql(GameDbCsvImportSql.updateIndex, dialect),
+  await dbMutate(
+    GameDbCsvImportSql.updateIndex,
     { currentIndex, importId },
   );
 }
@@ -197,8 +204,8 @@ export async function updateGameDbCsvImportIndex(
 export async function getNextGameDbCsvImportItem(
   importId: number,
 ): Promise<IGameDbCsvImportItem | null> {
-  const rows = await oraQuery(
-    getSql(GameDbCsvImportSql.getNextPendingItem, dialect),
+  const rows = await dbQuery(
+    GameDbCsvImportSql.getNextPendingItem,
     { importId },
     mapItem,
   );
@@ -208,8 +215,8 @@ export async function getNextGameDbCsvImportItem(
 export async function getGameDbCsvImportItemById(
   itemId: number,
 ): Promise<IGameDbCsvImportItem | null> {
-  const rows = await oraQuery(
-    getSql(GameDbCsvImportSql.getItemById, dialect),
+  const rows = await dbQuery(
+    GameDbCsvImportSql.getItemById,
     { itemId },
     mapItem,
   );
@@ -242,8 +249,8 @@ export async function updateGameDbCsvImportItem(
 
   if (!fields.length) return;
 
-  await oraMutate(
-    GameDbCsvImportSql.updateItem(fields)[dialect],
+  await dbMutate(
+    GameDbCsvImportSql.updateItem(fields),
     binds,
   );
 }
@@ -255,8 +262,8 @@ export async function countGameDbCsvImportItems(importId: number): Promise<{
   error: number;
 }> {
   const stats = { pending: 0, skipped: 0, imported: 0, error: 0 };
-  const rows = await oraQuery(
-    getSql(GameDbCsvImportSql.countItems, dialect),
+  const rows = await dbQuery(
+    GameDbCsvImportSql.countItems,
     { importId },
     (row: { STATUS: string; CNT: number }) => row,
   );

--- a/src/classes/GameDbCsvImportMapping.ts
+++ b/src/classes/GameDbCsvImportMapping.ts
@@ -1,9 +1,5 @@
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate } from "../db/SqlManager.js";
 import { GameDbCsvImportMappingSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type GameDbCsvTitleMapStatus = "MAPPED" | "SKIPPED";
 
@@ -47,8 +43,8 @@ function mapRow(row: {
 export async function getGameDbCsvTitleMapByNorm(
   titleNorm: string,
 ): Promise<IGameDbCsvTitleMap | null> {
-  const rows = await oraQuery(
-    getSql(GameDbCsvImportMappingSql.getByTitleNorm, dialect),
+  const rows = await dbQuery(
+    GameDbCsvImportMappingSql.getByTitleNorm,
     { titleNorm },
     mapRow,
   );
@@ -62,8 +58,8 @@ export async function upsertGameDbCsvTitleMap(params: {
   status: GameDbCsvTitleMapStatus;
   createdBy: string | null;
 }): Promise<void> {
-  await oraMutate(
-    getSql(GameDbCsvImportMappingSql.upsert, dialect),
+  await dbMutate(
+    GameDbCsvImportMappingSql.upsert,
     {
       titleRaw: params.titleRaw,
       titleNorm: params.titleNorm,

--- a/src/classes/GameKey.ts
+++ b/src/classes/GameKey.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraMutate } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { GameKeySql } from "../db/sql/index.js";
@@ -77,8 +77,8 @@ export async function createGameKey(
 }
 
 export async function getGameKeyById(keyId: number): Promise<IGameKey | null> {
-  const rows = await oraQuery(
-    getSql(GameKeySql.getById, dialect),
+  const rows = await dbQuery(
+    GameKeySql.getById,
     { id: keyId },
     mapGameKeyRow,
   );
@@ -86,8 +86,8 @@ export async function getGameKeyById(keyId: number): Promise<IGameKey | null> {
 }
 
 export async function countAvailableGameKeys(): Promise<number> {
-  const rows = await oraQuery(
-    getSql(GameKeySql.countAvailable, dialect),
+  const rows = await dbQuery(
+    GameKeySql.countAvailable,
     {},
     (row: { TOTAL: number | null }) => Number(row.TOTAL ?? 0),
   );
@@ -100,16 +100,16 @@ export async function listAvailableGameKeys(
 ): Promise<IGameKey[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 50);
   const safeOffset = Math.max(offset, 0);
-  return oraQuery(
-    getSql(GameKeySql.listAvailable, dialect),
+  return dbQuery(
+    GameKeySql.listAvailable,
     { offset: safeOffset, limit: safeLimit },
     mapGameKeyRow,
   );
 }
 
 export async function listKeysByDonor(userId: string): Promise<IGameKey[]> {
-  return oraQuery(
-    getSql(GameKeySql.listByDonor, dialect),
+  return dbQuery(
+    GameKeySql.listByDonor,
     { userId },
     mapGameKeyRow,
   );
@@ -119,17 +119,17 @@ export async function claimGameKey(
   keyId: number,
   userId: string,
 ): Promise<boolean> {
-  const result = await oraMutate(
-    getSql(GameKeySql.claim, dialect),
+  const count = await dbMutate(
+    GameKeySql.claim,
     { keyId, userId },
   );
-  return (result.rowsAffected ?? 0) > 0;
+  return count > 0;
 }
 
 export async function revokeGameKey(keyId: number): Promise<boolean> {
-  const result = await oraMutate(
-    getSql(GameKeySql.revoke, dialect),
+  const count = await dbMutate(
+    GameKeySql.revoke,
     { keyId },
   );
-  return (result.rowsAffected ?? 0) > 0;
+  return count > 0;
 }

--- a/src/classes/GameReleaseAnnouncement.ts
+++ b/src/classes/GameReleaseAnnouncement.ts
@@ -1,4 +1,4 @@
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { GameReleaseAnnouncementSql } from "../db/sql/index.js";
@@ -83,11 +83,10 @@ export default class GameReleaseAnnouncement {
   }
 
   static async markNonCanonicalAnnouncements(): Promise<number> {
-    const result = await oraMutate(
-      getSql(GameReleaseAnnouncementSql.markNonCanonical, dialect),
+    return dbMutate(
+      GameReleaseAnnouncementSql.markNonCanonical,
       { portOnlyReason: PORT_ONLY_RELEASE_REASON, sameDayReason: SAME_DAY_DUPLICATE_REASON },
     );
-    return Number(result.rowsAffected ?? 0);
   }
 
   static async listDueAnnouncements(
@@ -95,26 +94,25 @@ export default class GameReleaseAnnouncement {
     limit: number = DEFAULT_BATCH_SIZE,
   ): Promise<IReleaseAnnouncementCandidate[]> {
     const safeLimit = clampBatchSize(limit);
-    return oraQuery(
-      getSql(GameReleaseAnnouncementSql.listDueAnnouncements, dialect),
+    return dbQuery(
+      GameReleaseAnnouncementSql.listDueAnnouncements,
       { referenceTime, limit: safeLimit },
       mapCandidateRow,
     );
   }
 
   static async markAnnouncementSent(releaseId: number, sentAt: Date): Promise<boolean> {
-    const result = await oraMutate(
-      getSql(GameReleaseAnnouncementSql.markSent, dialect),
+    const count = await dbMutate(
+      GameReleaseAnnouncementSql.markSent,
       { releaseId, sentAt },
     );
-    return (result.rowsAffected ?? 0) > 0;
+    return count > 0;
   }
 
   static async markMissedAnnouncements(referenceTime: Date): Promise<number> {
-    const result = await oraMutate(
-      getSql(GameReleaseAnnouncementSql.markMissed, dialect),
+    return dbMutate(
+      GameReleaseAnnouncementSql.markMissed,
       { referenceTime, reason: MISSED_WINDOW_REASON },
     );
-    return Number(result.rowsAffected ?? 0);
   }
 }

--- a/src/classes/GameSearchSynonym.ts
+++ b/src/classes/GameSearchSynonym.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { dbQuery, oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { GameSearchSynonymSql } from "../db/sql/index.js";
@@ -89,8 +89,8 @@ export default class GameSearchSynonym {
     const searchQuery = query ? `%${query}%` : null;
     const normalizedQuery = query ? `%${normalizeSearchTerm(query)}%` : null;
     const limit = options.limit ?? 50;
-    return oraQuery(
-      getSql(GameSearchSynonymSql.listSynonyms, dialect),
+    return dbQuery(
+      GameSearchSynonymSql.listSynonyms,
       { searchQuery, normalizedQuery, limit },
       mapSynonymRow,
     );
@@ -102,8 +102,8 @@ export default class GameSearchSynonym {
     const normalizedQuery = cleanedQuery
       ? `%${normalizeSearchTerm(cleanedQuery)}%`
       : null;
-    const rows = await oraQuery(
-      getSql(GameSearchSynonymSql.countSynonymGroups, dialect),
+    const rows = await dbQuery(
+      GameSearchSynonymSql.countSynonymGroups,
       { searchQuery, normalizedQuery },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );

--- a/src/classes/GameSearchSynonymDraft.ts
+++ b/src/classes/GameSearchSynonymDraft.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { GameSearchSynonymDraftSql } from "../db/sql/index.js";
@@ -66,8 +66,8 @@ export default class GameSearchSynonymDraft {
   }
 
   static async getDraft(draftId: number): Promise<ISynonymDraft | null> {
-    const rows = await oraQuery(
-      getSql(GameSearchSynonymDraftSql.getDraft, dialect),
+    const rows = await dbQuery(
+      GameSearchSynonymDraftSql.getDraft,
       { draftId },
       mapDraftRow,
     );
@@ -92,8 +92,8 @@ export default class GameSearchSynonymDraft {
   }
 
   static async deleteDraft(draftId: number): Promise<void> {
-    await oraMutate(
-      getSql(GameSearchSynonymDraftSql.deleteDraft, dialect),
+    await dbMutate(
+      GameSearchSynonymDraftSql.deleteDraft,
       { draftId },
     );
   }

--- a/src/classes/Gotm.ts
+++ b/src/classes/Gotm.ts
@@ -1,4 +1,4 @@
-import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { GotmSql } from "../db/sql/index.js";
@@ -68,8 +68,8 @@ type GotmEntryRow = {
 };
 
 async function loadFromDatabaseInternal(): Promise<IGotmEntry[]> {
-  const rows = await oraQuery<GotmEntryRow, GotmEntryRow>(
-    getSql(GotmSql.loadAll, dialect),
+  const rows = await dbQuery<GotmEntryRow, GotmEntryRow>(
+    GotmSql.loadAll,
     {},
     (row) => row,
   );
@@ -388,8 +388,8 @@ export async function updateGotmVotingResultsInDatabase(
   round: number,
   messageId: string | null,
 ): Promise<void> {
-  await oraMutate(
-    getSql(GotmSql.updateVotingResults, dialect),
+  await dbMutate(
+    GotmSql.updateVotingResults,
     { round, value: messageId },
   );
 }
@@ -406,8 +406,8 @@ export async function insertGotmRoundInDatabase(
     throw new Error("At least one game is required for a GOTM round.");
   }
 
-  const countRows = await oraQuery<{ CNT: number }, { CNT: number }>(
-    getSql(GotmSql.checkRoundExists, dialect),
+  const countRows = await dbQuery<{ CNT: number }, { CNT: number }>(
+    GotmSql.checkRoundExists,
     { round },
     (row) => row,
   );
@@ -444,9 +444,8 @@ export async function deleteGotmRoundFromDatabase(round: number): Promise<number
     throw new Error("Invalid round number for GOTM delete.");
   }
 
-  const result = await oraMutate(
-    getSql(GotmSql.deleteRound, dialect),
+  return dbMutate(
+    GotmSql.deleteRound,
     { round },
   );
-  return result.rowsAffected ?? 0;
 }

--- a/src/classes/GotmAuditImport.ts
+++ b/src/classes/GotmAuditImport.ts
@@ -1,5 +1,12 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import {
+  dbQuery,
+  dbMutate,
+  oraQuery,
+  oraMutate,
+  oraWithConnection,
+  oraTransaction,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { GotmAuditImportSql } from "../db/sql/index.js";
@@ -175,8 +182,8 @@ export async function getGotmAuditImportById(
 export async function getActiveGotmAuditImportForUser(
   userId: string,
 ): Promise<IGotmAuditImport | null> {
-  const rows = await oraQuery(
-    getSql(GotmAuditImportSql.getActiveForUser, dialect),
+  const rows = await dbQuery(
+    GotmAuditImportSql.getActiveForUser,
     { userId },
     mapImport,
   );
@@ -187,8 +194,8 @@ export async function setGotmAuditImportStatus(
   importId: number,
   status: GotmAuditStatus,
 ): Promise<void> {
-  await oraMutate(
-    getSql(GotmAuditImportSql.setStatus, dialect),
+  await dbMutate(
+    GotmAuditImportSql.setStatus,
     { importId, status },
   );
 }
@@ -197,8 +204,8 @@ export async function updateGotmAuditImportIndex(
   importId: number,
   currentIndex: number,
 ): Promise<void> {
-  await oraMutate(
-    getSql(GotmAuditImportSql.updateIndex, dialect),
+  await dbMutate(
+    GotmAuditImportSql.updateIndex,
     { importId, currentIndex },
   );
 }
@@ -206,8 +213,8 @@ export async function updateGotmAuditImportIndex(
 export async function getNextGotmAuditItem(
   importId: number,
 ): Promise<IGotmAuditItem | null> {
-  const rows = await oraQuery(
-    getSql(GotmAuditImportSql.getNextPendingItem, dialect),
+  const rows = await dbQuery(
+    GotmAuditImportSql.getNextPendingItem,
     { importId },
     mapItem,
   );
@@ -217,8 +224,8 @@ export async function getNextGotmAuditItem(
 export async function getGotmAuditItemById(
   itemId: number,
 ): Promise<IGotmAuditItem | null> {
-  const rows = await oraQuery(
-    getSql(GotmAuditImportSql.getItemById, dialect),
+  const rows = await dbQuery(
+    GotmAuditImportSql.getItemById,
     { itemId },
     mapItem,
   );
@@ -251,8 +258,8 @@ export async function updateGotmAuditItem(
 
   if (!fields.length) return;
 
-  await oraMutate(
-    GotmAuditImportSql.updateItem(fields)[dialect],
+  await dbMutate(
+    GotmAuditImportSql.updateItem(fields),
     binds,
   );
 }
@@ -262,8 +269,8 @@ export async function getGotmAuditItemsForRound(
   kind: GotmAuditKind,
   roundNumber: number,
 ): Promise<IGotmAuditItem[]> {
-  return oraQuery(
-    getSql(GotmAuditImportSql.getItemsForRound, dialect),
+  return dbQuery(
+    GotmAuditImportSql.getItemsForRound,
     { importId, kind, roundNumber },
     mapItem,
   );
@@ -276,8 +283,8 @@ export async function countGotmAuditItems(importId: number): Promise<{
   error: number;
 }> {
   const stats = { pending: 0, imported: 0, skipped: 0, error: 0 };
-  const rows = await oraQuery(
-    getSql(GotmAuditImportSql.countItems, dialect),
+  const rows = await dbQuery(
+    GotmAuditImportSql.countItems,
     { importId },
     (row: { STATUS: GotmAuditItemStatus; CNT: number }) => row,
   );

--- a/src/classes/HltbCache.ts
+++ b/src/classes/HltbCache.ts
@@ -1,9 +1,5 @@
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate } from "../db/SqlManager.js";
 import { HltbCacheSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type HltbCacheEntry = {
   gameId: number;
@@ -60,8 +56,8 @@ function mapRow(row: {
 export async function getHltbCacheByGameId(
   gameId: number,
 ): Promise<HltbCacheEntry | null> {
-  const rows = await oraQuery(
-    getSql(HltbCacheSql.getByGameId, dialect),
+  const rows = await dbQuery(
+    HltbCacheSql.getByGameId,
     { gameId },
     mapRow,
   );
@@ -83,8 +79,8 @@ export async function upsertHltbCache(
     sourceQuery?: string | null;
   },
 ): Promise<void> {
-  await oraMutate(
-    getSql(HltbCacheSql.upsertCache, dialect),
+  await dbMutate(
+    HltbCacheSql.upsertCache,
     {
       gameId,
       name: payload.name ?? null,

--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -1,5 +1,7 @@
 import oracledb from "oracledb";
 import {
+  dbQuery,
+  dbMutate,
   oraQuery,
   oraMutate,
   oraWithConnection,
@@ -256,8 +258,8 @@ function buildParams(record: IMemberRecord) {
 export default class Member {
   static async touchLastSeen(userId: string, when: Date = new Date()): Promise<void> {
     try {
-      await oraMutate(
-        getSql(MemberSql.touchLastSeen, dialect),
+      await dbMutate(
+        MemberSql.touchLastSeen,
         { userId, lastSeen: when },
       );
     } catch (err: any) {
@@ -405,9 +407,9 @@ export default class Member {
       binds[`id${idx}`] = id;
     });
 
-    return oraQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
+    return dbQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
       { gameId: number; title: string; userId: string }>(
-      MemberSql.getNowPlayingByGameIds(placeholders.join(", "))[dialect],
+      MemberSql.getNowPlayingByGameIds(placeholders.join(", ")),
       binds,
       (row) => ({
         gameId: Number(row.GAME_ID),
@@ -424,9 +426,9 @@ export default class Member {
     if (!trimmed) return [];
     const searchQuery = `%${trimmed}%`;
     const normalizedQuery = `%${trimmed.replace(/[^a-z0-9]/g, "")}%`;
-    return oraQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
+    return dbQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
       { gameId: number; title: string; userId: string }>(
-      getSql(MemberSql.getNowPlayingByTitleSearch, dialect),
+      MemberSql.getNowPlayingByTitleSearch,
       { searchQuery, normalizedQuery },
       (row) => ({
         gameId: Number(row.GAME_ID),
@@ -451,7 +453,7 @@ export default class Member {
     journalEnabled: boolean;
     hasJournalEntry: boolean;
   }[]> {
-    return oraQuery<{
+    return dbQuery<{
       GAME_ID: number;
       TITLE: string;
       PLATFORM_ID: number | null;
@@ -475,7 +477,7 @@ export default class Member {
       journalEnabled: boolean;
       hasJournalEntry: boolean;
     }>(
-      getSql(MemberSql.getNowPlayingEntries, dialect),
+      MemberSql.getNowPlayingEntries,
       { userId },
       (r) => ({
         gameId: Number(r.GAME_ID),
@@ -508,8 +510,8 @@ export default class Member {
     if (!Number.isInteger(gameId) || gameId <= 0) {
       throw new Error("Invalid GameDB id.");
     }
-    const rows = await oraQuery<{ ADDED_AT: Date | string | null }, { addedAt: Date | null }>(
-      getSql(MemberSql.getNowPlayingEntryMeta, dialect),
+    const rows = await dbQuery<{ ADDED_AT: Date | string | null }, { addedAt: Date | null }>(
+      MemberSql.getNowPlayingEntryMeta,
       { userId, gameId },
       (row) => ({
         addedAt: row.ADDED_AT instanceof Date
@@ -538,11 +540,11 @@ export default class Member {
     const noteValue = normalizedNote ? normalizedNote : null;
     const noteUpdatedAt = noteValue ? new Date() : null;
 
-    const res = await oraMutate(
-      getSql(MemberSql.updateNowPlayingNote, dialect),
+    const count = await dbMutate(
+      MemberSql.updateNowPlayingNote,
       { userId, gameId, note: noteValue, noteUpdatedAt },
     );
-    return (res.rowsAffected ?? 0) > 0;
+    return count > 0;
   }
 
   static async addNowPlaying(
@@ -606,12 +608,12 @@ export default class Member {
     userId: string,
     gameId: number,
   ): Promise<IGameJournalPreference | null> {
-    const rows = await oraQuery<{
+    const rows = await dbQuery<{
       USER_ID: string;
       GAMEDB_GAME_ID: number;
       IS_ENABLED: number;
     }, IGameJournalPreference>(
-      getSql(MemberSql.getGameJournalPreference, dialect),
+      MemberSql.getGameJournalPreference,
       { userId, gameId },
       (row) => ({
         userId: row.USER_ID,
@@ -629,8 +631,8 @@ export default class Member {
     gameId: number,
     isEnabled: boolean,
   ): Promise<void> {
-    await oraMutate(
-      getSql(MemberSql.upsertGameJournalPreference, dialect),
+    await dbMutate(
+      MemberSql.upsertGameJournalPreference,
       {
         userId,
         gameId,
@@ -659,12 +661,12 @@ export default class Member {
     uniqueIds.forEach((id, idx) => {
       binds[`id${idx}`] = id;
     });
-    return oraQuery<{
+    return dbQuery<{
       GAME_ID: number;
       JOURNAL_COUNT: number;
       LAST_JOURNAL_AT: Date | string | null;
     }, { gameId: number; journalCount: number; lastJournalAt: Date | null }>(
-      MemberSql.getJournalStatusForGames(inlineTable)[dialect],
+      MemberSql.getJournalStatusForGames(inlineTable),
       binds,
       (row) => ({
         gameId: Number(row.GAME_ID),
@@ -686,7 +688,7 @@ export default class Member {
   ): Promise<IGameJournalEntry[]> {
     const safeLimit = Math.min(Math.max(params?.limit ?? 5, 1), 25);
     const safeOffset = Math.max(params?.offset ?? 0, 0);
-    return oraQuery<{
+    return dbQuery<{
       ENTRY_ID: number;
       USER_ID: string;
       GAMEDB_GAME_ID: number;
@@ -696,7 +698,7 @@ export default class Member {
       UPDATED_AT: Date | string;
       ENTRY_NUMBER: number;
     }, IGameJournalEntry>(
-      getSql(MemberSql.getGameJournalEntries, dialect),
+      MemberSql.getGameJournalEntries,
       { userId, gameId, offset: safeOffset, limit: safeLimit },
       (row) => ({
         entryId: Number(row.ENTRY_ID),
@@ -712,8 +714,8 @@ export default class Member {
   }
 
   static async countGameJournalEntries(userId: string, gameId: number): Promise<number> {
-    const rows = await oraQuery<{ CNT: number }, number>(
-      getSql(MemberSql.countGameJournalEntries, dialect),
+    const rows = await dbQuery<{ CNT: number }, number>(
+      MemberSql.countGameJournalEntries,
       { userId, gameId },
       (row) => Number(row.CNT),
     );
@@ -731,8 +733,8 @@ export default class Member {
     if (!bodyValue) {
       throw new Error("Journal body cannot be empty.");
     }
-    await oraMutate(
-      getSql(MemberSql.addGameJournalEntry, dialect),
+    await dbMutate(
+      MemberSql.addGameJournalEntry,
       {
         userId: params.userId,
         gameId: params.gameId,
@@ -746,7 +748,7 @@ export default class Member {
     userId: string,
     entryId: number,
   ): Promise<IGameJournalEntry | null> {
-    const rows = await oraQuery<{
+    const rows = await dbQuery<{
       ENTRY_ID: number;
       USER_ID: string;
       GAMEDB_GAME_ID: number;
@@ -756,7 +758,7 @@ export default class Member {
       UPDATED_AT: Date | string;
       ENTRY_NUMBER: number;
     }, IGameJournalEntry>(
-      getSql(MemberSql.getGameJournalEntryForUser, dialect),
+      MemberSql.getGameJournalEntryForUser,
       { userId, entryId },
       (row) => ({
         entryId: Number(row.ENTRY_ID),
@@ -801,19 +803,19 @@ export default class Member {
     if (!fields.length) return false;
     fields.push("UPDATED_AT = SYSTIMESTAMP");
 
-    const res = await oraMutate(
-      MemberSql.updateGameJournalEntry(fields)[dialect],
+    const count = await dbMutate(
+      MemberSql.updateGameJournalEntry(fields),
       binds as Record<string, any>,
     );
-    return Number(res.rowsAffected ?? 0) > 0;
+    return count > 0;
   }
 
   static async deleteGameJournalEntry(userId: string, entryId: number): Promise<boolean> {
-    const res = await oraMutate(
-      getSql(MemberSql.deleteGameJournalEntry, dialect),
+    const count = await dbMutate(
+      MemberSql.deleteGameJournalEntry,
       { userId, entryId },
     );
-    return Number(res.rowsAffected ?? 0) > 0;
+    return count > 0;
   }
 
   static async updateNowPlayingSort(
@@ -841,12 +843,11 @@ export default class Member {
       throw new Error("Invalid GameDB id.");
     }
 
-    const res = await oraMutate(
-      getSql(MemberSql.removeNowPlaying, dialect),
+    const count = await dbMutate(
+      MemberSql.removeNowPlaying,
       { userId, gameId },
     );
-    const rows = (res as any).rowsAffected ?? 0;
-    return rows > 0;
+    return count > 0;
   }
 
   static async addCompletion(params: {
@@ -924,7 +925,7 @@ export default class Member {
   }
 
   static async getCompletion(completionId: number): Promise<ICompletionRecord | null> {
-    const rows = await oraQuery<{
+    const rows = await dbQuery<{
       COMPLETION_ID: number;
       GAME_ID: number;
       TITLE: string;
@@ -936,7 +937,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      getSql(MemberSql.getCompletion, dialect),
+      MemberSql.getCompletion,
       { completionId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -970,7 +971,7 @@ export default class Member {
     userId: string,
     completionId: number,
   ): Promise<ICompletionRecord | null> {
-    const rows = await oraQuery<{
+    const rows = await dbQuery<{
       COMPLETION_ID: number;
       GAME_ID: number;
       TITLE: string;
@@ -982,7 +983,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      getSql(MemberSql.getCompletionForUser, dialect),
+      MemberSql.getCompletionForUser,
       { userId, completionId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1019,7 +1020,7 @@ export default class Member {
     if (!Number.isInteger(gameId) || gameId <= 0) {
       throw new Error("Invalid GameDB id.");
     }
-    const rows = await oraQuery<{
+    const rows = await dbQuery<{
       COMPLETION_ID: number;
       GAME_ID: number;
       TITLE: string;
@@ -1031,7 +1032,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      getSql(MemberSql.getCompletionByGameId, dialect),
+      MemberSql.getCompletionByGameId,
       { userId, gameId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1085,7 +1086,7 @@ export default class Member {
       binds.title = title;
     }
 
-    return oraQuery<{
+    return dbQuery<{
       COMPLETION_ID: number;
       GAME_ID: number;
       TITLE: string;
@@ -1097,7 +1098,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      MemberSql.getCompletions(clauses.join(" AND "))[dialect],
+      MemberSql.getCompletions(clauses.join(" AND ")),
       binds,
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1126,7 +1127,7 @@ export default class Member {
   }
 
   static async getAllCompletions(userId: string): Promise<ICompletionRecord[]> {
-    return oraQuery<{
+    return dbQuery<{
       COMPLETION_ID: number;
       GAME_ID: number;
       TITLE: string;
@@ -1138,7 +1139,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      getSql(MemberSql.getAllCompletions, dialect),
+      MemberSql.getAllCompletions,
       { userId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1184,8 +1185,8 @@ export default class Member {
       binds.title = title;
     }
 
-    const rows = await oraQuery<{ CNT: number }, number>(
-      MemberSql.countCompletions(clauses.join(" AND "))[dialect],
+    const rows = await dbQuery<{ CNT: number }, number>(
+      MemberSql.countCompletions(clauses.join(" AND ")),
       binds,
       (row) => Number(row.CNT),
     );
@@ -1238,24 +1239,22 @@ export default class Member {
 
     if (!fields.length) return false;
 
-    const res = await oraMutate(
-      MemberSql.updateCompletion(fields)[dialect],
+    const count = await dbMutate(
+      MemberSql.updateCompletion(fields),
       binds,
     );
-    const rows = (res as any).rowsAffected ?? 0;
-    return rows > 0;
+    return count > 0;
   }
 
   static async deleteCompletion(userId: string, completionId: number): Promise<boolean> {
     if (!Number.isInteger(completionId) || completionId <= 0) {
       throw new Error("Invalid completion id.");
     }
-    const res = await oraMutate(
-      getSql(MemberSql.deleteCompletion, dialect),
+    const count = await dbMutate(
+      MemberSql.deleteCompletion,
       { completionId, userId },
     );
-    const rows = (res as any).rowsAffected ?? 0;
-    return rows > 0;
+    return count > 0;
   }
 
   static async getRecentNickHistory(
@@ -1264,12 +1263,12 @@ export default class Member {
   ): Promise<IMemberNickHistory[]> {
     const safeLimit = Math.min(Math.max(limit, 1), 20);
     try {
-      return await oraQuery<{
+      return await dbQuery<{
         OLD_NICK: string | null;
         NEW_NICK: string | null;
         CHANGED_AT: Date;
       }, IMemberNickHistory>(
-        getSql(MemberSql.getRecentNickHistory, dialect),
+        MemberSql.getRecentNickHistory,
         { userId, limit: safeLimit },
         (row) => ({
           oldNick: row.OLD_NICK ?? null,
@@ -1301,13 +1300,13 @@ export default class Member {
       binds.title = title;
     }
 
-    return oraQuery<{
+    return dbQuery<{
       USER_ID: string;
       USERNAME: string | null;
       GLOBAL_NAME: string | null;
       CNT: number;
     }, { userId: string; username: string | null; globalName: string | null; count: number }>(
-      MemberSql.getCompletionLeaderboard(clauses.join(" AND "))[dialect],
+      MemberSql.getCompletionLeaderboard(clauses.join(" AND ")),
       binds,
       (row) => ({
         userId: row.USER_ID,
@@ -1377,7 +1376,7 @@ export default class Member {
 
     const where = clauses.length ? clauses.join(" AND ") : "1=1";
 
-    return oraQuery<{
+    return dbQuery<{
       USER_ID: string;
       USERNAME: string | null;
       GLOBAL_NAME: string | null;
@@ -1396,7 +1395,7 @@ export default class Member {
       SERVER_JOINED_AT: Date | null;
       LAST_SEEN_AT: Date | null;
     }, IMemberSearchResult>(
-      MemberSql.searchMembers(where)[dialect],
+      MemberSql.searchMembers(where),
       params,
       (row) => ({
         userId: row.USER_ID,
@@ -1513,11 +1512,11 @@ export default class Member {
     if (!Number.isInteger(platformId) || platformId <= 0) {
       throw new Error("Invalid platform selection.");
     }
-    const res = await oraMutate(
-      getSql(MemberSql.updateNowPlayingPlatform, dialect),
+    const count = await dbMutate(
+      MemberSql.updateNowPlayingPlatform,
       { userId, gameId, platformId },
     );
-    return (res.rowsAffected ?? 0) > 0;
+    return count > 0;
   }
 
   static async getAvatarHistory(
@@ -1564,7 +1563,7 @@ export default class Member {
     if (!Number.isInteger(gameId) || gameId <= 0) {
       throw new Error("Invalid GameDB id.");
     }
-    return oraQuery<{
+    return dbQuery<{
       COMPLETION_ID: number;
       GAME_ID: number;
       TITLE: string;
@@ -1576,7 +1575,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      getSql(MemberSql.getCompletionsForGame, dialect),
+      MemberSql.getCompletionsForGame,
       { userId, gameId },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1618,7 +1617,7 @@ export default class Member {
     const startDate = new Date(ref.getTime() - windowMs);
     const endDate = new Date(ref.getTime() + windowMs);
 
-    const rows = await oraQuery<{
+    const rows = await dbQuery<{
       COMPLETION_ID: number;
       GAME_ID: number;
       TITLE: string;
@@ -1630,7 +1629,7 @@ export default class Member {
       THREAD_ID: string | null;
       NOTE: string | null;
     }, ICompletionRecord>(
-      getSql(MemberSql.getRecentCompletionForGame, dialect),
+      MemberSql.getRecentCompletionForGame,
       { userId, gameId, startDate, endDate },
       (row) => ({
         completionId: Number(row.COMPLETION_ID),
@@ -1661,8 +1660,8 @@ export default class Member {
   }
 
   static async getGiveawayDonorNotifySetting(userId: string): Promise<boolean> {
-    const rows = await oraQuery<{ DONOR_NOTIFY_ON_CLAIM: number | null }, boolean>(
-      getSql(MemberSql.getGiveawayDonorNotifySetting, dialect),
+    const rows = await dbQuery<{ DONOR_NOTIFY_ON_CLAIM: number | null }, boolean>(
+      MemberSql.getGiveawayDonorNotifySetting,
       { userId },
       (row) => Boolean(row.DONOR_NOTIFY_ON_CLAIM),
     );
@@ -1708,8 +1707,8 @@ export default class Member {
   }
 
   static async countAvatarHistory(userId: string): Promise<number> {
-    const rows = await oraQuery<{ TOTAL: number | null }, number>(
-      getSql(MemberSql.countAvatarHistory, dialect),
+    const rows = await dbQuery<{ TOTAL: number | null }, number>(
+      MemberSql.countAvatarHistory,
       { userId },
       (row) => Number(row.TOTAL ?? 0),
     );
@@ -1722,20 +1721,20 @@ export default class Member {
     avatarUrl: string,
     avatarBlob: Buffer | null,
   ): Promise<void> {
-    await oraMutate(
-      getSql(MemberSql.insertAvatarHistoryRecord, dialect),
+    await dbMutate(
+      MemberSql.insertAvatarHistoryRecord,
       { userId, avatarHash, avatarUrl, avatarBlob },
     );
   }
 
   static async getAllMembersAvatarHistoryCounts(): Promise<IMemberAvatarHistoryCount[]> {
-    return oraQuery<{
+    return dbQuery<{
       USER_ID: string;
       USERNAME: string | null;
       GLOBAL_NAME: string | null;
       TOTAL: number;
     }, IMemberAvatarHistoryCount>(
-      getSql(MemberSql.getAllMembersAvatarHistoryCounts, dialect),
+      MemberSql.getAllMembersAvatarHistoryCounts,
       {},
       (row) => ({
         userId: String(row.USER_ID),
@@ -1747,7 +1746,7 @@ export default class Member {
   }
 
   static async getMembersWithPlatforms(): Promise<IMemberPlatformRecord[]> {
-    const members = await oraQuery<{
+    const members = await dbQuery<{
       USER_ID: string;
       USERNAME: string | null;
       GLOBAL_NAME: string | null;
@@ -1757,7 +1756,7 @@ export default class Member {
       NSW_FRIEND_CODE: string | null;
       SERVER_LEFT_AT: Date | null;
     }, IMemberPlatformRecord>(
-      getSql(MemberSql.getMembersWithPlatforms, dialect),
+      MemberSql.getMembersWithPlatforms,
       {},
       (row) => ({
         userId: row.USER_ID,
@@ -1854,12 +1853,12 @@ export default class Member {
   }
 
   static async getGameJournalList(userId: string): Promise<IGameJournalListEntry[]> {
-    return oraQuery<{
+    return dbQuery<{
       GAME_ID: number;
       TITLE: string;
       TOTAL_ENTRIES: number;
     }, IGameJournalListEntry>(
-      getSql(MemberSql.getGameJournalList, dialect),
+      MemberSql.getGameJournalList,
       { userId },
       (row) => ({
         gameId: Number(row.GAME_ID),
@@ -1870,14 +1869,14 @@ export default class Member {
   }
 
   static async getAllJournalUsers(): Promise<IJournalUserSummary[]> {
-    return oraQuery<{
+    return dbQuery<{
       USER_ID: string;
       USERNAME: string | null;
       GLOBAL_NAME: string | null;
       GAME_COUNT: number;
       ENTRY_COUNT: number;
     }, IJournalUserSummary>(
-      getSql(MemberSql.getAllJournalUsers, dialect),
+      MemberSql.getAllJournalUsers,
       {},
       (row) => ({
         userId: row.USER_ID,
@@ -1899,7 +1898,7 @@ export default class Member {
     const safeLimit = Math.min(Math.max(params.limit, 1), 25);
     const safeOffset = Math.max(params.offset, 0);
     const searchTerm = params.query.trim();
-    const rows = await oraQuery<{
+    const rows = await dbQuery<{
       TOTAL_COUNT: number;
       ENTRY_ID: number;
       USER_ID: string;
@@ -1911,7 +1910,7 @@ export default class Member {
       ENTRY_BODY: string;
       CREATED_AT: Date | string;
     }, IJournalSearchResult & { totalCount: number }>(
-      getSql(MemberSql.searchJournalEntries, dialect),
+      MemberSql.searchJournalEntries,
       {
         searchTerm,
         userId: params.userId ?? null,
@@ -1952,16 +1951,16 @@ export default class Member {
   }
 
   static async updateEmojiName(userId: string, emojiName: string | null): Promise<void> {
-    await oraMutate(
-      getSql(MemberSql.updateEmojiName, dialect),
+    await dbMutate(
+      MemberSql.updateEmojiName,
       { userId, emojiName },
     );
   }
 
   static async getAllWithEmojiName(): Promise<Array<{ userId: string; emojiName: string }>> {
-    return oraQuery<{ USER_ID: string; EMOJI_NAME: string },
+    return dbQuery<{ USER_ID: string; EMOJI_NAME: string },
       { userId: string; emojiName: string }>(
-      getSql(MemberSql.getAllWithEmojiName, dialect),
+      MemberSql.getAllWithEmojiName,
       {},
       (row) => ({
         userId: row.USER_ID,
@@ -1977,15 +1976,15 @@ export default class Member {
     ownerUserId: string,
     gameId: number,
   ): Promise<void> {
-    await oraMutate(
-      getSql(MemberSql.upsertJournalMessageContext, dialect),
+    await dbMutate(
+      MemberSql.upsertJournalMessageContext,
       { channelId, messageId, createdAtMs, ownerUserId, gameId },
     );
   }
 
   static async deleteJournalMessageContext(channelId: string, messageId: string): Promise<void> {
-    await oraMutate(
-      getSql(MemberSql.deleteJournalMessageContext, dialect),
+    await dbMutate(
+      MemberSql.deleteJournalMessageContext,
       { channelId, messageId },
     );
   }
@@ -2000,7 +1999,7 @@ export default class Member {
     gameId: number;
   }>> {
     const cutoffMs = Date.now() - ttlMs;
-    return oraQuery<{
+    return dbQuery<{
       CHANNEL_ID: string;
       MESSAGE_ID: string;
       CREATED_AT_MS: number;
@@ -2008,7 +2007,7 @@ export default class Member {
       GAME_ID: number;
     }, { channelId: string; messageId: string; createdAt: number;
         ownerUserId: string; gameId: number }>(
-      getSql(MemberSql.loadActiveJournalMessageContexts, dialect),
+      MemberSql.loadActiveJournalMessageContexts,
       { cutoffMs },
       (row) => ({
         channelId: row.CHANNEL_ID,
@@ -2022,8 +2021,8 @@ export default class Member {
 
   static async pruneExpiredJournalMessageContexts(ttlMs: number): Promise<void> {
     const cutoffMs = Date.now() - ttlMs;
-    await oraMutate(
-      getSql(MemberSql.pruneExpiredJournalMessageContexts, dialect),
+    await dbMutate(
+      MemberSql.pruneExpiredJournalMessageContexts,
       { cutoffMs },
     );
   }

--- a/src/classes/Nomination.ts
+++ b/src/classes/Nomination.ts
@@ -1,8 +1,5 @@
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
+import { dbQuery, dbMutate } from "../db/SqlManager.js";
 import { NominationSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type NominationKind = "gotm" | "nr-gotm";
 
@@ -60,8 +57,8 @@ export async function getNominationForUser(
   roundNumber: number,
   userId: string,
 ): Promise<INominationEntry | null> {
-  const rows = await oraQuery(
-    NominationSql.getNominationForUser(tableName(kind))[dialect],
+  const rows = await dbQuery(
+    NominationSql.getNominationForUser(tableName(kind)),
     { roundNumber, userId },
     mapRow,
   );
@@ -79,8 +76,8 @@ export async function upsertNomination(
     throw new Error("A valid GameDB game id is required to save a nomination.");
   }
 
-  await oraMutate(
-    NominationSql.upsertNomination(tableName(kind))[dialect],
+  await dbMutate(
+    NominationSql.upsertNomination(tableName(kind)),
     { roundNumber, userId, gamedbGameId, nominatedAt: new Date(), reason },
   );
 
@@ -96,19 +93,19 @@ export async function deleteNominationForUser(
   roundNumber: number,
   userId: string,
 ): Promise<boolean> {
-  const result = await oraMutate(
-    NominationSql.deleteNomination(tableName(kind))[dialect],
+  const count = await dbMutate(
+    NominationSql.deleteNomination(tableName(kind)),
     { roundNumber, userId },
   );
-  return (result.rowsAffected ?? 0) > 0;
+  return count > 0;
 }
 
 export async function listNominationsForRound(
   kind: NominationKind,
   roundNumber: number,
 ): Promise<INominationEntry[]> {
-  return oraQuery(
-    NominationSql.listNominationsForRound(tableName(kind))[dialect],
+  return dbQuery(
+    NominationSql.listNominationsForRound(tableName(kind)),
     { roundNumber },
     mapRow,
   );

--- a/src/classes/PresencePromptHistory.ts
+++ b/src/classes/PresencePromptHistory.ts
@@ -1,10 +1,6 @@
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate } from "../db/SqlManager.js";
 import { PresencePromptHistorySql } from "../db/sql/index.js";
 import { normalizePresenceGameTitle } from "./PresencePromptOptOut.js";
-
-const dialect = getDialect();
 
 export type PresencePromptStatus =
   | "PENDING"
@@ -20,15 +16,15 @@ export default class PresencePromptHistory {
     gameTitle: string,
   ): Promise<void> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    await oraMutate(
-      getSql(PresencePromptHistorySql.createPrompt, dialect),
+    await dbMutate(
+      PresencePromptHistorySql.createPrompt,
       { promptId, userId, gameTitle, gameTitleNorm: normalized },
     );
   }
 
   static async markResolved(promptId: string, status: PresencePromptStatus): Promise<void> {
-    await oraMutate(
-      getSql(PresencePromptHistorySql.markResolved, dialect),
+    await dbMutate(
+      PresencePromptHistorySql.markResolved,
       { status, promptId },
     );
   }
@@ -38,8 +34,8 @@ export default class PresencePromptHistory {
     gameTitle: string,
   ): Promise<Date | null> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    const rows = await oraQuery(
-      getSql(PresencePromptHistorySql.getLastPromptDate, dialect),
+    const rows = await dbQuery(
+      PresencePromptHistorySql.getLastPromptDate,
       { userId, gameTitleNorm: normalized },
       (row: { CREATED_AT: Date | string }) =>
         row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT as string),
@@ -49,8 +45,8 @@ export default class PresencePromptHistory {
 
   static async countPendingForGame(userId: string, gameTitle: string): Promise<number> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    const rows = await oraQuery(
-      getSql(PresencePromptHistorySql.countPendingForGame, dialect),
+    const rows = await dbQuery(
+      PresencePromptHistorySql.countPendingForGame,
       { userId, gameTitleNorm: normalized },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );
@@ -58,8 +54,8 @@ export default class PresencePromptHistory {
   }
 
   static async countPendingForUser(userId: string): Promise<number> {
-    const rows = await oraQuery(
-      getSql(PresencePromptHistorySql.countPendingForUser, dialect),
+    const rows = await dbQuery(
+      PresencePromptHistorySql.countPendingForUser,
       { userId },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );

--- a/src/classes/PresencePromptOptOut.ts
+++ b/src/classes/PresencePromptOptOut.ts
@@ -1,9 +1,5 @@
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate } from "../db/SqlManager.js";
 import { PresencePromptOptOutSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 const OPT_OUT_ALL_TOKEN = "__ALL__";
 
@@ -13,8 +9,8 @@ export function normalizePresenceGameTitle(title: string): string {
 
 export default class PresencePromptOptOut {
   static async isOptedOutAll(userId: string): Promise<boolean> {
-    const rows = await oraQuery(
-      getSql(PresencePromptOptOutSql.isOptedOutAll, dialect),
+    const rows = await dbQuery(
+      PresencePromptOptOutSql.isOptedOutAll,
       { userId, token: OPT_OUT_ALL_TOKEN },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );
@@ -25,8 +21,8 @@ export default class PresencePromptOptOut {
     const normalized = normalizePresenceGameTitle(gameTitle);
     if (!normalized) return false;
 
-    const rows = await oraQuery(
-      getSql(PresencePromptOptOutSql.isOptedOutGame, dialect),
+    const rows = await dbQuery(
+      PresencePromptOptOutSql.isOptedOutGame,
       { userId, gameTitleNorm: normalized },
       (row: { CNT: number }) => Number(row.CNT ?? 0),
     );
@@ -50,8 +46,8 @@ export default class PresencePromptOptOut {
     gameTitle: string | null,
   ): Promise<void> {
     try {
-      await oraMutate(
-        getSql(PresencePromptOptOutSql.insertOptOut, dialect),
+      await dbMutate(
+        PresencePromptOptOutSql.insertOptOut,
         { userId, scope, gameTitle, gameTitleNorm: normalizedTitle },
       );
     } catch (err: any) {

--- a/src/classes/PublicReminder.ts
+++ b/src/classes/PublicReminder.ts
@@ -1,7 +1,6 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraMutate, getSql } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { PublicReminderSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -54,8 +53,8 @@ export async function createReminder(
 
 export async function listUpcomingReminders(limit: number = 20): Promise<IPublicReminder[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 100);
-  return oraQuery(
-    getSql(PublicReminderSql.listUpcoming, dialect),
+  return dbQuery(
+    PublicReminderSql.listUpcoming,
     { limit: safeLimit },
     (row: {
       REMINDER_ID: number;
@@ -80,26 +79,26 @@ export async function listUpcomingReminders(limit: number = 20): Promise<IPublic
 }
 
 export async function deleteReminder(reminderId: number): Promise<boolean> {
-  const result = await oraMutate(
-    getSql(PublicReminderSql.delete, dialect),
+  const count = await dbMutate(
+    PublicReminderSql.delete,
     { id: reminderId },
   );
-  return (result.rowsAffected ?? 0) > 0;
+  return count > 0;
 }
 
 export async function updateReminderDueDate(
   reminderId: number,
   nextDue: Date,
 ): Promise<void> {
-  await oraMutate(
-    getSql(PublicReminderSql.updateDueDate, dialect),
+  await dbMutate(
+    PublicReminderSql.updateDueDate,
     { nextDue, id: reminderId },
   );
 }
 
 export async function disableReminder(reminderId: number): Promise<void> {
-  await oraMutate(
-    getSql(PublicReminderSql.disable, dialect),
+  await dbMutate(
+    PublicReminderSql.disable,
     { id: reminderId },
   );
 }

--- a/src/classes/Reminder.ts
+++ b/src/classes/Reminder.ts
@@ -1,8 +1,7 @@
 import oracledb from "oracledb";
 import type { Connection } from "oracledb";
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraQuery, oraMutate, getSql } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { ReminderSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -133,11 +132,7 @@ export default class Reminder {
   }
 
   static async listByUser(userId: string): Promise<IReminderRecord[]> {
-    return oraQuery(
-      getSql(ReminderSql.listByUser, dialect),
-      { userId },
-      mapRowToReminder,
-    );
+    return dbQuery(ReminderSql.listByUser, { userId }, mapRowToReminder);
   }
 
   static async getById(
@@ -156,11 +151,8 @@ export default class Reminder {
 
   static async delete(reminderId: number, userId: string): Promise<boolean> {
     const id = normalizeReminderId(reminderId);
-    const result = await oraMutate(
-      getSql(ReminderSql.delete, dialect),
-      { reminderId: id, userId },
-    );
-    return (result.rowsAffected ?? 0) > 0;
+    const count = await dbMutate(ReminderSql.delete, { reminderId: id, userId });
+    return count > 0;
   }
 
   static async snooze(
@@ -170,43 +162,30 @@ export default class Reminder {
   ): Promise<IReminderRecord | null> {
     const id = normalizeReminderId(reminderId);
     const normalizedDate = normalizeDate(remindAt);
-
-    const result = await oraMutate(
-      getSql(ReminderSql.snooze, dialect),
+    const count = await dbMutate(
+      ReminderSql.snooze,
       { reminderId: id, userId, remindAt: normalizedDate },
     );
-
-    if ((result.rowsAffected ?? 0) === 0) {
-      return null;
-    }
+    if (count === 0) return null;
     return Reminder.getById(reminderId);
   }
 
   static async markSent(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
-    const result = await oraMutate(
-      getSql(ReminderSql.markSent, dialect),
-      { reminderId: id },
-    );
-    if ((result.rowsAffected ?? 0) === 0) {
+    const count = await dbMutate(ReminderSql.markSent, { reminderId: id });
+    if (count === 0) {
       throw new Error(`No reminder found for id ${id} when marking as sent.`);
     }
   }
 
   static async recordFailure(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
-    await oraMutate(
-      getSql(ReminderSql.recordFailure, dialect),
-      { reminderId: id },
-    );
+    await dbMutate(ReminderSql.recordFailure, { reminderId: id });
   }
 
   static async markFailedPermanently(reminderId: number): Promise<void> {
     const id = normalizeReminderId(reminderId);
-    await oraMutate(
-      getSql(ReminderSql.markFailedPermanently, dialect),
-      { reminderId: id },
-    );
+    await dbMutate(ReminderSql.markFailedPermanently, { reminderId: id });
   }
 
   static async getDueUndelivered(
@@ -215,9 +194,8 @@ export default class Reminder {
   ): Promise<IReminderRecord[]> {
     const normalizedDate = normalizeDate(cutoff);
     const safeLimit = Math.max(1, Math.min(limit, 100));
-
-    return oraQuery(
-      getSql(ReminderSql.getDueUndelivered, dialect),
+    return dbQuery(
+      ReminderSql.getDueUndelivered,
       { cutoff: normalizedDate, limit: safeLimit },
       mapRowToReminder,
     );

--- a/src/classes/RssFeed.ts
+++ b/src/classes/RssFeed.ts
@@ -1,7 +1,6 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { dbMutate, oraQuery, oraMutate, oraWithConnection, getSql } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { RssFeedSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -86,11 +85,8 @@ export async function addFeed(
 }
 
 export async function removeFeed(feedId: number): Promise<boolean> {
-  const result = await oraMutate(
-    getSql(RssFeedSql.removeFeed, dialect),
-    { id: feedId },
-  );
-  return (result.rowsAffected ?? 0) > 0;
+  const count = await dbMutate(RssFeedSql.removeFeed, { id: feedId });
+  return count > 0;
 }
 
 export async function updateFeed(
@@ -125,11 +121,8 @@ export async function updateFeed(
 
   if (!sets.length) return false;
 
-  const result = await oraMutate(
-    RssFeedSql.updateFeed(sets)[dialect],
-    params,
-  );
-  return (result.rowsAffected ?? 0) > 0;
+  const count = await dbMutate(RssFeedSql.updateFeed(sets), params);
+  return count > 0;
 }
 
 export async function markItemsSeen(

--- a/src/classes/Starboard.ts
+++ b/src/classes/Starboard.ts
@@ -1,9 +1,5 @@
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate } from "../db/SqlManager.js";
 import { StarboardSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type StarboardRecord = {
   messageId: string;
@@ -16,8 +12,8 @@ export type StarboardRecord = {
 
 export default class Starboard {
   static async getByMessageId(messageId: string): Promise<StarboardRecord | null> {
-    const rows = await oraQuery(
-      getSql(StarboardSql.getByMessageId, dialect),
+    const rows = await dbQuery(
+      StarboardSql.getByMessageId,
       { messageId },
       (row: {
         MESSAGE_ID: string;
@@ -41,8 +37,8 @@ export default class Starboard {
   }
 
   static async insert(record: Omit<StarboardRecord, "createdAt">): Promise<void> {
-    await oraMutate(
-      getSql(StarboardSql.insert, dialect),
+    await dbMutate(
+      StarboardSql.insert,
       {
         messageId: record.messageId,
         channelId: record.channelId,

--- a/src/classes/Suggestion.ts
+++ b/src/classes/Suggestion.ts
@@ -1,7 +1,6 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraQuery, oraMutate, oraWithConnection, getSql } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { SuggestionSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -78,16 +77,12 @@ export async function createSuggestion(
 
 export async function listSuggestions(limit: number = 50): Promise<ISuggestionItem[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 200);
-  return oraQuery(
-    getSql(SuggestionSql.list, dialect),
-    { limit: safeLimit },
-    mapSuggestionRow,
-  );
+  return dbQuery(SuggestionSql.list, { limit: safeLimit }, mapSuggestionRow);
 }
 
 export async function countSuggestions(): Promise<number> {
-  const rows = await oraQuery(
-    getSql(SuggestionSql.count, dialect),
+  const rows = await dbQuery(
+    SuggestionSql.count,
     {},
     (row: { TOTAL: number | null }) => row,
   );
@@ -108,9 +103,6 @@ export async function getSuggestionById(
 }
 
 export async function deleteSuggestion(suggestionId: number): Promise<boolean> {
-  const result = await oraMutate(
-    getSql(SuggestionSql.delete, dialect),
-    { id: suggestionId },
-  );
-  return (result.rowsAffected ?? 0) > 0;
+  const count = await dbMutate(SuggestionSql.delete, { id: suggestionId });
+  return count > 0;
 }

--- a/src/classes/SuggestionReviewSession.ts
+++ b/src/classes/SuggestionReviewSession.ts
@@ -1,7 +1,12 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import {
+  dbMutate,
+  oraQuery,
+  oraMutate,
+  oraWithConnection,
+  getSql,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { SuggestionReviewSessionSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -113,42 +118,28 @@ export async function updateSuggestionReviewSession(
   session: ISuggestionReviewSession,
 ): Promise<void> {
   const suggestionIds = serializeSuggestionIds(session.suggestionIds);
-  await oraMutate(
-    getSql(SuggestionReviewSessionSql.update, dialect),
-    {
-      reviewerId: session.reviewerId,
-      suggestionIds,
-      currentIndex: Math.max(session.index, 0),
-      totalCount: Math.max(session.totalCount, 0),
-      sessionId: session.sessionId,
-    },
-  );
+  await dbMutate(SuggestionReviewSessionSql.update, {
+    reviewerId: session.reviewerId,
+    suggestionIds,
+    currentIndex: Math.max(session.index, 0),
+    totalCount: Math.max(session.totalCount, 0),
+    sessionId: session.sessionId,
+  });
 }
 
 export async function deleteSuggestionReviewSession(sessionId: string): Promise<boolean> {
-  const result = await oraMutate(
-    getSql(SuggestionReviewSessionSql.delete, dialect),
-    { sessionId },
-  );
-  return (result.rowsAffected ?? 0) > 0;
+  const count = await dbMutate(SuggestionReviewSessionSql.delete, { sessionId });
+  return count > 0;
 }
 
 export async function deleteSuggestionReviewSessionsForReviewer(
   reviewerId: string,
 ): Promise<number> {
-  const result = await oraMutate(
-    getSql(SuggestionReviewSessionSql.deleteForReviewer, dialect),
-    { reviewerId },
-  );
-  return Number(result.rowsAffected ?? 0);
+  return dbMutate(SuggestionReviewSessionSql.deleteForReviewer, { reviewerId });
 }
 
 export async function deleteExpiredSuggestionReviewSessions(
   cutoffDate: Date,
 ): Promise<number> {
-  const result = await oraMutate(
-    getSql(SuggestionReviewSessionSql.deleteExpired, dialect),
-    { cutoff: cutoffDate },
-  );
-  return Number(result.rowsAffected ?? 0);
+  return dbMutate(SuggestionReviewSessionSql.deleteExpired, { cutoff: cutoffDate });
 }

--- a/src/classes/Thread.ts
+++ b/src/classes/Thread.ts
@@ -1,6 +1,13 @@
-import { oraQuery, oraMutate, oraTransaction, oraWithConnection } from "../db/SqlManager.js";
+import {
+  dbQuery,
+  dbMutate,
+  oraQuery,
+  oraMutate,
+  oraTransaction,
+  oraWithConnection,
+  getSql,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { ThreadSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -20,18 +27,15 @@ export async function upsertThreadRecord(params: {
   lastSeenAt: NullableDate;
   skipLinking?: "Y" | "N";
 }): Promise<void> {
-  await oraMutate(
-    getSql(ThreadSql.upsertThread, dialect),
-    {
-      threadId: params.threadId,
-      forumChannelId: params.forumChannelId,
-      threadName: params.threadName,
-      isArchived: toYN(params.isArchived),
-      createdAt: params.createdAt,
-      lastSeenAt: params.lastSeenAt,
-      skipLinking: params.skipLinking ?? "N",
-    },
-  );
+  await dbMutate(ThreadSql.upsertThread, {
+    threadId: params.threadId,
+    forumChannelId: params.forumChannelId,
+    threadName: params.threadName,
+    isArchived: toYN(params.isArchived),
+    createdAt: params.createdAt,
+    lastSeenAt: params.lastSeenAt,
+    skipLinking: params.skipLinking ?? "N",
+  });
 }
 
 export async function setThreadGameLink(
@@ -97,15 +101,12 @@ export async function setThreadSkipLinking(
   threadId: string,
   skip: boolean,
 ): Promise<void> {
-  await oraMutate(
-    getSql(ThreadSql.setSkipLinking, dialect),
-    { skip: toYN(skip), threadId },
-  );
+  await dbMutate(ThreadSql.setSkipLinking, { skip: toYN(skip), threadId });
 }
 
 export async function getThreadSkipLinking(threadId: string): Promise<boolean> {
-  const rows = await oraQuery(
-    getSql(ThreadSql.getSkipLinking, dialect),
+  const rows = await dbQuery(
+    ThreadSql.getSkipLinking,
     { threadId },
     (row: { SKIP_LINKING: string }) => String(row.SKIP_LINKING ?? "N").toUpperCase() === "Y",
   );

--- a/src/classes/Todo.ts
+++ b/src/classes/Todo.ts
@@ -1,7 +1,6 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraMutate, getSql } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { TodoSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -53,8 +52,8 @@ function mapTodoRow(row: {
 }
 
 export async function fetchTodoById(todoId: number): Promise<ITodoItem | null> {
-  const rows = await oraQuery(
-    getSql(TodoSql.getById, dialect),
+  const rows = await dbQuery(
+    TodoSql.getById,
     { id: todoId },
     mapTodoRow,
   );
@@ -96,8 +95,8 @@ export async function listTodos(
 ): Promise<ITodoItem[]> {
   const safeLimit = Math.min(Math.max(limit, 1), 200);
   const whereClause = includeCompleted ? "" : "WHERE IS_COMPLETED = 0";
-  return oraQuery(
-    TodoSql.list(whereClause)[dialect],
+  return dbQuery(
+    TodoSql.list(whereClause),
     { limit: safeLimit },
     mapTodoRow,
   );
@@ -114,8 +113,8 @@ export async function updateTodo(
   const detailsProvided = details !== undefined ? 1 : 0;
   const categoryProvided = todoCategory !== undefined ? 1 : 0;
   const sizeProvided = todoSize !== undefined ? 1 : 0;
-  const result = await oraMutate(
-    getSql(TodoSql.update, dialect),
+  const count = await dbMutate(
+    TodoSql.update,
     {
       id: todoId,
       title,
@@ -128,31 +127,25 @@ export async function updateTodo(
       sizeProvided,
     },
   );
-  return (result.rowsAffected ?? 0) > 0;
+  return count > 0;
 }
 
 export async function deleteTodo(todoId: number): Promise<boolean> {
-  const result = await oraMutate(
-    getSql(TodoSql.delete, dialect),
-    { id: todoId },
-  );
-  return (result.rowsAffected ?? 0) > 0;
+  const count = await dbMutate(TodoSql.delete, { id: todoId });
+  return count > 0;
 }
 
 export async function completeTodo(
   todoId: number,
   completedBy: string | null,
 ): Promise<boolean> {
-  const result = await oraMutate(
-    getSql(TodoSql.complete, dialect),
-    { id: todoId, completedBy },
-  );
-  return (result.rowsAffected ?? 0) > 0;
+  const count = await dbMutate(TodoSql.complete, { id: todoId, completedBy });
+  return count > 0;
 }
 
 export async function countTodos(): Promise<{ open: number; completed: number }> {
-  const rows = await oraQuery(
-    getSql(TodoSql.countTodos, dialect),
+  const rows = await dbQuery(
+    TodoSql.countTodos,
     {},
     (row: { OPEN_COUNT: number | null; COMPLETED_COUNT: number | null }) => ({
       open: Number(row.OPEN_COUNT ?? 0),
@@ -173,8 +166,8 @@ export async function countTodoSummary(): Promise<{
     refactoring: number;
   };
 }> {
-  const rows = await oraQuery(
-    getSql(TodoSql.countTodoSummary, dialect),
+  const rows = await dbQuery(
+    TodoSql.countTodoSummary,
     {},
     (row: {
       OPEN_COUNT: number | null;

--- a/src/db/SqlManager.ts
+++ b/src/db/SqlManager.ts
@@ -1,82 +1,82 @@
 import oracledb from "oracledb";
-import { getOraclePool } from "./oracleClient.js";
+import pg from "pg";
+import { getDialect } from "./dialect.js";
+import type { SqlEntry } from "./sql/types.js";
+import {
+  oraQuery,
+  oraMutate,
+  oraWithConnection,
+  oraTransaction,
+} from "./oracleClient.js";
+import {
+  pgQuery,
+  pgMutate,
+  pgTransaction,
+  pgWithConnection,
+} from "./postgresClient.js";
 
-export { pgQuery, pgTransaction } from "./postgresClient.js";
+export { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "./oracleClient.js";
+export { pgQuery, pgMutate, pgTransaction, pgWithConnection } from "./postgresClient.js";
 export type { Dialect, SqlEntry } from "./sql/types.js";
 export { getSql, getSqlDynamic } from "./sql/index.js";
 
 /**
- * Runs a SELECT and maps each row with `mapper`. Defaults to OUT_FORMAT_OBJECT.
- * Pass `existingConn` to reuse a connection (caller manages its lifecycle).
+ * Dialect-agnostic SELECT. Passes the dialect-appropriate SQL from `entry`
+ * to the underlying driver and maps each row with `mapper`.
  */
-export async function oraQuery<RowT extends object, R>(
-  sql: string,
-  params: oracledb.BindParameters,
+export async function dbQuery<RowT extends object, R>(
+  entry: SqlEntry,
+  params: oracledb.BindParameters | unknown[],
   mapper: (row: RowT) => R,
-  existingConn?: oracledb.Connection,
 ): Promise<R[]> {
-  const conn = existingConn ?? (await getOraclePool().getConnection());
-  try {
-    const result = await conn.execute<RowT>(sql, params, {
-      outFormat: oracledb.OUT_FORMAT_OBJECT,
-    });
-    return (result.rows ?? []).map(mapper);
-  } finally {
-    if (!existingConn) await conn.close();
+  const dialect = getDialect();
+  if (dialect === "oracle") {
+    return oraQuery(entry.oracle, params as oracledb.BindParameters, mapper);
   }
+  const rows = await pgQuery<RowT>(entry.postgres, params as unknown[]);
+  return rows.map(mapper);
 }
 
 /**
- * Runs a single DML statement with autoCommit:true.
- * Returns the full Result so callers can inspect rowsAffected / outBinds.
- * Pass `existingConn` to reuse a connection (no autoCommit in that case).
+ * Dialect-agnostic DML. Returns the number of rows affected.
+ * For Oracle INSERT...RETURNING (BIND_OUT) cases, use oraMutate directly.
  */
-export async function oraMutate(
-  sql: string,
-  params: oracledb.BindParameters,
-  existingConn?: oracledb.Connection,
-): Promise<oracledb.Result<unknown>> {
-  const conn = existingConn ?? (await getOraclePool().getConnection());
-  try {
-    return await conn.execute(sql, params, {
-      autoCommit: existingConn ? false : true,
-    });
-  } finally {
-    if (!existingConn) await conn.close();
+export async function dbMutate(
+  entry: SqlEntry,
+  params: oracledb.BindParameters | unknown[],
+): Promise<number> {
+  const dialect = getDialect();
+  if (dialect === "oracle") {
+    const result = await oraMutate(entry.oracle, params as oracledb.BindParameters);
+    return result.rowsAffected ?? 0;
   }
+  return pgMutate(entry.postgres, params as unknown[]);
 }
 
 /**
- * Acquires a connection, runs `callback`, then closes it.
- * Each statement inside should use autoCommit:true (or pass conn to oraMutate).
- * For atomic multi-statement operations, use oraTransaction instead.
+ * Dialect-agnostic connection scope. Acquires a connection, runs callback,
+ * then releases it. Each statement inside should commit individually.
+ * For atomic multi-statement operations, use dbTransaction instead.
  */
-export async function oraWithConnection<T>(
-  callback: (conn: oracledb.Connection) => Promise<T>,
+export async function dbWithConnection<T>(
+  callback: (conn: oracledb.Connection | pg.PoolClient) => Promise<T>,
 ): Promise<T> {
-  const conn = await getOraclePool().getConnection();
-  try {
-    return await callback(conn);
-  } finally {
-    await conn.close();
+  const dialect = getDialect();
+  if (dialect === "oracle") {
+    return oraWithConnection(callback as (conn: oracledb.Connection) => Promise<T>);
   }
+  return pgWithConnection(callback as (client: pg.PoolClient) => Promise<T>);
 }
 
 /**
- * Runs `callback` inside a transaction. Commits on success, rolls back on throw.
+ * Dialect-agnostic transaction. Commits on success, rolls back on throw.
  */
-export async function oraTransaction<T>(
-  callback: (conn: oracledb.Connection) => Promise<T>,
+export async function dbTransaction<T>(
+  callback: (conn: oracledb.Connection | pg.PoolClient) => Promise<T>,
 ): Promise<T> {
-  const conn = await getOraclePool().getConnection();
-  try {
-    const result = await callback(conn);
-    await conn.commit();
-    return result;
-  } catch (err) {
-    await conn.rollback();
-    throw err;
-  } finally {
-    await conn.close();
+  const dialect = getDialect();
+  if (dialect === "oracle") {
+    return oraTransaction(callback as (conn: oracledb.Connection) => Promise<T>);
   }
+  return pgTransaction(callback as (client: pg.PoolClient) => Promise<T>);
 }

--- a/src/db/oracleClient.ts
+++ b/src/db/oracleClient.ts
@@ -29,3 +29,79 @@ export function getOraclePool(): oracledb.Pool {
   if (!pool) throw new Error("Oracle pool not initialized");
   return pool;
 }
+
+/**
+ * Runs a SELECT and maps each row with `mapper`. Defaults to OUT_FORMAT_OBJECT.
+ * Pass `existingConn` to reuse a connection (caller manages its lifecycle).
+ */
+export async function oraQuery<RowT extends object, R>(
+  sql: string,
+  params: oracledb.BindParameters,
+  mapper: (row: RowT) => R,
+  existingConn?: oracledb.Connection,
+): Promise<R[]> {
+  const conn = existingConn ?? (await getOraclePool().getConnection());
+  try {
+    const result = await conn.execute<RowT>(sql, params, {
+      outFormat: oracledb.OUT_FORMAT_OBJECT,
+    });
+    return (result.rows ?? []).map(mapper);
+  } finally {
+    if (!existingConn) await conn.close();
+  }
+}
+
+/**
+ * Runs a single DML statement with autoCommit:true.
+ * Returns the full Result so callers can inspect rowsAffected / outBinds.
+ * Pass `existingConn` to reuse a connection (no autoCommit in that case).
+ */
+export async function oraMutate(
+  sql: string,
+  params: oracledb.BindParameters,
+  existingConn?: oracledb.Connection,
+): Promise<oracledb.Result<unknown>> {
+  const conn = existingConn ?? (await getOraclePool().getConnection());
+  try {
+    return await conn.execute(sql, params, {
+      autoCommit: existingConn ? false : true,
+    });
+  } finally {
+    if (!existingConn) await conn.close();
+  }
+}
+
+/**
+ * Acquires a connection, runs `callback`, then closes it.
+ * Each statement inside should use autoCommit:true (or pass conn to oraMutate).
+ * For atomic multi-statement operations, use oraTransaction instead.
+ */
+export async function oraWithConnection<T>(
+  callback: (conn: oracledb.Connection) => Promise<T>,
+): Promise<T> {
+  const conn = await getOraclePool().getConnection();
+  try {
+    return await callback(conn);
+  } finally {
+    await conn.close();
+  }
+}
+
+/**
+ * Runs `callback` inside a transaction. Commits on success, rolls back on throw.
+ */
+export async function oraTransaction<T>(
+  callback: (conn: oracledb.Connection) => Promise<T>,
+): Promise<T> {
+  const conn = await getOraclePool().getConnection();
+  try {
+    const result = await callback(conn);
+    await conn.commit();
+    return result;
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    await conn.close();
+  }
+}

--- a/src/db/postgresClient.ts
+++ b/src/db/postgresClient.ts
@@ -95,3 +95,24 @@ export async function pgTransaction<T>(
     client.release();
   }
 }
+
+/** Runs a DML statement and returns the number of rows affected. */
+export async function pgMutate(
+  text: string,
+  values?: unknown[],
+): Promise<number> {
+  const result = await getPostgresPool().query(text, values);
+  return result.rowCount ?? 0;
+}
+
+/** Acquires a client from the pool, runs callback, then releases it. */
+export async function pgWithConnection<T>(
+  callback: (client: pg.PoolClient) => Promise<T>,
+): Promise<T> {
+  const client = await getPostgresPool().connect();
+  try {
+    return await callback(client);
+  } finally {
+    client.release();
+  }
+}


### PR DESCRIPTION
## Summary

- Moves `oraQuery`, `oraMutate`, `oraWithConnection`, `oraTransaction` from `SqlManager.ts` into `oracleClient.ts`, making it a symmetrical peer of `postgresClient.ts`
- Adds `pgMutate` and `pgWithConnection` to `postgresClient.ts`
- Adds four new dialect-agnostic wrappers to `SqlManager.ts` (`dbQuery`, `dbMutate`, `dbWithConnection`, `dbTransaction`) that dispatch to the right driver based on `DB_DIALECT` and accept a `SqlEntry` directly -- no more `getSql(Sql.key, dialect)` at call sites
- Migrates standalone `oraQuery`/`oraMutate` calls (no BIND_OUT, no connection-passing) across ~20 class files to the new `db*` wrappers; removes `getDialect()` and `getSql` imports from fully-migrated files
- Updates `SQL_MIGRATION_PLAN.md` with a detailed status table and description of remaining D1/D2/D3 work

## What is NOT migrated yet (noted in plan)

- **BIND_OUT** (`INSERT...RETURNING INTO :outVar`) -- blocked on postgres SQL being written
- **Connection-passing** (`oraWithConnection`/`oraTransaction` callbacks that pass `conn` to inner calls) -- needs postgres SQL + callback rewrite per function
- **`executeMany`** (`RssFeed.markItemsSeen`) -- needs a postgres batch-insert strategy
- Large files not yet started: `Game.ts`, `NrGotm.ts`, `SteamCollectionImport.ts`, `XboxCollectionImport.ts`, `UserGameCollection.ts`, `UserActivityIcon.ts`, `UserChannelMessageCount.ts`

## Test plan

- [x] `tsc --noEmit` passes with no errors
- [ ] Smoke-test oracle path: `DB_DIALECT=oracle` and exercise a command that hits a migrated file (e.g., reminders, starboard, todos)
- [ ] Confirm `DB_DIALECT=postgres` path reaches the pg helpers without panicking at startup (pool init aside)

🤖 Generated with [Claude Code](https://claude.com/claude-code)