### PR TITLE
fix: resolve np-remove button handler not found warning

### DIFF
--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -248,7 +248,7 @@ export async function promptRemoveFromNowPlaying(
     | ModalSubmitInteraction,
   gameTitle: string,
 ): Promise<boolean> {
-  const promptId = `np-remove:${interaction.user.id}`;
+  const promptId = `np-remove-confirm:${interaction.user.id}`;
   const yesId = `${promptId}:yes`;
   const noId = `${promptId}:no`;
   const row = new ActionRowBuilder<ButtonBuilder>().addComponents(


### PR DESCRIPTION
## Summary
- `promptRemoveFromNowPlaying` in `CompletionHelpers.ts` was building confirmation buttons with customIds `np-remove:{userId}:yes` and `np-remove:{userId}:no`
- discordx routes all button interactions through its `@ButtonComponent` registry; the registered handler only matches `np-remove:[^:]+:\d+` (numeric gameId from the remove-list flow)
- When a user clicked Yes/No on the confirmation prompt, discordx couldn't find a handler and logged `button component handler not found`
- Fix: rename the confirmation prompt prefix from `np-remove:` to `np-remove-confirm:` so discordx never attempts to dispatch these buttons (they are correctly handled by the inline `awaitMessageComponent` collector)

## Test plan
- [ ] Trigger a flow that calls `promptRemoveFromNowPlaying` (e.g., mark a game complete while it's in Now Playing)
- [ ] Click Yes or No on the confirmation prompt
- [ ] Confirm no "handler not found" warning appears in logs
- [ ] Confirm the Yes/No response still works correctly (removes or leaves the game)

🤖 Generated with [Claude Code](https://claude.com/claude-code)