### PR TITLE
fix: correct ON CONFLICT target in saveSession to match existing index

### DIFF
--- a/src/db/sql/adminWizardSession.sql.ts
+++ b/src/db/sql/adminWizardSession.sql.ts
@@ -70,11 +70,10 @@ export const AdminWizardSessionSql = {
         src.STATE_JSON,
         src.LAST_UPDATED_AT
       )`,
-    // Requires partial unique index: (command_key, owner_user_id, channel_id) WHERE status = 'ACTIVE'
     postgres: `INSERT INTO rpg_club_admin_wizard_sessions
         (session_id, command_key, owner_user_id, channel_id, guild_id, status, state_json, last_updated_at)
        VALUES (:sessionId, :commandKey, :ownerUserId, :channelId, :guildId, 'ACTIVE', :stateJson, :lastUpdatedAt)
-       ON CONFLICT (command_key, owner_user_id, channel_id) WHERE status = 'ACTIVE'
+       ON CONFLICT (command_key, owner_user_id, channel_id, status)
        DO UPDATE SET
          state_json = EXCLUDED.state_json,
          guild_id = EXCLUDED.guild_id,


### PR DESCRIPTION
## Summary

- The `saveSession` postgres statement referenced a partial unique index `(command_key, owner_user_id, channel_id) WHERE status = 'ACTIVE'` that does not exist in the database.
- The actual index is `ux_rpg_club_admin_wiz_active` — a full 4-column index on `(command_key, owner_user_id, channel_id, status)`.
- Updated the `ON CONFLICT` target to match the real index so the upsert works at runtime.

## Test plan

- [ ] Run a `saveSession` for a new session — should insert successfully
- [ ] Run `saveSession` again with the same `command_key`, `owner_user_id`, `channel_id` while an ACTIVE row exists — should update `state_json`, `guild_id`, and `last_updated_at` instead of inserting a duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)