### PR TITLE
feat: Phase D2 -- BIND_OUT and connection-passing migration to dialect-agnostic wrappers

### DIFF
--- a/SQL_MIGRATION_PLAN.md
+++ b/SQL_MIGRATION_PLAN.md
@@ -308,7 +308,7 @@ Files completed: `starboard`, `hltbCache`, `gameDbCsvImportMapping`, `nomination
 
 ---
 
-### Next Step: Phase D2 -- Oracle-only blockers are now unblocked
+### Phase D2 -- IN PROGRESS (branch `feature/phase-d2-bind-out-and-conn-passing`)
 
 ---
 
@@ -334,42 +334,53 @@ All standalone `oraQuery`/`oraMutate` calls (no BIND_OUT, no connection-passing)
 converted to `dbQuery`/`dbMutate` across all domain classes. Every remaining `ora*` call in the
 codebase is now a D2 blocker.
 
-**Call sites -- current status:**
+**D2 new wrappers added to `postgresClient.ts` and `SqlManager.ts`:**
 
-| File | Status |
+- `pgInsert(sql, params)` -- runs INSERT RETURNING on pool, returns first column of first row
+- `pgInsertConn(client, sql, params)` -- same on an existing PoolClient
+- `pgQueryConn(client, sql, params)` -- SELECT on an existing PoolClient
+- `pgMutateConn(client, sql, params)` -- DML on an existing PoolClient
+- `dbInsert(entry, params, bindOutKey)` -- dialect-agnostic INSERT returning generated id
+- `dbInsertConn(conn, entry, params, bindOutKey)` -- same, inside a connection callback
+- `dbQueryConn(conn, entry, params, mapper)` -- dialect-agnostic SELECT inside a callback
+- `dbMutateConn(conn, entry, params)` -- dialect-agnostic DML inside a callback
+
+**Call sites -- D2 status as of 2026-06-08:**
+
+| File | D2 Status |
 |---|---|
-| `AdminWizardSession.ts` | Partial -- `getActive` and `saveSession` done; `closeActive` uses `conn.execute` directly (oracle-specific) |
-| `BotVotingInfo.ts` | Partial -- all `get*` and `mark*` done; `setRoundInfo` uses `conn.execute` (oracle-specific) |
-| `CollectionCsvImport.ts` | Partial -- `getImportById` done; `createImport` (BIND_OUT) and `insertItem` (conn-passing) remain |
-| `CompletionatorImport.ts` | Partial -- same pattern as CollectionCsvImport |
-| `GameDbCsvImport.ts` | Partial -- same pattern |
-| `GameDbCsvImportMapping.ts` | Fully migrated |
-| `Game.ts` | Partial -- all standalone get/update/mutate done; BIND_OUT inserts, conn-passing blocks, and oracle-specific `conn.execute` paths remain |
-| `GameKey.ts` | Partial -- `get*`, `list*`, `claim`, `revoke` done; `create` (BIND_OUT) remains |
-| `GameReleaseAnnouncement.ts` | Partial -- `mark*` and `list*` done; `syncReleaseAnnouncements` (conn-passing) remains |
-| `GameSearchSynonymDraft.ts` | Partial -- `getDraft`, `deleteDraft` done; `createDraft` (BIND_OUT), `appendPairs` (conn-passing) remain |
-| `GameSearchSynonym.ts` | Partial -- standalone `dbQuery` lookups done; all mutation/insert paths use oracle conn-passing and BIND_OUT |
-| `GotmAuditImport.ts` | Partial -- `getById` done; `createSession` (BIND_OUT) and bulk insert (conn-passing) remain |
-| `Gotm.ts` | Partial -- most `get*` done; `updateRowOrder` and `commitRound` use conn-passing |
-| `HltbCache.ts` | Fully migrated |
-| `Member.ts` | Partial -- large file; many `get*` done; connection-passing and BIND_OUT methods remain |
-| `Nomination.ts` | Fully migrated |
-| `NrGotm.ts` | Partial -- `loadAll`, `updateVotingResults`, `checkRoundExists`, `deleteRound` done; conn-passing update block and BIND_OUT insert remain |
-| `PresencePromptHistory.ts` | Fully migrated |
-| `PresencePromptOptOut.ts` | Fully migrated |
-| `PublicReminder.ts` | Partial -- `list*`, `delete`, `update*` done; `create` (BIND_OUT) remains |
-| `Reminder.ts` | Partial -- all done except `create` (BIND_OUT) and `getById` (optional conn) |
-| `RssFeed.ts` | Partial -- `removeFeed`, `updateFeed` done; `addFeed` (BIND_OUT), `markItemsSeen` (executeMany), `getSeenItemHashes` (conn-passing) remain |
-| `Starboard.ts` | Fully migrated |
-| `SteamCollectionImport.ts` | Partial -- `getActiveForUser`, `setStatus`, `updateIndex`, `updateItem`, `countItems*`, `getHistoricalMappedIds` done; `createImport` (BIND_OUT), `insertItems` (oraTransaction conn-passing), `getItemById`/`getNextPending` (fetchInfo conn), `getAppMap`/`upsertAppMap` (optional conn) remain |
-| `SuggestionReviewSession.ts` | Partial -- `update`, `delete*` done; `create` (conn-passing) and `getById` (optional conn) remain |
-| `Suggestion.ts` | Partial -- `list`, `count`, `delete` done; `create` (BIND_OUT) and `getById` (optional conn) remain |
-| `Thread.ts` | Partial -- `upsertThread`, `setSkipLinking`, `getThreadSkipLinking` done; transactions and conn-passing remain |
-| `Todo.ts` | Partial -- all done except `create` (BIND_OUT) |
-| `UserActivityIcon.ts` | No D1 conversions possible -- all calls use dynamic Oracle-style named binds or oraTransaction conn-passing |
-| `UserChannelMessageCount.ts` | Partial -- `getScannedChannelIds`, `getChannelScanMeta` done; `upsertChannelCounts` (executeMany) remains |
-| `UserGameCollection.ts` | Partial -- all standalone selects and `removeEntry` done; `addEntry` (BIND_OUT), `updateEntry` (conn-passing), `getEntryById` (required conn) remain |
-| `XboxCollectionImport.ts` | Partial -- `getActiveForUser`, `setStatus`, `updateIndex`, `getItemById`, `getNextPending`, `updateItem`, `countItems*`, `getHistoricalMappedIds` done; `createImport` (BIND_OUT), `insertItems` (oraTransaction), `getImportById`/`getTitleMap` (optional conn), `upsertTitleMap` (conn-passing) remain |
+| `AdminWizardSession.ts` | COMPLETE -- `closeActive` converted to `dbTransaction` + `dbMutateConn` |
+| `BotVotingInfo.ts` | COMPLETE -- `setRoundInfo` converted to `dbTransaction` + `dbMutateConn` |
+| `CollectionCsvImport.ts` | COMPLETE -- `createImport` uses `dbInsert`; bulk insert uses `dbTransaction` + `dbMutateConn` |
+| `CompletionatorImport.ts` | COMPLETE -- same pattern as CollectionCsvImport |
+| `GameDbCsvImport.ts` | COMPLETE -- same pattern |
+| `GameDbCsvImportMapping.ts` | COMPLETE (was already done) |
+| `Game.ts` | PENDING -- BIND_OUT inserts, conn-passing blocks remain |
+| `GameKey.ts` | COMPLETE -- `create` uses `dbInsert` |
+| `GameReleaseAnnouncement.ts` | PENDING -- `syncReleaseAnnouncements` conn-passing remains |
+| `GameSearchSynonymDraft.ts` | COMPLETE -- `createDraft` uses `dbInsert`; `appendPairs` uses `dbTransaction` + `dbMutateConn` |
+| `GameSearchSynonym.ts` | COMPLETE -- all methods use `dbTransaction`/`dbWithConnection` + `dbInsertConn`/`dbQueryConn`/`dbMutateConn` |
+| `GotmAuditImport.ts` | COMPLETE -- `createSession` uses `dbInsert`; bulk insert uses `dbTransaction` + `dbMutateConn` |
+| `Gotm.ts` | COMPLETE -- `updateRowOrder` and `insertGotmRound` use `dbTransaction` + conn-scoped wrappers |
+| `HltbCache.ts` | COMPLETE (was already done) |
+| `Member.ts` | PENDING -- large file; BIND_OUT and conn-passing methods remain |
+| `Nomination.ts` | COMPLETE (was already done) |
+| `NrGotm.ts` | COMPLETE -- `updateRowOrder` and `insertNrGotmRound` use `dbTransaction` + `dbInsertConn`/`dbMutateConn` |
+| `PresencePromptHistory.ts` | COMPLETE (was already done) |
+| `PresencePromptOptOut.ts` | COMPLETE (was already done) |
+| `PublicReminder.ts` | COMPLETE -- `create` uses `dbInsert` |
+| `Reminder.ts` | COMPLETE -- `create` uses `dbInsert`; `getById` accepts union conn type |
+| `RssFeed.ts` | PENDING -- `addFeed` (BIND_OUT), `markItemsSeen` (executeMany D3), `getSeenItemHashes` (conn-passing) remain |
+| `Starboard.ts` | COMPLETE (was already done) |
+| `SteamCollectionImport.ts` | PENDING -- `createImport`, `insertItems`, `getAppMap`/`upsertAppMap` remain |
+| `SuggestionReviewSession.ts` | COMPLETE -- `create` uses `dbMutate`; `getById` uses `dbQuery` |
+| `Suggestion.ts` | COMPLETE -- `create` uses `dbInsert`; `getById` uses `dbQuery` |
+| `Thread.ts` | COMPLETE -- all transactions use `dbTransaction`/`dbWithConnection` + conn-scoped wrappers |
+| `Todo.ts` | COMPLETE -- `create` uses `dbInsert` |
+| `UserActivityIcon.ts` | PENDING -- oraTransaction loop + dynamic oraQuery remain |
+| `UserChannelMessageCount.ts` | PENDING -- `upsertChannelCounts` (executeMany D3) remains |
+| `UserGameCollection.ts` | COMPLETE -- `addEntry` uses `dbInsertConn`; `updateEntry` uses `dbTransaction` + `dbMutateConn` |
+| `XboxCollectionImport.ts` | PENDING -- BIND_OUT, oraTransaction, optional-conn methods remain |
 
 ---
 
@@ -380,27 +391,26 @@ codebase is now a D2 blocker.
 All standalone `oraQuery`/`oraMutate` call sites (no BIND_OUT, no connection argument) have been
 converted to `dbQuery`/`dbMutate`. No D1 work remains.
 
-**D2 -- Oracle-only blockers (now unblocked -- postgres SQL is complete)**
+**D2 -- Remaining files (on branch `feature/phase-d2-bind-out-and-conn-passing`):**
 
-Two categories of calls cannot use `db*` wrappers yet:
+1. `GameReleaseAnnouncement.ts` -- `syncReleaseAnnouncements` conn-passing block
+2. `UserActivityIcon.ts` -- `oraTransaction` loop + dynamic `oraQuery`
+3. `UserChannelMessageCount.ts` -- `upsertChannelCounts` (D3 executeMany, replace with loop)
+4. `RssFeed.ts` -- `addFeed` (BIND_OUT), `markItemsSeen` (D3 executeMany), `getSeenItemHashes` (conn-passing)
+5. `XboxCollectionImport.ts` -- `createImport` (BIND_OUT), `insertItems` (oraTransaction), optional-conn getters, `upsertTitleMap`
+6. `SteamCollectionImport.ts` -- same patterns as Xbox
+7. `Member.ts` -- large file; BIND_OUT inserts, conn-passing blocks remain
+8. `Game.ts` -- large file; BIND_OUT inserts, conn-passing blocks remain
 
-1. **BIND_OUT** (`INSERT ... RETURNING x INTO :outVar`): Postgres SQL is now written as
-   `INSERT ... RETURNING x`. Needs a new `dbInsert(entry, params): Promise<number>` wrapper that
-   returns the generated id (uses `outBinds[0]` on Oracle, `rows[0].id` on Postgres).
+**D3 -- `executeMany` calls**
 
-2. **Connection-passing** (`oraWithConnection`/`oraTransaction` callbacks that call
-   `oraMutate(sql, params, conn)` or `oraQuery(sql, params, mapper, conn)`): Postgres SQL is now
-   written. Needs the callback rewritten to accept a union connection type, dispatching to
-   driver-specific calls inside.
+Oracle's `conn.executeMany` has no pg equivalent. Replace with per-row `dbMutateConn` loop inside
+`dbTransaction`. Affects `RssFeed.markItemsSeen` and `UserChannelMessageCount.upsertChannelCounts`.
 
-**D3 -- `executeMany` (RssFeed.markItemsSeen)**
+#### Approach (still valid)
 
-Oracle's `conn.executeMany` has no pg equivalent in the current wrappers. When porting, replace
-with a per-row `pgMutate` loop or a postgres multi-row INSERT ... ON CONFLICT pattern.
-
-#### Previously planned approach (still valid)
-
-- `dbQuery` / `dbMutate` first (covers the bulk of standalone call sites).
-- `dbWithConnection` / `dbTransaction` next (connection-scoped multi-statement blocks).
-- BIND_OUT cases last (require postgres SQL to be written first).
+- `dbQuery` / `dbMutate` for all standalone call sites.
+- `dbWithConnection` / `dbTransaction` for connection-scoped multi-statement blocks.
+- `dbInsert` / `dbInsertConn` for BIND_OUT INSERT patterns.
+- `dbQueryConn` / `dbMutateConn` inside connection callbacks.
 - Run `tsc --noEmit` after each batch.

--- a/SQL_MIGRATION_PLAN.md
+++ b/SQL_MIGRATION_PLAN.md
@@ -119,36 +119,31 @@ Dynamic parts (whereClause, orderBy) are always code-generated, never raw user i
 
 | Oracle | PostgreSQL |
 |---|---|
-| `:paramName` bind | `$1, $2, ...` positional |
-| `SYSDATE` | `NOW()` |
+| `:paramName` named bind | `:paramName` named bind (converted to `$N` at runtime by `namedToPositional`) |
+| `SYSDATE` | `CURRENT_DATE` |
 | `SYSTIMESTAMP` | `NOW()` |
+| `CURRENT_TIMESTAMP` | `CURRENT_TIMESTAMP` (works in both) |
 | `ROWNUM <= n` | `LIMIT n` |
+| `FETCH FIRST n ROWS ONLY` | `LIMIT n` |
+| `OFFSET n ROWS FETCH NEXT m ROWS ONLY` | `LIMIT m OFFSET n` |
 | `LISTAGG(x, ',') WITHIN GROUP (ORDER BY y)` | `STRING_AGG(x, ',' ORDER BY y)` |
 | `MERGE INTO t USING dual ON (...) WHEN NOT MATCHED THEN INSERT` | `INSERT INTO t ... ON CONFLICT (...) DO UPDATE SET ...` / `DO NOTHING` |
 | `INSERT ... RETURNING x INTO :outVar` (with `BIND_OUT`) | `INSERT ... RETURNING x` (result in `rows[0]`) |
 | `SELECT ... FROM dual` | `SELECT ...` (omit FROM dual) |
-| `VARCHAR2` | `TEXT` or `VARCHAR` |
-| `NUMBER` | `NUMERIC` or `INTEGER` |
-| `DATE` | `TIMESTAMP` |
 | `NVL(x, y)` | `COALESCE(x, y)` |
-| `DECODE(x, v, r, def)` | `CASE WHEN x = v THEN r ELSE def END` |
-| `CONNECT BY LEVEL` | `generate_series()` |
+| `NUMTODSINTERVAL(:days, 'DAY')` | `:days * INTERVAL '1 day'` |
+| `REGEXP_REPLACE(str, pat, '')` | `REGEXP_REPLACE(str, pat, '', 'g')` (requires `'g'` flag) |
+| `UPPER_TABLE_NAME` | `lower_table_name` |
+| `COLUMN_NAME` (uppercase) | `column_name` (lowercase) |
+| `ALL_TAB_COLUMNS` system catalog | `information_schema.columns` |
+| `SYS_CONTEXT('USERENV', 'CURRENT_SCHEMA')` | `current_schema()` |
+| Integer booleans `0`/`1` | Native booleans `false`/`true` |
 
-### Bind Parameter Offset for IN-list Builders
+### Named Bind Parameters
 
-Oracle uses named binds (`:id0`, `:id1`), which are order-independent.
-PostgreSQL uses positional (`$1`, `$2`), so IN-list factory functions must accept a `startOffset` parameter:
-
-```typescript
-buildInList: (ids: number[], startOffset = 1) => {
-  const oraPlaceholders = ids.map((_, i) => `:id${i}`).join(", ");
-  const pgPlaceholders  = ids.map((_, i) => `$${startOffset + i}`).join(", ");
-  return {
-    oracle:   `WHERE GAME_ID IN (${oraPlaceholders})`,
-    postgres: `WHERE game_id IN (${pgPlaceholders})`,
-  } satisfies SqlEntry;
-},
-```
+Both Oracle and Postgres SQL in the registry use `:paramName` syntax. At runtime,
+`namedToPositional` in `src/db/postgresClient.ts` converts `:name` -> `$N` before sending to the
+`pg` driver. This means call sites require zero changes between dialects.
 
 ---
 
@@ -296,7 +291,24 @@ Migrated in this phase (Phases A/B/C):
 
 ---
 
-### Next Step: Phase D (in progress) -- Dialect-agnostic execution wrappers
+---
+
+### Phase E: Postgres SQL variants -- COMPLETE (PR #546, 2026-06-08)
+
+All 23 domain SQL registry files now have complete `postgres:` variants. The `namedToPositional`
+helper in `postgresClient.ts` converts `:paramName` -> `$N` at runtime so call sites need no
+changes. `tsc --noEmit` passes clean.
+
+Files completed: `starboard`, `hltbCache`, `gameDbCsvImportMapping`, `nomination`,
+`adminWizardSession`, `presencePrompt`, `userActivity`, `todo`, `botVotingInfo`, `gameKey`,
+`reminder`, `rssFeed`, `suggestion`, `thread`, `gameReleaseAnnouncement`, `gotm`,
+`gameSearchSynonym`, `gameDbCsvImport`, `collectionCsvImport`, `completionatorImport`,
+`gotmAuditImport`, `userGameCollection`, `steamCollectionImport`, `xboxCollectionImport`,
+`member`, `game`.
+
+---
+
+### Next Step: Phase D2 -- Oracle-only blockers are now unblocked
 
 ---
 
@@ -368,18 +380,18 @@ codebase is now a D2 blocker.
 All standalone `oraQuery`/`oraMutate` call sites (no BIND_OUT, no connection argument) have been
 converted to `dbQuery`/`dbMutate`. No D1 work remains.
 
-**D2 -- Oracle-only blockers (defer until postgres SQL is written)**
+**D2 -- Oracle-only blockers (now unblocked -- postgres SQL is complete)**
 
 Two categories of calls cannot use `db*` wrappers yet:
 
-1. **BIND_OUT** (`INSERT ... RETURNING x INTO :outVar`): These need postgres SQL filled in as
-   `INSERT ... RETURNING x` and a new `dbInsert(entry, params): Promise<number>` wrapper that
+1. **BIND_OUT** (`INSERT ... RETURNING x INTO :outVar`): Postgres SQL is now written as
+   `INSERT ... RETURNING x`. Needs a new `dbInsert(entry, params): Promise<number>` wrapper that
    returns the generated id (uses `outBinds[0]` on Oracle, `rows[0].id` on Postgres).
 
 2. **Connection-passing** (`oraWithConnection`/`oraTransaction` callbacks that call
-   `oraMutate(sql, params, conn)` or `oraQuery(sql, params, mapper, conn)`): These multi-statement
-   blocks need the postgres SQL filled in and the callback rewritten to accept a union connection
-   type, dispatching to driver-specific calls inside.
+   `oraMutate(sql, params, conn)` or `oraQuery(sql, params, mapper, conn)`): Postgres SQL is now
+   written. Needs the callback rewritten to accept a union connection type, dispatching to
+   driver-specific calls inside.
 
 **D3 -- `executeMany` (RssFeed.markItemsSeen)**
 

--- a/src/classes/AdminWizardSession.ts
+++ b/src/classes/AdminWizardSession.ts
@@ -1,9 +1,5 @@
-import { dbQuery, dbMutate, oraWithConnection } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, dbTransaction, dbMutateConn } from "../db/SqlManager.js";
 import { AdminWizardSessionSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export const ADMIN_WIZARD_COMMANDS = ["nextround-setup"] as const;
 export type AdminWizardCommand = (typeof ADMIN_WIZARD_COMMANDS)[number];
@@ -254,31 +250,23 @@ export async function closeActiveAdminWizardSession(params: {
   channelId: string;
   status: Exclude<AdminWizardSessionStatus, "active">;
 }): Promise<boolean> {
-  return oraWithConnection(async (conn) => {
+  return dbTransaction(async (conn) => {
     // Remove any prior historical row to avoid unique index collision when
     // promoting ACTIVE -> CANCELLED/COMPLETED.
-    await conn.execute(
-      getSql(AdminWizardSessionSql.deleteHistorical, dialect),
-      {
-        commandKey: params.commandKey,
-        ownerUserId: params.ownerUserId,
-        channelId: params.channelId,
-        status: toDbStatus(params.status),
-      },
-      { autoCommit: true },
-    );
+    await dbMutateConn(conn, AdminWizardSessionSql.deleteHistorical, {
+      commandKey: params.commandKey,
+      ownerUserId: params.ownerUserId,
+      channelId: params.channelId,
+      status: toDbStatus(params.status),
+    });
 
-    const result = await conn.execute(
-      getSql(AdminWizardSessionSql.updateStatus, dialect),
-      {
-        status: toDbStatus(params.status),
-        lastUpdatedAt: new Date(),
-        commandKey: params.commandKey,
-        ownerUserId: params.ownerUserId,
-        channelId: params.channelId,
-      },
-      { autoCommit: true },
-    );
-    return Number(result.rowsAffected ?? 0) > 0;
+    const rowsAffected = await dbMutateConn(conn, AdminWizardSessionSql.updateStatus, {
+      status: toDbStatus(params.status),
+      lastUpdatedAt: new Date(),
+      commandKey: params.commandKey,
+      ownerUserId: params.ownerUserId,
+      channelId: params.channelId,
+    });
+    return rowsAffected > 0;
   });
 }

--- a/src/classes/BotVotingInfo.ts
+++ b/src/classes/BotVotingInfo.ts
@@ -1,9 +1,5 @@
-import { dbQuery, dbMutate, oraWithConnection } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, dbTransaction, dbMutateConn } from "../db/SqlManager.js";
 import { BotVotingInfoSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export interface IBotVotingInfoEntry {
   roundNumber: number;
@@ -102,18 +98,17 @@ export default class BotVotingInfo {
     const round = normalizeRoundNumber(roundNumber);
     const nextVote = normalizeDate(nextVoteAt);
 
-    await oraWithConnection(async (conn) => {
-      const updateResult = await conn.execute(
-        getSql(BotVotingInfoSql.updateRoundInfo, dialect),
+    await dbTransaction(async (conn) => {
+      const rowsAffected = await dbMutateConn(
+        conn,
+        BotVotingInfoSql.updateRoundInfo,
         { round, nominationListId, nextVoteAt: nextVote },
-        { autoCommit: true },
       );
-      if ((updateResult.rowsAffected ?? 0) > 0) return;
-
-      await conn.execute(
-        getSql(BotVotingInfoSql.insertRoundInfo, dialect),
+      if (rowsAffected > 0) return;
+      await dbMutateConn(
+        conn,
+        BotVotingInfoSql.insertRoundInfo,
         { round, nominationListId, nextVoteAt: nextVote },
-        { autoCommit: true },
       );
     });
   }

--- a/src/classes/CollectionCsvImport.ts
+++ b/src/classes/CollectionCsvImport.ts
@@ -1,17 +1,5 @@
-import oracledb from "oracledb";
-import {
-  dbQuery,
-  dbMutate,
-  oraQuery,
-  oraMutate,
-  oraWithConnection,
-  oraTransaction,
-} from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, dbInsert, dbTransaction, dbMutateConn } from "../db/SqlManager.js";
 import { CollectionCsvImportSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type CollectionCsvImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type CollectionCsvImportItemStatus =
@@ -150,28 +138,18 @@ export async function createCollectionCsvImportSession(params: {
   sourceFileSize: number | null;
   templateVersion: string | null;
 }): Promise<ICollectionCsvImport> {
-  return oraWithConnection(async (conn) => {
-    const result = await oraMutate(
-      getSql(CollectionCsvImportSql.createImport, dialect),
-      {
-        userId: params.userId,
-        totalCount: params.totalCount,
-        sourceFileName: params.sourceFileName,
-        sourceFileSize: params.sourceFileSize,
-        templateVersion: params.templateVersion,
-        id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      conn,
-    );
-    await conn.commit();
+  const id = await dbInsert(CollectionCsvImportSql.createImport, {
+    userId: params.userId,
+    totalCount: params.totalCount,
+    sourceFileName: params.sourceFileName,
+    sourceFileSize: params.sourceFileSize,
+    templateVersion: params.templateVersion,
+  }, "id");
+  if (!id) throw new Error("Failed to create CSV collection import session.");
 
-    const id = Number((result.outBinds as { id?: number[] }).id?.[0] ?? 0);
-    if (!id) throw new Error("Failed to create CSV collection import session.");
-
-    const session = await getCollectionCsvImportById(id, conn);
-    if (!session) throw new Error("Failed to load CSV collection import session.");
-    return session;
-  });
+  const session = await getCollectionCsvImportById(id);
+  if (!session) throw new Error("Failed to load CSV collection import session.");
+  return session;
 }
 
 export async function insertCollectionCsvImportItems(
@@ -191,39 +169,29 @@ export async function insertCollectionCsvImportItems(
 ): Promise<void> {
   if (!items.length) return;
 
-  await oraTransaction(async (conn) => {
+  await dbTransaction(async (conn) => {
     for (const item of items) {
-      await oraMutate(
-        getSql(CollectionCsvImportSql.insertItem, dialect),
-        {
-          importId,
-          rowIndex: item.rowIndex,
-          rawTitle: item.rawTitle,
-          rawPlatform: item.rawPlatform,
-          rawOwnershipType: item.rawOwnershipType,
-          rawNote: item.rawNote,
-          rawGameDbId: item.rawGameDbId,
-          rawIgdbId: item.rawIgdbId,
-          platformId: item.platformId,
-          ownershipType: item.ownershipType,
-          note: item.note,
-        },
-        conn,
-      );
+      await dbMutateConn(conn, CollectionCsvImportSql.insertItem, {
+        importId,
+        rowIndex: item.rowIndex,
+        rawTitle: item.rawTitle,
+        rawPlatform: item.rawPlatform,
+        rawOwnershipType: item.rawOwnershipType,
+        rawNote: item.rawNote,
+        rawGameDbId: item.rawGameDbId,
+        rawIgdbId: item.rawIgdbId,
+        platformId: item.platformId,
+        ownershipType: item.ownershipType,
+        note: item.note,
+      });
     }
   });
 }
 
 export async function getCollectionCsvImportById(
   importId: number,
-  existingConn?: oracledb.Connection,
 ): Promise<ICollectionCsvImport | null> {
-  const rows = await oraQuery(
-    getSql(CollectionCsvImportSql.getImportById, dialect),
-    { importId },
-    mapImport,
-    existingConn,
-  );
+  const rows = await dbQuery(CollectionCsvImportSql.getImportById, { importId }, mapImport);
   return rows[0] ?? null;
 }
 

--- a/src/classes/CompletionatorImport.ts
+++ b/src/classes/CompletionatorImport.ts
@@ -1,17 +1,5 @@
-import oracledb from "oracledb";
-import {
-  dbQuery,
-  dbMutate,
-  oraQuery,
-  oraMutate,
-  oraWithConnection,
-  oraTransaction,
-} from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, dbInsert, dbTransaction, dbMutateConn } from "../db/SqlManager.js";
 import { CompletionatorImportSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type ImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type ImportItemStatus =
@@ -121,26 +109,16 @@ export async function createImportSession(params: {
   totalCount: number;
   sourceFilename: string | null;
 }): Promise<ICompletionatorImport> {
-  return oraWithConnection(async (conn) => {
-    const result = await oraMutate(
-      getSql(CompletionatorImportSql.createImport, dialect),
-      {
-        userId: params.userId,
-        totalCount: params.totalCount,
-        sourceFilename: params.sourceFilename,
-        id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      conn,
-    );
-    await conn.commit();
+  const id = await dbInsert(CompletionatorImportSql.createImport, {
+    userId: params.userId,
+    totalCount: params.totalCount,
+    sourceFilename: params.sourceFilename,
+  }, "id");
+  if (!id) throw new Error("Failed to create import session.");
 
-    const id = Number((result.outBinds as { id?: number[] })?.id?.[0] ?? 0);
-    if (!id) throw new Error("Failed to create import session.");
-
-    const session = await getImportById(id, conn);
-    if (!session) throw new Error("Failed to load import session.");
-    return session;
-  });
+  const session = await getImportById(id);
+  if (!session) throw new Error("Failed to load import session.");
+  return session;
 }
 
 export async function insertImportItems(
@@ -158,38 +136,28 @@ export async function insertImportItems(
   }>,
 ): Promise<void> {
   if (!items.length) return;
-  await oraTransaction(async (conn) => {
+  await dbTransaction(async (conn) => {
     for (const item of items) {
-      await oraMutate(
-        getSql(CompletionatorImportSql.insertItem, dialect),
-        {
-          importId,
-          rowIndex: item.rowIndex,
-          gameTitle: item.gameTitle,
-          platformName: item.platformName,
-          regionName: item.regionName,
-          sourceType: item.sourceType,
-          timeText: item.timeText,
-          completedAt: item.completedAt,
-          completionType: item.completionType,
-          playtimeHours: item.playtimeHours,
-        },
-        conn,
-      );
+      await dbMutateConn(conn, CompletionatorImportSql.insertItem, {
+        importId,
+        rowIndex: item.rowIndex,
+        gameTitle: item.gameTitle,
+        platformName: item.platformName,
+        regionName: item.regionName,
+        sourceType: item.sourceType,
+        timeText: item.timeText,
+        completedAt: item.completedAt,
+        completionType: item.completionType,
+        playtimeHours: item.playtimeHours,
+      });
     }
   });
 }
 
 export async function getImportById(
   importId: number,
-  existingConn?: oracledb.Connection,
 ): Promise<ICompletionatorImport | null> {
-  const rows = await oraQuery(
-    getSql(CompletionatorImportSql.getImportById, dialect),
-    { id: importId },
-    mapImport,
-    existingConn,
-  );
+  const rows = await dbQuery(CompletionatorImportSql.getImportById, { id: importId }, mapImport);
   return rows[0] ?? null;
 }
 

--- a/src/classes/GameDbCsvImport.ts
+++ b/src/classes/GameDbCsvImport.ts
@@ -1,17 +1,5 @@
-import oracledb from "oracledb";
-import {
-  dbQuery,
-  dbMutate,
-  oraQuery,
-  oraMutate,
-  oraWithConnection,
-  oraTransaction,
-} from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, dbInsert, dbTransaction, dbMutateConn } from "../db/SqlManager.js";
 import { GameDbCsvImportSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type GameDbCsvImportStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type GameDbCsvItemStatus = "PENDING" | "SKIPPED" | "IMPORTED" | "ERROR";
@@ -104,26 +92,16 @@ export async function createGameDbCsvImportSession(params: {
   totalCount: number;
   sourceFilename: string | null;
 }): Promise<IGameDbCsvImport> {
-  return oraWithConnection(async (conn) => {
-    const result = await oraMutate(
-      getSql(GameDbCsvImportSql.createImport, dialect),
-      {
-        userId: params.userId,
-        totalCount: params.totalCount,
-        sourceFilename: params.sourceFilename,
-        id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      conn,
-    );
-    await conn.commit();
+  const id = await dbInsert(GameDbCsvImportSql.createImport, {
+    userId: params.userId,
+    totalCount: params.totalCount,
+    sourceFilename: params.sourceFilename,
+  }, "id");
+  if (!id) throw new Error("Failed to create import session.");
 
-    const id = Number((result.outBinds as { id?: number[] })?.id?.[0] ?? 0);
-    if (!id) throw new Error("Failed to create import session.");
-
-    const session = await getGameDbCsvImportById(id, conn);
-    if (!session) throw new Error("Failed to load import session.");
-    return session;
-  });
+  const session = await getGameDbCsvImportById(id);
+  if (!session) throw new Error("Failed to load import session.");
+  return session;
 }
 
 export async function insertGameDbCsvImportItems(
@@ -138,35 +116,25 @@ export async function insertGameDbCsvImportItems(
   }>,
 ): Promise<void> {
   if (!items.length) return;
-  await oraTransaction(async (conn) => {
+  await dbTransaction(async (conn) => {
     for (const item of items) {
-      await oraMutate(
-        getSql(GameDbCsvImportSql.insertItem, dialect),
-        {
-          importId,
-          rowIndex: item.rowIndex,
-          gameTitle: item.gameTitle,
-          rawGameTitle: item.rawGameTitle,
-          platformName: item.platformName,
-          regionName: item.regionName,
-          initialReleaseDate: item.initialReleaseDate,
-        },
-        conn,
-      );
+      await dbMutateConn(conn, GameDbCsvImportSql.insertItem, {
+        importId,
+        rowIndex: item.rowIndex,
+        gameTitle: item.gameTitle,
+        rawGameTitle: item.rawGameTitle,
+        platformName: item.platformName,
+        regionName: item.regionName,
+        initialReleaseDate: item.initialReleaseDate,
+      });
     }
   });
 }
 
 export async function getGameDbCsvImportById(
   importId: number,
-  existingConn?: oracledb.Connection,
 ): Promise<IGameDbCsvImport | null> {
-  const rows = await oraQuery(
-    getSql(GameDbCsvImportSql.getImportById, dialect),
-    { id: importId },
-    mapImport,
-    existingConn,
-  );
+  const rows = await dbQuery(GameDbCsvImportSql.getImportById, { id: importId }, mapImport);
   return rows[0] ?? null;
 }
 

--- a/src/classes/GameKey.ts
+++ b/src/classes/GameKey.ts
@@ -1,10 +1,5 @@
-import oracledb from "oracledb";
-import { dbQuery, dbMutate, oraMutate } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, dbInsert } from "../db/SqlManager.js";
 import { GameKeySql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export interface IGameKey {
   keyId: number;
@@ -55,17 +50,7 @@ export async function createGameKey(
   keyValue: string,
   donorUserId: string,
 ): Promise<IGameKey> {
-  const result = await oraMutate(
-    getSql(GameKeySql.create, dialect),
-    {
-      title,
-      platform,
-      keyValue,
-      donorUserId,
-      id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-    },
-  );
-  const id = Number((result.outBinds as any)?.id?.[0] ?? 0);
+  const id = await dbInsert(GameKeySql.create, { title, platform, keyValue, donorUserId }, "id");
   if (!id) {
     throw new Error("Failed to create game key.");
   }

--- a/src/classes/GameSearchSynonym.ts
+++ b/src/classes/GameSearchSynonym.ts
@@ -1,10 +1,14 @@
-import oracledb from "oracledb";
-import { dbQuery, oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import type oracledb from "oracledb";
+import type pg from "pg";
+import {
+  dbQuery,
+  dbWithConnection,
+  dbTransaction,
+  dbQueryConn,
+  dbMutateConn,
+  dbInsertConn,
+} from "../db/SqlManager.js";
 import { GameSearchSynonymSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type IGameSearchSynonym = {
   termId: number;
@@ -37,34 +41,39 @@ export default class GameSearchSynonym {
 
   static async getGroupIdsForTerm(
     termText: string,
-    conn?: oracledb.Connection,
+    conn?: oracledb.Connection | pg.PoolClient,
   ): Promise<number[]> {
     const norm = normalizeSearchTerm(termText);
     if (!norm) return [];
-    return oraQuery(
-      getSql(GameSearchSynonymSql.getGroupIdsForTerm, dialect),
+    if (conn) {
+      return dbQueryConn(
+        conn,
+        GameSearchSynonymSql.getGroupIdsForTerm,
+        { termNorm: norm },
+        (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
+      );
+    }
+    return dbQuery(
+      GameSearchSynonymSql.getGroupIdsForTerm,
       { termNorm: norm },
       (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
-      conn,
     );
   }
 
   static async listGroupTerms(
     groupId: number,
-    conn?: oracledb.Connection,
+    conn?: oracledb.Connection | pg.PoolClient,
   ): Promise<IGameSearchSynonym[]> {
-    return oraQuery(
-      getSql(GameSearchSynonymSql.listGroupTerms, dialect),
-      { groupId },
-      mapSynonymRow,
-      conn,
-    );
+    if (conn) {
+      return dbQueryConn(conn, GameSearchSynonymSql.listGroupTerms, { groupId }, mapSynonymRow);
+    }
+    return dbQuery(GameSearchSynonymSql.listGroupTerms, { groupId }, mapSynonymRow);
   }
 
   static async getTermsForQuery(query: string): Promise<string[]> {
     const norm = normalizeSearchTerm(query);
     if (!norm) return [];
-    return oraWithConnection(async (conn) => {
+    return dbWithConnection(async (conn) => {
       const groupIds = await GameSearchSynonym.getGroupIdsForTerm(query, conn);
       if (!groupIds.length) return [];
       const binds: Record<string, number> = {};
@@ -73,11 +82,11 @@ export default class GameSearchSynonym {
         binds[key] = groupId;
         return `:${key}`;
       });
-      return oraQuery(
-        GameSearchSynonymSql.getTermsForQuery(placeholders.join(", "))[dialect],
+      return dbQueryConn(
+        conn,
+        GameSearchSynonymSql.getTermsForQuery(placeholders.join(", ")),
         binds,
         (row: { TERM_TEXT: string }) => String(row.TERM_TEXT),
-        conn,
       );
     });
   }
@@ -121,12 +130,12 @@ export default class GameSearchSynonym {
     const limit = options.limit ?? 10;
     const offset = options.offset ?? 0;
 
-    return oraWithConnection(async (conn) => {
-      const groupIds = await oraQuery(
-        getSql(GameSearchSynonymSql.listGroupIdsForSearch, dialect),
+    return dbWithConnection(async (conn) => {
+      const groupIds = await dbQueryConn(
+        conn,
+        GameSearchSynonymSql.listGroupIdsForSearch,
         { searchQuery, normalizedQuery, offset, limit },
         (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
-        conn,
       );
       if (!groupIds.length) return [];
 
@@ -136,11 +145,11 @@ export default class GameSearchSynonym {
         binds[key] = groupId;
         return `:${key}`;
       });
-      return oraQuery(
-        GameSearchSynonymSql.listTermsInGroups(placeholders.join(", "))[dialect],
+      return dbQueryConn(
+        conn,
+        GameSearchSynonymSql.listTermsInGroups(placeholders.join(", ")),
         binds,
         mapSynonymRow,
-        conn,
       );
     });
   }
@@ -156,23 +165,19 @@ export default class GameSearchSynonym {
       throw new Error("Both term and match text are required.");
     }
 
-    return oraWithConnection(async (conn) => {
+    return dbTransaction(async (conn) => {
       const termGroups = await GameSearchSynonym.getGroupIdsForTerm(trimmedTerm, conn);
       const matchGroups = await GameSearchSynonym.getGroupIdsForTerm(trimmedMatch, conn);
       const sharedGroup = termGroups.find((groupId) => matchGroups.includes(groupId));
-      let groupId = sharedGroup ?? null;
+      let groupId: number | null = sharedGroup ?? null;
 
       if (!groupId) {
-        const groupResult = await oraMutate(
-          getSql(GameSearchSynonymSql.insertSynonymGroup, dialect),
-          {
-            createdBy,
-            groupId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-          },
+        groupId = await dbInsertConn(
           conn,
+          GameSearchSynonymSql.insertSynonymGroup,
+          { createdBy },
+          "groupId",
         );
-        groupId = Number((groupResult.outBinds as any)?.groupId?.[0]);
-        await conn.commit();
       }
 
       for (const text of [trimmedTerm, trimmedMatch]) {
@@ -181,15 +186,14 @@ export default class GameSearchSynonym {
           throw new Error("Synonyms must include letters or numbers.");
         }
         try {
-          await oraMutate(
-            getSql(GameSearchSynonymSql.insertSynonymTerm, dialect),
-            { groupId, termText: text, termNorm: norm, createdBy },
+          await dbMutateConn(
             conn,
+            GameSearchSynonymSql.insertSynonymTerm,
+            { groupId, termText: text, termNorm: norm, createdBy },
           );
-          await conn.commit();
         } catch (err: any) {
           const msg = err?.message ?? "";
-          if (!/ORA-00001/i.test(msg)) {
+          if (!/ORA-00001/i.test(msg) && !/unique/i.test(msg)) {
             throw err;
           }
         }
@@ -215,13 +219,12 @@ export default class GameSearchSynonym {
       throw new Error("Term text must include letters or numbers.");
     }
 
-    return oraWithConnection(async (conn) => {
-      await oraMutate(
-        getSql(GameSearchSynonymSql.updateSynonymTerm, dialect),
-        { termId, termText: trimmed, termNorm },
+    return dbTransaction(async (conn) => {
+      await dbMutateConn(
         conn,
+        GameSearchSynonymSql.updateSynonymTerm,
+        { termId, termText: trimmed, termNorm },
       );
-      await conn.commit();
       return GameSearchSynonym.getSynonymById(termId, conn);
     });
   }
@@ -239,23 +242,18 @@ export default class GameSearchSynonym {
       throw new Error("A synonym group must contain at least two terms.");
     }
 
-    return oraWithConnection(async (conn) => {
-      const existsRows = await oraQuery(
-        getSql(GameSearchSynonymSql.checkGroupExists, dialect),
+    return dbTransaction(async (conn) => {
+      const existsRows = await dbQueryConn(
+        conn,
+        GameSearchSynonymSql.checkGroupExists,
         { groupId },
         (row: { CNT: number }) => Number(row.CNT ?? 0),
-        conn,
       );
       if ((existsRows[0] ?? 0) === 0) {
         throw new Error("Synonym group not found.");
       }
 
-      await oraMutate(
-        getSql(GameSearchSynonymSql.deleteSynonymsByGroup, dialect),
-        { groupId },
-        conn,
-      );
-      await conn.commit();
+      await dbMutateConn(conn, GameSearchSynonymSql.deleteSynonymsByGroup, { groupId });
 
       for (const text of cleaned) {
         const norm = normalizeSearchTerm(text);
@@ -263,15 +261,14 @@ export default class GameSearchSynonym {
           throw new Error("Synonym terms must include letters or numbers.");
         }
         try {
-          await oraMutate(
-            getSql(GameSearchSynonymSql.insertSynonymTerm, dialect),
-            { groupId, termText: text, termNorm: norm, createdBy: updatedBy },
+          await dbMutateConn(
             conn,
+            GameSearchSynonymSql.insertSynonymTerm,
+            { groupId, termText: text, termNorm: norm, createdBy: updatedBy },
           );
-          await conn.commit();
         } catch (err: any) {
           const msg = err?.message ?? "";
-          if (!/ORA-00001/i.test(msg)) {
+          if (!/ORA-00001/i.test(msg) && !/unique/i.test(msg)) {
             throw err;
           }
         }
@@ -302,29 +299,24 @@ export default class GameSearchSynonym {
       throw new Error("A synonym group must contain at least two terms.");
     }
 
-    return oraWithConnection(async (conn) => {
-      const groupResult = await oraMutate(
-        getSql(GameSearchSynonymSql.insertSynonymGroup, dialect),
-        {
-          createdBy,
-          groupId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-        },
+    return dbTransaction(async (conn) => {
+      const groupId = await dbInsertConn(
         conn,
+        GameSearchSynonymSql.insertSynonymGroup,
+        { createdBy },
+        "groupId",
       );
-      const groupId = Number((groupResult.outBinds as any)?.groupId?.[0]);
       if (!Number.isInteger(groupId) || groupId <= 0) {
         throw new Error("Failed to create synonym group.");
       }
-      await conn.commit();
 
       for (const text of cleaned) {
         const norm = normalizeSearchTerm(text);
-        await oraMutate(
-          getSql(GameSearchSynonymSql.insertSynonymTerm, dialect),
-          { groupId, termText: text, termNorm: norm, createdBy },
+        await dbMutateConn(
           conn,
+          GameSearchSynonymSql.insertSynonymTerm,
+          { groupId, termText: text, termNorm: norm, createdBy },
         );
-        await conn.commit();
       }
 
       return {
@@ -335,79 +327,71 @@ export default class GameSearchSynonym {
   }
 
   static async deleteSynonym(termId: number): Promise<boolean> {
-    return oraWithConnection(async (conn) => {
-      const groupRows = await oraQuery(
-        getSql(GameSearchSynonymSql.getSynonymGroupId, dialect),
+    return dbTransaction(async (conn) => {
+      const groupRows = await dbQueryConn(
+        conn,
+        GameSearchSynonymSql.getSynonymGroupId,
         { termId },
         (row: { GROUP_ID: number }) => Number(row.GROUP_ID),
-        conn,
       );
       const groupId = groupRows[0] ?? null;
 
-      const result = await oraMutate(
-        getSql(GameSearchSynonymSql.deleteSynonymById, dialect),
-        { termId },
+      const rowsAffected = await dbMutateConn(
         conn,
+        GameSearchSynonymSql.deleteSynonymById,
+        { termId },
       );
-      await conn.commit();
 
       if (groupId) {
-        const countRows = await oraQuery(
-          getSql(GameSearchSynonymSql.countSynonymsInGroup, dialect),
+        const countRows = await dbQueryConn(
+          conn,
+          GameSearchSynonymSql.countSynonymsInGroup,
           { groupId },
           (row: { CNT: number }) => Number(row.CNT ?? 0),
-          conn,
         );
         if ((countRows[0] ?? 0) === 0) {
-          await oraMutate(
-            getSql(GameSearchSynonymSql.deleteGroup, dialect),
-            { groupId },
-            conn,
-          );
-          await conn.commit();
+          await dbMutateConn(conn, GameSearchSynonymSql.deleteGroup, { groupId });
         }
       }
 
-      return (result.rowsAffected ?? 0) > 0;
+      return rowsAffected > 0;
     });
   }
 
   static async deleteGroup(groupId: number): Promise<boolean> {
     if (!Number.isInteger(groupId) || groupId <= 0) return false;
-    return oraWithConnection(async (conn) => {
-      const existsRows = await oraQuery(
-        getSql(GameSearchSynonymSql.checkGroupExists, dialect),
+    return dbTransaction(async (conn) => {
+      const existsRows = await dbQueryConn(
+        conn,
+        GameSearchSynonymSql.checkGroupExists,
         { groupId },
         (row: { CNT: number }) => Number(row.CNT ?? 0),
-        conn,
       );
       if ((existsRows[0] ?? 0) === 0) return false;
 
-      await oraMutate(
-        getSql(GameSearchSynonymSql.deleteSynonymsByGroup, dialect),
-        { groupId },
-        conn,
-      );
-      await conn.commit();
-      await oraMutate(
-        getSql(GameSearchSynonymSql.deleteGroup, dialect),
-        { groupId },
-        conn,
-      );
-      await conn.commit();
+      await dbMutateConn(conn, GameSearchSynonymSql.deleteSynonymsByGroup, { groupId });
+      await dbMutateConn(conn, GameSearchSynonymSql.deleteGroup, { groupId });
       return true;
     });
   }
 
   static async getSynonymById(
     termId: number,
-    conn?: oracledb.Connection,
+    conn?: oracledb.Connection | pg.PoolClient,
   ): Promise<IGameSearchSynonym | null> {
-    const rows = await oraQuery(
-      getSql(GameSearchSynonymSql.getSynonymById, dialect),
+    if (conn) {
+      const rows = await dbQueryConn(
+        conn,
+        GameSearchSynonymSql.getSynonymById,
+        { termId },
+        mapSynonymRow,
+      );
+      return rows[0] ?? null;
+    }
+    const rows = await dbQuery(
+      GameSearchSynonymSql.getSynonymById,
       { termId },
       mapSynonymRow,
-      conn,
     );
     return rows[0] ?? null;
   }

--- a/src/classes/GameSearchSynonymDraft.ts
+++ b/src/classes/GameSearchSynonymDraft.ts
@@ -1,10 +1,14 @@
-import oracledb from "oracledb";
-import { dbQuery, dbMutate, oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import type oracledb from "oracledb";
+import type pg from "pg";
+import {
+  dbQuery,
+  dbMutate,
+  dbInsert,
+  dbTransaction,
+  dbQueryConn,
+  dbMutateConn,
+} from "../db/SqlManager.js";
 import { GameSearchSynonymDraftSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type ISynonymDraftPair = {
   term: string;
@@ -49,15 +53,11 @@ function mapDraftRow(row: any): ISynonymDraft {
 
 export default class GameSearchSynonymDraft {
   static async createDraft(userId: string): Promise<ISynonymDraft> {
-    const result = await oraMutate(
-      getSql(GameSearchSynonymDraftSql.createDraft, dialect),
-      {
-        userId,
-        pairsJson: JSON.stringify([]),
-        draftId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
+    const draftId = await dbInsert(
+      GameSearchSynonymDraftSql.createDraft,
+      { userId, pairsJson: JSON.stringify([]) },
+      "draftId",
     );
-    const draftId = Number((result.outBinds as any)?.draftId?.[0]);
     const draft = await this.getDraft(draftId);
     if (!draft) {
       throw new Error("Failed to load synonym draft after creation.");
@@ -78,16 +78,16 @@ export default class GameSearchSynonymDraft {
     draftId: number,
     pairs: ISynonymDraftPair[],
   ): Promise<ISynonymDraft | null> {
-    return oraWithConnection(async (conn) => {
-      const existing = await GameSearchSynonymDraft.getDraftWithConn(draftId, conn);
+    return dbTransaction(async (conn) => {
+      const existing = await this.getDraftWithConn(draftId, conn);
       if (!existing) return null;
       const combined = [...existing.pairs, ...pairs];
-      await oraMutate(
-        getSql(GameSearchSynonymDraftSql.updateDraft, dialect),
-        { draftId, pairsJson: JSON.stringify(combined) },
+      await dbMutateConn(
         conn,
+        GameSearchSynonymDraftSql.updateDraft,
+        { draftId, pairsJson: JSON.stringify(combined) },
       );
-      return GameSearchSynonymDraft.getDraftWithConn(draftId, conn);
+      return this.getDraftWithConn(draftId, conn);
     });
   }
 
@@ -100,13 +100,13 @@ export default class GameSearchSynonymDraft {
 
   private static async getDraftWithConn(
     draftId: number,
-    conn: oracledb.Connection,
+    conn: oracledb.Connection | pg.PoolClient,
   ): Promise<ISynonymDraft | null> {
-    const rows = await oraQuery(
-      getSql(GameSearchSynonymDraftSql.getDraft, dialect),
+    const rows = await dbQueryConn(
+      conn,
+      GameSearchSynonymDraftSql.getDraft,
       { draftId },
       mapDraftRow,
-      conn,
     );
     return rows[0] ?? null;
   }

--- a/src/classes/Gotm.ts
+++ b/src/classes/Gotm.ts
@@ -1,10 +1,13 @@
-import { dbQuery, dbMutate, oraQuery, oraMutate, oraWithConnection, oraTransaction } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import {
+  dbQuery,
+  dbMutate,
+  dbTransaction,
+  dbWithConnection,
+  dbQueryConn,
+  dbMutateConn,
+} from "../db/SqlManager.js";
 import { GotmSql } from "../db/sql/index.js";
 import Game from "./Game.js";
-
-const dialect = getDialect();
 import { getThreadsByGameId } from "./Thread.js";
 
 export interface IGotmGame {
@@ -330,12 +333,12 @@ export async function updateGotmGameFieldInDatabase(
   };
   const columnName = columnMap[field];
 
-  await oraWithConnection(async (conn) => {
-    const rows = await oraQuery<GotmRowIndexRow, GotmRowIndexRow>(
-      getSql(GotmSql.getRowsByRound, dialect),
+  await dbTransaction(async (conn) => {
+    const rows = await dbQueryConn<GotmRowIndexRow, GotmRowIndexRow>(
+      conn,
+      GotmSql.getRowsByRound,
       { round },
       (row) => row,
-      conn,
     );
 
     if (!rows.length) {
@@ -361,12 +364,11 @@ export async function updateGotmGameFieldInDatabase(
       dbValue = newId;
     }
 
-    await oraMutate(
-      GotmSql.updateField(columnName)[dialect],
-      { round, gameIndex: dbGameIndex, value: dbValue },
-      conn,
-    );
-    await conn.commit();
+    await dbMutateConn(conn, GotmSql.updateField(columnName), {
+      round,
+      gameIndex: dbGameIndex,
+      value: dbValue,
+    });
   });
 
   const entry = gotmData.find((e) => e.round === round);
@@ -416,24 +418,20 @@ export async function insertGotmRoundInDatabase(
     throw new Error(`GOTM round ${round} already exists in the database.`);
   }
 
-  await oraTransaction(async (conn) => {
+  await dbTransaction(async (conn) => {
     for (let i = 0; i < games.length; i++) {
       const g = games[i];
       if (!Number.isInteger(g.gamedbGameId) || g.gamedbGameId <= 0) {
         throw new Error(`GameDB id is required for GOTM round ${round}, game ${i + 1}.`);
       }
       const gameMeta = await getGameDetailsCached(g.gamedbGameId);
-      await oraMutate(
-        getSql(GotmSql.insertRound, dialect),
-        {
-          round,
-          monthYear,
-          gameIndex: i,
-          redditUrl: g.redditUrl ?? null,
-          gamedbGameId: g.gamedbGameId,
-        },
-        conn,
-      );
+      await dbMutateConn(conn, GotmSql.insertRound, {
+        round,
+        monthYear,
+        gameIndex: i,
+        redditUrl: g.redditUrl ?? null,
+        gamedbGameId: g.gamedbGameId,
+      });
       games[i].title = gameMeta.title;
     }
   });

--- a/src/classes/GotmAuditImport.ts
+++ b/src/classes/GotmAuditImport.ts
@@ -1,17 +1,5 @@
-import oracledb from "oracledb";
-import {
-  dbQuery,
-  dbMutate,
-  oraQuery,
-  oraMutate,
-  oraWithConnection,
-  oraTransaction,
-} from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
-import { getSql } from "../db/SqlManager.js";
+import { dbQuery, dbMutate, dbInsert, dbTransaction, dbMutateConn } from "../db/SqlManager.js";
 import { GotmAuditImportSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type GotmAuditStatus = "ACTIVE" | "PAUSED" | "COMPLETED" | "CANCELED";
 export type GotmAuditItemStatus = "PENDING" | "SKIPPED" | "IMPORTED" | "ERROR";
@@ -107,26 +95,16 @@ export async function createGotmAuditImportSession(params: {
   totalCount: number;
   sourceFilename: string | null;
 }): Promise<IGotmAuditImport> {
-  return oraWithConnection(async (conn) => {
-    const result = await oraMutate(
-      getSql(GotmAuditImportSql.createSession, dialect),
-      {
-        userId: params.userId,
-        totalCount: params.totalCount,
-        sourceFilename: params.sourceFilename,
-        id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      conn,
-    );
-    await conn.commit();
+  const id = await dbInsert(GotmAuditImportSql.createSession, {
+    userId: params.userId,
+    totalCount: params.totalCount,
+    sourceFilename: params.sourceFilename,
+  }, "id");
+  if (!id) throw new Error("Failed to create GOTM audit session.");
 
-    const id = Number((result.outBinds as { id?: number[] })?.id?.[0] ?? 0);
-    if (!id) throw new Error("Failed to create GOTM audit session.");
-
-    const session = await getGotmAuditImportById(id, conn);
-    if (!session) throw new Error("Failed to load GOTM audit session.");
-    return session;
-  });
+  const session = await getGotmAuditImportById(id);
+  if (!session) throw new Error("Failed to load GOTM audit session.");
+  return session;
 }
 
 export async function insertGotmAuditImportItems(
@@ -144,38 +122,28 @@ export async function insertGotmAuditImportItems(
   }>,
 ): Promise<void> {
   if (!items.length) return;
-  await oraTransaction(async (conn) => {
+  await dbTransaction(async (conn) => {
     for (const item of items) {
-      await oraMutate(
-        getSql(GotmAuditImportSql.insertItems, dialect),
-        {
-          importId,
-          rowIndex: item.rowIndex,
-          kind: item.kind,
-          roundNumber: item.roundNumber,
-          monthYear: item.monthYear,
-          gameIndex: item.gameIndex,
-          gameTitle: item.gameTitle,
-          threadId: item.threadId,
-          redditUrl: item.redditUrl,
-          gameDbGameId: item.gameDbGameId,
-        },
-        conn,
-      );
+      await dbMutateConn(conn, GotmAuditImportSql.insertItems, {
+        importId,
+        rowIndex: item.rowIndex,
+        kind: item.kind,
+        roundNumber: item.roundNumber,
+        monthYear: item.monthYear,
+        gameIndex: item.gameIndex,
+        gameTitle: item.gameTitle,
+        threadId: item.threadId,
+        redditUrl: item.redditUrl,
+        gameDbGameId: item.gameDbGameId,
+      });
     }
   });
 }
 
 export async function getGotmAuditImportById(
   importId: number,
-  existingConn?: oracledb.Connection,
 ): Promise<IGotmAuditImport | null> {
-  const rows = await oraQuery(
-    getSql(GotmAuditImportSql.getById, dialect),
-    { id: importId },
-    mapImport,
-    existingConn,
-  );
+  const rows = await dbQuery(GotmAuditImportSql.getById, { id: importId }, mapImport);
   return rows[0] ?? null;
 }
 

--- a/src/classes/NrGotm.ts
+++ b/src/classes/NrGotm.ts
@@ -1,10 +1,13 @@
-import oracledb from "oracledb";
-import { dbQuery, dbMutate, oraQuery, oraMutate, oraWithConnection, getSql } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
+import {
+  dbQuery,
+  dbMutate,
+  dbTransaction,
+  dbQueryConn,
+  dbMutateConn,
+  dbInsertConn,
+} from "../db/SqlManager.js";
 import { NrGotmSql } from "../db/sql/index.js";
 import Game from "./Game.js";
-
-const dialect = getDialect();
 import { getThreadsByGameId } from "./Thread.js";
 
 export interface INrGotmGame {
@@ -353,14 +356,12 @@ export async function updateNrGotmGameFieldInDatabase(
     dbValue = newId;
   }
 
-  await oraWithConnection(async (conn) => {
+  await dbTransaction(async (conn) => {
     if (opts.rowId) {
-      await oraMutate(
-        NrGotmSql.updateByRowId(columnName)[dialect],
-        { rowIdValue: opts.rowId, bindValue: dbValue },
-        conn,
-      );
-      await conn.commit();
+      await dbMutateConn(conn, NrGotmSql.updateByRowId(columnName), {
+        rowIdValue: opts.rowId,
+        bindValue: dbValue,
+      });
 
       const entryWithRow = nrGotmData.find((e) =>
         e.gameOfTheMonth.some((g) => Number(g.id) === Number(opts.rowId)),
@@ -391,11 +392,11 @@ export async function updateNrGotmGameFieldInDatabase(
       throw new Error("gameIndex is required when rowId is not provided.");
     }
 
-    const rows = await oraQuery<NrGotmRowRef, NrGotmRowRef>(
-      getSql(NrGotmSql.getRowsByRound, dialect),
+    const rows = await dbQueryConn<NrGotmRowRef, NrGotmRowRef>(
+      conn,
+      NrGotmSql.getRowsByRound,
       { roundNumber: round },
       (row) => row,
-      conn,
     );
 
     if (!rows.length) {
@@ -412,12 +413,10 @@ export async function updateNrGotmGameFieldInDatabase(
 
     const rowId = rows[gi].NR_GOTM_ID;
 
-    await oraMutate(
-      NrGotmSql.updateByRowId(columnName)[dialect],
-      { rowIdValue: rowId, bindValue: dbValue },
-      conn,
-    );
-    await conn.commit();
+    await dbMutateConn(conn, NrGotmSql.updateByRowId(columnName), {
+      rowIdValue: rowId,
+      bindValue: dbValue,
+    });
 
     const entry = nrGotmData.find((e) => e.round === round);
     if (entry && entry.gameOfTheMonth[gi]) {
@@ -467,7 +466,7 @@ export async function insertNrGotmRoundInDatabase(
     throw new Error(`NR-GOTM round ${round} already exists in the database.`);
   }
 
-  return oraWithConnection(async (conn) => {
+  return dbTransaction(async (conn) => {
     const insertedIds: number[] = [];
 
     for (let i = 0; i < games.length; i++) {
@@ -476,26 +475,15 @@ export async function insertNrGotmRoundInDatabase(
         throw new Error(`GameDB id is required for NR-GOTM round ${round}, game ${i + 1}.`);
       }
       const meta = await getNrGameDetailsCached(g.gamedbGameId);
-      const result = await oraMutate(
-        getSql(NrGotmSql.insertRound, dialect),
-        {
-          roundNumber: round,
-          monthYear,
-          gameIndex: i,
-          redditUrl: g.redditUrl ?? null,
-          gamedbGameId: g.gamedbGameId,
-          outId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-        },
-        conn,
-      );
-      await conn.commit();
+      const newId = await dbInsertConn(conn, NrGotmSql.insertRound, {
+        roundNumber: round,
+        monthYear,
+        gameIndex: i,
+        redditUrl: g.redditUrl ?? null,
+        gamedbGameId: g.gamedbGameId,
+      }, "outId");
 
-      const outIdVal = (result.outBinds as { outId?: number[] })?.outId;
-      const newId = Array.isArray(outIdVal) ? outIdVal[0] : outIdVal;
-      if (newId != null) {
-        insertedIds.push(Number(newId));
-      }
-
+      if (newId) insertedIds.push(newId);
       games[i].title = meta.title;
     }
 

--- a/src/classes/PublicReminder.ts
+++ b/src/classes/PublicReminder.ts
@@ -1,9 +1,5 @@
-import oracledb from "oracledb";
-import { dbQuery, dbMutate, oraMutate, getSql } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
+import { dbQuery, dbMutate, dbInsert } from "../db/SqlManager.js";
 import { PublicReminderSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export type RecurrenceUnit = "minutes" | "hours" | "days" | "weeks" | "months" | "years";
 
@@ -26,21 +22,13 @@ export async function createReminder(
   recurUnit: RecurrenceUnit | null,
   createdBy: string | null,
 ): Promise<IPublicReminder> {
-  const result = await oraMutate(
-    getSql(PublicReminderSql.create, dialect),
-    {
-      channelId,
-      message,
-      dueAt,
-      recurEvery,
-      recurUnit,
-      createdBy,
-      id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-    },
+  const reminderId = await dbInsert(
+    PublicReminderSql.create,
+    { channelId, message, dueAt, recurEvery, recurUnit, createdBy },
+    "id",
   );
-  const id = (result.outBinds as any)?.id?.[0] ?? 0;
   return {
-    reminderId: Number(id),
+    reminderId: Number(reminderId),
     channelId,
     message,
     dueAt,

--- a/src/classes/Reminder.ts
+++ b/src/classes/Reminder.ts
@@ -1,10 +1,7 @@
-import oracledb from "oracledb";
-import type { Connection } from "oracledb";
-import { dbQuery, dbMutate, oraQuery, oraMutate, getSql } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
+import type oracledb from "oracledb";
+import type pg from "pg";
+import { dbQuery, dbMutate, dbInsert, dbQueryConn } from "../db/SqlManager.js";
 import { ReminderSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export interface IReminderRecord {
   reminderId: number;
@@ -110,19 +107,13 @@ export default class Reminder {
     const normalizedContent = normalizeContent(content);
     const noisyVal = isNoisy ? 1 : 0;
 
-    const result = await oraMutate(
-      getSql(ReminderSql.create, dialect),
-      {
-        userId,
-        remindAt: normalizedDate,
-        content: normalizedContent,
-        noisyVal,
-        reminderId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
+    const reminderId = normalizeReminderId(
+      await dbInsert(
+        ReminderSql.create,
+        { userId, remindAt: normalizedDate, content: normalizedContent, noisyVal },
+        "reminderId",
+      ),
     );
-
-    const out = (result.outBinds ?? {}) as { reminderId?: number[] };
-    const reminderId = normalizeReminderId(out.reminderId?.[0] ?? 0);
 
     const inserted = await Reminder.getById(reminderId);
     if (!inserted) {
@@ -137,15 +128,19 @@ export default class Reminder {
 
   static async getById(
     reminderId: number,
-    opts?: { connection?: Connection },
+    opts?: { connection?: oracledb.Connection | pg.PoolClient },
   ): Promise<IReminderRecord | null> {
     const id = normalizeReminderId(reminderId);
-    const rows = await oraQuery(
-      getSql(ReminderSql.getById, dialect),
-      { reminderId: id },
-      mapRowToReminder,
-      opts?.connection,
-    );
+    if (opts?.connection) {
+      const rows = await dbQueryConn(
+        opts.connection,
+        ReminderSql.getById,
+        { reminderId: id },
+        mapRowToReminder,
+      );
+      return rows[0] ?? null;
+    }
+    const rows = await dbQuery(ReminderSql.getById, { reminderId: id }, mapRowToReminder);
     return rows[0] ?? null;
   }
 

--- a/src/classes/Suggestion.ts
+++ b/src/classes/Suggestion.ts
@@ -1,9 +1,5 @@
-import oracledb from "oracledb";
-import { dbQuery, dbMutate, oraQuery, oraMutate, oraWithConnection, getSql } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
+import { dbQuery, dbMutate, dbInsert } from "../db/SqlManager.js";
 import { SuggestionSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export interface ISuggestionItem {
   suggestionId: number;
@@ -51,28 +47,16 @@ export async function createSuggestion(
   createdBy: string | null,
   createdByName: string | null,
 ): Promise<ISuggestionItem> {
-  return oraWithConnection(async (conn) => {
-    const result = await oraMutate(
-      getSql(SuggestionSql.create, dialect),
-      {
-        title,
-        details,
-        labels,
-        createdBy,
-        createdByName,
-        id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-      },
-      conn,
-    );
-    await conn.commit();
+  const id = await dbInsert(
+    SuggestionSql.create,
+    { title, details, labels, createdBy, createdByName },
+    "id",
+  );
+  if (!id) throw new Error("Failed to create suggestion.");
 
-    const id = Number((result.outBinds as { id?: number[] })?.id?.[0] ?? 0);
-    if (!id) throw new Error("Failed to create suggestion.");
-
-    const suggestion = await getSuggestionById(id, conn);
-    if (!suggestion) throw new Error("Failed to load suggestion after creation.");
-    return suggestion;
-  });
+  const suggestion = await getSuggestionById(id);
+  if (!suggestion) throw new Error("Failed to load suggestion after creation.");
+  return suggestion;
 }
 
 export async function listSuggestions(limit: number = 50): Promise<ISuggestionItem[]> {
@@ -91,14 +75,8 @@ export async function countSuggestions(): Promise<number> {
 
 export async function getSuggestionById(
   suggestionId: number,
-  existingConnection?: oracledb.Connection,
 ): Promise<ISuggestionItem | null> {
-  const rows = await oraQuery(
-    getSql(SuggestionSql.getById, dialect),
-    { id: suggestionId },
-    mapSuggestionRow,
-    existingConnection,
-  );
+  const rows = await dbQuery(SuggestionSql.getById, { id: suggestionId }, mapSuggestionRow);
   return rows[0] ?? null;
 }
 

--- a/src/classes/SuggestionReviewSession.ts
+++ b/src/classes/SuggestionReviewSession.ts
@@ -1,15 +1,5 @@
-import oracledb from "oracledb";
-import {
-  dbMutate,
-  oraQuery,
-  oraMutate,
-  oraWithConnection,
-  getSql,
-} from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
+import { dbQuery, dbMutate } from "../db/SqlManager.js";
 import { SuggestionReviewSessionSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export interface ISuggestionReviewSession {
   sessionId: string;
@@ -80,36 +70,27 @@ export async function createSuggestionReviewSessionRecord(session: {
   index: number;
   totalCount: number;
 }): Promise<ISuggestionReviewSession> {
-  return oraWithConnection(async (conn) => {
-    const suggestionIds = serializeSuggestionIds(session.suggestionIds);
-    await oraMutate(
-      getSql(SuggestionReviewSessionSql.create, dialect),
-      {
-        sessionId: session.sessionId,
-        reviewerId: session.reviewerId,
-        suggestionIds,
-        currentIndex: Math.max(session.index, 0),
-        totalCount: Math.max(session.totalCount, 0),
-      },
-      conn,
-    );
-    await conn.commit();
-
-    const saved = await getSuggestionReviewSession(session.sessionId, conn);
-    if (!saved) throw new Error("Failed to create suggestion review session.");
-    return saved;
+  const suggestionIds = serializeSuggestionIds(session.suggestionIds);
+  await dbMutate(SuggestionReviewSessionSql.create, {
+    sessionId: session.sessionId,
+    reviewerId: session.reviewerId,
+    suggestionIds,
+    currentIndex: Math.max(session.index, 0),
+    totalCount: Math.max(session.totalCount, 0),
   });
+
+  const saved = await getSuggestionReviewSession(session.sessionId);
+  if (!saved) throw new Error("Failed to create suggestion review session.");
+  return saved;
 }
 
 export async function getSuggestionReviewSession(
   sessionId: string,
-  existingConnection?: oracledb.Connection,
 ): Promise<ISuggestionReviewSession | null> {
-  const rows = await oraQuery(
-    getSql(SuggestionReviewSessionSql.getById, dialect),
+  const rows = await dbQuery(
+    SuggestionReviewSessionSql.getById,
     { sessionId },
     mapSessionRow,
-    existingConnection,
   );
   return rows[0] ?? null;
 }

--- a/src/classes/Thread.ts
+++ b/src/classes/Thread.ts
@@ -1,16 +1,12 @@
 import {
   dbQuery,
   dbMutate,
-  oraQuery,
-  oraMutate,
-  oraTransaction,
-  oraWithConnection,
-  getSql,
+  dbTransaction,
+  dbWithConnection,
+  dbQueryConn,
+  dbMutateConn,
 } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
 import { ThreadSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 type NullableDate = Date | null;
 
@@ -46,26 +42,14 @@ export async function setThreadGameLink(
     throw new Error("Invalid GameDB game id.");
   }
 
-  await oraTransaction(async (conn) => {
+  await dbTransaction(async (conn) => {
     if (gameId === null) {
-      await oraMutate(
-        getSql(ThreadSql.deleteThreadGameLink, dialect),
-        { threadId },
-        conn,
-      );
+      await dbMutateConn(conn, ThreadSql.deleteThreadGameLink, { threadId });
     } else {
-      await oraMutate(
-        getSql(ThreadSql.mergeThreadGameLink, dialect),
-        { threadId, gameId },
-        conn,
-      );
+      await dbMutateConn(conn, ThreadSql.mergeThreadGameLink, { threadId, gameId });
     }
 
-    await oraMutate(
-      getSql(ThreadSql.updateThreadsGameId, dialect),
-      { threadId },
-      conn,
-    );
+    await dbMutateConn(conn, ThreadSql.updateThreadsGameId, { threadId });
   });
 }
 
@@ -80,20 +64,16 @@ export async function removeThreadGameLink(
     throw new Error("Invalid GameDB game id.");
   }
 
-  return oraTransaction(async (conn) => {
-    const res = await oraMutate(
-      ThreadSql.removeThreadGameLinks(!!gameId)[dialect],
+  return dbTransaction(async (conn) => {
+    const rowsAffected = await dbMutateConn(
+      conn,
+      ThreadSql.removeThreadGameLinks(!!gameId),
       gameId ? { threadId, gameId } : { threadId },
-      conn,
     );
 
-    await oraMutate(
-      getSql(ThreadSql.updateThreadsGameId, dialect),
-      { threadId },
-      conn,
-    );
+    await dbMutateConn(conn, ThreadSql.updateThreadsGameId, { threadId });
 
-    return res.rowsAffected ?? 0;
+    return rowsAffected;
   });
 }
 
@@ -116,29 +96,29 @@ export async function getThreadSkipLinking(threadId: string): Promise<boolean> {
 export async function getThreadLinkInfo(
   threadId: string,
 ): Promise<{ skipLinking: boolean; gamedbGameIds: number[] }> {
-  return oraWithConnection(async (conn) => {
-    const [skipFlag] = await oraQuery(
-      getSql(ThreadSql.getSkipLinking, dialect),
+  return dbWithConnection(async (conn) => {
+    const [skipFlag] = await dbQueryConn(
+      conn,
+      ThreadSql.getSkipLinking,
       { threadId },
       (row: { SKIP_LINKING: string }) =>
         String(row.SKIP_LINKING ?? "N").toUpperCase() === "Y",
-      conn,
     );
 
-    const gameIds = await oraQuery(
-      getSql(ThreadSql.getThreadGameLinks, dialect),
+    const gameIds = await dbQueryConn(
+      conn,
+      ThreadSql.getThreadGameLinks,
       { threadId },
       (row: { GAMEDB_GAME_ID: number }) => Number(row.GAMEDB_GAME_ID),
-      conn,
     );
 
     if (!gameIds.length) {
-      const legacyIds = await oraQuery(
-        getSql(ThreadSql.getLegacyGameId, dialect),
+      const legacyIds = await dbQueryConn(
+        conn,
+        ThreadSql.getLegacyGameId,
         { threadId },
         (row: { GAMEDB_GAME_ID: number | null }) =>
           row.GAMEDB_GAME_ID != null ? Number(row.GAMEDB_GAME_ID) : null,
-        conn,
       );
       for (const id of legacyIds) {
         if (id != null) gameIds.push(id);
@@ -158,19 +138,19 @@ export async function getThreadGameIds(threadId: string): Promise<number[]> {
 }
 
 export async function getThreadsByGameId(gameId: number): Promise<string[]> {
-  return oraWithConnection(async (conn) => {
-    const threadIds = await oraQuery(
-      getSql(ThreadSql.getThreadLinksForGame, dialect),
+  return dbWithConnection(async (conn) => {
+    const threadIds = await dbQueryConn(
+      conn,
+      ThreadSql.getThreadLinksForGame,
       { gameId },
       (row: { THREAD_ID: string }) => String(row.THREAD_ID),
-      conn,
     );
 
-    const legacyIds = await oraQuery(
-      getSql(ThreadSql.getLegacyThreadIdForGame, dialect),
+    const legacyIds = await dbQueryConn(
+      conn,
+      ThreadSql.getLegacyThreadIdForGame,
       { gameId },
       (row: { THREAD_ID: string }) => String(row.THREAD_ID),
-      conn,
     );
 
     return Array.from(new Set([...threadIds, ...legacyIds]));

--- a/src/classes/Todo.ts
+++ b/src/classes/Todo.ts
@@ -1,9 +1,5 @@
-import oracledb from "oracledb";
-import { dbQuery, dbMutate, oraMutate, getSql } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
+import { dbQuery, dbMutate, dbInsert } from "../db/SqlManager.js";
 import { TodoSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export interface ITodoItem {
   todoId: number;
@@ -67,18 +63,7 @@ export async function createTodo(
   todoSize: string | null,
   createdBy: string | null,
 ): Promise<ITodoItem> {
-  const result = await oraMutate(
-    getSql(TodoSql.create, dialect),
-    {
-      title,
-      details,
-      todoCategory,
-      todoSize,
-      createdBy,
-      id: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-    },
-  );
-  const id = Number((result.outBinds as any)?.id?.[0] ?? 0);
+  const id = await dbInsert(TodoSql.create, { title, details, todoCategory, todoSize, createdBy }, "id");
   if (!id) {
     throw new Error("Failed to create TODO.");
   }

--- a/src/classes/UserGameCollection.ts
+++ b/src/classes/UserGameCollection.ts
@@ -1,13 +1,14 @@
-import oracledb from "oracledb";
+import type oracledb from "oracledb";
+import type pg from "pg";
 import {
-  dbQuery, dbMutate,
-  oraQuery, oraMutate, oraWithConnection,
-  getSql,
+  dbQuery,
+  dbMutate,
+  dbTransaction,
+  dbQueryConn,
+  dbInsertConn,
+  dbMutateConn,
 } from "../db/SqlManager.js";
-import { getDialect } from "../db/dialect.js";
 import { UserGameCollectionSql } from "../db/sql/index.js";
-
-const dialect = getDialect();
 
 export const COLLECTION_OWNERSHIP_TYPES = [
   "Digital",
@@ -106,13 +107,13 @@ function mapEntry(row: CollectionRow): IUserGameCollectionEntry {
 async function getEntryById(
   entryId: number,
   userId: string,
-  conn: oracledb.Connection,
+  conn: oracledb.Connection | pg.PoolClient,
 ): Promise<IUserGameCollectionEntry | null> {
-  const rows = await oraQuery(
-    getSql(UserGameCollectionSql.getEntryById, dialect),
+  const rows = await dbQueryConn(
+    conn,
+    UserGameCollectionSql.getEntryById,
     { entryId, userId },
     mapEntry,
-    conn,
   );
   return rows[0] ?? null;
 }
@@ -140,23 +141,17 @@ export default class UserGameCollection {
       throw new Error("Note must be 500 characters or fewer.");
     }
 
-    return oraWithConnection(async (conn) => {
-      let insert: oracledb.Result<unknown>;
+    return dbTransaction(async (conn) => {
+      let entryId: number;
       try {
-        insert = await oraMutate(
-          getSql(UserGameCollectionSql.addEntry, dialect),
-          {
-            userId,
-            gameId,
-            platformId,
-            ownershipType,
-            note,
-            isShared,
-            entryId: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
-          },
-          conn,
-        );
-        await conn.commit();
+        entryId = await dbInsertConn(conn, UserGameCollectionSql.addEntry, {
+          userId,
+          gameId,
+          platformId,
+          ownershipType,
+          note,
+          isShared,
+        }, "entryId");
       } catch (err: any) {
         const msg = String(err?.message ?? "");
         if (/ORA-00001/i.test(msg) || /unique constraint/i.test(msg)) {
@@ -167,9 +162,6 @@ export default class UserGameCollection {
         throw err;
       }
 
-      const entryId = Number(
-        (insert.outBinds as { entryId?: number[] })?.entryId?.[0] ?? 0,
-      );
       if (!entryId) throw new Error("Failed to create collection entry.");
 
       const saved = await getEntryById(entryId, userId, conn);
@@ -236,15 +228,10 @@ export default class UserGameCollection {
       throw new Error("No collection fields were provided to update.");
     }
 
-    return oraWithConnection(async (conn) => {
-      let result: oracledb.Result<unknown>;
+    return dbTransaction(async (conn) => {
+      let rowsAffected: number;
       try {
-        result = await oraMutate(
-          UserGameCollectionSql.updateEntry(updateParts)[dialect],
-          binds,
-          conn,
-        );
-        await conn.commit();
+        rowsAffected = await dbMutateConn(conn, UserGameCollectionSql.updateEntry(updateParts), binds);
       } catch (err: any) {
         const msg = String(err?.message ?? "");
         if (/ORA-00001/i.test(msg) || /unique constraint/i.test(msg)) {
@@ -255,7 +242,7 @@ export default class UserGameCollection {
         throw err;
       }
 
-      if ((result.rowsAffected ?? 0) <= 0) return null;
+      if (rowsAffected <= 0) return null;
       return getEntryById(entryId, userId, conn);
     });
   }

--- a/src/db/SqlManager.ts
+++ b/src/db/SqlManager.ts
@@ -13,10 +13,23 @@ import {
   pgMutate,
   pgTransaction,
   pgWithConnection,
+  pgInsert,
+  pgQueryConn,
+  pgMutateConn,
+  pgInsertConn,
 } from "./postgresClient.js";
 
 export { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "./oracleClient.js";
-export { pgQuery, pgMutate, pgTransaction, pgWithConnection } from "./postgresClient.js";
+export {
+  pgQuery,
+  pgMutate,
+  pgTransaction,
+  pgWithConnection,
+  pgInsert,
+  pgQueryConn,
+  pgMutateConn,
+  pgInsertConn,
+} from "./postgresClient.js";
 export type { Dialect, SqlEntry } from "./sql/types.js";
 export { getSql, getSqlDynamic } from "./sql/index.js";
 
@@ -82,4 +95,106 @@ export async function dbTransaction<T>(
     return oraTransaction(callback as (conn: oracledb.Connection) => Promise<T>);
   }
   return pgTransaction(callback as (client: pg.PoolClient) => Promise<T>);
+}
+
+/**
+ * Dialect-agnostic INSERT...RETURNING / BIND_OUT.
+ * On Oracle: runs the SQL with a BIND_OUT param for `bindOutKey` and returns the generated id.
+ * On Postgres: runs the SQL (which must end with RETURNING <col>) and returns the first column value.
+ * Pass `params` WITHOUT the BIND_OUT entry -- the function adds it for Oracle.
+ */
+export async function dbInsert(
+  entry: SqlEntry,
+  params: oracledb.BindParameters | Record<string, unknown>,
+  bindOutKey: string,
+): Promise<number> {
+  const dialect = getDialect();
+  if (dialect === "postgres") {
+    return pgInsert(entry.postgres, params as Record<string, unknown>);
+  }
+  const oraParams = {
+    ...(params as oracledb.BindParameters),
+    [bindOutKey]: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+  };
+  const result = await oraMutate(entry.oracle, oraParams);
+  return Number((result.outBinds as Record<string, number[]>)?.[bindOutKey]?.[0] ?? 0);
+}
+
+/**
+ * Dialect-agnostic SELECT on an existing connection.
+ * Use inside dbWithConnection / dbTransaction callbacks.
+ */
+export async function dbQueryConn<RowT extends object, R>(
+  conn: oracledb.Connection | pg.PoolClient,
+  entry: SqlEntry,
+  params: oracledb.BindParameters | Record<string, unknown> | unknown[],
+  mapper: (row: RowT) => R,
+): Promise<R[]> {
+  const dialect = getDialect();
+  if (dialect === "postgres") {
+    const rows = await pgQueryConn<RowT>(
+      conn as pg.PoolClient,
+      entry.postgres,
+      params as Record<string, unknown> | unknown[],
+    );
+    return rows.map(mapper);
+  }
+  return oraQuery(
+    entry.oracle,
+    params as oracledb.BindParameters,
+    mapper,
+    conn as oracledb.Connection,
+  );
+}
+
+/**
+ * Dialect-agnostic DML on an existing connection. Returns rows affected.
+ * Use inside dbWithConnection / dbTransaction callbacks.
+ */
+export async function dbMutateConn(
+  conn: oracledb.Connection | pg.PoolClient,
+  entry: SqlEntry,
+  params: oracledb.BindParameters | Record<string, unknown> | unknown[],
+): Promise<number> {
+  const dialect = getDialect();
+  if (dialect === "postgres") {
+    return pgMutateConn(
+      conn as pg.PoolClient,
+      entry.postgres,
+      params as Record<string, unknown> | unknown[],
+    );
+  }
+  const result = await oraMutate(
+    entry.oracle,
+    params as oracledb.BindParameters,
+    conn as oracledb.Connection,
+  );
+  return result.rowsAffected ?? 0;
+}
+
+/**
+ * Dialect-agnostic INSERT...RETURNING / BIND_OUT on an existing connection.
+ * Pass `params` WITHOUT the BIND_OUT entry -- the function adds it for Oracle.
+ * Use inside dbWithConnection / dbTransaction callbacks.
+ */
+export async function dbInsertConn(
+  conn: oracledb.Connection | pg.PoolClient,
+  entry: SqlEntry,
+  params: oracledb.BindParameters | Record<string, unknown>,
+  bindOutKey: string,
+): Promise<number> {
+  const dialect = getDialect();
+  if (dialect === "postgres") {
+    return pgInsertConn(conn as pg.PoolClient, entry.postgres, params as Record<string, unknown>);
+  }
+  const oraParams = {
+    ...(params as oracledb.BindParameters),
+    [bindOutKey]: { dir: oracledb.BIND_OUT, type: oracledb.NUMBER },
+  };
+  const result = await oraMutate(
+    entry.oracle,
+    oraParams,
+    conn as oracledb.Connection,
+  );
+  return Number((result.outBinds as Record<string, number[]>)?.[bindOutKey]?.[0] ?? 0);
 }

--- a/src/db/postgresClient.ts
+++ b/src/db/postgresClient.ts
@@ -144,3 +144,54 @@ export async function pgWithConnection<T>(
     client.release();
   }
 }
+
+/** Runs a SELECT on an existing PoolClient and returns all rows. */
+export async function pgQueryConn<T extends pg.QueryResultRow = pg.QueryResultRow>(
+  client: pg.PoolClient,
+  sql: string,
+  params?: Record<string, unknown> | unknown[],
+): Promise<T[]> {
+  const { text, values } = namedToPositional(sql, params ?? []);
+  const result = await client.query<T>(text, values);
+  return result.rows;
+}
+
+/** Runs a DML statement on an existing PoolClient and returns rows affected. */
+export async function pgMutateConn(
+  client: pg.PoolClient,
+  sql: string,
+  params?: Record<string, unknown> | unknown[],
+): Promise<number> {
+  const { text, values } = namedToPositional(sql, params ?? []);
+  const result = await client.query(text, values);
+  return result.rowCount ?? 0;
+}
+
+/**
+ * Runs an INSERT...RETURNING on a pool (no existing connection) and returns
+ * the first column of the first returned row as a number (the generated id).
+ */
+export async function pgInsert(
+  sql: string,
+  params?: Record<string, unknown> | unknown[],
+): Promise<number> {
+  const { text, values } = namedToPositional(sql, params ?? []);
+  const result = await getPostgresPool().query(text, values);
+  const row = result.rows[0];
+  return Number(Object.values(row ?? {})[0] ?? 0);
+}
+
+/**
+ * Runs an INSERT...RETURNING on an existing PoolClient and returns
+ * the first column of the first returned row as a number.
+ */
+export async function pgInsertConn(
+  client: pg.PoolClient,
+  sql: string,
+  params?: Record<string, unknown> | unknown[],
+): Promise<number> {
+  const { text, values } = namedToPositional(sql, params ?? []);
+  const result = await client.query(text, values);
+  const row = result.rows[0];
+  return Number(Object.values(row ?? {})[0] ?? 0);
+}


### PR DESCRIPTION
## Summary

- Adds `pgInsert`, `pgInsertConn`, `pgQueryConn`, `pgMutateConn` to `postgresClient.ts`
- Adds `dbInsert`, `dbInsertConn`, `dbQueryConn`, `dbMutateConn` to `SqlManager.ts` (dialect-agnostic wrappers)
- Migrates 21 domain files, eliminating all `oraWithConnection`, `oraTransaction`, `oraMutate(sql, params, conn)`, and `BIND_OUT` patterns from the migrated files
- Converts several `oraWithConnection` + manual `conn.commit()` patterns to `dbTransaction` (improved atomicity)
- Updates `SQL_MIGRATION_PLAN.md` with D2 in-progress status and per-file completion checklist

**Migrated in this PR:** `AdminWizardSession`, `BotVotingInfo`, `CollectionCsvImport`, `CompletionatorImport`, `GameDbCsvImport`, `GameKey`, `GameSearchSynonym`, `GameSearchSynonymDraft`, `Gotm`, `GotmAuditImport`, `NrGotm`, `PublicReminder`, `Reminder`, `Suggestion`, `SuggestionReviewSession`, `Thread`, `Todo`, `UserGameCollection`

**Remaining for follow-up:** `Game`, `Member`, `RssFeed`, `XboxCollectionImport`, `SteamCollectionImport`, `GameReleaseAnnouncement`, `UserActivityIcon`, `UserChannelMessageCount`

## Test plan

- [ ] `tsc --noEmit` passes clean (verified before commit)
- [ ] Smoke-test affected commands with `DB_DIALECT=oracle` on the bot machine
- [ ] Smoke-test same commands with `DB_DIALECT=postgres` once PG schema is available
- [ ] Verify atomic behavior: `closeActiveAdminWizardSession`, `setRoundInfo`, `setThreadGameLink`, `updateRowOrder` (Gotm/NrGotm) all now run inside `dbTransaction`

🤖 Generated with [Claude Code](https://claude.com/claude-code)