### PR TITLE
fix: correct postgres SQL variants to match actual schema

### DIFF
--- a/src/db/sql/adminWizardSession.sql.ts
+++ b/src/db/sql/adminWizardSession.sql.ts
@@ -73,7 +73,7 @@ export const AdminWizardSessionSql = {
     postgres: `INSERT INTO rpg_club_admin_wizard_sessions
         (session_id, command_key, owner_user_id, channel_id, guild_id, status, state_json, last_updated_at)
        VALUES (:sessionId, :commandKey, :ownerUserId, :channelId, :guildId, 'ACTIVE', :stateJson, :lastUpdatedAt)
-       ON CONFLICT (command_key, owner_user_id, channel_id, status)
+       ON CONFLICT (command_key, owner_user_id, channel_id) WHERE status = 'ACTIVE'
        DO UPDATE SET
          state_json = EXCLUDED.state_json,
          guild_id = EXCLUDED.guild_id,

--- a/src/db/sql/game.sql.ts
+++ b/src/db/sql/game.sql.ts
@@ -4,7 +4,7 @@ const GAME_COLS = `GAME_ID, TITLE, DESCRIPTION, IMAGE_DATA, THUMBNAIL_BAD,
               THUMBNAIL_APPROVED, IGDB_ID, SLUG, TOTAL_RATING, IGDB_URL,
               FEATURED_VIDEO_URL, INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT`;
 
-const GAME_COLS_PG = `game_id, title, description, image_data, thumbnail_bad,
+const GAME_COLS_PG = `game_id, title, description, thumbnail_bad,
               thumbnail_approved, igdb_id, slug, total_rating, igdb_url,
               featured_video_url, initial_release_date, created_at, updated_at`;
 
@@ -48,7 +48,6 @@ export const GameSql = {
     postgres: `INSERT INTO gamedb_games (
            title,
            description,
-           image_data,
            igdb_id,
            slug,
            total_rating,
@@ -57,7 +56,6 @@ export const GameSql = {
          ) VALUES (
            :title,
            :description,
-           :imageData,
            :igdbId,
            :slug,
            :totalRating,
@@ -73,7 +71,7 @@ export const GameSql = {
                 INITIAL_RELEASE_DATE, CREATED_AT, UPDATED_AT
            FROM GAMEDB_GAMES
           WHERE GAME_ID = :id`,
-    postgres: `SELECT game_id, title, description, image_data, thumbnail_bad,
+    postgres: `SELECT game_id, title, description, thumbnail_bad,
                 thumbnail_approved, igdb_id, slug, total_rating, igdb_url, featured_video_url,
                 initial_release_date, created_at, updated_at
            FROM gamedb_games
@@ -555,7 +553,7 @@ export const GameSql = {
            FROM GAMEDB_GAMES g
           WHERE ${combinedClause}
           ORDER BY g.TITLE ASC`,
-      postgres: `SELECT g.game_id, g.title, g.description, g.image_data, g.igdb_id, g.slug,
+      postgres: `SELECT g.game_id, g.title, g.description, g.igdb_id, g.slug,
                 g.total_rating, g.igdb_url, g.featured_video_url,
                 g.initial_release_date, g.created_at, g.updated_at
            FROM gamedb_games g
@@ -569,8 +567,7 @@ export const GameSql = {
              UPDATED_AT = SYSTIMESTAMP
        WHERE GAME_ID = :gameId`,
     postgres: `UPDATE gamedb_games
-         SET image_data = :imageData,
-             updated_at = NOW()
+         SET updated_at = NOW()
        WHERE game_id = :gameId`,
   } satisfies SqlEntry,
 


### PR DESCRIPTION
## Summary

- **`adminWizardSession.sql.ts`**: `ON CONFLICT` target incorrectly listed `status` as a conflict column. The actual index `ux_rpg_club_admin_wiz_active` is a partial index on `(command_key, owner_user_id, channel_id) WHERE status = 'ACTIVE'`. PostgreSQL requires the WHERE predicate on the conflict target for partial indexes, not the filtered column in the column list. Fixed to `ON CONFLICT (command_key, owner_user_id, channel_id) WHERE status = 'ACTIVE'`.
- **`game.sql.ts`**: `image_data` column does not exist in the postgres `gamedb_games` schema (column ordinal #4 is absent per the docs -- the numbering skips from #3 `description` to #5 `igdb_id`). Removed `image_data` from all postgres variants: `GAME_COLS_PG`, `createGame` INSERT, `getGameById` SELECT, `getGamesForAudit` SELECT, and `updateGameImage` SET clause. The `updateGameImage` postgres variant now only touches `updated_at` since there is no column to store binary image data.

## Test plan

- [ ] Confirm `npx tsc --noEmit` passes clean (it does)
- [ ] Run `saveSession` against postgres and confirm no conflict-target error
- [ ] Run `createGame` against postgres and confirm INSERT succeeds without `image_data`
- [ ] Run `getGameById` against postgres and confirm rows return without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)