### PR TITLE
feat: Phase D1 -- migrate remaining standalone oraQuery/oraMutate to db* wrappers

### DIFF
--- a/SQL_MIGRATION_PLAN.md
+++ b/SQL_MIGRATION_PLAN.md
@@ -316,7 +316,13 @@ Migrated in this phase (Phases A/B/C):
   - `dbWithConnection(callback)` -- single-connection scope
   - `dbTransaction(callback)` -- atomic transaction
 
-**Call sites migrated (simple `oraQuery`/`oraMutate` with no BIND_OUT or conn-passing):**
+**D1 complete as of 2026-06-08 (PR #545, branch `feature/phase-d-d1-remaining-call-sites`):**
+
+All standalone `oraQuery`/`oraMutate` calls (no BIND_OUT, no connection-passing) have been
+converted to `dbQuery`/`dbMutate` across all domain classes. Every remaining `ora*` call in the
+codebase is now a D2 blocker.
+
+**Call sites -- current status:**
 
 | File | Status |
 |---|---|
@@ -326,6 +332,7 @@ Migrated in this phase (Phases A/B/C):
 | `CompletionatorImport.ts` | Partial -- same pattern as CollectionCsvImport |
 | `GameDbCsvImport.ts` | Partial -- same pattern |
 | `GameDbCsvImportMapping.ts` | Fully migrated |
+| `Game.ts` | Partial -- all standalone get/update/mutate done; BIND_OUT inserts, conn-passing blocks, and oracle-specific `conn.execute` paths remain |
 | `GameKey.ts` | Partial -- `get*`, `list*`, `claim`, `revoke` done; `create` (BIND_OUT) remains |
 | `GameReleaseAnnouncement.ts` | Partial -- `mark*` and `list*` done; `syncReleaseAnnouncements` (conn-passing) remains |
 | `GameSearchSynonymDraft.ts` | Partial -- `getDraft`, `deleteDraft` done; `createDraft` (BIND_OUT), `appendPairs` (conn-passing) remain |
@@ -335,36 +342,31 @@ Migrated in this phase (Phases A/B/C):
 | `HltbCache.ts` | Fully migrated |
 | `Member.ts` | Partial -- large file; many `get*` done; connection-passing and BIND_OUT methods remain |
 | `Nomination.ts` | Fully migrated |
+| `NrGotm.ts` | Partial -- `loadAll`, `updateVotingResults`, `checkRoundExists`, `deleteRound` done; conn-passing update block and BIND_OUT insert remain |
 | `PresencePromptHistory.ts` | Fully migrated |
 | `PresencePromptOptOut.ts` | Fully migrated |
 | `PublicReminder.ts` | Partial -- `list*`, `delete`, `update*` done; `create` (BIND_OUT) remains |
 | `Reminder.ts` | Partial -- all done except `create` (BIND_OUT) and `getById` (optional conn) |
 | `RssFeed.ts` | Partial -- `removeFeed`, `updateFeed` done; `addFeed` (BIND_OUT), `markItemsSeen` (executeMany), `getSeenItemHashes` (conn-passing) remain |
 | `Starboard.ts` | Fully migrated |
+| `SteamCollectionImport.ts` | Partial -- `getActiveForUser`, `setStatus`, `updateIndex`, `updateItem`, `countItems*`, `getHistoricalMappedIds` done; `createImport` (BIND_OUT), `insertItems` (oraTransaction conn-passing), `getItemById`/`getNextPending` (fetchInfo conn), `getAppMap`/`upsertAppMap` (optional conn) remain |
 | `SuggestionReviewSession.ts` | Partial -- `update`, `delete*` done; `create` (conn-passing) and `getById` (optional conn) remain |
 | `Suggestion.ts` | Partial -- `list`, `count`, `delete` done; `create` (BIND_OUT) and `getById` (optional conn) remain |
 | `Thread.ts` | Partial -- `upsertThread`, `setSkipLinking`, `getThreadSkipLinking` done; transactions and conn-passing remain |
 | `Todo.ts` | Partial -- all done except `create` (BIND_OUT) |
-
-**Not yet started (oracle-specific throughout):**
-
-- `Game.ts` (69 remaining ora* calls)
-- `NrGotm.ts` (11)
-- `SteamCollectionImport.ts` (17)
-- `UserActivityIcon.ts` (3)
-- `UserChannelMessageCount.ts` (4)
-- `UserGameCollection.ts` (15)
-- `XboxCollectionImport.ts` (18)
+| `UserActivityIcon.ts` | No D1 conversions possible -- all calls use dynamic Oracle-style named binds or oraTransaction conn-passing |
+| `UserChannelMessageCount.ts` | Partial -- `getScannedChannelIds`, `getChannelScanMeta` done; `upsertChannelCounts` (executeMany) remains |
+| `UserGameCollection.ts` | Partial -- all standalone selects and `removeEntry` done; `addEntry` (BIND_OUT), `updateEntry` (conn-passing), `getEntryById` (required conn) remain |
+| `XboxCollectionImport.ts` | Partial -- `getActiveForUser`, `setStatus`, `updateIndex`, `getItemById`, `getNextPending`, `updateItem`, `countItems*`, `getHistoricalMappedIds` done; `createImport` (BIND_OUT), `insertItems` (oraTransaction), `getImportById`/`getTitleMap` (optional conn), `upsertTitleMap` (conn-passing) remain |
 
 ---
 
 #### Remaining work in Phase D
 
-**D1 -- Migrate standalone oraQuery/oraMutate in untouched files**
+**D1 -- COMPLETE**
 
-Files above with `ora=N db=0`. For each: replace `oraQuery(getSql(Sql.key, dialect), params, mapper)`
-with `dbQuery(Sql.key, params, mapper)` and `oraMutate(...)` -> `dbMutate(...)` for all calls that
-do not use BIND_OUT or pass a connection argument.
+All standalone `oraQuery`/`oraMutate` call sites (no BIND_OUT, no connection argument) have been
+converted to `dbQuery`/`dbMutate`. No D1 work remains.
 
 **D2 -- Oracle-only blockers (defer until postgres SQL is written)**
 

--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -1,13 +1,14 @@
 import oracledb from "oracledb";
 import axios from "axios";
 import {
+  dbQuery, dbMutate,
   oraQuery,
   oraMutate,
   oraWithConnection,
   oraTransaction,
+  getSql,
 } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { GameSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -968,15 +969,15 @@ export default class Game {
   }
 
   static async updateInitialReleaseDate(gameId: number): Promise<void> {
-    const rows = await oraQuery(
-      getSql(GameSql.updateInitialReleaseDateSelect, dialect),
+    const rows = await dbQuery(
+      GameSql.updateInitialReleaseDateSelect,
       { gameId },
       (row: { MIN_DATE: Date | null }) => row.MIN_DATE,
     );
     const minDate = rows[0] ?? null;
     if (!minDate) return;
-    await oraMutate(
-      getSql(GameSql.updateInitialReleaseDateUpdate, dialect),
+    await dbMutate(
+      GameSql.updateInitialReleaseDateUpdate,
       { releaseDate: minDate, gameId },
     );
   }
@@ -991,8 +992,8 @@ export default class Game {
     }
 
     try {
-      await oraMutate(
-        getSql(GameSql.insertPlatform, dialect),
+      await dbMutate(
+        GameSql.insertPlatform,
         {
           code: buildPlatformCode(igdbPlatform.name, igdbPlatform.id),
           name: igdbPlatform.name ?? `IGDB Platform ${igdbPlatform.id}`,
@@ -1055,8 +1056,8 @@ export default class Game {
     gameId: number,
     role: string,
   ): Promise<string[]> {
-    return oraQuery(
-      getSql(GameSql.getGameCompanies, dialect),
+    return dbQuery(
+      GameSql.getGameCompanies,
       { gameId, role },
       (row: { NAME: string }) => row.NAME,
     );
@@ -1117,8 +1118,8 @@ export default class Game {
   }
 
   static async getGameSeries(gameId: number): Promise<string | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getGameSeries, dialect),
+    const rows = await dbQuery(
+      GameSql.getGameSeries,
       { gameId },
       (row: { NAME: string }) => row.NAME,
     );
@@ -1131,8 +1132,8 @@ export default class Game {
     mapTable: string,
     idCol: string,
   ): Promise<string[]> {
-    return oraQuery(
-      GameSql.getSimpleList(defTable, mapTable, idCol)[dialect],
+    return dbQuery(
+      GameSql.getSimpleList(defTable, mapTable, idCol),
       { gameId },
       (row: { NAME: string }) => row.NAME,
     );
@@ -1167,8 +1168,8 @@ export default class Game {
   }
 
   static async getReleaseById(id: number): Promise<IRelease | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getReleaseById, dialect),
+    const rows = await dbQuery(
+      GameSql.getReleaseById,
       { id },
       mapReleaseRow,
     );
@@ -1176,24 +1177,24 @@ export default class Game {
   }
 
   static async getGameReleases(gameId: number): Promise<IRelease[]> {
-    return oraQuery(
-      getSql(GameSql.getGameReleases, dialect),
+    return dbQuery(
+      GameSql.getGameReleases,
       { gameId },
       mapReleaseRow,
     );
   }
 
   static async getPlatformsForGame(gameId: number): Promise<IPlatformDef[]> {
-    return oraQuery(
-      getSql(GameSql.getPlatformsForGame, dialect),
+    return dbQuery(
+      GameSql.getPlatformsForGame,
       { gameId },
       mapPlatformDefRow,
     );
   }
 
   static async getAllPlatforms(): Promise<IPlatformDef[]> {
-    return oraQuery(
-      getSql(GameSql.getAllPlatforms, dialect),
+    return dbQuery(
+      GameSql.getAllPlatforms,
       {},
       mapPlatformDefRow,
     );
@@ -1217,8 +1218,8 @@ export default class Game {
       placeholders.push(`:${key}`);
     });
 
-    const platforms = await oraQuery(
-      GameSql.getPlatformsByIgdbIds(placeholders.join(", "))[dialect],
+    const platforms = await dbQuery(
+      GameSql.getPlatformsByIgdbIds(placeholders.join(", ")),
       binds,
       mapPlatformDefRow,
     );
@@ -1261,8 +1262,8 @@ export default class Game {
   }
 
   static async getPlatformByCode(code: string): Promise<IPlatformDef | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getPlatformByCode, dialect),
+    const rows = await dbQuery(
+      GameSql.getPlatformByCode,
       { code },
       mapPlatformDefRow,
     );
@@ -1270,8 +1271,8 @@ export default class Game {
   }
 
   static async getPlatformById(id: number): Promise<IPlatformDef | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getPlatformById, dialect),
+    const rows = await dbQuery(
+      GameSql.getPlatformById,
       { id },
       mapPlatformDefRow,
     );
@@ -1303,8 +1304,8 @@ export default class Game {
     const gameToPlatforms = new Map<number, IPlatformDef[]>();
     const missingPlatformIds = new Set<number>();
 
-    const rows = await oraQuery(
-      GameSql.attachPlatformsToGames(placeholders.join(", "))[dialect],
+    const rows = await dbQuery(
+      GameSql.attachPlatformsToGames(placeholders.join(", ")),
       binds,
       (row: {
         GAME_ID: number;
@@ -1354,8 +1355,8 @@ export default class Game {
   static async getPlatformByIgdbId(
     igdbId: number,
   ): Promise<IPlatformDef | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getPlatformByIgdbId, dialect),
+    const rows = await dbQuery(
+      GameSql.getPlatformByIgdbId,
       { igdbId },
       mapPlatformDefRow,
     );
@@ -1363,16 +1364,16 @@ export default class Game {
   }
 
   static async getAllRegions(): Promise<IRegionDef[]> {
-    return oraQuery(
-      getSql(GameSql.getAllRegions, dialect),
+    return dbQuery(
+      GameSql.getAllRegions,
       {},
       mapRegionDefRow,
     );
   }
 
   static async getRegionByCode(code: string): Promise<IRegionDef | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getRegionByCode, dialect),
+    const rows = await dbQuery(
+      GameSql.getRegionByCode,
       { code },
       mapRegionDefRow,
     );
@@ -1380,8 +1381,8 @@ export default class Game {
   }
 
   static async getRegionById(id: number): Promise<IRegionDef | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getRegionById, dialect),
+    const rows = await dbQuery(
+      GameSql.getRegionById,
       { id },
       mapRegionDefRow,
     );
@@ -1389,8 +1390,8 @@ export default class Game {
   }
 
   static async getRegionByIgdbId(igdbId: number): Promise<IRegionDef | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getRegionByIgdbId, dialect),
+    const rows = await dbQuery(
+      GameSql.getRegionByIgdbId,
       { igdbId },
       mapRegionDefRow,
     );
@@ -1481,8 +1482,8 @@ export default class Game {
   }
 
   static async getAllCompanies(): Promise<ICompany[]> {
-    return oraQuery(
-      getSql(GameSql.getAllCompanies, dialect),
+    return dbQuery(
+      GameSql.getAllCompanies,
       {},
       (row: {
         COMPANY_ID: number;
@@ -1497,8 +1498,8 @@ export default class Game {
   }
 
   static async getCompanyById(id: number): Promise<ICompany | null> {
-    const rows = await oraQuery(
-      getSql(GameSql.getCompanyById, dialect),
+    const rows = await dbQuery(
+      GameSql.getCompanyById,
       { id },
       (row: {
         COMPANY_ID: number;
@@ -1863,8 +1864,8 @@ export default class Game {
     gameId: number,
     imageData: Buffer,
   ): Promise<void> {
-    await oraMutate(
-      getSql(GameSql.updateGameImage, dialect),
+    await dbMutate(
+      GameSql.updateGameImage,
       { imageData, gameId },
     );
   }
@@ -1873,8 +1874,8 @@ export default class Game {
     gameId: number,
     isBad: boolean,
   ): Promise<void> {
-    await oraMutate(
-      getSql(GameSql.updateGameThumbnailBad, dialect),
+    await dbMutate(
+      GameSql.updateGameThumbnailBad,
       { thumbnailBad: isBad ? 1 : 0, gameId },
     );
   }
@@ -1883,8 +1884,8 @@ export default class Game {
     gameId: number,
     isApproved: boolean,
   ): Promise<void> {
-    await oraMutate(
-      getSql(GameSql.updateGameThumbnailApproved, dialect),
+    await dbMutate(
+      GameSql.updateGameThumbnailApproved,
       { thumbnailApproved: isApproved ? 1 : 0, gameId },
     );
   }
@@ -1903,8 +1904,8 @@ export default class Game {
       binds[`id${idx}`] = id;
     });
 
-    const rows = await oraQuery(
-      GameSql.getThreadStatusForGameIds(placeholders)[dialect],
+    const rows = await dbQuery(
+      GameSql.getThreadStatusForGameIds(placeholders),
       binds,
       (row: { GAME_ID: number }) => Number(row.GAME_ID),
     );
@@ -1915,8 +1916,8 @@ export default class Game {
     gameId: number,
     featuredVideoUrl: string | null,
   ): Promise<void> {
-    await oraMutate(
-      getSql(GameSql.updateFeaturedVideoUrl, dialect),
+    await dbMutate(
+      GameSql.updateFeaturedVideoUrl,
       { featuredVideoUrl, gameId },
     );
   }
@@ -1925,8 +1926,8 @@ export default class Game {
     gameId: number,
     description: string | null,
   ): Promise<void> {
-    await oraMutate(
-      getSql(GameSql.updateGameDescription, dialect),
+    await dbMutate(
+      GameSql.updateGameDescription,
       { description, gameId },
     );
   }
@@ -1967,8 +1968,8 @@ export default class Game {
   }
 
   static async touchGameUpdatedAt(gameId: number): Promise<void> {
-    await oraMutate(
-      getSql(GameSql.touchGameUpdatedAt, dialect),
+    await dbMutate(
+      GameSql.touchGameUpdatedAt,
       { gameId },
     );
   }
@@ -1991,7 +1992,7 @@ export default class Game {
 
     const [gotmWins, nrGotmWins, gotmNominations, nrGotmNominations] =
       await Promise.all([
-        oraQuery<
+        dbQuery<
           WinRow,
           {
             round: number;
@@ -2000,7 +2001,7 @@ export default class Game {
             monthYear: string;
           }
         >(
-          getSql(GameSql.getGotmWins, dialect),
+          GameSql.getGotmWins,
           { gameId },
           (row) => ({
             round: Number(row.ROUND_NUMBER),
@@ -2009,7 +2010,7 @@ export default class Game {
             monthYear: String(row.MONTH_YEAR),
           }),
         ),
-        oraQuery<
+        dbQuery<
           WinRow,
           {
             round: number;
@@ -2018,7 +2019,7 @@ export default class Game {
             monthYear: string;
           }
         >(
-          getSql(GameSql.getNrGotmWins, dialect),
+          GameSql.getNrGotmWins,
           { gameId },
           (row) => ({
             round: Number(row.ROUND_NUMBER),
@@ -2027,8 +2028,8 @@ export default class Game {
             monthYear: String(row.MONTH_YEAR),
           }),
         ),
-        oraQuery<NomRow, { round: number; userId: string; username: string }>(
-          getSql(GameSql.getGotmNominations, dialect),
+        dbQuery<NomRow, { round: number; userId: string; username: string }>(
+          GameSql.getGotmNominations,
           { gameId },
           (row) => ({
             round: Number(row.ROUND_NUMBER),
@@ -2036,8 +2037,8 @@ export default class Game {
             username: String(row.GLOBAL_NAME || row.USERNAME || row.USER_ID),
           }),
         ),
-        oraQuery<NomRow, { round: number; userId: string; username: string }>(
-          getSql(GameSql.getNrGotmNominations, dialect),
+        dbQuery<NomRow, { round: number; userId: string; username: string }>(
+          GameSql.getNrGotmNominations,
           { gameId },
           (row) => ({
             round: Number(row.ROUND_NUMBER),
@@ -2053,8 +2054,8 @@ export default class Game {
   static async getNowPlayingMembers(
     gameId: number,
   ): Promise<INowPlayingMember[]> {
-    return oraQuery(
-      getSql(GameSql.getNowPlayingMembers, dialect),
+    return dbQuery(
+      GameSql.getNowPlayingMembers,
       { gameId },
       (row: {
         USER_ID: string;
@@ -2078,8 +2079,8 @@ export default class Game {
   }
 
   static async getGameCompletions(gameId: number): Promise<ICompletedMember[]> {
-    return oraQuery(
-      getSql(GameSql.getGameCompletions, dialect),
+    return dbQuery(
+      GameSql.getGameCompletions,
       { gameId },
       (row: {
         USER_ID: string;
@@ -2110,8 +2111,8 @@ export default class Game {
   static async getGameCollectionOwners(
     gameId: number,
   ): Promise<ICollectionOwnerMember[]> {
-    return oraQuery(
-      getSql(GameSql.getGameCollectionOwners, dialect),
+    return dbQuery(
+      GameSql.getGameCollectionOwners,
       { gameId },
       (row: {
         USER_ID: string;

--- a/src/classes/NrGotm.ts
+++ b/src/classes/NrGotm.ts
@@ -1,7 +1,6 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, oraQuery, oraMutate, oraWithConnection, getSql } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { NrGotmSql } from "../db/sql/index.js";
 import Game from "./Game.js";
 
@@ -71,8 +70,8 @@ type NrGotmEntryRow = {
 };
 
 async function loadFromDatabaseInternal(): Promise<INrGotmEntry[]> {
-  const rows = await oraQuery<NrGotmEntryRow, NrGotmEntryRow>(
-    getSql(NrGotmSql.loadAll, dialect),
+  const rows = await dbQuery<NrGotmEntryRow, NrGotmEntryRow>(
+    NrGotmSql.loadAll,
     {},
     (row) => row,
   );
@@ -440,8 +439,8 @@ export async function updateNrGotmVotingResultsInDatabase(
   round: number,
   messageId: string | null,
 ): Promise<void> {
-  await oraMutate(
-    getSql(NrGotmSql.updateVotingResults, dialect),
+  await dbMutate(
+    NrGotmSql.updateVotingResults,
     { roundNumber: round, bindValue: messageId },
   );
 }
@@ -458,8 +457,8 @@ export async function insertNrGotmRoundInDatabase(
     throw new Error("At least one game is required for an NR-GOTM round.");
   }
 
-  const countRows = await oraQuery<{ CNT: number }, { CNT: number }>(
-    getSql(NrGotmSql.checkRoundExists, dialect),
+  const countRows = await dbQuery<{ CNT: number }, { CNT: number }>(
+    NrGotmSql.checkRoundExists,
     { roundNumber: round },
     (row) => row,
   );
@@ -509,9 +508,8 @@ export async function deleteNrGotmRoundFromDatabase(round: number): Promise<numb
     throw new Error("Invalid round number for NR-GOTM delete.");
   }
 
-  const result = await oraMutate(
-    getSql(NrGotmSql.deleteRound, dialect),
+  return dbMutate(
+    NrGotmSql.deleteRound,
     { roundNumber: round },
   );
-  return result.rowsAffected ?? 0;
 }

--- a/src/classes/SteamCollectionImport.ts
+++ b/src/classes/SteamCollectionImport.ts
@@ -1,7 +1,10 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import {
+  dbQuery, dbMutate,
+  oraQuery, oraMutate, oraWithConnection, oraTransaction,
+  getSql,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { SteamCollectionImportSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -258,8 +261,8 @@ export async function getSteamCollectionImportById(
 export async function getActiveSteamCollectionImportForUser(
   userId: string,
 ): Promise<ISteamCollectionImport | null> {
-  const rows = await oraQuery(
-    getSql(SteamCollectionImportSql.getActiveForUser, dialect),
+  const rows = await dbQuery(
+    SteamCollectionImportSql.getActiveForUser,
     { userId },
     mapImport,
   );
@@ -270,8 +273,8 @@ export async function setSteamCollectionImportStatus(
   importId: number,
   status: SteamCollectionImportStatus,
 ): Promise<void> {
-  await oraMutate(
-    getSql(SteamCollectionImportSql.setStatus, dialect),
+  await dbMutate(
+    SteamCollectionImportSql.setStatus,
     { status, importId },
   );
 }
@@ -280,8 +283,8 @@ export async function updateSteamCollectionImportIndex(
   importId: number,
   currentIndex: number,
 ): Promise<void> {
-  await oraMutate(
-    getSql(SteamCollectionImportSql.updateIndex, dialect),
+  await dbMutate(
+    SteamCollectionImportSql.updateIndex,
     { currentIndex, importId },
   );
 }
@@ -361,8 +364,8 @@ export async function updateSteamCollectionImportItem(
 
   if (!setParts.length) return;
 
-  await oraMutate(
-    SteamCollectionImportSql.updateItem(setParts)[dialect],
+  await dbMutate(
+    SteamCollectionImportSql.updateItem(setParts),
     binds,
   );
 }
@@ -376,8 +379,8 @@ export async function countSteamCollectionImportItems(
   skipped: number;
   failed: number;
 }> {
-  const rows = await oraQuery(
-    getSql(SteamCollectionImportSql.countItemsByStatus, dialect),
+  const rows = await dbQuery(
+    SteamCollectionImportSql.countItemsByStatus,
     { importId },
     (row: { STATUS: SteamCollectionImportItemStatus; CNT: number }) => row,
   );
@@ -397,8 +400,8 @@ export async function countSteamCollectionImportItems(
 export async function countSteamCollectionImportResultReasons(
   importId: number,
 ): Promise<Record<string, number>> {
-  const rows = await oraQuery(
-    getSql(SteamCollectionImportSql.countItemsByReason, dialect),
+  const rows = await dbQuery(
+    SteamCollectionImportSql.countItemsByReason,
     { importId },
     (row: { RESULT_REASON: string | null; CNT: number }) => row,
   );
@@ -457,8 +460,8 @@ export async function getSteamAppHistoricalMappedGameIds(params: {
   const limit = Number.isInteger(params.limit) && (params.limit ?? 0) > 0
     ? Number(params.limit) : 5;
 
-  const rows = await oraQuery(
-    getSql(SteamCollectionImportSql.getHistoricalMappedIds, dialect),
+  const rows = await dbQuery(
+    SteamCollectionImportSql.getHistoricalMappedIds,
     {
       steamAppId: params.steamAppId,
       excludeUserId: params.excludeUserId ?? null,

--- a/src/classes/UserChannelMessageCount.ts
+++ b/src/classes/UserChannelMessageCount.ts
@@ -1,5 +1,5 @@
 import oracledb from "oracledb";
-import { oraQuery, oraWithConnection } from "../db/SqlManager.js";
+import { dbQuery, oraWithConnection } from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
 import { getSql } from "../db/SqlManager.js";
 import { UserChannelMessageCountSql } from "../db/sql/index.js";
@@ -52,8 +52,8 @@ export default class UserChannelMessageCount {
 
   static async getScannedChannelIds(): Promise<Set<string>> {
     try {
-      const rows = await oraQuery(
-        getSql(UserChannelMessageCountSql.getScannedChannelIds, dialect),
+      const rows = await dbQuery(
+        UserChannelMessageCountSql.getScannedChannelIds,
         [],
         (row: { CHANNEL_ID: string }) => row.CHANNEL_ID,
       );
@@ -67,8 +67,8 @@ export default class UserChannelMessageCount {
 
   static async getChannelScanMeta(): Promise<Map<string, Date>> {
     try {
-      const rows = await oraQuery(
-        getSql(UserChannelMessageCountSql.getChannelScanMeta, dialect),
+      const rows = await dbQuery(
+        UserChannelMessageCountSql.getChannelScanMeta,
         [],
         (row: { CHANNEL_ID: string; LAST_SCANNED_AT: Date }) => row,
       );

--- a/src/classes/UserGameCollection.ts
+++ b/src/classes/UserGameCollection.ts
@@ -1,7 +1,10 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
+import {
+  dbQuery, dbMutate,
+  oraQuery, oraMutate, oraWithConnection,
+  getSql,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { UserGameCollectionSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -182,8 +185,8 @@ export default class UserGameCollection {
     if (!Number.isInteger(entryId) || entryId <= 0) {
       throw new Error("Invalid entry id.");
     }
-    const rows = await oraQuery(
-      getSql(UserGameCollectionSql.getEntryForUser, dialect),
+    const rows = await dbQuery(
+      UserGameCollectionSql.getEntryForUser,
       { entryId, userId },
       mapEntry,
     );
@@ -261,11 +264,10 @@ export default class UserGameCollection {
     if (!Number.isInteger(entryId) || entryId <= 0) {
       throw new Error("Invalid entry id.");
     }
-    const result = await oraMutate(
-      getSql(UserGameCollectionSql.removeEntry, dialect),
+    return (await dbMutate(
+      UserGameCollectionSql.removeEntry,
       { entryId, userId },
-    );
-    return (result.rowsAffected ?? 0) > 0;
+    )) > 0;
   }
 
   static async searchEntries(filters: {
@@ -317,8 +319,8 @@ export default class UserGameCollection {
     }
     const fetchClause = hasLimit ? "FETCH FIRST :limit ROWS ONLY" : "";
 
-    return oraQuery(
-      UserGameCollectionSql.searchEntries(where.join(" AND "), fetchClause)[dialect],
+    return dbQuery(
+      UserGameCollectionSql.searchEntries(where.join(" AND "), fetchClause),
       binds,
       mapEntry,
     );
@@ -333,13 +335,13 @@ export default class UserGameCollection {
     }
 
     const [totalRows, platformRows] = await Promise.all([
-      oraQuery(
-        getSql(UserGameCollectionSql.getTotalCount, dialect),
+      dbQuery(
+        UserGameCollectionSql.getTotalCount,
         { userId },
         (row: { TOTAL_COUNT: number }) => row,
       ),
-      oraQuery(
-        getSql(UserGameCollectionSql.getPlatformCounts, dialect),
+      dbQuery(
+        UserGameCollectionSql.getPlatformCounts,
         { userId },
         (row: {
           PLATFORM_ID: number | null;
@@ -367,13 +369,13 @@ export default class UserGameCollection {
     users: IUserGameCollectionUserOverview[];
   }> {
     const [totalRows, platformRows, userRows] = await Promise.all([
-      oraQuery(
-        getSql(UserGameCollectionSql.getTotalAllCount, dialect),
+      dbQuery(
+        UserGameCollectionSql.getTotalAllCount,
         {},
         (row: { TOTAL_COUNT: number }) => row,
       ),
-      oraQuery(
-        getSql(UserGameCollectionSql.getAllPlatformCounts, dialect),
+      dbQuery(
+        UserGameCollectionSql.getAllPlatformCounts,
         {},
         (row: {
           PLATFORM_ID: number | null;
@@ -387,8 +389,8 @@ export default class UserGameCollection {
           total: Number(row.TOTAL_COUNT ?? 0),
         }),
       ),
-      oraQuery(
-        getSql(UserGameCollectionSql.getAllUserRows, dialect),
+      dbQuery(
+        UserGameCollectionSql.getAllUserRows,
         {},
         (row: {
           USER_ID: string;
@@ -461,8 +463,8 @@ export default class UserGameCollection {
       binds.query = `%${trimmed}%`;
     }
 
-    const rows = await oraQuery(
-      UserGameCollectionSql.autocompleteEntries(titleWhere)[dialect],
+    const rows = await dbQuery(
+      UserGameCollectionSql.autocompleteEntries(titleWhere),
       binds,
       mapEntry,
     );

--- a/src/classes/XboxCollectionImport.ts
+++ b/src/classes/XboxCollectionImport.ts
@@ -1,7 +1,10 @@
 import oracledb from "oracledb";
-import { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
+import {
+  dbQuery, dbMutate,
+  oraQuery, oraMutate, oraWithConnection, oraTransaction,
+  getSql,
+} from "../db/SqlManager.js";
 import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
 import { XboxCollectionImportSql } from "../db/sql/index.js";
 
 const dialect = getDialect();
@@ -287,8 +290,8 @@ export async function getXboxCollectionImportById(
 export async function getActiveXboxCollectionImportForUser(
   userId: string,
 ): Promise<IXboxCollectionImport | null> {
-  const rows = await oraQuery(
-    getSql(XboxCollectionImportSql.getActiveForUser, dialect),
+  const rows = await dbQuery(
+    XboxCollectionImportSql.getActiveForUser,
     { userId },
     mapImport,
   );
@@ -299,8 +302,8 @@ export async function setXboxCollectionImportStatus(
   importId: number,
   status: XboxCollectionImportStatus,
 ): Promise<void> {
-  await oraMutate(
-    getSql(XboxCollectionImportSql.setStatus, dialect),
+  await dbMutate(
+    XboxCollectionImportSql.setStatus,
     { importId, status },
   );
 }
@@ -309,8 +312,8 @@ export async function updateXboxCollectionImportIndex(
   importId: number,
   currentIndex: number,
 ): Promise<void> {
-  await oraMutate(
-    getSql(XboxCollectionImportSql.updateIndex, dialect),
+  await dbMutate(
+    XboxCollectionImportSql.updateIndex,
     { importId, currentIndex },
   );
 }
@@ -318,8 +321,8 @@ export async function updateXboxCollectionImportIndex(
 export async function getXboxCollectionImportItemById(
   itemId: number,
 ): Promise<IXboxCollectionImportItem | null> {
-  const rows = await oraQuery(
-    getSql(XboxCollectionImportSql.getItemById, dialect),
+  const rows = await dbQuery(
+    XboxCollectionImportSql.getItemById,
     { itemId },
     mapItem,
   );
@@ -329,8 +332,8 @@ export async function getXboxCollectionImportItemById(
 export async function getNextPendingXboxCollectionImportItem(
   importId: number,
 ): Promise<IXboxCollectionImportItem | null> {
-  const rows = await oraQuery(
-    getSql(XboxCollectionImportSql.getNextPendingItem, dialect),
+  const rows = await dbQuery(
+    XboxCollectionImportSql.getNextPendingItem,
     { importId },
     mapItem,
   );
@@ -383,8 +386,8 @@ export async function updateXboxCollectionImportItem(
 
   if (!fields.length) return;
 
-  await oraMutate(
-    XboxCollectionImportSql.updateItem(fields)[dialect],
+  await dbMutate(
+    XboxCollectionImportSql.updateItem(fields),
     binds,
   );
 }
@@ -398,8 +401,8 @@ export async function countXboxCollectionImportItems(
   skipped: number;
   failed: number;
 }> {
-  const rows = await oraQuery(
-    getSql(XboxCollectionImportSql.countItemsByStatus, dialect),
+  const rows = await dbQuery(
+    XboxCollectionImportSql.countItemsByStatus,
     { importId },
     (row: { STATUS: XboxCollectionImportItemStatus; CNT: number }) => row,
   );
@@ -418,8 +421,8 @@ export async function countXboxCollectionImportItems(
 export async function countXboxCollectionImportResultReasons(
   importId: number,
 ): Promise<Record<string, number>> {
-  const rows = await oraQuery(
-    getSql(XboxCollectionImportSql.countItemsByReason, dialect),
+  const rows = await dbQuery(
+    XboxCollectionImportSql.countItemsByReason,
     { importId },
     (row: { RESULT_REASON: XboxCollectionImportResultReason | null; CNT: number }) => row,
   );
@@ -477,8 +480,8 @@ export async function getXboxTitleHistoricalMappedGameIds(params: {
   const limit = Number.isInteger(params.limit) &&
     (params.limit ?? 0) > 0 ? Number(params.limit) : 5;
 
-  const rows = await oraQuery(
-    getSql(XboxCollectionImportSql.getHistoricalMappedIds, dialect),
+  const rows = await dbQuery(
+    XboxCollectionImportSql.getHistoricalMappedIds,
     {
       xboxTitleId: params.xboxTitleId,
       excludeUserId: params.excludeUserId ?? null,


### PR DESCRIPTION
## Summary

- Converts all remaining standalone (non-connection-passing, non-BIND_OUT) `oraQuery` and `oraMutate` call sites to the dialect-agnostic `dbQuery` and `dbMutate` wrappers
- Files migrated: `Game.ts`, `NrGotm.ts`, `SteamCollectionImport.ts`, `UserChannelMessageCount.ts`, `UserGameCollection.ts`, `XboxCollectionImport.ts`
- Dynamic factory calls (`XxxSql.factory(args)[dialect]`) converted to `dbQuery(XxxSql.factory(args), ...)` -- the `SqlEntry` is passed directly and the wrapper resolves dialect internally
- Merges duplicate `getSql` import lines into the main `SqlManager` import in affected files
- `tsc --noEmit` passes clean

## What's left after this PR

All remaining `ora*` calls in these files are **D2 blockers** -- they require either:
1. Optional/required connection passing (`existingConn?: oracledb.Connection` pattern)
2. `BIND_OUT` (`INSERT ... RETURNING` via `oracledb.BIND_OUT`) -- needs a `dbInsert` wrapper
3. `oraWithConnection`/`oraTransaction` callbacks that use `conn.execute` directly

These will be addressed in subsequent phases once the Postgres SQL variants are filled in and a `dbInsert` helper is added.

## Test plan

- [x] `tsc --noEmit` passes with no errors
- [ ] Oracle smoke test: start bot with `DB_DIALECT=oracle` and verify affected commands (game lookup, collection operations, GOTM data load, Xbox/Steam import status checks) behave correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)