### PR TITLE
refactor: add safeDeferUpdateOrBail() and replace try/catch bail pattern

### DIFF
--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -12,6 +12,7 @@ import {
   replyIfNotOwner,
   safeDeferReply,
   safeDeferUpdate,
+  safeDeferUpdateOrBail,
   safeReply,
 } from "../../functions/InteractionUtils.js";
 import {
@@ -49,11 +50,7 @@ export async function handleCompletionPageSelect(
   const year = parseCompletionYearFilter(yearRaw);
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
 
-  try {
-    await safeDeferUpdate(interaction);
-  } catch {
-    return;
-  }
+  if (!await safeDeferUpdateOrBail(interaction)) return;
 
   if (mode === "list") {
     await renderCompletionPage(
@@ -88,11 +85,7 @@ export async function handleCompletionPaging(interaction: ButtonInteraction): Pr
   const year = parseCompletionYearFilter(yearRaw);
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
 
-  try {
-    await safeDeferUpdate(interaction);
-  } catch {
-    return;
-  }
+  if (!await safeDeferUpdateOrBail(interaction)) return;
 
   if (mode === "list") {
     await renderCompletionPage(
@@ -207,11 +200,7 @@ export async function handleCompletionClearYearFilter(
   const userId = parts[1];
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
 
-  try {
-    await safeDeferUpdate(interaction);
-  } catch {
-    return;
-  }
+  if (!await safeDeferUpdateOrBail(interaction)) return;
 
   const firstPage = 0;
   const noYearFilter = null;
@@ -230,11 +219,7 @@ export async function handleCompletionYearSelect(
   const year = parseCompletionYearFilter(selectedYear);
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
 
-  try {
-    await safeDeferUpdate(interaction);
-  } catch {
-    return;
-  }
+  if (!await safeDeferUpdateOrBail(interaction)) return;
 
   const firstPage = 0;
   await renderCompletionPage(interaction, userId, firstPage, year, ephemeral);

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -324,6 +324,16 @@ export async function safeDeferUpdate(interaction: AnyRepliable): Promise<void> 
   }
 }
 
+/** Defers the update. Returns false if deferral failed (caller should return). */
+export async function safeDeferUpdateOrBail(interaction: AnyRepliable): Promise<boolean> {
+  try {
+    await safeDeferUpdate(interaction);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 // Ensure we do not hit "Interaction already acknowledged" when replying
 const isAckError = (err: any): boolean => {
   const code = err?.code ?? err?.rawError?.code;


### PR DESCRIPTION
Closes #558

## Summary
- Added `safeDeferUpdateOrBail()` to `src/functions/InteractionUtils.ts`
- Replaced 4 instances of the `try { await safeDeferUpdate(...) } catch { return; }` boilerplate in `completion-pagination.service.ts` with `if (!await safeDeferUpdateOrBail(interaction)) return;`

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npx eslint src/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)