### PR TITLE
feat: Postgres SQL variants for all domain SQL registry files

### DIFF
--- a/src/db/SqlManager.ts
+++ b/src/db/SqlManager.ts
@@ -26,14 +26,17 @@ export { getSql, getSqlDynamic } from "./sql/index.js";
  */
 export async function dbQuery<RowT extends object, R>(
   entry: SqlEntry,
-  params: oracledb.BindParameters | unknown[],
+  params: oracledb.BindParameters | Record<string, unknown> | unknown[],
   mapper: (row: RowT) => R,
 ): Promise<R[]> {
   const dialect = getDialect();
   if (dialect === "oracle") {
     return oraQuery(entry.oracle, params as oracledb.BindParameters, mapper);
   }
-  const rows = await pgQuery<RowT>(entry.postgres, params as unknown[]);
+  const rows = await pgQuery<RowT>(
+    entry.postgres,
+    params as Record<string, unknown> | unknown[],
+  );
   return rows.map(mapper);
 }
 
@@ -43,14 +46,14 @@ export async function dbQuery<RowT extends object, R>(
  */
 export async function dbMutate(
   entry: SqlEntry,
-  params: oracledb.BindParameters | unknown[],
+  params: oracledb.BindParameters | Record<string, unknown> | unknown[],
 ): Promise<number> {
   const dialect = getDialect();
   if (dialect === "oracle") {
     const result = await oraMutate(entry.oracle, params as oracledb.BindParameters);
     return result.rowsAffected ?? 0;
   }
-  return pgMutate(entry.postgres, params as unknown[]);
+  return pgMutate(entry.postgres, params as Record<string, unknown> | unknown[]);
 }
 
 /**

--- a/src/db/postgresClient.ts
+++ b/src/db/postgresClient.ts
@@ -61,15 +61,42 @@ export function getPostgresPool(): pg.Pool {
 }
 
 /**
+ * Converts a SQL string using Oracle-style `:name` placeholders and a named
+ * bind object into a positional `$N` SQL string and ordered values array.
+ * Repeated uses of the same name get the same `$N`. Array params are returned
+ * unchanged so callers that already use positional style still work.
+ */
+export function namedToPositional(
+  sql: string,
+  params: Record<string, unknown> | unknown[],
+): { text: string; values: unknown[] } {
+  if (Array.isArray(params)) {
+    return { text: sql, values: params };
+  }
+  const values: unknown[] = [];
+  const seen = new Map<string, number>();
+  const text = sql.replace(/:([A-Za-z_]\w*)/g, (_, name: string) => {
+    if (!seen.has(name)) {
+      seen.set(name, values.length + 1);
+      values.push(params[name]);
+    }
+    return `$${seen.get(name)}`;
+  });
+  return { text, values };
+}
+
+/**
  * Convenience helper -- runs a parameterised query and returns all rows.
+ * Accepts either positional `unknown[]` or named `:param` bind objects.
  *
  * @example
- * const rows = await pgQuery<{ id: number }>("SELECT id FROM users WHERE name = $1", ["alice"]);
+ * const rows = await pgQuery<{ id: number }>("SELECT id FROM users WHERE name = :name", { name: "alice" });
  */
 export async function pgQuery<T extends pg.QueryResultRow = pg.QueryResultRow>(
-  text: string,
-  values?: unknown[],
+  sql: string,
+  params?: Record<string, unknown> | unknown[],
 ): Promise<T[]> {
+  const { text, values } = namedToPositional(sql, params ?? []);
   const result = await getPostgresPool().query<T>(text, values);
   return result.rows;
 }
@@ -98,9 +125,10 @@ export async function pgTransaction<T>(
 
 /** Runs a DML statement and returns the number of rows affected. */
 export async function pgMutate(
-  text: string,
-  values?: unknown[],
+  sql: string,
+  params?: Record<string, unknown> | unknown[],
 ): Promise<number> {
+  const { text, values } = namedToPositional(sql, params ?? []);
   const result = await getPostgresPool().query(text, values);
   return result.rowCount ?? 0;
 }

--- a/src/db/sql/adminWizardSession.sql.ts
+++ b/src/db/sql/adminWizardSession.sql.ts
@@ -19,7 +19,23 @@ export const AdminWizardSessionSql = {
         AND STATUS = 'ACTIVE'
       ORDER BY LAST_UPDATED_AT DESC
       FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT session_id,
+            command_key,
+            owner_user_id,
+            channel_id,
+            guild_id,
+            status,
+            state_json,
+            last_updated_at,
+            created_at,
+            updated_at
+       FROM rpg_club_admin_wizard_sessions
+      WHERE command_key = :commandKey
+        AND owner_user_id = :ownerUserId
+        AND channel_id = :channelId
+        AND status = 'ACTIVE'
+      ORDER BY last_updated_at DESC
+      LIMIT 1`,
   } satisfies SqlEntry,
 
   saveSession: {
@@ -54,7 +70,15 @@ export const AdminWizardSessionSql = {
         src.STATE_JSON,
         src.LAST_UPDATED_AT
       )`,
-    postgres: ``,
+    // Requires partial unique index: (command_key, owner_user_id, channel_id) WHERE status = 'ACTIVE'
+    postgres: `INSERT INTO rpg_club_admin_wizard_sessions
+        (session_id, command_key, owner_user_id, channel_id, guild_id, status, state_json, last_updated_at)
+       VALUES (:sessionId, :commandKey, :ownerUserId, :channelId, :guildId, 'ACTIVE', :stateJson, :lastUpdatedAt)
+       ON CONFLICT (command_key, owner_user_id, channel_id) WHERE status = 'ACTIVE'
+       DO UPDATE SET
+         state_json = EXCLUDED.state_json,
+         guild_id = EXCLUDED.guild_id,
+         last_updated_at = EXCLUDED.last_updated_at`,
   } satisfies SqlEntry,
 
   deleteHistorical: {
@@ -63,7 +87,11 @@ export const AdminWizardSessionSql = {
           AND OWNER_USER_ID = :ownerUserId
           AND CHANNEL_ID = :channelId
           AND STATUS = :status`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_admin_wizard_sessions
+        WHERE command_key = :commandKey
+          AND owner_user_id = :ownerUserId
+          AND channel_id = :channelId
+          AND status = :status`,
   } satisfies SqlEntry,
 
   updateStatus: {
@@ -74,6 +102,12 @@ export const AdminWizardSessionSql = {
           AND OWNER_USER_ID = :ownerUserId
           AND CHANNEL_ID = :channelId
           AND STATUS = 'ACTIVE'`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_admin_wizard_sessions
+          SET status = :status,
+              last_updated_at = :lastUpdatedAt
+        WHERE command_key = :commandKey
+          AND owner_user_id = :ownerUserId
+          AND channel_id = :channelId
+          AND status = 'ACTIVE'`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/botVotingInfo.sql.ts
+++ b/src/db/sql/botVotingInfo.sql.ts
@@ -6,19 +6,29 @@ const VOTING_COLS = `ROUND_NUMBER,
                 FIVE_DAY_REMINDER_SENT,
                 ONE_DAY_REMINDER_SENT`;
 
+const VOTING_COLS_PG = `round_number,
+                nomination_list_id,
+                next_vote_at,
+                five_day_reminder_sent,
+                one_day_reminder_sent`;
+
 export const BotVotingInfoSql = {
   getAll: {
     oracle: `SELECT ${VOTING_COLS}
          FROM BOT_VOTING_INFO
         ORDER BY ROUND_NUMBER`,
-    postgres: ``,
+    postgres: `SELECT ${VOTING_COLS_PG}
+         FROM bot_voting_info
+        ORDER BY round_number`,
   } satisfies SqlEntry,
 
   getByRound: {
     oracle: `SELECT ${VOTING_COLS}
          FROM BOT_VOTING_INFO
         WHERE ROUND_NUMBER = :round`,
-    postgres: ``,
+    postgres: `SELECT ${VOTING_COLS_PG}
+         FROM bot_voting_info
+        WHERE round_number = :round`,
   } satisfies SqlEntry,
 
   getCurrentRound: {
@@ -27,7 +37,11 @@ export const BotVotingInfoSql = {
         WHERE ROUND_NUMBER = (
           SELECT MAX(ROUND_NUMBER) FROM BOT_VOTING_INFO
         )`,
-    postgres: ``,
+    postgres: `SELECT ${VOTING_COLS_PG}
+         FROM bot_voting_info
+        WHERE round_number = (
+          SELECT MAX(round_number) FROM bot_voting_info
+        )`,
   } satisfies SqlEntry,
 
   updateRoundInfo: {
@@ -35,7 +49,10 @@ export const BotVotingInfoSql = {
             SET NOMINATION_LIST_ID = :nominationListId,
                 NEXT_VOTE_AT = :nextVoteAt
           WHERE ROUND_NUMBER = :round`,
-    postgres: ``,
+    postgres: `UPDATE bot_voting_info
+            SET nomination_list_id = :nominationListId,
+                next_vote_at = :nextVoteAt
+          WHERE round_number = :round`,
   } satisfies SqlEntry,
 
   insertRoundInfo: {
@@ -52,7 +69,19 @@ export const BotVotingInfoSql = {
            0,
            0
          )`,
-    postgres: ``,
+    postgres: `INSERT INTO bot_voting_info (
+           round_number,
+           nomination_list_id,
+           next_vote_at,
+           five_day_reminder_sent,
+           one_day_reminder_sent
+         ) VALUES (
+           :round,
+           :nominationListId,
+           :nextVoteAt,
+           false,
+           false
+         )`,
   } satisfies SqlEntry,
 
   markReminderSent: (column: string) =>
@@ -60,26 +89,33 @@ export const BotVotingInfoSql = {
       oracle: `UPDATE BOT_VOTING_INFO
           SET ${column} = 1
         WHERE ROUND_NUMBER = :round`,
-      postgres: ``,
+      postgres: `UPDATE bot_voting_info
+          SET ${column.toLowerCase()} = true
+        WHERE round_number = :round`,
     }) satisfies SqlEntry,
 
   updateNextVoteAt: {
     oracle: `UPDATE BOT_VOTING_INFO
           SET NEXT_VOTE_AT = :nextVoteAt
         WHERE ROUND_NUMBER = :round`,
-    postgres: ``,
+    postgres: `UPDATE bot_voting_info
+          SET next_vote_at = :nextVoteAt
+        WHERE round_number = :round`,
   } satisfies SqlEntry,
 
   updateNominationListId: {
     oracle: `UPDATE BOT_VOTING_INFO
           SET NOMINATION_LIST_ID = :nominationListId
         WHERE ROUND_NUMBER = :round`,
-    postgres: ``,
+    postgres: `UPDATE bot_voting_info
+          SET nomination_list_id = :nominationListId
+        WHERE round_number = :round`,
   } satisfies SqlEntry,
 
   deleteRound: {
     oracle: `DELETE FROM BOT_VOTING_INFO
         WHERE ROUND_NUMBER = :round`,
-    postgres: ``,
+    postgres: `DELETE FROM bot_voting_info
+        WHERE round_number = :round`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/collectionCsvImport.sql.ts
+++ b/src/db/sql/collectionCsvImport.sql.ts
@@ -20,6 +20,26 @@ const ITEM_COLS = `ITEM_ID,
             RESULT_REASON,
             ERROR_TEXT`;
 
+const ITEM_COLS_PG = `item_id,
+            import_id,
+            row_index,
+            raw_title,
+            raw_platform,
+            raw_ownership_type,
+            raw_note,
+            raw_gamedb_id,
+            raw_igdb_id,
+            platform_id,
+            ownership_type,
+            note,
+            status,
+            match_confidence,
+            match_candidate_json,
+            gamedb_game_id,
+            collection_entry_id,
+            result_reason,
+            error_text`;
+
 export const CollectionCsvImportSql = {
   createImport: {
     oracle: `INSERT INTO RPG_CLUB_COLLECTION_CSV_IMPORTS (
@@ -39,7 +59,23 @@ export const CollectionCsvImportSql = {
          :sourceFileSize,
          :templateVersion
        ) RETURNING IMPORT_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_collection_csv_imports (
+         user_id,
+         status,
+         current_index,
+         total_count,
+         source_file_name,
+         source_file_size,
+         template_version
+       ) VALUES (
+         :userId,
+         'ACTIVE',
+         0,
+         :totalCount,
+         :sourceFileName,
+         :sourceFileSize,
+         :templateVersion
+       ) RETURNING import_id`,
   } satisfies SqlEntry,
 
   insertItem: {
@@ -70,7 +106,33 @@ export const CollectionCsvImportSql = {
            :note,
            'PENDING'
          )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_collection_csv_import_items (
+           import_id,
+           row_index,
+           raw_title,
+           raw_platform,
+           raw_ownership_type,
+           raw_note,
+           raw_gamedb_id,
+           raw_igdb_id,
+           platform_id,
+           ownership_type,
+           note,
+           status
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :rawTitle,
+           :rawPlatform,
+           :rawOwnershipType,
+           :rawNote,
+           :rawGameDbId,
+           :rawIgdbId,
+           :platformId,
+           :ownershipType,
+           :note,
+           'PENDING'
+         )`,
   } satisfies SqlEntry,
 
   getImportById: {
@@ -86,7 +148,18 @@ export const CollectionCsvImportSql = {
             UPDATED_AT
        FROM RPG_CLUB_COLLECTION_CSV_IMPORTS
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `SELECT import_id,
+            user_id,
+            status,
+            current_index,
+            total_count,
+            source_file_name,
+            source_file_size,
+            template_version,
+            created_at,
+            updated_at
+       FROM rpg_club_collection_csv_imports
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getActiveForUser: {
@@ -105,28 +178,48 @@ export const CollectionCsvImportSql = {
         AND STATUS IN ('ACTIVE', 'PAUSED')
       ORDER BY CREATED_AT DESC, IMPORT_ID DESC
       FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT import_id,
+            user_id,
+            status,
+            current_index,
+            total_count,
+            source_file_name,
+            source_file_size,
+            template_version,
+            created_at,
+            updated_at
+       FROM rpg_club_collection_csv_imports
+      WHERE user_id = :userId
+        AND status IN ('ACTIVE', 'PAUSED')
+      ORDER BY created_at DESC, import_id DESC
+      LIMIT 1`,
   } satisfies SqlEntry,
 
   setStatus: {
     oracle: `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORTS
         SET STATUS = :status
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_collection_csv_imports
+        SET status = :status
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   updateIndex: {
     oracle: `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORTS
         SET CURRENT_INDEX = :currentIndex
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_collection_csv_imports
+        SET current_index = :currentIndex
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getItemById: {
     oracle: `SELECT ${ITEM_COLS}
        FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
       WHERE ITEM_ID = :itemId`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_collection_csv_import_items
+      WHERE item_id = :itemId`,
   } satisfies SqlEntry,
 
   getNextPendingItem: {
@@ -136,15 +229,23 @@ export const CollectionCsvImportSql = {
         AND STATUS = 'PENDING'
       ORDER BY ROW_INDEX ASC, ITEM_ID ASC
       FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_collection_csv_import_items
+      WHERE import_id = :importId
+        AND status = 'PENDING'
+      ORDER BY row_index ASC, item_id ASC
+      LIMIT 1`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres (e.g. "status = :status")
   updateItem: (setParts: string[]) =>
     ({
       oracle: `UPDATE RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
         SET ${setParts.join(", ")}
       WHERE ITEM_ID = :itemId`,
-      postgres: ``,
+      postgres: `UPDATE rpg_club_collection_csv_import_items
+        SET ${setParts.join(", ")}
+      WHERE item_id = :itemId`,
     }) satisfies SqlEntry,
 
   countItemsByStatus: {
@@ -152,7 +253,10 @@ export const CollectionCsvImportSql = {
        FROM RPG_CLUB_COLLECTION_CSV_IMPORT_ITEMS
       WHERE IMPORT_ID = :importId
       GROUP BY STATUS`,
-    postgres: ``,
+    postgres: `SELECT status, COUNT(*) AS total
+       FROM rpg_club_collection_csv_import_items
+      WHERE import_id = :importId
+      GROUP BY status`,
   } satisfies SqlEntry,
 
   countItemsByReason: {
@@ -161,6 +265,10 @@ export const CollectionCsvImportSql = {
       WHERE IMPORT_ID = :importId
         AND RESULT_REASON IS NOT NULL
       GROUP BY RESULT_REASON`,
-    postgres: ``,
+    postgres: `SELECT result_reason, COUNT(*) AS total
+       FROM rpg_club_collection_csv_import_items
+      WHERE import_id = :importId
+        AND result_reason IS NOT NULL
+      GROUP BY result_reason`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/completionatorImport.sql.ts
+++ b/src/db/sql/completionatorImport.sql.ts
@@ -16,6 +16,22 @@ const ITEM_COLS = `ITEM_ID,
             COMPLETION_ID,
             ERROR_TEXT`;
 
+const ITEM_COLS_PG = `item_id,
+            import_id,
+            row_index,
+            game_title,
+            platform_name,
+            region_name,
+            source_type,
+            time_text,
+            completed_at,
+            completion_type,
+            playtime_hrs,
+            status,
+            gamedb_game_id,
+            completion_id,
+            error_text`;
+
 export const CompletionatorImportSql = {
   createImport: {
     oracle: `INSERT INTO RPG_CLUB_COMPLETIONATOR_IMPORTS (
@@ -23,7 +39,11 @@ export const CompletionatorImportSql = {
        ) VALUES (
          :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
        ) RETURNING IMPORT_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_completionator_imports (
+         user_id, status, current_index, total_count, source_filename
+       ) VALUES (
+         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
+       ) RETURNING import_id`,
   } satisfies SqlEntry,
 
   insertItem: {
@@ -52,7 +72,31 @@ export const CompletionatorImportSql = {
            :playtimeHours,
            'PENDING'
          )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_completionator_import_items (
+           import_id,
+           row_index,
+           game_title,
+           platform_name,
+           region_name,
+           source_type,
+           time_text,
+           completed_at,
+           completion_type,
+           playtime_hrs,
+           status
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :gameTitle,
+           :platformName,
+           :regionName,
+           :sourceType,
+           :timeText,
+           :completedAt,
+           :completionType,
+           :playtimeHours,
+           'PENDING'
+         )`,
   } satisfies SqlEntry,
 
   getImportById: {
@@ -66,7 +110,16 @@ export const CompletionatorImportSql = {
             UPDATED_AT
        FROM RPG_CLUB_COMPLETIONATOR_IMPORTS
       WHERE IMPORT_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT import_id,
+            user_id,
+            status,
+            current_index,
+            total_count,
+            source_filename,
+            created_at,
+            updated_at
+       FROM rpg_club_completionator_imports
+      WHERE import_id = :id`,
   } satisfies SqlEntry,
 
   getActiveForUser: {
@@ -83,28 +136,46 @@ export const CompletionatorImportSql = {
         AND STATUS IN ('ACTIVE', 'PAUSED')
       ORDER BY CREATED_AT DESC, IMPORT_ID DESC
       FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT import_id,
+            user_id,
+            status,
+            current_index,
+            total_count,
+            source_filename,
+            created_at,
+            updated_at
+       FROM rpg_club_completionator_imports
+      WHERE user_id = :userId
+        AND status IN ('ACTIVE', 'PAUSED')
+      ORDER BY created_at DESC, import_id DESC
+      LIMIT 1`,
   } satisfies SqlEntry,
 
   setStatus: {
     oracle: `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORTS
         SET STATUS = :status
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_completionator_imports
+        SET status = :status
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   updateIndex: {
     oracle: `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORTS
         SET CURRENT_INDEX = :currentIndex
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_completionator_imports
+        SET current_index = :currentIndex
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getItemById: {
     oracle: `SELECT ${ITEM_COLS}
        FROM RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
       WHERE ITEM_ID = :itemId`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_completionator_import_items
+      WHERE item_id = :itemId`,
   } satisfies SqlEntry,
 
   getNextPendingItem: {
@@ -114,15 +185,23 @@ export const CompletionatorImportSql = {
         AND STATUS = 'PENDING'
       ORDER BY ROW_INDEX ASC
       FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_completionator_import_items
+      WHERE import_id = :importId
+        AND status = 'PENDING'
+      ORDER BY row_index ASC
+      LIMIT 1`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres (e.g. "status = :status")
   updateItem: (fields: string[]) =>
     ({
       oracle: `UPDATE RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
         SET ${fields.join(", ")}
       WHERE ITEM_ID = :itemId`,
-      postgres: ``,
+      postgres: `UPDATE rpg_club_completionator_import_items
+        SET ${fields.join(", ")}
+      WHERE item_id = :itemId`,
     }) satisfies SqlEntry,
 
   countItemsByStatus: {
@@ -130,6 +209,9 @@ export const CompletionatorImportSql = {
        FROM RPG_CLUB_COMPLETIONATOR_IMPORT_ITEMS
       WHERE IMPORT_ID = :importId
       GROUP BY STATUS`,
-    postgres: ``,
+    postgres: `SELECT status, COUNT(*) AS cnt
+       FROM rpg_club_completionator_import_items
+      WHERE import_id = :importId
+      GROUP BY status`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/game.sql.ts
+++ b/src/db/sql/game.sql.ts
@@ -4,13 +4,24 @@ const GAME_COLS = `GAME_ID, TITLE, DESCRIPTION, IMAGE_DATA, THUMBNAIL_BAD,
               THUMBNAIL_APPROVED, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL,
               FEATURED_VIDEO_URL, INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT`;
 
+const GAME_COLS_PG = `game_id, title, description, image_data, thumbnail_bad,
+              thumbnail_approved, igdb_id, slug, total_rating, igdb_url,
+              featured_video_url, initial_release_date, created_at, updated_at`;
+
 const PLATFORM_COLS = `PLATFORM_ID,
               PLATFORM_CODE,
               PLATFORM_NAME,
               PLATFORM_ABBREVIATION,
               IGDB_PLATFORM_ID`;
 
+const PLATFORM_COLS_PG = `platform_id,
+              platform_code,
+              platform_name,
+              platform_abbreviation,
+              igdb_platform_id`;
+
 const REGION_COLS = `REGION_ID, REGION_CODE, REGION_NAME, IGDB_REGION_ID`;
+const REGION_COLS_PG = `region_id, region_code, region_name, igdb_region_id`;
 
 export const GameSql = {
   createGame: {
@@ -34,7 +45,26 @@ export const GameSql = {
            :featuredVideoUrl
          )
          RETURNING GAME_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_games (
+           title,
+           description,
+           image_data,
+           igdb_id,
+           slug,
+           total_rating,
+           igdb_url,
+           featured_video_url
+         ) VALUES (
+           :title,
+           :description,
+           :imageData,
+           :igdbId,
+           :slug,
+           :totalRating,
+           :igdbUrl,
+           :featuredVideoUrl
+         )
+         RETURNING game_id`,
   } satisfies SqlEntry,
 
   getGameById: {
@@ -43,7 +73,11 @@ export const GameSql = {
                 INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
            FROM GAMEDB_GAMES
           WHERE GAME_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT game_id, title, description, image_data, thumbnail_bad,
+                thumbnail_approved, igdb_id, slug, total_rating, igdb_url, featured_video_url,
+                initial_release_date, created_at, updated_at
+           FROM gamedb_games
+          WHERE game_id = :id`,
   } satisfies SqlEntry,
 
   getGamesByIds: (placeholders: string) =>
@@ -51,7 +85,9 @@ export const GameSql = {
       oracle: `SELECT ${GAME_COLS}
            FROM GAMEDB_GAMES
           WHERE GAME_ID IN (${placeholders})`,
-      postgres: ``,
+      postgres: `SELECT ${GAME_COLS_PG}
+           FROM gamedb_games
+          WHERE game_id IN (${placeholders})`,
     }) satisfies SqlEntry,
 
   getAlternateVersions: {
@@ -66,7 +102,17 @@ export const GameSql = {
              WHERE GAME_ID = :id OR ALT_GAME_ID = :id
           )
           ORDER BY UPPER(TITLE)`,
-    postgres: ``,
+    postgres: `SELECT ${GAME_COLS_PG}
+           FROM gamedb_games
+          WHERE game_id IN (
+            SELECT CASE
+                     WHEN game_id = :id THEN alt_game_id
+                     ELSE game_id
+                   END
+              FROM gamedb_game_alternates
+             WHERE game_id = :id OR alt_game_id = :id
+          )
+          ORDER BY UPPER(title)`,
   } satisfies SqlEntry,
 
   linkAlternateVersions: {
@@ -81,16 +127,21 @@ export const GameSql = {
          WHEN NOT MATCHED THEN
            INSERT (GAME_ID, ALT_GAME_ID, CREATED_BY)
            VALUES (s.GAME_ID, s.ALT_GAME_ID, s.CREATED_BY)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_alternates (game_id, alt_game_id, created_by)
+           VALUES (:gameId, :altGameId, :createdBy)
+           ON CONFLICT (game_id, alt_game_id) DO NOTHING`,
   } satisfies SqlEntry,
 
   getGameByIgdbId: {
     oracle: `SELECT ${GAME_COLS}
            FROM GAMEDB_GAMES
           WHERE IGDB_ID = :igdbId`,
-    postgres: ``,
+    postgres: `SELECT ${GAME_COLS_PG}
+           FROM gamedb_games
+          WHERE igdb_id = :igdbId`,
   } satisfies SqlEntry,
 
+  // Caller should pass lowercase identifiers for Postgres
   getOrInsertMetadataSelect: (
     idCol: string,
     table: string,
@@ -98,9 +149,10 @@ export const GameSql = {
   ) =>
     ({
       oracle: `SELECT ${idCol} FROM ${table} WHERE ${igdbIdCol} = :igdbId`,
-      postgres: ``,
+      postgres: `SELECT ${idCol.toLowerCase()} FROM ${table.toLowerCase()} WHERE ${igdbIdCol.toLowerCase()} = :igdbId`,
     }) satisfies SqlEntry,
 
+  // Caller should pass lowercase identifiers for Postgres
   getOrInsertMetadataInsert: (
     table: string,
     nameCol: string,
@@ -111,50 +163,55 @@ export const GameSql = {
       oracle: `INSERT INTO ${table} (${nameCol}, ${igdbIdCol})
          VALUES (:name, :igdbId)
          RETURNING ${idCol} INTO :id`,
-      postgres: ``,
+      postgres: `INSERT INTO ${table.toLowerCase()} (${nameCol.toLowerCase()}, ${igdbIdCol.toLowerCase()})
+         VALUES (:name, :igdbId)
+         RETURNING ${idCol.toLowerCase()}`,
     }) satisfies SqlEntry,
 
   insertGameCompany: {
     oracle: `INSERT INTO GAMEDB_GAME_COMPANIES (GAME_ID, COMPANY_ID, ROLE)
              VALUES (:gameId, :companyId, :role)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_companies (game_id, company_id, role)
+             VALUES (:gameId, :companyId, :role)`,
   } satisfies SqlEntry,
 
   insertGameGenre: {
     oracle: `INSERT INTO GAMEDB_GAME_GENRES (GAME_ID, GENRE_ID) VALUES (:gameId, :genreId)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_genres (game_id, genre_id) VALUES (:gameId, :genreId)`,
   } satisfies SqlEntry,
 
   insertGameTheme: {
     oracle: `INSERT INTO GAMEDB_GAME_THEMES (GAME_ID, THEME_ID) VALUES (:gameId, :themeId)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_themes (game_id, theme_id) VALUES (:gameId, :themeId)`,
   } satisfies SqlEntry,
 
   insertGameMode: {
     oracle: `INSERT INTO GAMEDB_GAME_MODES (GAME_ID, MODE_ID) VALUES (:gameId, :modeId)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_modes (game_id, mode_id) VALUES (:gameId, :modeId)`,
   } satisfies SqlEntry,
 
   insertGamePerspective: {
     oracle: `INSERT INTO GAMEDB_GAME_PERSPECTIVES (GAME_ID, PERSPECTIVE_ID)
              VALUES (:gameId, :persId)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_perspectives (game_id, perspective_id)
+             VALUES (:gameId, :persId)`,
   } satisfies SqlEntry,
 
   insertGameEngine: {
     oracle: `INSERT INTO GAMEDB_GAME_ENGINES (GAME_ID, ENGINE_ID) VALUES (:gameId, :engineId)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_engines (game_id, engine_id) VALUES (:gameId, :engineId)`,
   } satisfies SqlEntry,
 
   insertGameFranchise: {
     oracle: `INSERT INTO GAMEDB_GAME_FRANCHISES (GAME_ID, FRANCHISE_ID)
              VALUES (:gameId, :franchiseId)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_franchises (game_id, franchise_id)
+             VALUES (:gameId, :franchiseId)`,
   } satisfies SqlEntry,
 
   updateCollectionId: {
     oracle: `UPDATE GAMEDB_GAMES SET COLLECTION_ID = :collectionId WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games SET collection_id = :collectionId WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   updateParentIgdbId: {
@@ -162,7 +219,10 @@ export const GameSql = {
                SET PARENT_IGDB_ID = :parentId,
                    PARENT_GAME_NAME = :parentName
              WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games
+               SET parent_igdb_id = :parentId,
+                   parent_game_name = :parentName
+             WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   updateInitialReleaseDateSelect: {
@@ -170,49 +230,64 @@ export const GameSql = {
          FROM GAMEDB_RELEASES
         WHERE GAME_ID = :gameId
           AND RELEASE_DATE IS NOT NULL`,
-    postgres: ``,
+    postgres: `SELECT MIN(release_date) AS min_date
+         FROM gamedb_releases
+        WHERE game_id = :gameId
+          AND release_date IS NOT NULL`,
   } satisfies SqlEntry,
 
   updateInitialReleaseDateUpdate: {
     oracle: `UPDATE GAMEDB_GAMES
           SET INITIAL_RELEASE_DATE = :releaseDate
         WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games
+          SET initial_release_date = :releaseDate
+        WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   insertPlatform: {
     oracle: `INSERT INTO GAMEDB_PLATFORMS (PLATFORM_CODE, PLATFORM_NAME, IGDB_PLATFORM_ID)
          VALUES (:code, :name, :igdbId)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_platforms (platform_code, platform_name, igdb_platform_id)
+         VALUES (:code, :name, :igdbId)`,
   } satisfies SqlEntry,
 
   insertRegion: {
     oracle: `INSERT INTO GAMEDB_REGIONS (REGION_CODE, REGION_NAME, IGDB_REGION_ID)
          VALUES (:code, :name, :igdbId)
          RETURNING REGION_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_regions (region_code, region_name, igdb_region_id)
+         VALUES (:code, :name, :igdbId)
+         RETURNING region_id`,
   } satisfies SqlEntry,
 
   getGameCompanies: {
     oracle: `SELECT c.NAME FROM GAMEDB_COMPANIES c
        JOIN GAMEDB_GAME_COMPANIES gc ON c.COMPANY_ID = gc.COMPANY_ID
        WHERE gc.GAME_ID = :gameId AND gc.ROLE = :role`,
-    postgres: ``,
+    postgres: `SELECT c.name FROM gamedb_companies c
+       JOIN gamedb_game_companies gc ON c.company_id = gc.company_id
+       WHERE gc.game_id = :gameId AND gc.role = :role`,
   } satisfies SqlEntry,
 
+  // Caller should pass lowercase identifiers for Postgres
   getSimpleList: (defTable: string, mapTable: string, idCol: string) =>
     ({
       oracle: `SELECT t.NAME FROM ${defTable} t
        JOIN ${mapTable} m ON t.${idCol} = m.${idCol}
        WHERE m.GAME_ID = :gameId`,
-      postgres: ``,
+      postgres: `SELECT t.name FROM ${defTable.toLowerCase()} t
+       JOIN ${mapTable.toLowerCase()} m ON t.${idCol.toLowerCase()} = m.${idCol.toLowerCase()}
+       WHERE m.game_id = :gameId`,
     }) satisfies SqlEntry,
 
   getGameSeries: {
     oracle: `SELECT c.NAME FROM GAMEDB_COLLECTIONS c
        JOIN GAMEDB_GAMES g ON c.COLLECTION_ID = g.COLLECTION_ID
        WHERE g.GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `SELECT c.name FROM gamedb_collections c
+       JOIN gamedb_games g ON c.collection_id = g.collection_id
+       WHERE g.game_id = :gameId`,
   } satisfies SqlEntry,
 
   insertRelease: {
@@ -220,14 +295,19 @@ export const GameSql = {
        (GAME_ID, PLATFORM_ID, REGION_ID, FORMAT, RELEASE_DATE, NOTES)
        VALUES (:gameId, :platformId, :regionId, :format, :releaseDate, :notes)
        RETURNING RELEASE_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_releases
+       (game_id, platform_id, region_id, format, release_date, notes)
+       VALUES (:gameId, :platformId, :regionId, :format, :releaseDate, :notes)
+       RETURNING release_id`,
   } satisfies SqlEntry,
 
   getReleaseById: {
     oracle: `SELECT RELEASE_ID, GAME_ID, PLATFORM_ID, REGION_ID, FORMAT, RELEASE_DATE, NOTES
          FROM GAMEDB_RELEASES
         WHERE RELEASE_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT release_id, game_id, platform_id, region_id, format, release_date, notes
+         FROM gamedb_releases
+        WHERE release_id = :id`,
   } satisfies SqlEntry,
 
   getGameReleases: {
@@ -235,7 +315,10 @@ export const GameSql = {
          FROM GAMEDB_RELEASES
         WHERE GAME_ID = :gameId
         ORDER BY RELEASE_DATE ASC`,
-    postgres: ``,
+    postgres: `SELECT release_id, game_id, platform_id, region_id, format, release_date, notes
+         FROM gamedb_releases
+        WHERE game_id = :gameId
+        ORDER BY release_date ASC`,
   } satisfies SqlEntry,
 
   getPlatformsForGame: {
@@ -248,14 +331,24 @@ export const GameSql = {
          JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = r.PLATFORM_ID
         WHERE r.GAME_ID = :gameId
         ORDER BY p.PLATFORM_NAME ASC`,
-    postgres: ``,
+    postgres: `SELECT DISTINCT p.platform_id,
+              p.platform_code,
+              p.platform_name,
+              p.platform_abbreviation,
+              p.igdb_platform_id
+         FROM gamedb_releases r
+         JOIN gamedb_platforms p ON p.platform_id = r.platform_id
+        WHERE r.game_id = :gameId
+        ORDER BY p.platform_name ASC`,
   } satisfies SqlEntry,
 
   getAllPlatforms: {
     oracle: `SELECT ${PLATFORM_COLS}
          FROM GAMEDB_PLATFORMS
         ORDER BY PLATFORM_NAME ASC`,
-    postgres: ``,
+    postgres: `SELECT ${PLATFORM_COLS_PG}
+         FROM gamedb_platforms
+        ORDER BY platform_name ASC`,
   } satisfies SqlEntry,
 
   getPlatformsByIgdbIds: (placeholders: string) =>
@@ -263,7 +356,9 @@ export const GameSql = {
       oracle: `SELECT ${PLATFORM_COLS}
          FROM GAMEDB_PLATFORMS
         WHERE IGDB_PLATFORM_ID IN (${placeholders})`,
-      postgres: ``,
+      postgres: `SELECT ${PLATFORM_COLS_PG}
+         FROM gamedb_platforms
+        WHERE igdb_platform_id IN (${placeholders})`,
     }) satisfies SqlEntry,
 
   attachPlatformsToGames: (placeholders: string) =>
@@ -277,44 +372,63 @@ export const GameSql = {
          FROM GAMEDB_GAME_PLATFORMS gp
          LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = gp.PLATFORM_ID
         WHERE gp.GAME_ID IN (${placeholders})`,
-      postgres: ``,
+      postgres: `SELECT gp.game_id,
+              gp.platform_id,
+              p.platform_code,
+              p.platform_name,
+              p.platform_abbreviation,
+              p.igdb_platform_id
+         FROM gamedb_game_platforms gp
+         LEFT JOIN gamedb_platforms p ON p.platform_id = gp.platform_id
+        WHERE gp.game_id IN (${placeholders})`,
     }) satisfies SqlEntry,
 
   getPlatformByIgdbId: {
     oracle: `SELECT ${PLATFORM_COLS}
          FROM GAMEDB_PLATFORMS
         WHERE IGDB_PLATFORM_ID = :igdbId`,
-    postgres: ``,
+    postgres: `SELECT ${PLATFORM_COLS_PG}
+         FROM gamedb_platforms
+        WHERE igdb_platform_id = :igdbId`,
   } satisfies SqlEntry,
 
   getAllRegions: {
     oracle: `SELECT ${REGION_COLS}
          FROM GAMEDB_REGIONS
         ORDER BY REGION_NAME ASC`,
-    postgres: ``,
+    postgres: `SELECT ${REGION_COLS_PG}
+         FROM gamedb_regions
+        ORDER BY region_name ASC`,
   } satisfies SqlEntry,
 
   getRegionByCode: {
     oracle: `SELECT ${REGION_COLS}
          FROM GAMEDB_REGIONS
         WHERE REGION_CODE = :code`,
-    postgres: ``,
+    postgres: `SELECT ${REGION_COLS_PG}
+         FROM gamedb_regions
+        WHERE region_code = :code`,
   } satisfies SqlEntry,
 
   getRegionById: {
     oracle: `SELECT ${REGION_COLS}
          FROM GAMEDB_REGIONS
         WHERE REGION_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT ${REGION_COLS_PG}
+         FROM gamedb_regions
+        WHERE region_id = :id`,
   } satisfies SqlEntry,
 
   getRegionByIgdbId: {
     oracle: `SELECT ${REGION_COLS}
          FROM GAMEDB_REGIONS
         WHERE IGDB_REGION_ID = :igdbId`,
-    postgres: ``,
+    postgres: `SELECT ${REGION_COLS_PG}
+         FROM gamedb_regions
+        WHERE igdb_region_id = :igdbId`,
   } satisfies SqlEntry,
 
+  // titleFoldExpr and titleNormExpr are dialect-specific SQL fragments
   searchGamesAutocomplete: (
     titleFoldExpr: string,
     titleNormExpr: string,
@@ -338,23 +452,45 @@ export const GameSql = {
                    END,
                    TITLE ASC
           FETCH FIRST :limit ROWS ONLY`,
-      postgres: ``,
+      postgres: `SELECT game_id, title, initial_release_date
+           FROM gamedb_games
+          WHERE ${titleFoldExpr} LIKE :rawContains
+             OR (
+               :exactNorm IS NOT NULL AND
+               ${titleNormExpr} LIKE :normContains
+             )
+          ORDER BY CASE
+                     WHEN ${titleFoldExpr} = :exactRaw THEN 0
+                     WHEN ${titleFoldExpr} LIKE :rawPrefix THEN 1
+                     WHEN :exactNorm IS NOT NULL AND
+                          ${titleNormExpr} = :exactNorm THEN 2
+                     WHEN :exactNorm IS NOT NULL AND
+                          ${titleNormExpr} LIKE :normPrefix THEN 3
+                     ELSE 4
+                   END,
+                   title ASC
+          LIMIT :limit`,
     }) satisfies SqlEntry,
 
   getAllCompanies: {
     oracle: `SELECT COMPANY_ID, NAME, IGDB_COMPANY_ID
        FROM GAMEDB_COMPANIES
        ORDER BY NAME ASC`,
-    postgres: ``,
+    postgres: `SELECT company_id, name, igdb_company_id
+       FROM gamedb_companies
+       ORDER BY name ASC`,
   } satisfies SqlEntry,
 
   getCompanyById: {
     oracle: `SELECT COMPANY_ID, NAME, IGDB_COMPANY_ID
        FROM GAMEDB_COMPANIES
        WHERE COMPANY_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT company_id, name, igdb_company_id
+       FROM gamedb_companies
+       WHERE company_id = :id`,
   } satisfies SqlEntry,
 
+  // whereClause and orderPrefix are dialect-specific SQL fragments
   searchGames: (whereClause: string, orderPrefix: string) =>
     ({
       oracle: `WITH upcoming AS (
@@ -377,7 +513,26 @@ export const GameSql = {
            LEFT JOIN upcoming u ON u.GAME_ID = g.GAME_ID
           WHERE ${whereClause}
           ORDER BY ${orderPrefix}g.TITLE ASC`,
-      postgres: ``,
+      postgres: `WITH upcoming AS (
+           SELECT game_id, MIN(release_date) AS upcoming_date
+             FROM gamedb_releases
+            WHERE release_date > CURRENT_DATE
+            GROUP BY game_id
+         )
+         SELECT g.game_id, g.title, g.description, g.igdb_id, g.slug, g.total_rating,
+                g.igdb_url, g.featured_video_url, g.initial_release_date,
+                g.created_at, g.updated_at,
+                u.upcoming_date AS upcoming_release_date,
+                (SELECT STRING_AGG(COALESCE(p.platform_abbreviation, p.platform_name), ','
+                        ORDER BY p.platform_name)
+                   FROM gamedb_releases r
+                   JOIN gamedb_platforms p ON p.platform_id = r.platform_id
+                  WHERE r.game_id = g.game_id AND r.release_date = u.upcoming_date
+                ) AS upcoming_platforms
+           FROM gamedb_games g
+           LEFT JOIN upcoming u ON u.game_id = g.game_id
+          WHERE ${whereClause}
+          ORDER BY ${orderPrefix}g.title ASC`,
     }) satisfies SqlEntry,
 
   addGamePlatformMerge: {
@@ -386,9 +541,12 @@ export const GameSql = {
            ON (gp.GAME_ID = src.GAME_ID AND gp.PLATFORM_ID = src.PLATFORM_ID)
            WHEN NOT MATCHED THEN
              INSERT (GAME_ID, PLATFORM_ID) VALUES (src.GAME_ID, src.PLATFORM_ID)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_game_platforms (game_id, platform_id)
+           VALUES (:gameId, :platformId)
+           ON CONFLICT (game_id, platform_id) DO NOTHING`,
   } satisfies SqlEntry,
 
+  // combinedClause is a dialect-specific SQL fragment
   getGamesForAudit: (combinedClause: string) =>
     ({
       oracle: `SELECT g.GAME_ID, g.TITLE, g.DESCRIPTION, g.IMAGE_DATA, g.IGDB_ID, g.SLUG,
@@ -397,7 +555,12 @@ export const GameSql = {
            FROM GAMEDB_GAMES g
           WHERE ${combinedClause}
           ORDER BY g.TITLE ASC`,
-      postgres: ``,
+      postgres: `SELECT g.game_id, g.title, g.description, g.image_data, g.igdb_id, g.slug,
+                g.total_rating, g.igdb_url, g.featured_video_url,
+                g.initial_release_date, g.created_at, g.updated_at
+           FROM gamedb_games g
+          WHERE ${combinedClause}
+          ORDER BY g.title ASC`,
     }) satisfies SqlEntry,
 
   updateGameImage: {
@@ -405,7 +568,10 @@ export const GameSql = {
          SET IMAGE_DATA = :imageData,
              UPDATED_AT = SYSTIMESTAMP
        WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games
+         SET image_data = :imageData,
+             updated_at = NOW()
+       WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   updateGameThumbnailBad: {
@@ -413,7 +579,10 @@ export const GameSql = {
           SET THUMBNAIL_BAD = :thumbnailBad,
               UPDATED_AT = SYSTIMESTAMP
         WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games
+          SET thumbnail_bad = :thumbnailBad,
+              updated_at = NOW()
+        WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   updateGameThumbnailApproved: {
@@ -421,7 +590,10 @@ export const GameSql = {
           SET THUMBNAIL_APPROVED = :thumbnailApproved,
               UPDATED_AT = SYSTIMESTAMP
         WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games
+          SET thumbnail_approved = :thumbnailApproved,
+              updated_at = NOW()
+        WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   getThreadStatusForGameIds: (placeholders: string) =>
@@ -433,7 +605,13 @@ export const GameSql = {
             EXISTS (SELECT 1 FROM THREAD_GAME_LINKS tgl WHERE tgl.GAMEDB_GAME_ID = g.GAME_ID)
             OR EXISTS (SELECT 1 FROM THREADS th WHERE th.GAMEDB_GAME_ID = g.GAME_ID)
           )`,
-      postgres: ``,
+      postgres: `SELECT DISTINCT g.game_id
+         FROM gamedb_games g
+        WHERE g.game_id IN (${placeholders})
+          AND (
+            EXISTS (SELECT 1 FROM thread_game_links tgl WHERE tgl.gamedb_game_id = g.game_id)
+            OR EXISTS (SELECT 1 FROM threads th WHERE th.gamedb_game_id = g.game_id)
+          )`,
     }) satisfies SqlEntry,
 
   updateFeaturedVideoUrl: {
@@ -441,7 +619,10 @@ export const GameSql = {
           SET FEATURED_VIDEO_URL = :featuredVideoUrl,
               UPDATED_AT = SYSTIMESTAMP
         WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games
+          SET featured_video_url = :featuredVideoUrl,
+              updated_at = NOW()
+        WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   updateGameDescription: {
@@ -449,7 +630,10 @@ export const GameSql = {
           SET DESCRIPTION = :description,
               UPDATED_AT = SYSTIMESTAMP
         WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games
+          SET description = :description,
+              updated_at = NOW()
+        WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   clearReleaseAnnouncements: {
@@ -457,24 +641,29 @@ export const GameSql = {
           WHERE RELEASE_ID IN (
             SELECT RELEASE_ID FROM GAMEDB_RELEASES WHERE GAME_ID = :gameId
           )`,
-    postgres: ``,
+    postgres: `DELETE FROM gamedb_release_announcements
+          WHERE release_id IN (
+            SELECT release_id FROM gamedb_releases WHERE game_id = :gameId
+          )`,
   } satisfies SqlEntry,
 
   clearReleases: {
     oracle: `DELETE FROM GAMEDB_RELEASES WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `DELETE FROM gamedb_releases WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   clearInitialReleaseDate: {
     oracle: `UPDATE GAMEDB_GAMES
             SET INITIAL_RELEASE_DATE = NULL, UPDATED_AT = SYSTIMESTAMP
           WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games
+            SET initial_release_date = NULL, updated_at = NOW()
+          WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   touchGameUpdatedAt: {
     oracle: `UPDATE GAMEDB_GAMES SET UPDATED_AT = SYSTIMESTAMP WHERE GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_games SET updated_at = NOW() WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 
   getGotmWins: {
@@ -491,7 +680,19 @@ export const GameSql = {
            FROM GOTM_ENTRIES ge
           WHERE ge.GAMEDB_GAME_ID = :gameId
           ORDER BY ge.ROUND_NUMBER`,
-    postgres: ``,
+    postgres: `SELECT ge.round_number,
+                COALESCE(
+                  (SELECT MIN(tgl.thread_id)
+                     FROM thread_game_links tgl
+                    WHERE tgl.gamedb_game_id = ge.gamedb_game_id),
+                  (SELECT MIN(th.thread_id)
+                     FROM threads th
+                    WHERE th.gamedb_game_id = ge.gamedb_game_id)
+                ) AS thread_id,
+                ge.reddit_url, ge.month_year
+           FROM gotm_entries ge
+          WHERE ge.gamedb_game_id = :gameId
+          ORDER BY ge.round_number`,
   } satisfies SqlEntry,
 
   getNrGotmWins: {
@@ -508,7 +709,19 @@ export const GameSql = {
            FROM NR_GOTM_ENTRIES nge
           WHERE nge.GAMEDB_GAME_ID = :gameId
           ORDER BY nge.ROUND_NUMBER`,
-    postgres: ``,
+    postgres: `SELECT nge.round_number,
+                COALESCE(
+                  (SELECT MIN(tgl.thread_id)
+                     FROM thread_game_links tgl
+                    WHERE tgl.gamedb_game_id = nge.gamedb_game_id),
+                  (SELECT MIN(th.thread_id)
+                     FROM threads th
+                    WHERE th.gamedb_game_id = nge.gamedb_game_id)
+                ) AS thread_id,
+                nge.reddit_url, nge.month_year
+           FROM nr_gotm_entries nge
+          WHERE nge.gamedb_game_id = :gameId
+          ORDER BY nge.round_number`,
   } satisfies SqlEntry,
 
   getGotmNominations: {
@@ -517,7 +730,11 @@ export const GameSql = {
            LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = n.USER_ID
           WHERE n.GAMEDB_GAME_ID = :gameId
           ORDER BY n.ROUND_NUMBER`,
-    postgres: ``,
+    postgres: `SELECT n.round_number, n.user_id, u.username, u.global_name
+           FROM gotm_nominations n
+           LEFT JOIN rpg_club_users u ON u.user_id = n.user_id
+          WHERE n.gamedb_game_id = :gameId
+          ORDER BY n.round_number`,
   } satisfies SqlEntry,
 
   getNrGotmNominations: {
@@ -526,7 +743,11 @@ export const GameSql = {
            LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = n.USER_ID
           WHERE n.GAMEDB_GAME_ID = :gameId
           ORDER BY n.ROUND_NUMBER`,
-    postgres: ``,
+    postgres: `SELECT n.round_number, n.user_id, u.username, u.global_name
+           FROM nr_gotm_nominations n
+           LEFT JOIN rpg_club_users u ON u.user_id = n.user_id
+          WHERE n.gamedb_game_id = :gameId
+          ORDER BY n.round_number`,
   } satisfies SqlEntry,
 
   getNowPlayingMembers: {
@@ -544,7 +765,20 @@ export const GameSql = {
          JOIN RPG_CLUB_USERS ru ON ru.USER_ID = u.USER_ID
         WHERE u.GAMEDB_GAME_ID = :gameId
         ORDER BY u.ADDED_AT DESC, u.ENTRY_ID DESC`,
-    postgres: ``,
+    postgres: `SELECT u.user_id,
+              ru.username,
+              ru.global_name,
+              COALESCE(
+                (SELECT MIN(tgl.thread_id) FROM thread_game_links tgl
+                  WHERE tgl.gamedb_game_id = u.gamedb_game_id),
+                (SELECT MIN(th.thread_id) FROM threads th
+                  WHERE th.gamedb_game_id = u.gamedb_game_id)
+              ) AS thread_id,
+              u.added_at
+         FROM user_now_playing u
+         JOIN rpg_club_users ru ON ru.user_id = u.user_id
+        WHERE u.gamedb_game_id = :gameId
+        ORDER BY u.added_at DESC, u.entry_id DESC`,
   } satisfies SqlEntry,
 
   getGameCompletions: {
@@ -554,7 +788,12 @@ export const GameSql = {
          LEFT JOIN RPG_CLUB_USERS u ON u.USER_ID = c.USER_ID
         WHERE c.GAMEDB_GAME_ID = :gameId
         ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.CREATED_AT DESC, c.COMPLETION_ID DESC`,
-    postgres: ``,
+    postgres: `SELECT c.user_id, u.username, u.global_name,
+              c.completion_type, c.completed_at, c.final_playtime_hrs
+         FROM user_game_completions c
+         LEFT JOIN rpg_club_users u ON u.user_id = c.user_id
+        WHERE c.gamedb_game_id = :gameId
+        ORDER BY c.completed_at DESC NULLS LAST, c.created_at DESC, c.completion_id DESC`,
   } satisfies SqlEntry,
 
   getGameCollectionOwners: {
@@ -564,20 +803,29 @@ export const GameSql = {
         WHERE c.GAMEDB_GAME_ID = :gameId
         GROUP BY c.USER_ID, u.USERNAME, u.GLOBAL_NAME
         ORDER BY LOWER(COALESCE(u.GLOBAL_NAME, u.USERNAME, c.USER_ID))`,
-    postgres: ``,
+    postgres: `SELECT c.user_id, u.username, u.global_name
+         FROM user_game_collections c
+         LEFT JOIN rpg_club_users u ON u.user_id = c.user_id
+        WHERE c.gamedb_game_id = :gameId
+        GROUP BY c.user_id, u.username, u.global_name
+        ORDER BY LOWER(COALESCE(u.global_name, u.username, c.user_id))`,
   } satisfies SqlEntry,
 
   getPlatformByCode: {
     oracle: `SELECT ${PLATFORM_COLS}
          FROM GAMEDB_PLATFORMS
         WHERE PLATFORM_CODE = :code`,
-    postgres: ``,
+    postgres: `SELECT ${PLATFORM_COLS_PG}
+         FROM gamedb_platforms
+        WHERE platform_code = :code`,
   } satisfies SqlEntry,
 
   getPlatformById: {
     oracle: `SELECT ${PLATFORM_COLS}
          FROM GAMEDB_PLATFORMS
         WHERE PLATFORM_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT ${PLATFORM_COLS_PG}
+         FROM gamedb_platforms
+        WHERE platform_id = :id`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/gameDbCsvImport.sql.ts
+++ b/src/db/sql/gameDbCsvImport.sql.ts
@@ -12,6 +12,18 @@ const ITEM_COLS = `ITEM_ID,
             GAMEDB_GAME_ID,
             ERROR_TEXT`;
 
+const ITEM_COLS_PG = `item_id,
+            import_id,
+            row_index,
+            game_title,
+            raw_game_title,
+            platform_name,
+            region_name,
+            initial_release_date,
+            status,
+            gamedb_game_id,
+            error_text`;
+
 export const GameDbCsvImportSql = {
   createImport: {
     oracle: `INSERT INTO RPG_CLUB_GAMEDB_IMPORTS (
@@ -19,7 +31,11 @@ export const GameDbCsvImportSql = {
        ) VALUES (
          :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
        ) RETURNING IMPORT_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_gamedb_imports (
+         user_id, status, current_index, total_count, source_filename
+       ) VALUES (
+         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
+       ) RETURNING import_id`,
   } satisfies SqlEntry,
 
   insertItem: {
@@ -42,7 +58,25 @@ export const GameDbCsvImportSql = {
            :initialReleaseDate,
            'PENDING'
          )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_gamedb_import_items (
+           import_id,
+           row_index,
+           game_title,
+           raw_game_title,
+           platform_name,
+           region_name,
+           initial_release_date,
+           status
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :gameTitle,
+           :rawGameTitle,
+           :platformName,
+           :regionName,
+           :initialReleaseDate,
+           'PENDING'
+         )`,
   } satisfies SqlEntry,
 
   getImportById: {
@@ -56,7 +90,16 @@ export const GameDbCsvImportSql = {
             UPDATED_AT
        FROM RPG_CLUB_GAMEDB_IMPORTS
       WHERE IMPORT_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT import_id,
+            user_id,
+            status,
+            current_index,
+            total_count,
+            source_filename,
+            created_at,
+            updated_at
+       FROM rpg_club_gamedb_imports
+      WHERE import_id = :id`,
   } satisfies SqlEntry,
 
   getActiveForUser: {
@@ -73,21 +116,37 @@ export const GameDbCsvImportSql = {
         AND STATUS IN ('ACTIVE', 'PAUSED')
       ORDER BY CREATED_AT DESC, IMPORT_ID DESC
       FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT import_id,
+            user_id,
+            status,
+            current_index,
+            total_count,
+            source_filename,
+            created_at,
+            updated_at
+       FROM rpg_club_gamedb_imports
+      WHERE user_id = :userId
+        AND status IN ('ACTIVE', 'PAUSED')
+      ORDER BY created_at DESC, import_id DESC
+      LIMIT 1`,
   } satisfies SqlEntry,
 
   setStatus: {
     oracle: `UPDATE RPG_CLUB_GAMEDB_IMPORTS
         SET STATUS = :status
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_gamedb_imports
+        SET status = :status
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   updateIndex: {
     oracle: `UPDATE RPG_CLUB_GAMEDB_IMPORTS
         SET CURRENT_INDEX = :currentIndex
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_gamedb_imports
+        SET current_index = :currentIndex
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getNextPendingItem: {
@@ -97,22 +156,32 @@ export const GameDbCsvImportSql = {
         AND STATUS = 'PENDING'
       ORDER BY ROW_INDEX ASC
       FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_gamedb_import_items
+      WHERE import_id = :importId
+        AND status = 'PENDING'
+      ORDER BY row_index ASC
+      LIMIT 1`,
   } satisfies SqlEntry,
 
   getItemById: {
     oracle: `SELECT ${ITEM_COLS}
        FROM RPG_CLUB_GAMEDB_IMPORT_ITEMS
       WHERE ITEM_ID = :itemId`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_gamedb_import_items
+      WHERE item_id = :itemId`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres (e.g. "status = :status")
   updateItem: (fields: string[]) =>
     ({
       oracle: `UPDATE RPG_CLUB_GAMEDB_IMPORT_ITEMS
         SET ${fields.join(", ")}
       WHERE ITEM_ID = :itemId`,
-      postgres: ``,
+      postgres: `UPDATE rpg_club_gamedb_import_items
+        SET ${fields.join(", ")}
+      WHERE item_id = :itemId`,
     }) satisfies SqlEntry,
 
   countItems: {
@@ -120,6 +189,9 @@ export const GameDbCsvImportSql = {
        FROM RPG_CLUB_GAMEDB_IMPORT_ITEMS
       WHERE IMPORT_ID = :importId
       GROUP BY STATUS`,
-    postgres: ``,
+    postgres: `SELECT status, COUNT(*) AS cnt
+       FROM rpg_club_gamedb_import_items
+      WHERE import_id = :importId
+      GROUP BY status`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/gameDbCsvImportMapping.sql.ts
+++ b/src/db/sql/gameDbCsvImportMapping.sql.ts
@@ -12,7 +12,16 @@ export const GameDbCsvImportMappingSql = {
             UPDATED_AT
        FROM RPG_CLUB_GAMEDB_IMPORT_TITLE_MAP
       WHERE TITLE_NORM = :titleNorm`,
-    postgres: ``,
+    postgres: `SELECT map_id,
+            title_raw,
+            title_norm,
+            gamedb_game_id,
+            status,
+            created_by,
+            created_at,
+            updated_at
+       FROM rpg_club_gamedb_import_title_map
+      WHERE title_norm = :titleNorm`,
   } satisfies SqlEntry,
 
   upsert: {
@@ -30,6 +39,12 @@ export const GameDbCsvImportMappingSql = {
      WHEN NOT MATCHED THEN
        INSERT (TITLE_RAW, TITLE_NORM, GAMEDB_GAME_ID, STATUS, CREATED_BY)
        VALUES (:titleRaw, :titleNorm, :gameDbGameId, :status, :createdBy)`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_gamedb_import_title_map (title_raw, title_norm, gamedb_game_id, status, created_by)
+       VALUES (:titleRaw, :titleNorm, :gameDbGameId, :status, :createdBy)
+       ON CONFLICT (title_norm) DO UPDATE SET
+         title_raw = EXCLUDED.title_raw,
+         gamedb_game_id = EXCLUDED.gamedb_game_id,
+         status = EXCLUDED.status,
+         created_by = EXCLUDED.created_by`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/gameKey.sql.ts
+++ b/src/db/sql/gameKey.sql.ts
@@ -10,26 +10,42 @@ const GAME_KEY_COLS = `KEY_ID,
         CREATED_AT,
         UPDATED_AT`;
 
+const GAME_KEY_COLS_PG = `key_id,
+        game_title,
+        platform,
+        key_value,
+        donor_user_id,
+        claimed_by_user_id,
+        claimed_at,
+        created_at,
+        updated_at`;
+
 export const GameKeySql = {
   create: {
     oracle: `INSERT INTO RPG_CLUB_GAME_KEYS (GAME_TITLE, PLATFORM, KEY_VALUE, DONOR_USER_ID)
      VALUES (:title, :platform, :keyValue, :donorUserId)
      RETURNING KEY_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_game_keys (game_title, platform, key_value, donor_user_id)
+     VALUES (:title, :platform, :keyValue, :donorUserId)
+     RETURNING key_id`,
   } satisfies SqlEntry,
 
   getById: {
     oracle: `SELECT ${GAME_KEY_COLS}
        FROM RPG_CLUB_GAME_KEYS
       WHERE KEY_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT ${GAME_KEY_COLS_PG}
+       FROM rpg_club_game_keys
+      WHERE key_id = :id`,
   } satisfies SqlEntry,
 
   countAvailable: {
     oracle: `SELECT COUNT(*) AS TOTAL
        FROM RPG_CLUB_GAME_KEYS
       WHERE CLAIMED_BY_USER_ID IS NULL`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS total
+       FROM rpg_club_game_keys
+      WHERE claimed_by_user_id IS NULL`,
   } satisfies SqlEntry,
 
   listAvailable: {
@@ -38,7 +54,11 @@ export const GameKeySql = {
       WHERE CLAIMED_BY_USER_ID IS NULL
       ORDER BY UPPER(GAME_TITLE), KEY_ID
       OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${GAME_KEY_COLS_PG}
+       FROM rpg_club_game_keys
+      WHERE claimed_by_user_id IS NULL
+      ORDER BY UPPER(game_title), key_id
+      LIMIT :limit OFFSET :offset`,
   } satisfies SqlEntry,
 
   listByDonor: {
@@ -46,7 +66,10 @@ export const GameKeySql = {
        FROM RPG_CLUB_GAME_KEYS
       WHERE DONOR_USER_ID = :userId
       ORDER BY CREATED_AT DESC, KEY_ID DESC`,
-    postgres: ``,
+    postgres: `SELECT ${GAME_KEY_COLS_PG}
+       FROM rpg_club_game_keys
+      WHERE donor_user_id = :userId
+      ORDER BY created_at DESC, key_id DESC`,
   } satisfies SqlEntry,
 
   claim: {
@@ -55,11 +78,15 @@ export const GameKeySql = {
             CLAIMED_AT = SYSTIMESTAMP
       WHERE KEY_ID = :keyId
         AND CLAIMED_BY_USER_ID IS NULL`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_game_keys
+        SET claimed_by_user_id = :userId,
+            claimed_at = NOW()
+      WHERE key_id = :keyId
+        AND claimed_by_user_id IS NULL`,
   } satisfies SqlEntry,
 
   revoke: {
     oracle: `DELETE FROM RPG_CLUB_GAME_KEYS WHERE KEY_ID = :keyId`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_game_keys WHERE key_id = :keyId`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/gameReleaseAnnouncement.sql.ts
+++ b/src/db/sql/gameReleaseAnnouncement.sql.ts
@@ -25,7 +25,18 @@ export const GameReleaseAnnouncementSql = {
              src.RELEASE_ID, src.ANNOUNCE_AT, NULL, NULL, NULL,
              CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
            )`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_release_announcements
+         (release_id, announce_at, sent_at, skipped_at, skip_reason, created_at, updated_at)
+         SELECT r.release_id, r.release_date - INTERVAL '7 days', NULL, NULL, NULL,
+                CURRENT_TIMESTAMP, CURRENT_TIMESTAMP
+           FROM gamedb_releases r
+          WHERE r.release_date IS NOT NULL
+         ON CONFLICT (release_id) DO UPDATE SET
+           announce_at = EXCLUDED.announce_at,
+           updated_at = CURRENT_TIMESTAMP
+         WHERE gamedb_release_announcements.sent_at IS NULL
+           AND gamedb_release_announcements.skipped_at IS NULL
+           AND gamedb_release_announcements.announce_at <> EXCLUDED.announce_at`,
   } satisfies SqlEntry,
 
   restoreNonCanonical: {
@@ -58,7 +69,32 @@ export const GameReleaseAnnouncementSql = {
               ) non_canonical
               WHERE non_canonical.RELEASE_ID = a.RELEASE_ID
             )`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_release_announcements
+            SET skipped_at = NULL,
+                skip_reason = NULL,
+                updated_at = CURRENT_TIMESTAMP
+          WHERE sent_at IS NULL
+            AND skip_reason IN (:portOnlyReason, :sameDayReason)
+            AND NOT EXISTS (
+              SELECT 1
+              FROM (
+                SELECT r.release_id,
+                       r.release_date,
+                       MIN(r.release_date) OVER (PARTITION BY r.game_id) AS first_release_date,
+                       ROW_NUMBER() OVER (
+                         PARTITION BY r.game_id, r.release_date
+                         ORDER BY r.release_id ASC
+                       ) AS same_day_rank
+                FROM gamedb_releases r
+                WHERE r.release_date IS NOT NULL
+              ) ranked
+              WHERE (ranked.release_date > ranked.first_release_date
+                 OR (
+                   ranked.release_date = ranked.first_release_date
+                   AND ranked.same_day_rank > 1
+                 ))
+                AND ranked.release_id = gamedb_release_announcements.release_id
+            )`,
   } satisfies SqlEntry,
 
   markNonCanonical: {
@@ -94,7 +130,36 @@ export const GameReleaseAnnouncementSql = {
            a.UPDATED_AT = CURRENT_TIMESTAMP
          WHERE a.SENT_AT IS NULL
            AND a.SKIPPED_AT IS NULL`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_release_announcements a
+         SET skipped_at = CURRENT_TIMESTAMP,
+             skip_reason = src.skip_reason,
+             updated_at = CURRENT_TIMESTAMP
+        FROM (
+          SELECT ranked.release_id,
+                 CASE
+                   WHEN ranked.release_date > ranked.first_release_date THEN :portOnlyReason
+                   ELSE :sameDayReason
+                 END AS skip_reason
+          FROM (
+            SELECT r.release_id,
+                   r.release_date,
+                   MIN(r.release_date) OVER (PARTITION BY r.game_id) AS first_release_date,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY r.game_id, r.release_date
+                     ORDER BY r.release_id ASC
+                   ) AS same_day_rank
+            FROM gamedb_releases r
+            WHERE r.release_date IS NOT NULL
+          ) ranked
+          WHERE ranked.release_date > ranked.first_release_date
+             OR (
+               ranked.release_date = ranked.first_release_date
+               AND ranked.same_day_rank > 1
+             )
+        ) src
+        WHERE a.release_id = src.release_id
+          AND a.sent_at IS NULL
+          AND a.skipped_at IS NULL`,
   } satisfies SqlEntry,
 
   listDueAnnouncements: {
@@ -132,7 +197,40 @@ export const GameReleaseAnnouncementSql = {
           AND r.RELEASE_DATE > :referenceTime
         ORDER BY a.ANNOUNCE_AT ASC, r.RELEASE_DATE ASC, r.GAME_ID ASC, a.RELEASE_ID ASC
         FETCH FIRST :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT a.release_id,
+              r.game_id,
+              g.title,
+              r.release_date,
+              a.announce_at,
+              p.platform_name,
+              p.platform_abbreviation,
+              g.igdb_url
+         FROM gamedb_release_announcements a
+         JOIN gamedb_releases r ON r.release_id = a.release_id
+         JOIN gamedb_games g ON g.game_id = r.game_id
+         LEFT JOIN gamedb_platforms p ON p.platform_id = r.platform_id
+         JOIN (
+           SELECT canonical.release_id
+           FROM (
+             SELECT r.release_id,
+                    r.release_date,
+                    MIN(r.release_date) OVER (PARTITION BY r.game_id) AS first_release_date,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY r.game_id, r.release_date
+                      ORDER BY r.release_id ASC
+                    ) AS same_day_rank
+             FROM gamedb_releases r
+             WHERE r.release_date IS NOT NULL
+           ) canonical
+           WHERE canonical.release_date = canonical.first_release_date
+             AND canonical.same_day_rank = 1
+         ) c ON c.release_id = a.release_id
+        WHERE a.sent_at IS NULL
+          AND a.skipped_at IS NULL
+          AND a.announce_at <= :referenceTime
+          AND r.release_date > :referenceTime
+        ORDER BY a.announce_at ASC, r.release_date ASC, r.game_id ASC, a.release_id ASC
+        LIMIT :limit`,
   } satisfies SqlEntry,
 
   markSent: {
@@ -143,7 +241,13 @@ export const GameReleaseAnnouncementSql = {
         WHERE RELEASE_ID = :releaseId
           AND SENT_AT IS NULL
           AND SKIPPED_AT IS NULL`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_release_announcements
+          SET sent_at = :sentAt,
+              skip_reason = NULL,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE release_id = :releaseId
+          AND sent_at IS NULL
+          AND skipped_at IS NULL`,
   } satisfies SqlEntry,
 
   markMissed: {
@@ -160,6 +264,18 @@ export const GameReleaseAnnouncementSql = {
             WHERE r.RELEASE_ID = a.RELEASE_ID
               AND r.RELEASE_DATE <= :referenceTime
           )`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_release_announcements
+          SET skipped_at = :referenceTime,
+              skip_reason = :reason,
+              updated_at = CURRENT_TIMESTAMP
+        WHERE sent_at IS NULL
+          AND skipped_at IS NULL
+          AND announce_at <= :referenceTime
+          AND EXISTS (
+            SELECT 1
+            FROM gamedb_releases r
+            WHERE r.release_id = gamedb_release_announcements.release_id
+              AND r.release_date <= :referenceTime
+          )`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/gameSearchSynonym.sql.ts
+++ b/src/db/sql/gameSearchSynonym.sql.ts
@@ -1,13 +1,16 @@
 import type { SqlEntry } from "./types.js";
 
 const SYNONYM_COLS = `TERM_ID, GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_AT, CREATED_BY`;
+const SYNONYM_COLS_PG = `term_id, group_id, term_text, term_norm, created_at, created_by`;
 
 export const GameSearchSynonymSql = {
   getGroupIdsForTerm: {
     oracle: `SELECT GROUP_ID
          FROM GAMEDB_SEARCH_SYNONYMS
         WHERE TERM_NORM = :termNorm`,
-    postgres: ``,
+    postgres: `SELECT group_id
+         FROM gamedb_search_synonyms
+        WHERE term_norm = :termNorm`,
   } satisfies SqlEntry,
 
   listGroupTerms: {
@@ -15,7 +18,10 @@ export const GameSearchSynonymSql = {
          FROM GAMEDB_SEARCH_SYNONYMS
         WHERE GROUP_ID = :groupId
         ORDER BY TERM_TEXT ASC`,
-    postgres: ``,
+    postgres: `SELECT ${SYNONYM_COLS_PG}
+         FROM gamedb_search_synonyms
+        WHERE group_id = :groupId
+        ORDER BY term_text ASC`,
   } satisfies SqlEntry,
 
   getTermsForQuery: (placeholders: string) =>
@@ -24,7 +30,10 @@ export const GameSearchSynonymSql = {
            FROM GAMEDB_SEARCH_SYNONYMS
           WHERE GROUP_ID IN (${placeholders})
           ORDER BY TERM_TEXT ASC`,
-      postgres: ``,
+      postgres: `SELECT DISTINCT term_text
+           FROM gamedb_search_synonyms
+          WHERE group_id IN (${placeholders})
+          ORDER BY term_text ASC`,
     }) satisfies SqlEntry,
 
   listSynonyms: {
@@ -35,7 +44,13 @@ export const GameSearchSynonymSql = {
            OR TERM_NORM LIKE :normalizedQuery)
         ORDER BY GROUP_ID ASC, TERM_TEXT ASC
         FETCH FIRST :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${SYNONYM_COLS_PG}
+         FROM gamedb_search_synonyms
+        WHERE (:searchQuery IS NULL
+           OR LOWER(term_text) LIKE :searchQuery
+           OR term_norm LIKE :normalizedQuery)
+        ORDER BY group_id ASC, term_text ASC
+        LIMIT :limit`,
   } satisfies SqlEntry,
 
   countSynonymGroups: {
@@ -44,7 +59,11 @@ export const GameSearchSynonymSql = {
         WHERE (:searchQuery IS NULL
            OR LOWER(TERM_TEXT) LIKE :searchQuery
            OR TERM_NORM LIKE :normalizedQuery)`,
-    postgres: ``,
+    postgres: `SELECT COUNT(DISTINCT group_id) AS cnt
+         FROM gamedb_search_synonyms
+        WHERE (:searchQuery IS NULL
+           OR LOWER(term_text) LIKE :searchQuery
+           OR term_norm LIKE :normalizedQuery)`,
   } satisfies SqlEntry,
 
   listGroupIdsForSearch: {
@@ -55,7 +74,13 @@ export const GameSearchSynonymSql = {
              OR TERM_NORM LIKE :normalizedQuery)
           ORDER BY GROUP_ID ASC
           OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT DISTINCT group_id
+           FROM gamedb_search_synonyms
+          WHERE (:searchQuery IS NULL
+             OR LOWER(term_text) LIKE :searchQuery
+             OR term_norm LIKE :normalizedQuery)
+          ORDER BY group_id ASC
+          LIMIT :limit OFFSET :offset`,
   } satisfies SqlEntry,
 
   listTermsInGroups: (placeholders: string) =>
@@ -64,21 +89,28 @@ export const GameSearchSynonymSql = {
            FROM GAMEDB_SEARCH_SYNONYMS
           WHERE GROUP_ID IN (${placeholders})
           ORDER BY GROUP_ID ASC, TERM_TEXT ASC`,
-      postgres: ``,
+      postgres: `SELECT ${SYNONYM_COLS_PG}
+           FROM gamedb_search_synonyms
+          WHERE group_id IN (${placeholders})
+          ORDER BY group_id ASC, term_text ASC`,
     }) satisfies SqlEntry,
 
   insertSynonymGroup: {
     oracle: `INSERT INTO GAMEDB_SEARCH_SYNONYM_GROUPS (CREATED_BY)
            VALUES (:createdBy)
            RETURNING GROUP_ID INTO :groupId`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_search_synonym_groups (created_by)
+           VALUES (:createdBy)
+           RETURNING group_id`,
   } satisfies SqlEntry,
 
   insertSynonymTerm: {
     oracle: `INSERT INTO GAMEDB_SEARCH_SYNONYMS
                (GROUP_ID, TERM_TEXT, TERM_NORM, CREATED_BY)
              VALUES (:groupId, :termText, :termNorm, :createdBy)`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_search_synonyms
+               (group_id, term_text, term_norm, created_by)
+             VALUES (:groupId, :termText, :termNorm, :createdBy)`,
   } satisfies SqlEntry,
 
   updateSynonymTerm: {
@@ -86,50 +118,61 @@ export const GameSearchSynonymSql = {
             SET TERM_TEXT = :termText,
                 TERM_NORM = :termNorm
           WHERE TERM_ID = :termId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_search_synonyms
+            SET term_text = :termText,
+                term_norm = :termNorm
+          WHERE term_id = :termId`,
   } satisfies SqlEntry,
 
   checkGroupExists: {
     oracle: `SELECT COUNT(*) AS CNT
            FROM GAMEDB_SEARCH_SYNONYM_GROUPS
           WHERE GROUP_ID = :groupId`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+           FROM gamedb_search_synonym_groups
+          WHERE group_id = :groupId`,
   } satisfies SqlEntry,
 
   deleteSynonymsByGroup: {
     oracle: `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE GROUP_ID = :groupId`,
-    postgres: ``,
+    postgres: `DELETE FROM gamedb_search_synonyms WHERE group_id = :groupId`,
   } satisfies SqlEntry,
 
   getSynonymById: {
     oracle: `SELECT ${SYNONYM_COLS}
          FROM GAMEDB_SEARCH_SYNONYMS
         WHERE TERM_ID = :termId`,
-    postgres: ``,
+    postgres: `SELECT ${SYNONYM_COLS_PG}
+         FROM gamedb_search_synonyms
+        WHERE term_id = :termId`,
   } satisfies SqlEntry,
 
   deleteGroup: {
     oracle: `DELETE FROM GAMEDB_SEARCH_SYNONYM_GROUPS WHERE GROUP_ID = :groupId`,
-    postgres: ``,
+    postgres: `DELETE FROM gamedb_search_synonym_groups WHERE group_id = :groupId`,
   } satisfies SqlEntry,
 
   getSynonymGroupId: {
     oracle: `SELECT GROUP_ID
            FROM GAMEDB_SEARCH_SYNONYMS
           WHERE TERM_ID = :termId`,
-    postgres: ``,
+    postgres: `SELECT group_id
+           FROM gamedb_search_synonyms
+          WHERE term_id = :termId`,
   } satisfies SqlEntry,
 
   countSynonymsInGroup: {
     oracle: `SELECT COUNT(*) AS CNT
              FROM GAMEDB_SEARCH_SYNONYMS
             WHERE GROUP_ID = :groupId`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+             FROM gamedb_search_synonyms
+            WHERE group_id = :groupId`,
   } satisfies SqlEntry,
 
   deleteSynonymById: {
     oracle: `DELETE FROM GAMEDB_SEARCH_SYNONYMS WHERE TERM_ID = :termId`,
-    postgres: ``,
+    postgres: `DELETE FROM gamedb_search_synonyms WHERE term_id = :termId`,
   } satisfies SqlEntry,
 };
 
@@ -138,14 +181,18 @@ export const GameSearchSynonymDraftSql = {
     oracle: `INSERT INTO GAMEDB_SEARCH_SYNONYM_DRAFTS (USER_ID, PAIRS_JSON)
        VALUES (:userId, :pairsJson)
        RETURNING DRAFT_ID INTO :draftId`,
-    postgres: ``,
+    postgres: `INSERT INTO gamedb_search_synonym_drafts (user_id, pairs_json)
+       VALUES (:userId, :pairsJson)
+       RETURNING draft_id`,
   } satisfies SqlEntry,
 
   getDraft: {
     oracle: `SELECT DRAFT_ID, USER_ID, PAIRS_JSON, CREATED_AT, UPDATED_AT
          FROM GAMEDB_SEARCH_SYNONYM_DRAFTS
         WHERE DRAFT_ID = :draftId`,
-    postgres: ``,
+    postgres: `SELECT draft_id, user_id, pairs_json, created_at, updated_at
+         FROM gamedb_search_synonym_drafts
+        WHERE draft_id = :draftId`,
   } satisfies SqlEntry,
 
   updateDraft: {
@@ -153,11 +200,14 @@ export const GameSearchSynonymDraftSql = {
             SET PAIRS_JSON = :pairsJson,
                 UPDATED_AT = CURRENT_TIMESTAMP
           WHERE DRAFT_ID = :draftId`,
-    postgres: ``,
+    postgres: `UPDATE gamedb_search_synonym_drafts
+            SET pairs_json = :pairsJson,
+                updated_at = CURRENT_TIMESTAMP
+          WHERE draft_id = :draftId`,
   } satisfies SqlEntry,
 
   deleteDraft: {
     oracle: `DELETE FROM GAMEDB_SEARCH_SYNONYM_DRAFTS WHERE DRAFT_ID = :draftId`,
-    postgres: ``,
+    postgres: `DELETE FROM gamedb_search_synonym_drafts WHERE draft_id = :draftId`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/gotm.sql.ts
+++ b/src/db/sql/gotm.sql.ts
@@ -10,7 +10,14 @@ export const GotmSql = {
             GAMEDB_GAME_ID
        FROM GOTM_ENTRIES
       ORDER BY ROUND_NUMBER, GAME_INDEX`,
-    postgres: ``,
+    postgres: `SELECT round_number,
+            month_year,
+            game_index,
+            reddit_url,
+            voting_results_message_id,
+            gamedb_game_id
+       FROM gotm_entries
+      ORDER BY round_number, game_index`,
   } satisfies SqlEntry,
 
   getRowsByRound: {
@@ -19,7 +26,11 @@ export const GotmSql = {
          FROM GOTM_ENTRIES
         WHERE ROUND_NUMBER = :round
         ORDER BY GAME_INDEX`,
-    postgres: ``,
+    postgres: `SELECT round_number,
+              game_index
+         FROM gotm_entries
+        WHERE round_number = :round
+        ORDER BY game_index`,
   } satisfies SqlEntry,
 
   updateField: (columnName: string) =>
@@ -28,21 +39,28 @@ export const GotmSql = {
           SET ${columnName} = :value
         WHERE ROUND_NUMBER = :round
           AND GAME_INDEX = :gameIndex`,
-      postgres: ``,
+      postgres: `UPDATE gotm_entries
+          SET ${columnName.toLowerCase()} = :value
+        WHERE round_number = :round
+          AND game_index = :gameIndex`,
     }) satisfies SqlEntry,
 
   updateVotingResults: {
     oracle: `UPDATE GOTM_ENTRIES
         SET VOTING_RESULTS_MESSAGE_ID = :value
       WHERE ROUND_NUMBER = :round`,
-    postgres: ``,
+    postgres: `UPDATE gotm_entries
+        SET voting_results_message_id = :value
+      WHERE round_number = :round`,
   } satisfies SqlEntry,
 
   checkRoundExists: {
     oracle: `SELECT COUNT(*) AS CNT
        FROM GOTM_ENTRIES
       WHERE ROUND_NUMBER = :round`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+       FROM gotm_entries
+      WHERE round_number = :round`,
   } satisfies SqlEntry,
 
   insertRound: {
@@ -61,13 +79,28 @@ export const GotmSql = {
            NULL,
            :gamedbGameId
          )`,
-    postgres: ``,
+    postgres: `INSERT INTO gotm_entries (
+           round_number,
+           month_year,
+           game_index,
+           reddit_url,
+           voting_results_message_id,
+           gamedb_game_id
+         ) VALUES (
+           :round,
+           :monthYear,
+           :gameIndex,
+           :redditUrl,
+           NULL,
+           :gamedbGameId
+         )`,
   } satisfies SqlEntry,
 
   deleteRound: {
     oracle: `DELETE FROM GOTM_ENTRIES
       WHERE ROUND_NUMBER = :round`,
-    postgres: ``,
+    postgres: `DELETE FROM gotm_entries
+      WHERE round_number = :round`,
   } satisfies SqlEntry,
 };
 
@@ -81,7 +114,14 @@ export const NrGotmSql = {
             GAMEDB_GAME_ID
        FROM NR_GOTM_ENTRIES
       ORDER BY ROUND_NUMBER, GAME_INDEX`,
-    postgres: ``,
+    postgres: `SELECT round_number,
+            month_year,
+            game_index,
+            reddit_url,
+            voting_results_message_id,
+            gamedb_game_id
+       FROM nr_gotm_entries
+      ORDER BY round_number, game_index`,
   } satisfies SqlEntry,
 
   getRowsByRound: {
@@ -91,7 +131,12 @@ export const NrGotmSql = {
          FROM NR_GOTM_ENTRIES
         WHERE ROUND_NUMBER = :roundNumber
         ORDER BY GAME_INDEX`,
-    postgres: ``,
+    postgres: `SELECT nr_gotm_id,
+              round_number,
+              game_index
+         FROM nr_gotm_entries
+        WHERE round_number = :roundNumber
+        ORDER BY game_index`,
   } satisfies SqlEntry,
 
   updateByRowId: (columnName: string) =>
@@ -99,7 +144,9 @@ export const NrGotmSql = {
       oracle: `UPDATE NR_GOTM_ENTRIES
             SET ${columnName} = :bindValue
           WHERE NR_GOTM_ID = :rowIdValue`,
-      postgres: ``,
+      postgres: `UPDATE nr_gotm_entries
+            SET ${columnName.toLowerCase()} = :bindValue
+          WHERE nr_gotm_id = :rowIdValue`,
     }) satisfies SqlEntry,
 
   updateByRound: (columnName: string) =>
@@ -107,21 +154,27 @@ export const NrGotmSql = {
       oracle: `UPDATE NR_GOTM_ENTRIES
           SET ${columnName} = :bindValue
         WHERE NR_GOTM_ID = :rowIdValue`,
-      postgres: ``,
+      postgres: `UPDATE nr_gotm_entries
+          SET ${columnName.toLowerCase()} = :bindValue
+        WHERE nr_gotm_id = :rowIdValue`,
     }) satisfies SqlEntry,
 
   updateVotingResults: {
     oracle: `UPDATE NR_GOTM_ENTRIES
         SET VOTING_RESULTS_MESSAGE_ID = :bindValue
       WHERE ROUND_NUMBER = :roundNumber`,
-    postgres: ``,
+    postgres: `UPDATE nr_gotm_entries
+        SET voting_results_message_id = :bindValue
+      WHERE round_number = :roundNumber`,
   } satisfies SqlEntry,
 
   checkRoundExists: {
     oracle: `SELECT COUNT(*) AS CNT
        FROM NR_GOTM_ENTRIES
       WHERE ROUND_NUMBER = :roundNumber`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+       FROM nr_gotm_entries
+      WHERE round_number = :roundNumber`,
   } satisfies SqlEntry,
 
   insertRound: {
@@ -141,12 +194,28 @@ export const NrGotmSql = {
            :gamedbGameId
          )
          RETURNING NR_GOTM_ID INTO :outId`,
-    postgres: ``,
+    postgres: `INSERT INTO nr_gotm_entries (
+           round_number,
+           month_year,
+           game_index,
+           reddit_url,
+           voting_results_message_id,
+           gamedb_game_id
+         ) VALUES (
+           :roundNumber,
+           :monthYear,
+           :gameIndex,
+           :redditUrl,
+           NULL,
+           :gamedbGameId
+         )
+         RETURNING nr_gotm_id`,
   } satisfies SqlEntry,
 
   deleteRound: {
     oracle: `DELETE FROM NR_GOTM_ENTRIES
       WHERE ROUND_NUMBER = :roundNumber`,
-    postgres: ``,
+    postgres: `DELETE FROM nr_gotm_entries
+      WHERE round_number = :roundNumber`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/gotmAuditImport.sql.ts
+++ b/src/db/sql/gotmAuditImport.sql.ts
@@ -14,6 +14,20 @@ const ITEM_COLS = `ITEM_ID,
             GAMEDB_GAME_ID,
             ERROR_TEXT`;
 
+const ITEM_COLS_PG = `item_id,
+            import_id,
+            row_index,
+            kind,
+            round_number,
+            month_year,
+            game_index,
+            game_title,
+            thread_id,
+            reddit_url,
+            status,
+            gamedb_game_id,
+            error_text`;
+
 export const GotmAuditImportSql = {
   createSession: {
     oracle: `INSERT INTO RPG_CLUB_GOTM_AUDIT_IMPORTS (
@@ -21,7 +35,11 @@ export const GotmAuditImportSql = {
        ) VALUES (
          :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
        ) RETURNING IMPORT_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_gotm_audit_imports (
+         user_id, status, current_index, total_count, source_filename
+       ) VALUES (
+         :userId, 'ACTIVE', 0, :totalCount, :sourceFilename
+       ) RETURNING import_id`,
   } satisfies SqlEntry,
 
   insertItems: {
@@ -50,7 +68,31 @@ export const GotmAuditImportSql = {
            'PENDING',
            :gameDbGameId
          )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_gotm_audit_items (
+           import_id,
+           row_index,
+           kind,
+           round_number,
+           month_year,
+           game_index,
+           game_title,
+           thread_id,
+           reddit_url,
+           status,
+           gamedb_game_id
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :kind,
+           :roundNumber,
+           :monthYear,
+           :gameIndex,
+           :gameTitle,
+           :threadId,
+           :redditUrl,
+           'PENDING',
+           :gameDbGameId
+         )`,
   } satisfies SqlEntry,
 
   getById: {
@@ -64,7 +106,16 @@ export const GotmAuditImportSql = {
             UPDATED_AT
        FROM RPG_CLUB_GOTM_AUDIT_IMPORTS
       WHERE IMPORT_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT import_id,
+            user_id,
+            status,
+            current_index,
+            total_count,
+            source_filename,
+            created_at,
+            updated_at
+       FROM rpg_club_gotm_audit_imports
+      WHERE import_id = :id`,
   } satisfies SqlEntry,
 
   getActiveForUser: {
@@ -80,21 +131,36 @@ export const GotmAuditImportSql = {
       WHERE USER_ID = :userId
         AND STATUS IN ('ACTIVE', 'PAUSED')
       ORDER BY IMPORT_ID DESC`,
-    postgres: ``,
+    postgres: `SELECT import_id,
+            user_id,
+            status,
+            current_index,
+            total_count,
+            source_filename,
+            created_at,
+            updated_at
+       FROM rpg_club_gotm_audit_imports
+      WHERE user_id = :userId
+        AND status IN ('ACTIVE', 'PAUSED')
+      ORDER BY import_id DESC`,
   } satisfies SqlEntry,
 
   setStatus: {
     oracle: `UPDATE RPG_CLUB_GOTM_AUDIT_IMPORTS
         SET STATUS = :status
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_gotm_audit_imports
+        SET status = :status
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   updateIndex: {
     oracle: `UPDATE RPG_CLUB_GOTM_AUDIT_IMPORTS
         SET CURRENT_INDEX = :currentIndex
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_gotm_audit_imports
+        SET current_index = :currentIndex
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getNextPendingItem: {
@@ -104,22 +170,32 @@ export const GotmAuditImportSql = {
         AND STATUS = 'PENDING'
       ORDER BY ROW_INDEX
       FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_gotm_audit_items
+      WHERE import_id = :importId
+        AND status = 'PENDING'
+      ORDER BY row_index
+      LIMIT 1`,
   } satisfies SqlEntry,
 
   getItemById: {
     oracle: `SELECT ${ITEM_COLS}
        FROM RPG_CLUB_GOTM_AUDIT_ITEMS
       WHERE ITEM_ID = :itemId`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_gotm_audit_items
+      WHERE item_id = :itemId`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres (e.g. "status = :status")
   updateItem: (fields: string[]) =>
     ({
       oracle: `UPDATE RPG_CLUB_GOTM_AUDIT_ITEMS
         SET ${fields.join(", ")}
       WHERE ITEM_ID = :itemId`,
-      postgres: ``,
+      postgres: `UPDATE rpg_club_gotm_audit_items
+        SET ${fields.join(", ")}
+      WHERE item_id = :itemId`,
     }) satisfies SqlEntry,
 
   getItemsForRound: {
@@ -129,7 +205,12 @@ export const GotmAuditImportSql = {
         AND KIND = :kind
         AND ROUND_NUMBER = :roundNumber
       ORDER BY GAME_INDEX`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+       FROM rpg_club_gotm_audit_items
+      WHERE import_id = :importId
+        AND kind = :kind
+        AND round_number = :roundNumber
+      ORDER BY game_index`,
   } satisfies SqlEntry,
 
   countItems: {
@@ -137,6 +218,9 @@ export const GotmAuditImportSql = {
        FROM RPG_CLUB_GOTM_AUDIT_ITEMS
       WHERE IMPORT_ID = :importId
       GROUP BY STATUS`,
-    postgres: ``,
+    postgres: `SELECT status, COUNT(*) AS cnt
+       FROM rpg_club_gotm_audit_items
+      WHERE import_id = :importId
+      GROUP BY status`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/hltbCache.sql.ts
+++ b/src/db/sql/hltbCache.sql.ts
@@ -17,7 +17,21 @@ export const HltbCacheSql = {
             UPDATED_AT
        FROM RPG_CLUB_HLTB_CACHE
       WHERE GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `SELECT gamedb_game_id,
+            hltb_name,
+            hltb_url,
+            hltb_image_url,
+            main,
+            main_sides,
+            completionist,
+            single_player,
+            co_op,
+            vs,
+            source_query,
+            scraped_at,
+            updated_at
+       FROM rpg_club_hltb_cache
+      WHERE gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   upsertCache: {
@@ -68,6 +82,47 @@ export const HltbCacheSql = {
          SYSTIMESTAMP,
          SYSTIMESTAMP
        )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_hltb_cache (
+         gamedb_game_id,
+         hltb_name,
+         hltb_url,
+         hltb_image_url,
+         main,
+         main_sides,
+         completionist,
+         single_player,
+         co_op,
+         vs,
+         source_query,
+         scraped_at,
+         updated_at
+       ) VALUES (
+         :gameId,
+         :name,
+         :url,
+         :imageUrl,
+         :main,
+         :mainSides,
+         :completionist,
+         :singlePlayer,
+         :coOp,
+         :vs,
+         :sourceQuery,
+         NOW(),
+         NOW()
+       )
+       ON CONFLICT (gamedb_game_id) DO UPDATE SET
+         hltb_name = EXCLUDED.hltb_name,
+         hltb_url = EXCLUDED.hltb_url,
+         hltb_image_url = EXCLUDED.hltb_image_url,
+         main = EXCLUDED.main,
+         main_sides = EXCLUDED.main_sides,
+         completionist = EXCLUDED.completionist,
+         single_player = EXCLUDED.single_player,
+         co_op = EXCLUDED.co_op,
+         vs = EXCLUDED.vs,
+         source_query = EXCLUDED.source_query,
+         scraped_at = NOW(),
+         updated_at = NOW()`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/member.sql.ts
+++ b/src/db/sql/member.sql.ts
@@ -24,15 +24,43 @@ const COMPLETION_SELECT_SQL = `SELECT c.COMPLETION_ID,
         FROM USER_GAME_COMPLETIONS c
         JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID`;
 
+const COMPLETION_SELECT_SQL_PG = `SELECT c.completion_id,
+             g.game_id,
+             g.title,
+             c.completion_type,
+             c.platform_id,
+             c.completed_at,
+             c.final_playtime_hrs,
+             c.created_at,
+             c.note,
+             COALESCE(
+                (
+                  SELECT MIN(tgl.thread_id)
+                  FROM thread_game_links tgl
+                  WHERE tgl.gamedb_game_id = c.gamedb_game_id
+                ),
+                (
+                  SELECT MIN(th.thread_id)
+                  FROM threads th
+                  WHERE th.gamedb_game_id = c.gamedb_game_id
+                )
+              ) AS thread_id
+        FROM user_game_completions c
+        JOIN gamedb_games g ON g.game_id = c.gamedb_game_id`;
+
 export const MemberSql = {
   touchLastSeen: {
     oracle: `UPDATE RPG_CLUB_USERS
             SET LAST_SEEN_AT = :lastSeen,
                 UPDATED_AT = SYSTIMESTAMP
           WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_users
+            SET last_seen_at = :lastSeen,
+                updated_at = NOW()
+          WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
+  // threadIdSql is a dialect-specific SQL fragment; caller must supply appropriate version
   getNowPlaying: (threadIdSql: string) =>
     ({
       oracle: `SELECT g.GAME_ID,
@@ -72,9 +100,46 @@ export const MemberSql = {
           WHERE u.USER_ID = :userId
             AND u.GAMEDB_GAME_ID IS NOT NULL
           ORDER BY u.SORT_ORDER NULLS LAST, u.ADDED_AT DESC, u.ENTRY_ID DESC`,
-      postgres: ``,
+      postgres: `SELECT g.game_id,
+                g.title,
+                u.platform_id,
+                p.platform_name,
+                p.platform_abbreviation,
+                ${threadIdSql} AS thread_id,
+                u.note,
+                u.added_at,
+                u.note_updated_at,
+                u.sort_order,
+                COALESCE(jp.is_enabled, true) AS journal_enabled,
+                CASE
+                  WHEN EXISTS (
+                    SELECT 1
+                    FROM user_game_journal_entries je
+                    WHERE je.user_id = u.user_id
+                      AND je.gamedb_game_id = u.gamedb_game_id
+                  ) THEN 1
+                  ELSE 0
+                END AS has_journal_entry,
+                (SELECT COUNT(*)
+                   FROM user_game_journal_entries je2
+                  WHERE je2.user_id = u.user_id
+                    AND je2.gamedb_game_id = u.gamedb_game_id) AS journal_count,
+                (SELECT MAX(je3.created_at)
+                   FROM user_game_journal_entries je3
+                  WHERE je3.user_id = u.user_id
+                    AND je3.gamedb_game_id = u.gamedb_game_id) AS last_journal_at
+           FROM user_now_playing u
+           JOIN gamedb_games g ON g.game_id = u.gamedb_game_id
+           LEFT JOIN gamedb_platforms p ON p.platform_id = u.platform_id
+           LEFT JOIN user_game_journal_prefs jp
+             ON jp.user_id = u.user_id
+            AND jp.gamedb_game_id = u.gamedb_game_id
+          WHERE u.user_id = :userId
+            AND u.gamedb_game_id IS NOT NULL
+          ORDER BY u.sort_order NULLS LAST, u.added_at DESC, u.entry_id DESC`,
     }) satisfies SqlEntry,
 
+  // threadIdSql is a dialect-specific SQL fragment; caller must supply appropriate version
   getAllNowPlaying: (threadIdSql: string) =>
     ({
       oracle: `SELECT u.USER_ID,
@@ -99,7 +164,28 @@ export const MemberSql = {
           ORDER BY COALESCE(ru.GLOBAL_NAME, ru.USERNAME, ru.USER_ID),
                    u.ADDED_AT DESC,
                    u.ENTRY_ID DESC`,
-      postgres: ``,
+      postgres: `SELECT u.user_id,
+                ru.username,
+                ru.global_name,
+                g.game_id,
+                g.title,
+                u.platform_id,
+                p.platform_name,
+                p.platform_abbreviation,
+                ${threadIdSql} AS thread_id,
+                u.note,
+                u.added_at,
+                u.note_updated_at,
+                u.entry_id
+           FROM user_now_playing u
+           JOIN rpg_club_users ru ON ru.user_id = u.user_id
+           JOIN gamedb_games g ON g.game_id = u.gamedb_game_id
+           LEFT JOIN gamedb_platforms p ON p.platform_id = u.platform_id
+          WHERE COALESCE(ru.is_bot, false) = false
+            AND ru.server_left_at IS NULL
+          ORDER BY COALESCE(ru.global_name, ru.username, ru.user_id),
+                   u.added_at DESC,
+                   u.entry_id DESC`,
     }) satisfies SqlEntry,
 
   getNowPlayingByGameIds: (placeholders: string) =>
@@ -114,7 +200,16 @@ export const MemberSql = {
           AND NVL(ru.IS_BOT, 0) = 0
           AND ru.SERVER_LEFT_AT IS NULL
         ORDER BY g.TITLE, u.USER_ID`,
-      postgres: ``,
+      postgres: `SELECT u.gamedb_game_id AS game_id,
+              g.title,
+              u.user_id
+         FROM user_now_playing u
+         JOIN rpg_club_users ru ON ru.user_id = u.user_id
+         JOIN gamedb_games g ON g.game_id = u.gamedb_game_id
+        WHERE u.gamedb_game_id IN (${placeholders})
+          AND COALESCE(ru.is_bot, false) = false
+          AND ru.server_left_at IS NULL
+        ORDER BY g.title, u.user_id`,
     }) satisfies SqlEntry,
 
   getNowPlayingByTitleSearch: {
@@ -129,7 +224,17 @@ export const MemberSql = {
           AND NVL(ru.IS_BOT, 0) = 0
           AND ru.SERVER_LEFT_AT IS NULL
         ORDER BY g.TITLE, u.USER_ID`,
-    postgres: ``,
+    postgres: `SELECT u.gamedb_game_id AS game_id,
+              g.title,
+              u.user_id
+         FROM user_now_playing u
+         JOIN rpg_club_users ru ON ru.user_id = u.user_id
+         JOIN gamedb_games g ON g.game_id = u.gamedb_game_id
+        WHERE (LOWER(g.title) LIKE :searchQuery
+            OR REGEXP_REPLACE(LOWER(g.title), '[^a-z0-9]', '', 'g') LIKE :normalizedQuery)
+          AND COALESCE(ru.is_bot, false) = false
+          AND ru.server_left_at IS NULL
+        ORDER BY g.title, u.user_id`,
   } satisfies SqlEntry,
 
   getNowPlayingEntries: {
@@ -152,7 +257,25 @@ export const MemberSql = {
         WHERE u.USER_ID = :userId
           AND u.GAMEDB_GAME_ID IS NOT NULL
         ORDER BY u.SORT_ORDER NULLS LAST, u.ADDED_AT DESC, u.ENTRY_ID DESC`,
-    postgres: ``,
+    postgres: `SELECT u.gamedb_game_id AS game_id,
+              g.title,
+              u.platform_id,
+              p.platform_name,
+              p.platform_abbreviation,
+              u.note,
+              u.added_at,
+              u.note_updated_at,
+              u.sort_order,
+              jp.is_enabled AS journal_enabled
+         FROM user_now_playing u
+         JOIN gamedb_games g ON g.game_id = u.gamedb_game_id
+         LEFT JOIN gamedb_platforms p ON p.platform_id = u.platform_id
+         LEFT JOIN user_game_journal_prefs jp
+           ON jp.user_id = u.user_id
+          AND jp.gamedb_game_id = u.gamedb_game_id
+        WHERE u.user_id = :userId
+          AND u.gamedb_game_id IS NOT NULL
+        ORDER BY u.sort_order NULLS LAST, u.added_at DESC, u.entry_id DESC`,
   } satisfies SqlEntry,
 
   getNowPlayingEntryMeta: {
@@ -160,7 +283,10 @@ export const MemberSql = {
          FROM USER_NOW_PLAYING
         WHERE USER_ID = :userId
           AND GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `SELECT added_at
+         FROM user_now_playing
+        WHERE user_id = :userId
+          AND gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   updateNowPlayingNote: {
@@ -169,26 +295,34 @@ export const MemberSql = {
               NOTE_UPDATED_AT = :noteUpdatedAt
         WHERE USER_ID = :userId
           AND GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE user_now_playing
+          SET note = :note,
+              note_updated_at = :noteUpdatedAt
+        WHERE user_id = :userId
+          AND gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   countNowPlaying: {
     oracle: `SELECT COUNT(*) AS CNT FROM USER_NOW_PLAYING WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt FROM user_now_playing WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   getNowPlayingMaxSort: {
     oracle: `SELECT MAX(SORT_ORDER) AS MAX_SORT
              FROM USER_NOW_PLAYING
             WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `SELECT MAX(sort_order) AS max_sort
+             FROM user_now_playing
+            WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   insertNowPlaying: {
     oracle: `INSERT INTO USER_NOW_PLAYING
             (USER_ID, GAMEDB_GAME_ID, PLATFORM_ID, NOTE, NOTE_UPDATED_AT, SORT_ORDER)
            VALUES (:userId, :gameId, :platformId, :note, :noteUpdatedAt, :sortOrder)`,
-    postgres: ``,
+    postgres: `INSERT INTO user_now_playing
+            (user_id, gamedb_game_id, platform_id, note, note_updated_at, sort_order)
+           VALUES (:userId, :gameId, :platformId, :note, :noteUpdatedAt, :sortOrder)`,
   } satisfies SqlEntry,
 
   mergeJournalPrefs: {
@@ -200,7 +334,11 @@ export const MemberSql = {
            WHEN NOT MATCHED THEN
              INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
              VALUES (:userId, :gameId, 1, 0)`,
-    postgres: ``,
+    postgres: `INSERT INTO user_game_journal_prefs (user_id, gamedb_game_id, is_enabled, default_is_public)
+           VALUES (:userId, :gameId, true, false)
+           ON CONFLICT (user_id, gamedb_game_id) DO UPDATE SET
+             is_enabled = true,
+             updated_at = NOW()`,
   } satisfies SqlEntry,
 
   getGameJournalPreference: {
@@ -210,7 +348,12 @@ export const MemberSql = {
          FROM USER_GAME_JOURNAL_PREFS
         WHERE USER_ID = :userId
           AND GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `SELECT user_id,
+              gamedb_game_id,
+              is_enabled
+         FROM user_game_journal_prefs
+        WHERE user_id = :userId
+          AND gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   upsertGameJournalPreference: {
@@ -224,7 +367,12 @@ export const MemberSql = {
         WHEN NOT MATCHED THEN
           INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
           VALUES (:userId, :gameId, :isEnabled, 1)`,
-    postgres: ``,
+    postgres: `INSERT INTO user_game_journal_prefs (user_id, gamedb_game_id, is_enabled, default_is_public)
+          VALUES (:userId, :gameId, :isEnabled, true)
+          ON CONFLICT (user_id, gamedb_game_id) DO UPDATE SET
+            is_enabled = EXCLUDED.is_enabled,
+            default_is_public = true,
+            updated_at = NOW()`,
   } satisfies SqlEntry,
 
   getJournalStatusForGames: (inlineTable: string) =>
@@ -237,7 +385,14 @@ export const MemberSql = {
            ON je.USER_ID = :userId
           AND je.GAMEDB_GAME_ID = gids.GAME_ID
         GROUP BY gids.GAME_ID`,
-      postgres: ``,
+      postgres: `SELECT gids.game_id,
+              COUNT(*) AS journal_count,
+              MAX(je.created_at) AS last_journal_at
+         FROM (${inlineTable}) gids
+         LEFT JOIN user_game_journal_entries je
+           ON je.user_id = :userId
+          AND je.gamedb_game_id = gids.game_id
+        GROUP BY gids.game_id`,
     }) satisfies SqlEntry,
 
   getGameJournalEntries: {
@@ -265,7 +420,30 @@ export const MemberSql = {
          FROM all_entries
         ORDER BY CREATED_AT DESC, ENTRY_ID DESC
         OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `WITH all_entries AS (
+         SELECT entry_id,
+                user_id,
+                gamedb_game_id,
+                entry_title,
+                entry_body,
+                created_at,
+                updated_at,
+                ROW_NUMBER() OVER (ORDER BY created_at ASC, entry_id ASC) AS entry_number
+           FROM user_game_journal_entries
+          WHERE user_id = :userId
+            AND gamedb_game_id = :gameId
+       )
+       SELECT entry_id,
+              user_id,
+              gamedb_game_id,
+              entry_title,
+              entry_body,
+              created_at,
+              updated_at,
+              entry_number
+         FROM all_entries
+        ORDER BY created_at DESC, entry_id DESC
+        LIMIT :limit OFFSET :offset`,
   } satisfies SqlEntry,
 
   countGameJournalEntries: {
@@ -273,7 +451,10 @@ export const MemberSql = {
          FROM USER_GAME_JOURNAL_ENTRIES
         WHERE USER_ID = :userId
           AND GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+         FROM user_game_journal_entries
+        WHERE user_id = :userId
+          AND gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   addGameJournalEntry: {
@@ -281,7 +462,10 @@ export const MemberSql = {
         (USER_ID, GAMEDB_GAME_ID, ENTRY_TITLE, ENTRY_BODY, IS_PUBLIC)
        VALUES
         (:userId, :gameId, :title, :body, 1)`,
-    postgres: ``,
+    postgres: `INSERT INTO user_game_journal_entries
+        (user_id, gamedb_game_id, entry_title, entry_body, is_public)
+       VALUES
+        (:userId, :gameId, :title, :body, true)`,
   } satisfies SqlEntry,
 
   getGameJournalEntryForUser: {
@@ -303,23 +487,46 @@ export const MemberSql = {
         WHERE e.USER_ID = :userId
           AND e.ENTRY_ID = :entryId
         FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT e.entry_id,
+              e.user_id,
+              e.gamedb_game_id,
+              e.entry_title,
+              e.entry_body,
+              e.created_at,
+              e.updated_at,
+              (SELECT COUNT(*) + 1
+                 FROM user_game_journal_entries e2
+                WHERE e2.user_id = e.user_id
+                  AND e2.gamedb_game_id = e.gamedb_game_id
+                  AND (e2.created_at < e.created_at
+                       OR (e2.created_at = e.created_at AND e2.entry_id < e.entry_id))
+              ) AS entry_number
+         FROM user_game_journal_entries e
+        WHERE e.user_id = :userId
+          AND e.entry_id = :entryId
+        LIMIT 1`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres
   updateGameJournalEntry: (fields: string[]) =>
     ({
       oracle: `UPDATE USER_GAME_JOURNAL_ENTRIES
           SET ${fields.join(", ")}
         WHERE USER_ID = :userId
           AND ENTRY_ID = :entryId`,
-      postgres: ``,
+      postgres: `UPDATE user_game_journal_entries
+          SET ${fields.join(", ")}
+        WHERE user_id = :userId
+          AND entry_id = :entryId`,
     }) satisfies SqlEntry,
 
   deleteGameJournalEntry: {
     oracle: `DELETE FROM USER_GAME_JOURNAL_ENTRIES
         WHERE USER_ID = :userId
           AND ENTRY_ID = :entryId`,
-    postgres: ``,
+    postgres: `DELETE FROM user_game_journal_entries
+        WHERE user_id = :userId
+          AND entry_id = :entryId`,
   } satisfies SqlEntry,
 
   updateNowPlayingSort: {
@@ -327,12 +534,15 @@ export const MemberSql = {
             SET SORT_ORDER = :sortOrder
           WHERE USER_ID = :userId
             AND GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE user_now_playing
+            SET sort_order = :sortOrder
+          WHERE user_id = :userId
+            AND gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   removeNowPlaying: {
     oracle: `DELETE FROM USER_NOW_PLAYING WHERE USER_ID = :userId AND GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `DELETE FROM user_now_playing WHERE user_id = :userId AND gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   addCompletion: {
@@ -343,26 +553,36 @@ export const MemberSql = {
           :userId, :gameId, :type, :platformId, :completedAt, :playtime, :note
         )
         RETURNING COMPLETION_ID INTO :completionId`,
-    postgres: ``,
+    postgres: `INSERT INTO user_game_completions (
+          user_id, gamedb_game_id, completion_type, platform_id,
+          completed_at, final_playtime_hrs, note
+        ) VALUES (
+          :userId, :gameId, :type, :platformId, :completedAt, :playtime, :note
+        )
+        RETURNING completion_id`,
   } satisfies SqlEntry,
 
   verifyCompletion: {
     oracle: `SELECT COUNT(*) AS CNT FROM USER_GAME_COMPLETIONS
           WHERE COMPLETION_ID = :id AND USER_ID = :userId`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt FROM user_game_completions
+          WHERE completion_id = :id AND user_id = :userId`,
   } satisfies SqlEntry,
 
   getCompletion: {
     oracle: `${COMPLETION_SELECT_SQL}
        WHERE c.COMPLETION_ID = :completionId`,
-    postgres: ``,
+    postgres: `${COMPLETION_SELECT_SQL_PG}
+       WHERE c.completion_id = :completionId`,
   } satisfies SqlEntry,
 
   getCompletionForUser: {
     oracle: `${COMPLETION_SELECT_SQL}
        WHERE c.USER_ID = :userId
          AND c.COMPLETION_ID = :completionId`,
-    postgres: ``,
+    postgres: `${COMPLETION_SELECT_SQL_PG}
+       WHERE c.user_id = :userId
+         AND c.completion_id = :completionId`,
   } satisfies SqlEntry,
 
   getCompletionByGameId: {
@@ -370,48 +590,67 @@ export const MemberSql = {
        WHERE c.USER_ID = :userId
          AND c.GAMEDB_GAME_ID = :gameId
        FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `${COMPLETION_SELECT_SQL_PG}
+       WHERE c.user_id = :userId
+         AND c.gamedb_game_id = :gameId
+       LIMIT 1`,
   } satisfies SqlEntry,
 
+  // Caller must pass dialect-appropriate whereClause
   getCompletions: (whereClause: string) =>
     ({
       oracle: `${COMPLETION_SELECT_SQL}
        WHERE ${whereClause}
        ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC
        OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-      postgres: ``,
+      postgres: `${COMPLETION_SELECT_SQL_PG}
+       WHERE ${whereClause}
+       ORDER BY c.completed_at DESC NULLS LAST, c.completion_id DESC
+       LIMIT :limit OFFSET :offset`,
     }) satisfies SqlEntry,
 
   getAllCompletions: {
     oracle: `${COMPLETION_SELECT_SQL}
        WHERE c.USER_ID = :userId
        ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.CREATED_AT DESC, c.COMPLETION_ID DESC`,
-    postgres: ``,
+    postgres: `${COMPLETION_SELECT_SQL_PG}
+       WHERE c.user_id = :userId
+       ORDER BY c.completed_at DESC NULLS LAST, c.created_at DESC, c.completion_id DESC`,
   } satisfies SqlEntry,
 
+  // Caller must pass dialect-appropriate whereClause
   countCompletions: (whereClause: string) =>
     ({
       oracle: `SELECT COUNT(*) AS CNT
         FROM USER_GAME_COMPLETIONS c
         JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
        WHERE ${whereClause}`,
-      postgres: ``,
+      postgres: `SELECT COUNT(*) AS cnt
+        FROM user_game_completions c
+        JOIN gamedb_games g ON g.game_id = c.gamedb_game_id
+       WHERE ${whereClause}`,
     }) satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres
   updateCompletion: (fields: string[]) =>
     ({
       oracle: `UPDATE USER_GAME_COMPLETIONS
          SET ${fields.join(", ")}
        WHERE COMPLETION_ID = :completionId
          AND USER_ID = :userId`,
-      postgres: ``,
+      postgres: `UPDATE user_game_completions
+         SET ${fields.join(", ")}
+       WHERE completion_id = :completionId
+         AND user_id = :userId`,
     }) satisfies SqlEntry,
 
   deleteCompletion: {
     oracle: `DELETE FROM USER_GAME_COMPLETIONS
        WHERE COMPLETION_ID = :completionId
          AND USER_ID = :userId`,
-    postgres: ``,
+    postgres: `DELETE FROM user_game_completions
+       WHERE completion_id = :completionId
+         AND user_id = :userId`,
   } satisfies SqlEntry,
 
   getCompletionsForGame: {
@@ -419,7 +658,10 @@ export const MemberSql = {
        WHERE c.USER_ID = :userId
          AND c.GAMEDB_GAME_ID = :gameId
        ORDER BY c.COMPLETED_AT DESC NULLS LAST, c.COMPLETION_ID DESC`,
-    postgres: ``,
+    postgres: `${COMPLETION_SELECT_SQL_PG}
+       WHERE c.user_id = :userId
+         AND c.gamedb_game_id = :gameId
+       ORDER BY c.completed_at DESC NULLS LAST, c.completion_id DESC`,
   } satisfies SqlEntry,
 
   getRecentCompletionForGame: {
@@ -429,7 +671,12 @@ export const MemberSql = {
          AND COALESCE(c.COMPLETED_AT, c.CREATED_AT) BETWEEN :startDate AND :endDate
        ORDER BY COALESCE(c.COMPLETED_AT, c.CREATED_AT) DESC
        FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `${COMPLETION_SELECT_SQL_PG}
+       WHERE c.user_id = :userId
+         AND c.gamedb_game_id = :gameId
+         AND COALESCE(c.completed_at, c.created_at) BETWEEN :startDate AND :endDate
+       ORDER BY COALESCE(c.completed_at, c.created_at) DESC
+       LIMIT 1`,
   } satisfies SqlEntry,
 
   getRecentNickHistory: {
@@ -438,9 +685,14 @@ export const MemberSql = {
           WHERE USER_ID = :userId
           ORDER BY CHANGED_AT DESC
           FETCH FIRST :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT old_nick, new_nick, changed_at
+           FROM rpg_club_user_nick_history
+          WHERE user_id = :userId
+          ORDER BY changed_at DESC
+          LIMIT :limit`,
   } satisfies SqlEntry,
 
+  // Caller must pass dialect-appropriate whereClause
   getCompletionLeaderboard: (whereClause: string) =>
     ({
       oracle: `SELECT c.USER_ID, u.USERNAME, u.GLOBAL_NAME, COUNT(*) AS CNT
@@ -451,9 +703,17 @@ export const MemberSql = {
        GROUP BY c.USER_ID, u.USERNAME, u.GLOBAL_NAME
        ORDER BY CNT DESC
        FETCH FIRST :limit ROWS ONLY`,
-      postgres: ``,
+      postgres: `SELECT c.user_id, u.username, u.global_name, COUNT(*) AS cnt
+        FROM user_game_completions c
+        JOIN rpg_club_users u ON u.user_id = c.user_id
+        JOIN gamedb_games g ON g.game_id = c.gamedb_game_id
+       WHERE ${whereClause}
+       GROUP BY c.user_id, u.username, u.global_name
+       ORDER BY cnt DESC
+       LIMIT :limit`,
     }) satisfies SqlEntry,
 
+  // Caller must pass dialect-appropriate where clause
   searchMembers: (where: string) =>
     ({
       oracle: `SELECT USER_ID,
@@ -477,7 +737,27 @@ export const MemberSql = {
         WHERE ${where}
         ORDER BY COALESCE(UPPER(GLOBAL_NAME), UPPER(USERNAME), USER_ID)
         FETCH FIRST :limit ROWS ONLY`,
-      postgres: ``,
+      postgres: `SELECT user_id,
+              username,
+              global_name,
+              is_bot,
+              completionator_url,
+              steam_url,
+              psn_username,
+              xbl_username,
+              nsw_friend_code,
+              role_admin,
+              role_moderator,
+              role_regular,
+              role_member,
+              role_newcomer,
+              server_left_at,
+              server_joined_at,
+              last_seen_at
+         FROM rpg_club_users
+        WHERE ${where}
+        ORDER BY COALESCE(UPPER(global_name), UPPER(username), user_id)
+        LIMIT :limit`,
     }) satisfies SqlEntry,
 
   getByUserId: {
@@ -504,7 +784,29 @@ export const MemberSql = {
                 PROFILE_IMAGE_AT
            FROM RPG_CLUB_USERS
           WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `SELECT user_id,
+                is_bot,
+                username,
+                global_name,
+               avatar_blob,
+               server_joined_at,
+                server_left_at,
+                last_seen_at,
+                role_admin,
+                role_moderator,
+                role_regular,
+                role_member,
+                role_newcomer,
+                message_count,
+                completionator_url,
+                psn_username,
+                xbl_username,
+                nsw_friend_code,
+                steam_url,
+                profile_image,
+                profile_image_at
+           FROM rpg_club_users
+          WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   updateNowPlayingPlatform: {
@@ -512,7 +814,10 @@ export const MemberSql = {
           SET PLATFORM_ID = :platformId
         WHERE USER_ID = :userId
           AND GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `UPDATE user_now_playing
+          SET platform_id = :platformId
+        WHERE user_id = :userId
+          AND gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   getAvatarHistory: {
@@ -526,7 +831,16 @@ export const MemberSql = {
           WHERE USER_ID = :userId
           ORDER BY CHANGED_AT DESC, EVENT_ID DESC
           OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT event_id,
+                user_id,
+                avatar_hash,
+                avatar_url,
+                avatar_blob,
+                changed_at
+           FROM rpg_club_user_avatar_history
+          WHERE user_id = :userId
+          ORDER BY changed_at DESC, event_id DESC
+          LIMIT :limit OFFSET :offset`,
   } satisfies SqlEntry,
 
   updateMember: {
@@ -551,7 +865,27 @@ export const MemberSql = {
                 STEAM_URL = :steamUrl,
                 UPDATED_AT = SYSTIMESTAMP
           WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_users
+            SET is_bot = :isBot,
+                username = :username,
+                global_name = :globalName,
+                avatar_blob = :avatarBlob,
+                server_joined_at = :joinedAt,
+                server_left_at = :leftAt,
+                last_seen_at = :lastSeenAt,
+                last_fetched_at = NOW(),
+                role_admin = :roleAdmin,
+                role_moderator = :roleModerator,
+                role_regular = :roleRegular,
+                role_member = :roleMember,
+                role_newcomer = :roleNewcomer,
+                completionator_url = :completionatorUrl,
+                psn_username = :psnUsername,
+                xbl_username = :xblUsername,
+                nsw_friend_code = :nswFriendCode,
+                steam_url = :steamUrl,
+                updated_at = NOW()
+          WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   insertMember: {
@@ -570,7 +904,21 @@ export const MemberSql = {
              :nswFriendCode, :steamUrl,
              SYSTIMESTAMP, SYSTIMESTAMP
            )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_users (
+             user_id, is_bot, username, global_name, avatar_blob,
+             server_joined_at, server_left_at, last_seen_at, last_fetched_at,
+             role_admin, role_moderator, role_regular, role_member, role_newcomer,
+             completionator_url, psn_username, xbl_username, nsw_friend_code,
+             steam_url,
+             created_at, updated_at
+           ) VALUES (
+             :userId, :isBot, :username, :globalName, :avatarBlob,
+             :joinedAt, :leftAt, :lastSeenAt, NOW(),
+             :roleAdmin, :roleModerator, :roleRegular, :roleMember, :roleNewcomer,
+             :completionatorUrl, :psnUsername, :xblUsername,
+             :nswFriendCode, :steamUrl,
+             NOW(), NOW()
+           )`,
   } satisfies SqlEntry,
 
   markDepartedNotIn: (placeholders: string) =>
@@ -580,7 +928,11 @@ export const MemberSql = {
                  UPDATED_AT = SYSTIMESTAMP
            WHERE SERVER_LEFT_AT IS NULL
              AND USER_ID NOT IN (${placeholders})`,
-      postgres: ``,
+      postgres: `UPDATE rpg_club_users
+             SET server_left_at = NOW(),
+                 updated_at = NOW()
+           WHERE server_left_at IS NULL
+             AND user_id NOT IN (${placeholders})`,
     }) satisfies SqlEntry,
 
   getGameJournalList: {
@@ -597,7 +949,19 @@ export const MemberSql = {
         GROUP BY g.GAME_ID, g.TITLE
        HAVING COUNT(e.ENTRY_ID) > 0
         ORDER BY g.TITLE`,
-    postgres: ``,
+    postgres: `SELECT g.game_id,
+              g.title,
+              COUNT(e.entry_id) AS total_entries
+         FROM user_game_journal_prefs jp
+         JOIN gamedb_games g ON g.game_id = jp.gamedb_game_id
+         LEFT JOIN user_game_journal_entries e
+           ON e.user_id = jp.user_id
+          AND e.gamedb_game_id = jp.gamedb_game_id
+        WHERE jp.user_id = :userId
+          AND jp.is_enabled = true
+        GROUP BY g.game_id, g.title
+       HAVING COUNT(e.entry_id) > 0
+        ORDER BY g.title`,
   } satisfies SqlEntry,
 
   getAllJournalUsers: {
@@ -614,7 +978,19 @@ export const MemberSql = {
         ORDER BY COUNT(DISTINCT je.GAMEDB_GAME_ID) DESC,
                  u.GLOBAL_NAME NULLS LAST,
                  u.USERNAME NULLS LAST`,
-    postgres: ``,
+    postgres: `SELECT u.user_id,
+              u.username,
+              u.global_name,
+              COUNT(DISTINCT je.gamedb_game_id) AS game_count,
+              COUNT(je.entry_id) AS entry_count
+         FROM user_game_journal_entries je
+         JOIN rpg_club_users u ON u.user_id = je.user_id
+        WHERE COALESCE(u.is_bot, false) = false
+          AND u.server_left_at IS NULL
+        GROUP BY u.user_id, u.username, u.global_name
+        ORDER BY COUNT(DISTINCT je.gamedb_game_id) DESC,
+                 u.global_name NULLS LAST,
+                 u.username NULLS LAST`,
   } satisfies SqlEntry,
 
   searchJournalEntries: {
@@ -639,7 +1015,27 @@ export const MemberSql = {
           AND (:gameId IS NULL OR je.GAMEDB_GAME_ID = :gameId)
         ORDER BY je.CREATED_AT DESC, je.ENTRY_ID DESC
         OFFSET :offset ROWS FETCH NEXT :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) OVER () AS total_count,
+              je.entry_id,
+              je.user_id,
+              u.global_name,
+              u.username,
+              je.gamedb_game_id,
+              g.title         AS game_title,
+              je.entry_title,
+              je.entry_body,
+              je.created_at
+         FROM user_game_journal_entries je
+         JOIN gamedb_games g ON g.game_id = je.gamedb_game_id
+         JOIN rpg_club_users u ON u.user_id = je.user_id
+        WHERE (
+                je.entry_title ILIKE '%' || :searchTerm || '%'
+             OR je.entry_body  ILIKE '%' || :searchTerm || '%'
+              )
+          AND (:userId IS NULL OR je.user_id = :userId)
+          AND (:gameId IS NULL OR je.gamedb_game_id = :gameId)
+        ORDER BY je.created_at DESC, je.entry_id DESC
+        LIMIT :limit OFFSET :offset`,
   } satisfies SqlEntry,
 
   updateEmojiName: {
@@ -647,14 +1043,19 @@ export const MemberSql = {
           SET EMOJI_NAME = :emojiName,
               UPDATED_AT = SYSTIMESTAMP
         WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_users
+          SET emoji_name = :emojiName,
+              updated_at = NOW()
+        WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   getAllWithEmojiName: {
     oracle: `SELECT USER_ID, EMOJI_NAME
          FROM RPG_CLUB_USERS
         WHERE EMOJI_NAME IS NOT NULL`,
-    postgres: ``,
+    postgres: `SELECT user_id, emoji_name
+         FROM rpg_club_users
+        WHERE emoji_name IS NOT NULL`,
   } satisfies SqlEntry,
 
   upsertJournalMessageContext: {
@@ -668,60 +1069,78 @@ export const MemberSql = {
         WHEN NOT MATCHED THEN
           INSERT (CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID)
           VALUES (:channelId, :messageId, :createdAtMs, :ownerUserId, :gameId)`,
-    postgres: ``,
+    postgres: `INSERT INTO journal_message_contexts (channel_id, message_id, created_at_ms, owner_user_id, game_id)
+          VALUES (:channelId, :messageId, :createdAtMs, :ownerUserId, :gameId)
+          ON CONFLICT (channel_id, message_id) DO UPDATE SET
+            created_at_ms = EXCLUDED.created_at_ms,
+            owner_user_id = EXCLUDED.owner_user_id,
+            game_id = EXCLUDED.game_id`,
   } satisfies SqlEntry,
 
   deleteJournalMessageContext: {
     oracle: `DELETE FROM JOURNAL_MESSAGE_CONTEXTS
         WHERE CHANNEL_ID = :channelId
           AND MESSAGE_ID = :messageId`,
-    postgres: ``,
+    postgres: `DELETE FROM journal_message_contexts
+        WHERE channel_id = :channelId
+          AND message_id = :messageId`,
   } satisfies SqlEntry,
 
   loadActiveJournalMessageContexts: {
     oracle: `SELECT CHANNEL_ID, MESSAGE_ID, CREATED_AT_MS, OWNER_USER_ID, GAME_ID
          FROM JOURNAL_MESSAGE_CONTEXTS
         WHERE CREATED_AT_MS >= :cutoffMs`,
-    postgres: ``,
+    postgres: `SELECT channel_id, message_id, created_at_ms, owner_user_id, game_id
+         FROM journal_message_contexts
+        WHERE created_at_ms >= :cutoffMs`,
   } satisfies SqlEntry,
 
   pruneExpiredJournalMessageContexts: {
     oracle: `DELETE FROM JOURNAL_MESSAGE_CONTEXTS WHERE CREATED_AT_MS < :cutoffMs`,
-    postgres: ``,
+    postgres: `DELETE FROM journal_message_contexts WHERE created_at_ms < :cutoffMs`,
   } satisfies SqlEntry,
 
   getGiveawayDonorNotifySetting: {
     oracle: `SELECT DONOR_NOTIFY_ON_CLAIM
          FROM RPG_CLUB_USERS
         WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `SELECT donor_notify_on_claim
+         FROM rpg_club_users
+        WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   updateGiveawayDonorNotifySetting: {
     oracle: `UPDATE RPG_CLUB_USERS
             SET DONOR_NOTIFY_ON_CLAIM = :enabled
           WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_users
+            SET donor_notify_on_claim = :enabled
+          WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   insertGiveawayDonorNotifySetting: {
     oracle: `INSERT INTO RPG_CLUB_USERS (USER_ID, DONOR_NOTIFY_ON_CLAIM)
            VALUES (:userId, :enabled)`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_users (user_id, donor_notify_on_claim)
+           VALUES (:userId, :enabled)`,
   } satisfies SqlEntry,
 
   countAvatarHistory: {
     oracle: `SELECT COUNT(*) AS TOTAL
          FROM RPG_CLUB_USER_AVATAR_HISTORY
         WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS total
+         FROM rpg_club_user_avatar_history
+        WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   insertAvatarHistoryRecord: {
     oracle: `INSERT INTO RPG_CLUB_USER_AVATAR_HISTORY
        (USER_ID, AVATAR_HASH, AVATAR_URL, AVATAR_BLOB)
        VALUES (:userId, :avatarHash, :avatarUrl, :avatarBlob)`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_user_avatar_history
+       (user_id, avatar_hash, avatar_url, avatar_blob)
+       VALUES (:userId, :avatarHash, :avatarUrl, :avatarBlob)`,
   } satisfies SqlEntry,
 
   getAllMembersAvatarHistoryCounts: {
@@ -735,7 +1154,16 @@ export const MemberSql = {
           AND u.SERVER_LEFT_AT IS NULL
         GROUP BY h.USER_ID, u.USERNAME, u.GLOBAL_NAME
         ORDER BY COALESCE(u.GLOBAL_NAME, u.USERNAME, h.USER_ID)`,
-    postgres: ``,
+    postgres: `SELECT h.user_id,
+              u.username,
+              u.global_name,
+              COUNT(*) AS total
+         FROM rpg_club_user_avatar_history h
+         JOIN rpg_club_users u ON u.user_id = h.user_id
+        WHERE COALESCE(u.is_bot, false) = false
+          AND u.server_left_at IS NULL
+        GROUP BY h.user_id, u.username, u.global_name
+        ORDER BY COALESCE(u.global_name, u.username, h.user_id)`,
   } satisfies SqlEntry,
 
   getMembersWithPlatforms: {
@@ -754,7 +1182,21 @@ export const MemberSql = {
                OR NSW_FRIEND_CODE IS NOT NULL)
           AND NVL(IS_BOT, 0) = 0
           AND SERVER_LEFT_AT IS NULL`,
-    postgres: ``,
+    postgres: `SELECT user_id,
+              username,
+              global_name,
+              steam_url,
+              psn_username,
+              xbl_username,
+              nsw_friend_code,
+              server_left_at
+         FROM rpg_club_users
+        WHERE (steam_url IS NOT NULL
+               OR psn_username IS NOT NULL
+               OR xbl_username IS NOT NULL
+               OR nsw_friend_code IS NOT NULL)
+          AND COALESCE(is_bot, false) = false
+          AND server_left_at IS NULL`,
   } satisfies SqlEntry,
 
   checkLinkedThreadColumn: {
@@ -763,6 +1205,10 @@ export const MemberSql = {
           WHERE OWNER = SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')
             AND TABLE_NAME = 'GAMEDB_GAMES'
             AND COLUMN_NAME = 'LINKED_THREAD_ID'`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+           FROM information_schema.columns
+          WHERE table_schema = current_schema()
+            AND table_name = 'gamedb_games'
+            AND column_name = 'linked_thread_id'`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/nomination.sql.ts
+++ b/src/db/sql/nomination.sql.ts
@@ -14,7 +14,17 @@ export const NominationSql = {
        LEFT JOIN GAMEDB_GAMES g ON g.GAME_ID = n.GAMEDB_GAME_ID
       WHERE n.ROUND_NUMBER = :roundNumber
         AND n.USER_ID = :userId`,
-      postgres: ``,
+      postgres: `SELECT n.nomination_id,
+            n.round_number,
+            n.user_id,
+            n.gamedb_game_id,
+            g.title AS gamedb_title,
+            n.nominated_at,
+            n.reason
+       FROM ${table.toLowerCase()} n
+       LEFT JOIN gamedb_games g ON g.game_id = n.gamedb_game_id
+      WHERE n.round_number = :roundNumber
+        AND n.user_id = :userId`,
     }) satisfies SqlEntry,
 
   upsertNomination: (table: string) =>
@@ -36,7 +46,12 @@ export const NominationSql = {
     WHEN NOT MATCHED THEN
       INSERT (ROUND_NUMBER, USER_ID, GAMEDB_GAME_ID, NOMINATED_AT, REASON)
       VALUES (src.ROUND_NUMBER, src.USER_ID, src.GAMEDB_GAME_ID, src.NOMINATED_AT, src.REASON)`,
-      postgres: ``,
+      postgres: `INSERT INTO ${table.toLowerCase()} (round_number, user_id, gamedb_game_id, nominated_at, reason)
+      VALUES (:roundNumber, :userId, :gamedbGameId, :nominatedAt, :reason)
+      ON CONFLICT (round_number, user_id) DO UPDATE SET
+        gamedb_game_id = EXCLUDED.gamedb_game_id,
+        nominated_at = EXCLUDED.nominated_at,
+        reason = EXCLUDED.reason`,
     }) satisfies SqlEntry,
 
   deleteNomination: (table: string) =>
@@ -44,7 +59,9 @@ export const NominationSql = {
       oracle: `DELETE FROM ${table}
       WHERE ROUND_NUMBER = :roundNumber
         AND USER_ID = :userId`,
-      postgres: ``,
+      postgres: `DELETE FROM ${table.toLowerCase()}
+      WHERE round_number = :roundNumber
+        AND user_id = :userId`,
     }) satisfies SqlEntry,
 
   listNominationsForRound: (table: string) =>
@@ -60,6 +77,16 @@ export const NominationSql = {
        LEFT JOIN GAMEDB_GAMES g ON g.GAME_ID = n.GAMEDB_GAME_ID
       WHERE n.ROUND_NUMBER = :roundNumber
       ORDER BY g.TITLE ASC`,
-      postgres: ``,
+      postgres: `SELECT n.nomination_id,
+            n.round_number,
+            n.user_id,
+            n.gamedb_game_id,
+            g.title AS gamedb_title,
+            n.nominated_at,
+            n.reason
+       FROM ${table.toLowerCase()} n
+       LEFT JOIN gamedb_games g ON g.game_id = n.gamedb_game_id
+      WHERE n.round_number = :roundNumber
+      ORDER BY g.title ASC`,
     }) satisfies SqlEntry,
 };

--- a/src/db/sql/presencePrompt.sql.ts
+++ b/src/db/sql/presencePrompt.sql.ts
@@ -5,7 +5,9 @@ export const PresencePromptHistorySql = {
     oracle: `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_HISTORY
         (PROMPT_ID, USER_ID, GAME_TITLE, GAME_TITLE_NORM, STATUS)
        VALUES (:promptId, :userId, :gameTitle, :gameTitleNorm, 'PENDING')`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_presence_prompt_history
+        (prompt_id, user_id, game_title, game_title_norm, status)
+       VALUES (:promptId, :userId, :gameTitle, :gameTitleNorm, 'PENDING')`,
   } satisfies SqlEntry,
 
   markResolved: {
@@ -13,7 +15,10 @@ export const PresencePromptHistorySql = {
           SET STATUS = :status,
               RESOLVED_AT = SYSTIMESTAMP
         WHERE PROMPT_ID = :promptId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_presence_prompt_history
+          SET status = :status,
+              resolved_at = NOW()
+        WHERE prompt_id = :promptId`,
   } satisfies SqlEntry,
 
   getLastPromptDate: {
@@ -23,7 +28,12 @@ export const PresencePromptHistorySql = {
           AND GAME_TITLE_NORM = :gameTitleNorm
         ORDER BY CREATED_AT DESC
         FETCH NEXT 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT created_at
+         FROM rpg_club_presence_prompt_history
+        WHERE user_id = :userId
+          AND game_title_norm = :gameTitleNorm
+        ORDER BY created_at DESC
+        LIMIT 1`,
   } satisfies SqlEntry,
 
   countPendingForGame: {
@@ -32,7 +42,11 @@ export const PresencePromptHistorySql = {
         WHERE USER_ID = :userId
           AND GAME_TITLE_NORM = :gameTitleNorm
           AND STATUS = 'PENDING'`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+         FROM rpg_club_presence_prompt_history
+        WHERE user_id = :userId
+          AND game_title_norm = :gameTitleNorm
+          AND status = 'PENDING'`,
   } satisfies SqlEntry,
 
   countPendingForUser: {
@@ -40,7 +54,10 @@ export const PresencePromptHistorySql = {
          FROM RPG_CLUB_PRESENCE_PROMPT_HISTORY
         WHERE USER_ID = :userId
           AND STATUS = 'PENDING'`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+         FROM rpg_club_presence_prompt_history
+        WHERE user_id = :userId
+          AND status = 'PENDING'`,
   } satisfies SqlEntry,
 };
 
@@ -51,7 +68,11 @@ export const PresencePromptOptOutSql = {
         WHERE USER_ID = :userId
           AND SCOPE = 'ALL'
           AND GAME_TITLE_NORM = :token`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+         FROM rpg_club_presence_prompt_opts
+        WHERE user_id = :userId
+          AND scope = 'ALL'
+          AND game_title_norm = :token`,
   } satisfies SqlEntry,
 
   isOptedOutGame: {
@@ -60,13 +81,19 @@ export const PresencePromptOptOutSql = {
         WHERE USER_ID = :userId
           AND SCOPE = 'GAME'
           AND GAME_TITLE_NORM = :gameTitleNorm`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS cnt
+         FROM rpg_club_presence_prompt_opts
+        WHERE user_id = :userId
+          AND scope = 'GAME'
+          AND game_title_norm = :gameTitleNorm`,
   } satisfies SqlEntry,
 
   insertOptOut: {
     oracle: `INSERT INTO RPG_CLUB_PRESENCE_PROMPT_OPTS
           (USER_ID, SCOPE, GAME_TITLE, GAME_TITLE_NORM)
          VALUES (:userId, :scope, :gameTitle, :gameTitleNorm)`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_presence_prompt_opts
+          (user_id, scope, game_title, game_title_norm)
+         VALUES (:userId, :scope, :gameTitle, :gameTitleNorm)`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/reminder.sql.ts
+++ b/src/db/sql/reminder.sql.ts
@@ -4,6 +4,10 @@ const REMINDER_COLS =
   "REMINDER_ID, USER_ID, REMIND_AT, CONTENT, IS_NOISY, SENT_AT," +
   " FAILURE_COUNT, FAILED_AT, CREATED_AT, UPDATED_AT";
 
+const REMINDER_COLS_PG =
+  "reminder_id, user_id, remind_at, content, is_noisy, sent_at," +
+  " failure_count, failed_at, created_at, updated_at";
+
 export const ReminderSql = {
   create: {
     oracle: `INSERT INTO USER_REMINDERS (
@@ -14,7 +18,14 @@ export const ReminderSql = {
          SYSTIMESTAMP, SYSTIMESTAMP
        )
        RETURNING REMINDER_ID INTO :reminderId`,
-    postgres: ``,
+    postgres: `INSERT INTO user_reminders (
+         user_id, remind_at, content, is_noisy, sent_at, failure_count,
+         failed_at, created_at, updated_at
+       ) VALUES (
+         :userId, :remindAt, :content, :noisyVal, NULL, 0, NULL,
+         NOW(), NOW()
+       )
+       RETURNING reminder_id`,
   } satisfies SqlEntry,
 
   listByUser: {
@@ -22,21 +33,28 @@ export const ReminderSql = {
          FROM USER_REMINDERS
         WHERE USER_ID = :userId
         ORDER BY REMIND_AT`,
-    postgres: ``,
+    postgres: `SELECT ${REMINDER_COLS_PG}
+         FROM user_reminders
+        WHERE user_id = :userId
+        ORDER BY remind_at`,
   } satisfies SqlEntry,
 
   getById: {
     oracle: `SELECT ${REMINDER_COLS}
          FROM USER_REMINDERS
         WHERE REMINDER_ID = :reminderId`,
-    postgres: ``,
+    postgres: `SELECT ${REMINDER_COLS_PG}
+         FROM user_reminders
+        WHERE reminder_id = :reminderId`,
   } satisfies SqlEntry,
 
   delete: {
     oracle: `DELETE FROM USER_REMINDERS
         WHERE REMINDER_ID = :reminderId
           AND USER_ID = :userId`,
-    postgres: ``,
+    postgres: `DELETE FROM user_reminders
+        WHERE reminder_id = :reminderId
+          AND user_id = :userId`,
   } satisfies SqlEntry,
 
   snooze: {
@@ -48,7 +66,14 @@ export const ReminderSql = {
               UPDATED_AT = SYSTIMESTAMP
         WHERE REMINDER_ID = :reminderId
           AND USER_ID = :userId`,
-    postgres: ``,
+    postgres: `UPDATE user_reminders
+          SET remind_at = :remindAt,
+              sent_at = NULL,
+              failure_count = 0,
+              failed_at = NULL,
+              updated_at = NOW()
+        WHERE reminder_id = :reminderId
+          AND user_id = :userId`,
   } satisfies SqlEntry,
 
   markSent: {
@@ -58,7 +83,12 @@ export const ReminderSql = {
               FAILED_AT = NULL,
               UPDATED_AT = SYSTIMESTAMP
         WHERE REMINDER_ID = :reminderId`,
-    postgres: ``,
+    postgres: `UPDATE user_reminders
+          SET sent_at = NOW(),
+              failure_count = 0,
+              failed_at = NULL,
+              updated_at = NOW()
+        WHERE reminder_id = :reminderId`,
   } satisfies SqlEntry,
 
   recordFailure: {
@@ -67,7 +97,11 @@ export const ReminderSql = {
               FAILED_AT = SYSTIMESTAMP,
               UPDATED_AT = SYSTIMESTAMP
         WHERE REMINDER_ID = :reminderId`,
-    postgres: ``,
+    postgres: `UPDATE user_reminders
+          SET failure_count = failure_count + 1,
+              failed_at = NOW(),
+              updated_at = NOW()
+        WHERE reminder_id = :reminderId`,
   } satisfies SqlEntry,
 
   markFailedPermanently: {
@@ -75,7 +109,10 @@ export const ReminderSql = {
           SET SENT_AT = SYSTIMESTAMP,
               UPDATED_AT = SYSTIMESTAMP
         WHERE REMINDER_ID = :reminderId`,
-    postgres: ``,
+    postgres: `UPDATE user_reminders
+          SET sent_at = NOW(),
+              updated_at = NOW()
+        WHERE reminder_id = :reminderId`,
   } satisfies SqlEntry,
 
   getDueUndelivered: {
@@ -89,7 +126,13 @@ export const ReminderSql = {
             ORDER BY REMIND_AT
          )
         WHERE ROWNUM <= :limit`,
-    postgres: ``,
+    postgres: `SELECT ${REMINDER_COLS_PG}
+         FROM user_reminders
+        WHERE remind_at <= :cutoff
+          AND sent_at IS NULL
+          AND failure_count < 5
+        ORDER BY remind_at
+        LIMIT :limit`,
   } satisfies SqlEntry,
 };
 
@@ -113,7 +156,24 @@ export const PublicReminderSql = {
        :createdBy
      )
      RETURNING REMINDER_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_public_reminders (
+       channel_id,
+       message,
+       due_at,
+       recur_every,
+       recur_unit,
+       enabled,
+       created_by
+     ) VALUES (
+       :channelId,
+       :message,
+       :dueAt,
+       :recurEvery,
+       :recurUnit,
+       true,
+       :createdBy
+     )
+     RETURNING reminder_id`,
   } satisfies SqlEntry,
 
   listUpcoming: {
@@ -129,25 +189,40 @@ export const PublicReminderSql = {
       WHERE ENABLED = 1
       ORDER BY DUE_AT ASC
       FETCH FIRST :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT reminder_id,
+            channel_id,
+            message,
+            due_at,
+            recur_every,
+            recur_unit,
+            enabled,
+            created_by
+       FROM rpg_club_public_reminders
+      WHERE enabled = true
+      ORDER BY due_at ASC
+      LIMIT :limit`,
   } satisfies SqlEntry,
 
   delete: {
     oracle: `DELETE FROM RPG_CLUB_PUBLIC_REMINDERS WHERE REMINDER_ID = :id`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_public_reminders WHERE reminder_id = :id`,
   } satisfies SqlEntry,
 
   updateDueDate: {
     oracle: `UPDATE RPG_CLUB_PUBLIC_REMINDERS
         SET DUE_AT = :nextDue
       WHERE REMINDER_ID = :id`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_public_reminders
+        SET due_at = :nextDue
+      WHERE reminder_id = :id`,
   } satisfies SqlEntry,
 
   disable: {
     oracle: `UPDATE RPG_CLUB_PUBLIC_REMINDERS
         SET ENABLED = 0
       WHERE REMINDER_ID = :id`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_public_reminders
+        SET enabled = false
+      WHERE reminder_id = :id`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/rssFeed.sql.ts
+++ b/src/db/sql/rssFeed.sql.ts
@@ -10,7 +10,14 @@ export const RssFeedSql = {
             EXCLUDE_KEYWORDS
        FROM RPG_CLUB_RSS_FEEDS
       ORDER BY FEED_ID`,
-    postgres: ``,
+    postgres: `SELECT feed_id,
+            feed_name,
+            feed_url,
+            channel_id,
+            include_keywords,
+            exclude_keywords
+       FROM rpg_club_rss_feeds
+      ORDER BY feed_id`,
   } satisfies SqlEntry,
 
   addFeed: {
@@ -28,20 +35,36 @@ export const RssFeedSql = {
        :excludes
      )
      RETURNING FEED_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_rss_feeds (
+       feed_name,
+       feed_url,
+       channel_id,
+       include_keywords,
+       exclude_keywords
+     ) VALUES (
+       :feedName,
+       :feedUrl,
+       :channelId,
+       :includes,
+       :excludes
+     )
+     RETURNING feed_id`,
   } satisfies SqlEntry,
 
   removeFeed: {
     oracle: `DELETE FROM RPG_CLUB_RSS_FEEDS WHERE FEED_ID = :id`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_rss_feeds WHERE feed_id = :id`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres (e.g. "feed_name = :feedName")
   updateFeed: (sets: string[]) =>
     ({
       oracle: `UPDATE RPG_CLUB_RSS_FEEDS
         SET ${sets.join(", ")}
       WHERE FEED_ID = :feedId`,
-      postgres: ``,
+      postgres: `UPDATE rpg_club_rss_feeds
+        SET ${sets.join(", ")}
+      WHERE feed_id = :feedId`,
     }) satisfies SqlEntry,
 
   markItemsSeen: {
@@ -58,7 +81,10 @@ export const RssFeedSql = {
      WHEN NOT MATCHED THEN
        INSERT (FEED_ID, ITEM_ID_HASH, ITEM_GUID, ITEM_LINK, PUBLISHED_AT, FIRST_SEEN_AT)
        VALUES (s.feed_id, s.item_id_hash, s.item_guid, s.item_link, s.published_at, SYSTIMESTAMP)`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_rss_feed_items
+       (feed_id, item_id_hash, item_guid, item_link, published_at, first_seen_at)
+       VALUES (:feedId, :itemIdHash, :itemGuid, :itemLink, :publishedAt, NOW())
+       ON CONFLICT (feed_id, item_id_hash) DO NOTHING`,
   } satisfies SqlEntry,
 
   isItemSeen: {
@@ -66,7 +92,10 @@ export const RssFeedSql = {
        FROM RPG_CLUB_RSS_FEED_ITEMS
       WHERE FEED_ID = :feedId
         AND ITEM_ID_HASH = :hash`,
-    postgres: ``,
+    postgres: `SELECT 1 AS found
+       FROM rpg_club_rss_feed_items
+      WHERE feed_id = :feedId
+        AND item_id_hash = :hash`,
   } satisfies SqlEntry,
 
   getSeenItemHashes: (bindPlaceholders: string) =>
@@ -75,6 +104,9 @@ export const RssFeedSql = {
            FROM RPG_CLUB_RSS_FEED_ITEMS
           WHERE FEED_ID = :feedId
             AND ITEM_ID_HASH IN (${bindPlaceholders})`,
-      postgres: ``,
+      postgres: `SELECT item_id_hash
+           FROM rpg_club_rss_feed_items
+          WHERE feed_id = :feedId
+            AND item_id_hash IN (${bindPlaceholders})`,
     }) satisfies SqlEntry,
 };

--- a/src/db/sql/starboard.sql.ts
+++ b/src/db/sql/starboard.sql.ts
@@ -10,13 +10,22 @@ export const StarboardSql = {
               CREATED_AT
          FROM RPG_CLUB_STARBOARD
         WHERE MESSAGE_ID = :messageId`,
-    postgres: ``,
+    postgres: `SELECT message_id,
+              channel_id,
+              starboard_message_id,
+              author_id,
+              star_count,
+              created_at
+         FROM rpg_club_starboard
+        WHERE message_id = :messageId`,
   } satisfies SqlEntry,
 
   insert: {
     oracle: `INSERT INTO RPG_CLUB_STARBOARD
         (MESSAGE_ID, CHANNEL_ID, STARBOARD_MESSAGE_ID, AUTHOR_ID, STAR_COUNT)
        VALUES (:messageId, :channelId, :starboardMessageId, :authorId, :starCount)`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_starboard
+        (message_id, channel_id, starboard_message_id, author_id, star_count)
+       VALUES (:messageId, :channelId, :starboardMessageId, :authorId, :starCount)`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/steamCollectionImport.sql.ts
+++ b/src/db/sql/steamCollectionImport.sql.ts
@@ -11,6 +11,17 @@ const IMPORT_COLS = `IMPORT_ID,
        CREATED_AT,
        UPDATED_AT`;
 
+const IMPORT_COLS_PG = `import_id,
+       user_id,
+       status,
+       current_index,
+       total_count,
+       steam_id64,
+       steam_profile_ref,
+       source_profile_name,
+       created_at,
+       updated_at`;
+
 const ITEM_COLS = `ITEM_ID,
        IMPORT_ID,
        ROW_INDEX,
@@ -29,6 +40,25 @@ const ITEM_COLS = `ITEM_ID,
        COLLECTION_ENTRY_ID,
        RESULT_REASON,
        ERROR_TEXT`;
+
+const ITEM_COLS_PG = `item_id,
+       import_id,
+       row_index,
+       steam_app_id,
+       steam_app_name,
+       playtime_forever_min,
+       playtime_windows_min,
+       playtime_mac_min,
+       playtime_linux_min,
+       playtime_deck_min,
+       last_played_at,
+       status,
+       match_confidence,
+       match_candidate_json,
+       gamedb_game_id,
+       collection_entry_id,
+       result_reason,
+       error_text`;
 
 export const SteamCollectionImportSql = {
   createImport: {
@@ -49,7 +79,23 @@ export const SteamCollectionImportSql = {
          :steamProfileRef,
          :sourceProfileName
        ) RETURNING IMPORT_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_steam_collection_imports (
+         user_id,
+         status,
+         current_index,
+         total_count,
+         steam_id64,
+         steam_profile_ref,
+         source_profile_name
+       ) VALUES (
+         :userId,
+         'ACTIVE',
+         0,
+         :totalCount,
+         :steamId64,
+         :steamProfileRef,
+         :sourceProfileName
+       ) RETURNING import_id`,
   } satisfies SqlEntry,
 
   insertItem: {
@@ -78,13 +124,38 @@ export const SteamCollectionImportSql = {
            :lastPlayedAt,
            'PENDING'
          )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_steam_collection_import_items (
+           import_id,
+           row_index,
+           steam_app_id,
+           steam_app_name,
+           playtime_forever_min,
+           playtime_windows_min,
+           playtime_mac_min,
+           playtime_linux_min,
+           playtime_deck_min,
+           last_played_at,
+           status
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :steamAppId,
+           :steamAppName,
+           :playtimeForeverMin,
+           :playtimeWindowsMin,
+           :playtimeMacMin,
+           :playtimeLinuxMin,
+           :playtimeDeckMin,
+           :lastPlayedAt,
+           'PENDING'
+         )`,
   } satisfies SqlEntry,
 
   getImportById: {
     oracle: `SELECT ${IMPORT_COLS}
   FROM RPG_CLUB_STEAM_COLLECTION_IMPORTS WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `SELECT ${IMPORT_COLS_PG}
+  FROM rpg_club_steam_collection_imports WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getActiveForUser: {
@@ -94,27 +165,37 @@ export const SteamCollectionImportSql = {
        AND STATUS IN ('ACTIVE', 'PAUSED')
      ORDER BY CREATED_AT DESC, IMPORT_ID DESC
      FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${IMPORT_COLS_PG}
+  FROM rpg_club_steam_collection_imports
+     WHERE user_id = :userId
+       AND status IN ('ACTIVE', 'PAUSED')
+     ORDER BY created_at DESC, import_id DESC
+     LIMIT 1`,
   } satisfies SqlEntry,
 
   setStatus: {
     oracle: `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
         SET STATUS = :status
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_steam_collection_imports
+        SET status = :status
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   updateIndex: {
     oracle: `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORTS
         SET CURRENT_INDEX = :currentIndex
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_steam_collection_imports
+        SET current_index = :currentIndex
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getItemById: {
     oracle: `SELECT ${ITEM_COLS}
   FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS WHERE ITEM_ID = :itemId`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+  FROM rpg_club_steam_collection_import_items WHERE item_id = :itemId`,
   } satisfies SqlEntry,
 
   getNextPendingItem: {
@@ -124,15 +205,23 @@ export const SteamCollectionImportSql = {
        AND STATUS = 'PENDING'
      ORDER BY ROW_INDEX ASC
      FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+  FROM rpg_club_steam_collection_import_items
+     WHERE import_id = :importId
+       AND status = 'PENDING'
+     ORDER BY row_index ASC
+     LIMIT 1`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres (e.g. "status = :status")
   updateItem: (setParts: string[]) =>
     ({
       oracle: `UPDATE RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
         SET ${setParts.join(", ")}
       WHERE ITEM_ID = :itemId`,
-      postgres: ``,
+      postgres: `UPDATE rpg_club_steam_collection_import_items
+        SET ${setParts.join(", ")}
+      WHERE item_id = :itemId`,
     }) satisfies SqlEntry,
 
   countItemsByStatus: {
@@ -140,7 +229,10 @@ export const SteamCollectionImportSql = {
        FROM RPG_CLUB_STEAM_COLLECTION_IMPORT_ITEMS
       WHERE IMPORT_ID = :importId
       GROUP BY STATUS`,
-    postgres: ``,
+    postgres: `SELECT status, COUNT(*) AS cnt
+       FROM rpg_club_steam_collection_import_items
+      WHERE import_id = :importId
+      GROUP BY status`,
   } satisfies SqlEntry,
 
   countItemsByReason: {
@@ -149,7 +241,11 @@ export const SteamCollectionImportSql = {
       WHERE IMPORT_ID = :importId
         AND RESULT_REASON IS NOT NULL
       GROUP BY RESULT_REASON`,
-    postgres: ``,
+    postgres: `SELECT result_reason, COUNT(*) AS cnt
+       FROM rpg_club_steam_collection_import_items
+      WHERE import_id = :importId
+        AND result_reason IS NOT NULL
+      GROUP BY result_reason`,
   } satisfies SqlEntry,
 
   getAppMap: {
@@ -162,7 +258,15 @@ export const SteamCollectionImportSql = {
             UPDATED_AT
        FROM RPG_CLUB_STEAM_APP_GAMEDB_MAP
       WHERE STEAM_APP_ID = :steamAppId`,
-    postgres: ``,
+    postgres: `SELECT map_id,
+            steam_app_id,
+            gamedb_game_id,
+            status,
+            created_by,
+            created_at,
+            updated_at
+       FROM rpg_club_steam_app_gamedb_map
+      WHERE steam_app_id = :steamAppId`,
   } satisfies SqlEntry,
 
   upsertAppMap: {
@@ -190,7 +294,12 @@ export const SteamCollectionImportSql = {
          src.status,
          src.createdBy
        )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_steam_app_gamedb_map (steam_app_id, gamedb_game_id, status, created_by)
+       VALUES (:steamAppId, :gameDbGameId, :status, :createdBy)
+       ON CONFLICT (steam_app_id) DO UPDATE SET
+         gamedb_game_id = EXCLUDED.gamedb_game_id,
+         status = EXCLUDED.status,
+         created_by = EXCLUDED.created_by`,
   } satisfies SqlEntry,
 
   getHistoricalMappedIds: {
@@ -210,6 +319,15 @@ export const SteamCollectionImportSql = {
           ORDER BY CNT DESC, LAST_ITEM_ID DESC
        ) t
       WHERE ROWNUM <= :limit`,
-    postgres: ``,
+    postgres: `SELECT ii.gamedb_game_id
+         FROM rpg_club_steam_collection_import_items ii
+         JOIN rpg_club_steam_collection_imports i ON i.import_id = ii.import_id
+        WHERE ii.steam_app_id = :steamAppId
+          AND ii.gamedb_game_id IS NOT NULL
+          AND ii.result_reason = 'MANUAL_REMAP'
+          AND (:excludeUserId IS NULL OR i.user_id <> :excludeUserId)
+        GROUP BY ii.gamedb_game_id
+        ORDER BY COUNT(*) DESC, MAX(ii.item_id) DESC
+        LIMIT :limit`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/suggestion.sql.ts
+++ b/src/db/sql/suggestion.sql.ts
@@ -5,7 +5,9 @@ export const SuggestionSql = {
     oracle: `INSERT INTO RPG_CLUB_SUGGESTIONS (TITLE, DETAILS, LABELS, CREATED_BY, CREATED_BY_NAME)
        VALUES (:title, :details, :labels, :createdBy, :createdByName)
        RETURNING SUGGESTION_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_suggestions (title, details, labels, created_by, created_by_name)
+       VALUES (:title, :details, :labels, :createdBy, :createdByName)
+       RETURNING suggestion_id`,
   } satisfies SqlEntry,
 
   list: {
@@ -20,12 +22,22 @@ export const SuggestionSql = {
        FROM RPG_CLUB_SUGGESTIONS
       ORDER BY CREATED_AT DESC, SUGGESTION_ID DESC
       FETCH FIRST :limit ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT suggestion_id,
+            title,
+            details,
+            labels,
+            created_by,
+            created_by_name,
+            created_at,
+            updated_at
+       FROM rpg_club_suggestions
+      ORDER BY created_at DESC, suggestion_id DESC
+      LIMIT :limit`,
   } satisfies SqlEntry,
 
   count: {
     oracle: `SELECT COUNT(*) AS TOTAL FROM RPG_CLUB_SUGGESTIONS`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS total FROM rpg_club_suggestions`,
   } satisfies SqlEntry,
 
   getById: {
@@ -39,12 +51,21 @@ export const SuggestionSql = {
             UPDATED_AT
        FROM RPG_CLUB_SUGGESTIONS
       WHERE SUGGESTION_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT suggestion_id,
+            title,
+            details,
+            labels,
+            created_by,
+            created_by_name,
+            created_at,
+            updated_at
+       FROM rpg_club_suggestions
+      WHERE suggestion_id = :id`,
   } satisfies SqlEntry,
 
   delete: {
     oracle: `DELETE FROM RPG_CLUB_SUGGESTIONS WHERE SUGGESTION_ID = :id`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_suggestions WHERE suggestion_id = :id`,
   } satisfies SqlEntry,
 };
 
@@ -53,7 +74,9 @@ export const SuggestionReviewSessionSql = {
     oracle: `INSERT INTO RPG_CLUB_SUGGESTION_REVIEW_SESSIONS
          (SESSION_ID, REVIEWER_ID, SUGGESTION_IDS, CURRENT_INDEX, TOTAL_COUNT)
        VALUES (:sessionId, :reviewerId, :suggestionIds, :currentIndex, :totalCount)`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_suggestion_review_sessions
+         (session_id, reviewer_id, suggestion_ids, current_index, total_count)
+       VALUES (:sessionId, :reviewerId, :suggestionIds, :currentIndex, :totalCount)`,
   } satisfies SqlEntry,
 
   getById: {
@@ -66,7 +89,15 @@ export const SuggestionReviewSessionSql = {
             UPDATED_AT
        FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS
       WHERE SESSION_ID = :sessionId`,
-    postgres: ``,
+    postgres: `SELECT session_id,
+            reviewer_id,
+            suggestion_ids,
+            current_index,
+            total_count,
+            created_at,
+            updated_at
+       FROM rpg_club_suggestion_review_sessions
+      WHERE session_id = :sessionId`,
   } satisfies SqlEntry,
 
   update: {
@@ -76,21 +107,26 @@ export const SuggestionReviewSessionSql = {
             CURRENT_INDEX = :currentIndex,
             TOTAL_COUNT = :totalCount
       WHERE SESSION_ID = :sessionId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_suggestion_review_sessions
+        SET reviewer_id = :reviewerId,
+            suggestion_ids = :suggestionIds,
+            current_index = :currentIndex,
+            total_count = :totalCount
+      WHERE session_id = :sessionId`,
   } satisfies SqlEntry,
 
   delete: {
     oracle: `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE SESSION_ID = :sessionId`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_suggestion_review_sessions WHERE session_id = :sessionId`,
   } satisfies SqlEntry,
 
   deleteForReviewer: {
     oracle: `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE REVIEWER_ID = :reviewerId`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_suggestion_review_sessions WHERE reviewer_id = :reviewerId`,
   } satisfies SqlEntry,
 
   deleteExpired: {
     oracle: `DELETE FROM RPG_CLUB_SUGGESTION_REVIEW_SESSIONS WHERE CREATED_AT < :cutoff`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_suggestion_review_sessions WHERE created_at < :cutoff`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/thread.sql.ts
+++ b/src/db/sql/thread.sql.ts
@@ -27,12 +27,19 @@ export const ThreadSql = {
        s.THREAD_ID, s.FORUM_CHANNEL_ID, s.THREAD_NAME, s.IS_ARCHIVED,
        s.CREATED_AT, s.LAST_SEEN_AT, s.SKIP_LINKING
      )`,
-    postgres: ``,
+    postgres: `INSERT INTO threads
+       (thread_id, forum_channel_id, thread_name, is_archived, created_at, last_seen_at, skip_linking)
+       VALUES (:threadId, :forumChannelId, :threadName, :isArchived, :createdAt, :lastSeenAt, :skipLinking)
+       ON CONFLICT (thread_id) DO UPDATE SET
+         thread_name = EXCLUDED.thread_name,
+         forum_channel_id = EXCLUDED.forum_channel_id,
+         is_archived = EXCLUDED.is_archived,
+         last_seen_at = EXCLUDED.last_seen_at`,
   } satisfies SqlEntry,
 
   deleteThreadGameLink: {
     oracle: `DELETE FROM THREAD_GAME_LINKS WHERE THREAD_ID = :threadId`,
-    postgres: ``,
+    postgres: `DELETE FROM thread_game_links WHERE thread_id = :threadId`,
   } satisfies SqlEntry,
 
   mergeThreadGameLink: {
@@ -44,7 +51,9 @@ export const ThreadSql = {
          WHEN NOT MATCHED THEN
            INSERT (THREAD_ID, GAMEDB_GAME_ID, LINKED_AT)
            VALUES (src.THREAD_ID, src.GAMEDB_GAME_ID, SYSTIMESTAMP)`,
-    postgres: ``,
+    postgres: `INSERT INTO thread_game_links (thread_id, gamedb_game_id, linked_at)
+         VALUES (:threadId, :gameId, NOW())
+         ON CONFLICT (thread_id, gamedb_game_id) DO NOTHING`,
   } satisfies SqlEntry,
 
   updateThreadsGameId: {
@@ -55,7 +64,13 @@ export const ThreadSql = {
           WHERE g.THREAD_ID = t.THREAD_ID
        )
        WHERE t.THREAD_ID = :threadId`,
-    postgres: ``,
+    postgres: `UPDATE threads
+       SET gamedb_game_id = (
+         SELECT MIN(g.gamedb_game_id)
+           FROM thread_game_links g
+          WHERE g.thread_id = threads.thread_id
+       )
+       WHERE thread_id = :threadId`,
   } satisfies SqlEntry,
 
   removeThreadGameLinks: (withGameId: boolean) =>
@@ -63,38 +78,42 @@ export const ThreadSql = {
       oracle: `DELETE FROM THREAD_GAME_LINKS
        WHERE THREAD_ID = :threadId
        ${withGameId ? "AND GAMEDB_GAME_ID = :gameId" : ""}`,
-      postgres: ``,
+      postgres: `DELETE FROM thread_game_links
+       WHERE thread_id = :threadId
+       ${withGameId ? "AND gamedb_game_id = :gameId" : ""}`,
     }) satisfies SqlEntry,
 
   setSkipLinking: {
     oracle: `UPDATE THREADS
         SET SKIP_LINKING = :skip
       WHERE THREAD_ID = :threadId`,
-    postgres: ``,
+    postgres: `UPDATE threads
+        SET skip_linking = :skip
+      WHERE thread_id = :threadId`,
   } satisfies SqlEntry,
 
   getSkipLinking: {
     oracle: `SELECT SKIP_LINKING FROM THREADS WHERE THREAD_ID = :threadId`,
-    postgres: ``,
+    postgres: `SELECT skip_linking FROM threads WHERE thread_id = :threadId`,
   } satisfies SqlEntry,
 
   getThreadLinksForGame: {
     oracle: `SELECT THREAD_ID FROM THREAD_GAME_LINKS WHERE GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `SELECT thread_id FROM thread_game_links WHERE gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 
   getLegacyGameId: {
     oracle: `SELECT GAMEDB_GAME_ID FROM THREADS WHERE THREAD_ID = :threadId`,
-    postgres: ``,
+    postgres: `SELECT gamedb_game_id FROM threads WHERE thread_id = :threadId`,
   } satisfies SqlEntry,
 
   getThreadGameLinks: {
     oracle: `SELECT GAMEDB_GAME_ID FROM THREAD_GAME_LINKS WHERE THREAD_ID = :threadId`,
-    postgres: ``,
+    postgres: `SELECT gamedb_game_id FROM thread_game_links WHERE thread_id = :threadId`,
   } satisfies SqlEntry,
 
   getLegacyThreadIdForGame: {
     oracle: `SELECT THREAD_ID FROM THREADS WHERE GAMEDB_GAME_ID = :gameId`,
-    postgres: ``,
+    postgres: `SELECT thread_id FROM threads WHERE gamedb_game_id = :gameId`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/todo.sql.ts
+++ b/src/db/sql/todo.sql.ts
@@ -12,19 +12,35 @@ const TODO_COLS = `TODO_ID,
               COMPLETED_BY,
               IS_COMPLETED`;
 
+const TODO_COLS_PG = `todo_id,
+              title,
+              details,
+              todo_category,
+              todo_size,
+              created_by,
+              created_at,
+              updated_at,
+              completed_at,
+              completed_by,
+              is_completed`;
+
 export const TodoSql = {
   getById: {
     oracle: `SELECT ${TODO_COLS}
        FROM RPG_CLUB_TODOS
       WHERE TODO_ID = :id`,
-    postgres: ``,
+    postgres: `SELECT ${TODO_COLS_PG}
+       FROM rpg_club_todos
+      WHERE todo_id = :id`,
   } satisfies SqlEntry,
 
   create: {
     oracle: `INSERT INTO RPG_CLUB_TODOS (TITLE, DETAILS, TODO_CATEGORY, TODO_SIZE, CREATED_BY)
      VALUES (:title, :details, :todoCategory, :todoSize, :createdBy)
      RETURNING TODO_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_todos (title, details, todo_category, todo_size, created_by)
+     VALUES (:title, :details, :todoCategory, :todoSize, :createdBy)
+     RETURNING todo_id`,
   } satisfies SqlEntry,
 
   list: (whereClause: string) =>
@@ -34,7 +50,11 @@ export const TodoSql = {
        ${whereClause}
       ORDER BY IS_COMPLETED ASC, CREATED_AT ASC
       FETCH FIRST :limit ROWS ONLY`,
-      postgres: ``,
+      postgres: `SELECT ${TODO_COLS_PG}
+       FROM rpg_club_todos
+       ${whereClause}
+      ORDER BY is_completed ASC, created_at ASC
+      LIMIT :limit`,
     }) satisfies SqlEntry,
 
   update: {
@@ -50,12 +70,23 @@ export const TodoSql = {
               ELSE TODO_SIZE
             END
       WHERE TODO_ID = :id`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_todos
+        SET title = CASE WHEN :titleProvided = 1 THEN :title ELSE title END,
+            details = CASE WHEN :detailsProvided = 1 THEN :details ELSE details END,
+            todo_category = CASE
+              WHEN :categoryProvided = 1 THEN :todoCategory
+              ELSE todo_category
+            END,
+            todo_size = CASE
+              WHEN :sizeProvided = 1 THEN :todoSize
+              ELSE todo_size
+            END
+      WHERE todo_id = :id`,
   } satisfies SqlEntry,
 
   delete: {
     oracle: `DELETE FROM RPG_CLUB_TODOS WHERE TODO_ID = :id`,
-    postgres: ``,
+    postgres: `DELETE FROM rpg_club_todos WHERE todo_id = :id`,
   } satisfies SqlEntry,
 
   complete: {
@@ -65,14 +96,21 @@ export const TodoSql = {
             COMPLETED_BY = :completedBy
       WHERE TODO_ID = :id
         AND IS_COMPLETED = 0`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_todos
+        SET is_completed = true,
+            completed_at = NOW(),
+            completed_by = :completedBy
+      WHERE todo_id = :id
+        AND is_completed = false`,
   } satisfies SqlEntry,
 
   countTodos: {
     oracle: `SELECT SUM(CASE WHEN IS_COMPLETED = 1 THEN 0 ELSE 1 END) AS OPEN_COUNT,
             SUM(CASE WHEN IS_COMPLETED = 1 THEN 1 ELSE 0 END) AS COMPLETED_COUNT
        FROM RPG_CLUB_TODOS`,
-    postgres: ``,
+    postgres: `SELECT SUM(CASE WHEN is_completed THEN 0 ELSE 1 END) AS open_count,
+            SUM(CASE WHEN is_completed THEN 1 ELSE 0 END) AS completed_count
+       FROM rpg_club_todos`,
   } satisfies SqlEntry,
 
   countTodoSummary: {
@@ -109,6 +147,38 @@ export const TodoSql = {
               END
             ) AS OPEN_REFACTORING
        FROM RPG_CLUB_TODOS`,
-    postgres: ``,
+    postgres: `SELECT SUM(CASE WHEN is_completed THEN 0 ELSE 1 END) AS open_count,
+            SUM(CASE WHEN is_completed THEN 1 ELSE 0 END) AS completed_count,
+            SUM(
+              CASE
+                WHEN NOT is_completed AND todo_category = 'New Features' THEN 1
+                ELSE 0
+              END
+            ) AS open_new_features,
+            SUM(
+              CASE
+                WHEN NOT is_completed AND todo_category = 'Improvements' THEN 1
+                ELSE 0
+              END
+            ) AS open_improvements,
+            SUM(
+              CASE
+                WHEN NOT is_completed AND todo_category = 'Defects' THEN 1
+                ELSE 0
+              END
+            ) AS open_defects,
+            SUM(
+              CASE
+                WHEN NOT is_completed AND todo_category = 'Blocked' THEN 1
+                ELSE 0
+              END
+            ) AS open_blocked,
+            SUM(
+              CASE
+                WHEN NOT is_completed AND todo_category = 'Refactoring' THEN 1
+                ELSE 0
+              END
+            ) AS open_refactoring
+       FROM rpg_club_todos`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/userActivity.sql.ts
+++ b/src/db/sql/userActivity.sql.ts
@@ -37,7 +37,16 @@ WHEN NOT MATCHED THEN
     s.ICON_TYPE, s.SOURCE_REF, s.ICON_URL,
     SYSTIMESTAMP, SYSTIMESTAMP, 1
   )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_user_activity_icons
+  (user_id, username, activity_name, activity_name_norm, icon_type, source_ref, icon_url,
+   first_seen_at, last_seen_at, seen_count)
+  VALUES (:userId, :username, :activityName, :activityNameNorm, :iconType, :sourceRef, :iconUrl,
+          NOW(), NOW(), 1)
+  ON CONFLICT (user_id, activity_name_norm, icon_type, source_ref) DO UPDATE SET
+    username = EXCLUDED.username,
+    icon_url = EXCLUDED.icon_url,
+    last_seen_at = NOW(),
+    seen_count = rpg_club_user_activity_icons.seen_count + 1`,
   } satisfies SqlEntry,
 
   getRecentForUsers: (userGroupClauses: string) =>
@@ -55,7 +64,19 @@ WHEN NOT MATCHED THEN
          AND (:activityNameNorm IS NULL OR ACTIVITY_NAME_NORM = :activityNameNorm)
          AND (:iconType IS NULL OR ICON_TYPE = :iconType)
        ORDER BY LAST_SEEN_AT DESC`,
-      postgres: ``,
+      postgres: `SELECT
+         user_id,
+         activity_name,
+         icon_type,
+         source_ref,
+         icon_url,
+         last_seen_at
+       FROM rpg_club_user_activity_icons
+       WHERE (${userGroupClauses})
+         AND last_seen_at >= NOW() - (:days * INTERVAL '1 day')
+         AND (:activityNameNorm IS NULL OR activity_name_norm = :activityNameNorm)
+         AND (:iconType IS NULL OR icon_type = :iconType)
+       ORDER BY last_seen_at DESC`,
     }) satisfies SqlEntry,
 };
 
@@ -79,16 +100,22 @@ export const UserChannelMessageCountSql = {
                        CREATED_AT, UPDATED_AT)
                VALUES (s.user_id, s.channel_id, s.message_count, s.scanned,
                        SYSTIMESTAMP, SYSTIMESTAMP)`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_user_channel_counts
+              (user_id, channel_id, message_count, last_scanned_at, created_at, updated_at)
+              VALUES (:userId, :channelId, :count, :scanned, NOW(), NOW())
+              ON CONFLICT (user_id, channel_id) DO UPDATE SET
+                message_count = COALESCE(rpg_club_user_channel_counts.message_count, 0) + :count,
+                last_scanned_at = :scanned,
+                updated_at = NOW()`,
   } satisfies SqlEntry,
 
   getScannedChannelIds: {
     oracle: `SELECT DISTINCT CHANNEL_ID FROM RPG_CLUB_USER_CHANNEL_COUNTS`,
-    postgres: ``,
+    postgres: `SELECT DISTINCT channel_id FROM rpg_club_user_channel_counts`,
   } satisfies SqlEntry,
 
   getChannelScanMeta: {
     oracle: `SELECT CHANNEL_ID, LAST_SCANNED_AT FROM RPG_CLUB_USER_CHANNEL_COUNTS`,
-    postgres: ``,
+    postgres: `SELECT channel_id, last_scanned_at FROM rpg_club_user_channel_counts`,
   } satisfies SqlEntry,
 };

--- a/src/db/sql/userGameCollection.sql.ts
+++ b/src/db/sql/userGameCollection.sql.ts
@@ -16,6 +16,22 @@ const ENTRY_SELECT_SQL = `SELECT c.ENTRY_ID,
   JOIN GAMEDB_GAMES g ON g.GAME_ID = c.GAMEDB_GAME_ID
   LEFT JOIN GAMEDB_PLATFORMS p ON p.PLATFORM_ID = c.PLATFORM_ID`;
 
+const ENTRY_SELECT_SQL_PG = `SELECT c.entry_id,
+       c.user_id,
+       c.gamedb_game_id,
+       g.title,
+       c.platform_id,
+       p.platform_name,
+       p.platform_abbreviation,
+       c.ownership_type,
+       c.note,
+       c.is_shared,
+       c.created_at,
+       c.updated_at
+  FROM user_game_collections c
+  JOIN gamedb_games g ON g.game_id = c.gamedb_game_id
+  LEFT JOIN gamedb_platforms p ON p.platform_id = c.platform_id`;
+
 export const UserGameCollectionSql = {
   addEntry: {
     oracle: `INSERT INTO USER_GAME_COLLECTIONS (
@@ -34,39 +50,65 @@ export const UserGameCollectionSql = {
              :isShared
            )
            RETURNING ENTRY_ID INTO :entryId`,
-    postgres: ``,
+    postgres: `INSERT INTO user_game_collections (
+             user_id,
+             gamedb_game_id,
+             platform_id,
+             ownership_type,
+             note,
+             is_shared
+           ) VALUES (
+             :userId,
+             :gameId,
+             :platformId,
+             :ownershipType,
+             :note,
+             :isShared
+           )
+           RETURNING entry_id`,
   } satisfies SqlEntry,
 
   getEntryById: {
     oracle: `${ENTRY_SELECT_SQL}
      WHERE c.ENTRY_ID = :entryId
        AND c.USER_ID = :userId`,
-    postgres: ``,
+    postgres: `${ENTRY_SELECT_SQL_PG}
+     WHERE c.entry_id = :entryId
+       AND c.user_id = :userId`,
   } satisfies SqlEntry,
 
   getEntryForUser: {
     oracle: `${ENTRY_SELECT_SQL}
        WHERE c.ENTRY_ID = :entryId
          AND c.USER_ID = :userId`,
-    postgres: ``,
+    postgres: `${ENTRY_SELECT_SQL_PG}
+       WHERE c.entry_id = :entryId
+         AND c.user_id = :userId`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres (e.g. "note = :note")
   updateEntry: (updateParts: string[]) =>
     ({
       oracle: `UPDATE USER_GAME_COLLECTIONS
               SET ${updateParts.join(", ")}
             WHERE ENTRY_ID = :entryId
               AND USER_ID = :userId`,
-      postgres: ``,
+      postgres: `UPDATE user_game_collections
+              SET ${updateParts.join(", ")}
+            WHERE entry_id = :entryId
+              AND user_id = :userId`,
     }) satisfies SqlEntry,
 
   removeEntry: {
     oracle: `DELETE FROM USER_GAME_COLLECTIONS
         WHERE ENTRY_ID = :entryId
           AND USER_ID = :userId`,
-    postgres: ``,
+    postgres: `DELETE FROM user_game_collections
+        WHERE entry_id = :entryId
+          AND user_id = :userId`,
   } satisfies SqlEntry,
 
+  // Caller must pass dialect-appropriate whereClause and fetchClause
   searchEntries: (whereClause: string, fetchClause: string) =>
     ({
       oracle: `SELECT c.ENTRY_ID,
@@ -87,14 +129,33 @@ export const UserGameCollectionSql = {
         WHERE ${whereClause}
         ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
         ${fetchClause}`,
-      postgres: ``,
+      postgres: `SELECT c.entry_id,
+              c.user_id,
+              c.gamedb_game_id,
+              g.title,
+              c.platform_id,
+              p.platform_name,
+              p.platform_abbreviation,
+              c.ownership_type,
+              c.note,
+              c.is_shared,
+              c.created_at,
+              c.updated_at
+         FROM user_game_collections c
+         JOIN gamedb_games g ON g.game_id = c.gamedb_game_id
+        LEFT JOIN gamedb_platforms p ON p.platform_id = c.platform_id
+        WHERE ${whereClause}
+        ORDER BY LOWER(g.title), LOWER(COALESCE(p.platform_name, '')), c.entry_id
+        ${fetchClause}`,
     }) satisfies SqlEntry,
 
   getTotalCount: {
     oracle: `SELECT COUNT(*) AS TOTAL_COUNT
            FROM USER_GAME_COLLECTIONS
           WHERE USER_ID = :userId`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS total_count
+           FROM user_game_collections
+          WHERE user_id = :userId`,
   } satisfies SqlEntry,
 
   getPlatformCounts: {
@@ -109,7 +170,17 @@ export const UserGameCollectionSql = {
           ORDER BY COUNT(*) DESC,
                    LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
                    c.PLATFORM_ID`,
-    postgres: ``,
+    postgres: `SELECT c.platform_id,
+                p.platform_name,
+                p.platform_abbreviation,
+                COUNT(*) AS total_count
+           FROM user_game_collections c
+           LEFT JOIN gamedb_platforms p ON p.platform_id = c.platform_id
+          WHERE c.user_id = :userId
+          GROUP BY c.platform_id, p.platform_name, p.platform_abbreviation
+          ORDER BY COUNT(*) DESC,
+                   LOWER(COALESCE(p.platform_name, 'Unknown')),
+                   c.platform_id`,
   } satisfies SqlEntry,
 
   getAllPlatformCounts: {
@@ -123,7 +194,16 @@ export const UserGameCollectionSql = {
           ORDER BY COUNT(*) DESC,
                    LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
                    c.PLATFORM_ID`,
-    postgres: ``,
+    postgres: `SELECT c.platform_id,
+                p.platform_name,
+                p.platform_abbreviation,
+                COUNT(*) AS total_count
+           FROM user_game_collections c
+           LEFT JOIN gamedb_platforms p ON p.platform_id = c.platform_id
+          GROUP BY c.platform_id, p.platform_name, p.platform_abbreviation
+          ORDER BY COUNT(*) DESC,
+                   LOWER(COALESCE(p.platform_name, 'Unknown')),
+                   c.platform_id`,
   } satisfies SqlEntry,
 
   getAllUserRows: {
@@ -149,12 +229,33 @@ export const UserGameCollectionSql = {
                    COUNT(*) DESC,
                    LOWER(NVL(p.PLATFORM_NAME, 'Unknown')),
                    c.PLATFORM_ID`,
-    postgres: ``,
+    postgres: `SELECT c.user_id,
+                u.username,
+                u.global_name,
+                c.platform_id,
+                p.platform_name,
+                p.platform_abbreviation,
+                COUNT(*) AS total_count
+           FROM user_game_collections c
+           LEFT JOIN rpg_club_users u ON u.user_id = c.user_id
+           LEFT JOIN gamedb_platforms p ON p.platform_id = c.platform_id
+          WHERE COALESCE(u.is_bot, false) = false
+          GROUP BY c.user_id,
+                   u.username,
+                   u.global_name,
+                   c.platform_id,
+                   p.platform_name,
+                   p.platform_abbreviation
+          ORDER BY LOWER(COALESCE(u.global_name, u.username, c.user_id)),
+                   c.user_id,
+                   COUNT(*) DESC,
+                   LOWER(COALESCE(p.platform_name, 'Unknown')),
+                   c.platform_id`,
   } satisfies SqlEntry,
 
   getTotalAllCount: {
     oracle: `SELECT COUNT(*) AS TOTAL_COUNT FROM USER_GAME_COLLECTIONS`,
-    postgres: ``,
+    postgres: `SELECT COUNT(*) AS total_count FROM user_game_collections`,
   } satisfies SqlEntry,
 
   autocompleteEntries: (titleWhere: string) =>
@@ -178,6 +279,24 @@ export const UserGameCollectionSql = {
           ${titleWhere}
         ORDER BY LOWER(g.TITLE), LOWER(NVL(p.PLATFORM_NAME, '')), c.ENTRY_ID
         FETCH FIRST :limit ROWS ONLY`,
-      postgres: ``,
+      postgres: `SELECT c.entry_id,
+              c.user_id,
+              c.gamedb_game_id,
+              g.title,
+              c.platform_id,
+              p.platform_name,
+              p.platform_abbreviation,
+              c.ownership_type,
+              c.note,
+              c.is_shared,
+              c.created_at,
+              c.updated_at
+         FROM user_game_collections c
+         JOIN gamedb_games g ON g.game_id = c.gamedb_game_id
+         LEFT JOIN gamedb_platforms p ON p.platform_id = c.platform_id
+        WHERE c.user_id = :userId
+          ${titleWhere}
+        ORDER BY LOWER(g.title), LOWER(COALESCE(p.platform_name, '')), c.entry_id
+        LIMIT :limit`,
     }) satisfies SqlEntry,
 };

--- a/src/db/sql/xboxCollectionImport.sql.ts
+++ b/src/db/sql/xboxCollectionImport.sql.ts
@@ -14,6 +14,20 @@ const IMPORT_COLS = `IMPORT_ID,
        CREATED_AT,
        UPDATED_AT`;
 
+const IMPORT_COLS_PG = `import_id,
+       user_id,
+       status,
+       current_index,
+       total_count,
+       xuid,
+       gamertag,
+       source_type,
+       source_file_name,
+       source_file_size,
+       template_version,
+       created_at,
+       updated_at`;
+
 const ITEM_COLS = `ITEM_ID,
        IMPORT_ID,
        ROW_INDEX,
@@ -35,6 +49,28 @@ const ITEM_COLS = `ITEM_ID,
        COLLECTION_ENTRY_ID,
        RESULT_REASON,
        ERROR_TEXT`;
+
+const ITEM_COLS_PG = `item_id,
+       import_id,
+       row_index,
+       xbox_title_id,
+       xbox_product_id,
+       xbox_title_name,
+       raw_platform,
+       raw_ownership_type,
+       raw_note,
+       raw_gamedb_id,
+       raw_igdb_id,
+       platform_id,
+       ownership_type,
+       note,
+       status,
+       match_confidence,
+       match_candidate_json,
+       gamedb_game_id,
+       collection_entry_id,
+       result_reason,
+       error_text`;
 
 export const XboxCollectionImportSql = {
   createImport: {
@@ -61,7 +97,29 @@ export const XboxCollectionImportSql = {
          :sourceFileSize,
          :templateVersion
        ) RETURNING IMPORT_ID INTO :id`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_xbox_collection_imports (
+         user_id,
+         status,
+         current_index,
+         total_count,
+         xuid,
+         gamertag,
+         source_type,
+         source_file_name,
+         source_file_size,
+         template_version
+       ) VALUES (
+         :userId,
+         'ACTIVE',
+         0,
+         :totalCount,
+         :xuid,
+         :gamertag,
+         :sourceType,
+         :sourceFileName,
+         :sourceFileSize,
+         :templateVersion
+       ) RETURNING import_id`,
   } satisfies SqlEntry,
 
   insertItem: {
@@ -96,13 +154,44 @@ export const XboxCollectionImportSql = {
            :note,
            'PENDING'
          )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_xbox_collection_import_items (
+           import_id,
+           row_index,
+           xbox_title_id,
+           xbox_product_id,
+           xbox_title_name,
+           raw_platform,
+           raw_ownership_type,
+           raw_note,
+           raw_gamedb_id,
+           raw_igdb_id,
+           platform_id,
+           ownership_type,
+           note,
+           status
+         ) VALUES (
+           :importId,
+           :rowIndex,
+           :xboxTitleId,
+           :xboxProductId,
+           :xboxTitleName,
+           :rawPlatform,
+           :rawOwnershipType,
+           :rawNote,
+           :rawGameDbId,
+           :rawIgdbId,
+           :platformId,
+           :ownershipType,
+           :note,
+           'PENDING'
+         )`,
   } satisfies SqlEntry,
 
   getImportById: {
     oracle: `SELECT ${IMPORT_COLS}
   FROM RPG_CLUB_XBOX_COLLECTION_IMPORTS WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `SELECT ${IMPORT_COLS_PG}
+  FROM rpg_club_xbox_collection_imports WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getActiveForUser: {
@@ -111,27 +200,36 @@ export const XboxCollectionImportSql = {
      WHERE USER_ID = :userId
        AND STATUS IN ('ACTIVE', 'PAUSED')
      ORDER BY IMPORT_ID DESC`,
-    postgres: ``,
+    postgres: `SELECT ${IMPORT_COLS_PG}
+  FROM rpg_club_xbox_collection_imports
+     WHERE user_id = :userId
+       AND status IN ('ACTIVE', 'PAUSED')
+     ORDER BY import_id DESC`,
   } satisfies SqlEntry,
 
   setStatus: {
     oracle: `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
         SET STATUS = :status
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_xbox_collection_imports
+        SET status = :status
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   updateIndex: {
     oracle: `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORTS
         SET CURRENT_INDEX = :currentIndex
       WHERE IMPORT_ID = :importId`,
-    postgres: ``,
+    postgres: `UPDATE rpg_club_xbox_collection_imports
+        SET current_index = :currentIndex
+      WHERE import_id = :importId`,
   } satisfies SqlEntry,
 
   getItemById: {
     oracle: `SELECT ${ITEM_COLS}
   FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS WHERE ITEM_ID = :itemId`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+  FROM rpg_club_xbox_collection_import_items WHERE item_id = :itemId`,
   } satisfies SqlEntry,
 
   getNextPendingItem: {
@@ -141,15 +239,23 @@ export const XboxCollectionImportSql = {
        AND STATUS = 'PENDING'
      ORDER BY ROW_INDEX ASC
      FETCH FIRST 1 ROWS ONLY`,
-    postgres: ``,
+    postgres: `SELECT ${ITEM_COLS_PG}
+  FROM rpg_club_xbox_collection_import_items
+     WHERE import_id = :importId
+       AND status = 'PENDING'
+     ORDER BY row_index ASC
+     LIMIT 1`,
   } satisfies SqlEntry,
 
+  // Caller must pass lowercase column=value expressions for Postgres (e.g. "status = :status")
   updateItem: (fields: string[]) =>
     ({
       oracle: `UPDATE RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
         SET ${fields.join(", ")}
       WHERE ITEM_ID = :itemId`,
-      postgres: ``,
+      postgres: `UPDATE rpg_club_xbox_collection_import_items
+        SET ${fields.join(", ")}
+      WHERE item_id = :itemId`,
     }) satisfies SqlEntry,
 
   countItemsByStatus: {
@@ -157,7 +263,10 @@ export const XboxCollectionImportSql = {
        FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
       WHERE IMPORT_ID = :importId
       GROUP BY STATUS`,
-    postgres: ``,
+    postgres: `SELECT status, COUNT(*) AS cnt
+       FROM rpg_club_xbox_collection_import_items
+      WHERE import_id = :importId
+      GROUP BY status`,
   } satisfies SqlEntry,
 
   countItemsByReason: {
@@ -165,7 +274,10 @@ export const XboxCollectionImportSql = {
        FROM RPG_CLUB_XBOX_COLLECTION_IMPORT_ITEMS
       WHERE IMPORT_ID = :importId
       GROUP BY RESULT_REASON`,
-    postgres: ``,
+    postgres: `SELECT result_reason, COUNT(*) AS cnt
+       FROM rpg_club_xbox_collection_import_items
+      WHERE import_id = :importId
+      GROUP BY result_reason`,
   } satisfies SqlEntry,
 
   getTitleMap: {
@@ -178,7 +290,15 @@ export const XboxCollectionImportSql = {
             UPDATED_AT
        FROM RPG_CLUB_XBOX_TITLE_GAMEDB_MAP
       WHERE XBOX_TITLE_ID = :xboxTitleId`,
-    postgres: ``,
+    postgres: `SELECT map_id,
+            xbox_title_id,
+            gamedb_game_id,
+            status,
+            created_by,
+            created_at,
+            updated_at
+       FROM rpg_club_xbox_title_gamedb_map
+      WHERE xbox_title_id = :xboxTitleId`,
   } satisfies SqlEntry,
 
   upsertTitleMap: {
@@ -206,7 +326,12 @@ export const XboxCollectionImportSql = {
          src.status,
          src.createdBy
        )`,
-    postgres: ``,
+    postgres: `INSERT INTO rpg_club_xbox_title_gamedb_map (xbox_title_id, gamedb_game_id, status, created_by)
+       VALUES (:xboxTitleId, :gameDbGameId, :status, :createdBy)
+       ON CONFLICT (xbox_title_id) DO UPDATE SET
+         gamedb_game_id = EXCLUDED.gamedb_game_id,
+         status = EXCLUDED.status,
+         created_by = EXCLUDED.created_by`,
   } satisfies SqlEntry,
 
   getHistoricalMappedIds: {
@@ -226,6 +351,15 @@ export const XboxCollectionImportSql = {
           ORDER BY CNT DESC, LAST_ITEM_ID DESC
        ) t
       WHERE ROWNUM <= :limit`,
-    postgres: ``,
+    postgres: `SELECT ii.gamedb_game_id
+         FROM rpg_club_xbox_collection_import_items ii
+         JOIN rpg_club_xbox_collection_imports i ON i.import_id = ii.import_id
+        WHERE ii.xbox_title_id = :xboxTitleId
+          AND ii.gamedb_game_id IS NOT NULL
+          AND ii.result_reason = 'MANUAL_REMAP'
+          AND (:excludeUserId IS NULL OR i.user_id <> :excludeUserId)
+        GROUP BY ii.gamedb_game_id
+        ORDER BY COUNT(*) DESC, MAX(ii.item_id) DESC
+        LIMIT :limit`,
   } satisfies SqlEntry,
 };


### PR DESCRIPTION
## Summary

- Populates the \`postgres:\` field on every \`SqlEntry\` across all 23 domain SQL registry files (all previously had empty strings)
- Adds \`namedToPositional\` in \`postgresClient.ts\` so Postgres SQL can use Oracle-style \`:paramName\` bind syntax with zero call-site changes
- Widens bind parameter types in \`SqlManager.ts\` \`dbQuery\`/\`dbMutate\` to accept named bind objects for the Postgres path

Key SQL translations applied throughout:
- Table/column names lowercased for Postgres conventions
- \`SYSTIMESTAMP\` -> \`NOW()\`, \`SYSDATE\` -> \`CURRENT_DATE\`
- \`FETCH FIRST N ROWS ONLY\` -> \`LIMIT N\`, \`OFFSET/FETCH\` -> \`LIMIT/OFFSET\`
- \`MERGE INTO...USING dual\` -> \`INSERT...ON CONFLICT DO UPDATE/NOTHING\`
- \`NVL\` -> \`COALESCE\`, \`NUMTODSINTERVAL(:days,'DAY')\` -> \`:days * INTERVAL '1 day'\`
- \`ROWNUM\` subqueries -> inline \`LIMIT\`
- \`RETURNING col INTO :bind\` -> \`RETURNING col\` (caller reads result row)
- Oracle integer booleans (0/1) -> Postgres \`true\`/\`false\`
- \`LISTAGG...WITHIN GROUP\` -> \`STRING_AGG...ORDER BY\`
- \`REGEXP_REPLACE\` global flag \`'g'\` added for Postgres
- Oracle system catalog queries (\`ALL_TAB_COLUMNS\`) -> \`information_schema.columns\`
- Dynamic factory column/table name params lowercased for Postgres

## Test plan

- [x] \`tsc --noEmit\` passes clean
- [ ] Validate Postgres SQL at runtime once a Postgres instance is connected (Phase E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)