### PR TITLE
refactor: add deferWithShowInChat() helper to centralize ephemeral defer pattern (#559)

### DIFF
--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -18,6 +18,7 @@ import {
 } from "@discordjs/builders";
 import { ButtonComponent, Discord, SelectMenuComponent, Slash, SlashOption } from "discordx";
 import {
+  deferWithShowInChat,
   replyIfNotOwner,
   safeDeferReply,
   safeReply,
@@ -271,7 +272,7 @@ export class AvatarHistoryCommand {
     }
 
     if (showAll === true) {
-      await safeDeferReply(interaction, { flags: buildComponentsV2Flags(ephemeral) });
+      await deferWithShowInChat(interaction, showInChat);
       const pageResult = await buildAvatarHistoryAllPage(
         interaction.guild,
         0,
@@ -304,7 +305,7 @@ export class AvatarHistoryCommand {
       return;
     }
 
-    await safeDeferReply(interaction, { flags: buildComponentsV2Flags(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     const target = member ?? interaction.user;
     const pageResult = await buildAvatarHistoryV2Page(target, 0);

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -22,7 +22,7 @@ import {
   ModalComponent,
 } from "discordx";
 import {
-  ephemeralFlag,
+  deferWithShowInChat,
   safeDeferReply,
   safeReply,
   safeUpdate,
@@ -318,7 +318,7 @@ export class GameCompletionCommands {
     interaction: CommandInteraction,
   ): Promise<void> {
     const ephemeral = !showInChat;
-    await safeDeferReply(interaction, { flags: ephemeralFlag(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     const sanitizedQuery = query
       ? sanitizeUserInput(query, { preserveNewlines: false })
@@ -421,7 +421,7 @@ export class GameCompletionCommands {
     interaction: CommandInteraction,
   ): Promise<void> {
     const ephemeral = !showInChat;
-    await safeDeferReply(interaction, { flags: ephemeralFlag(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     let leftUserId = interaction.user.id;
     let rightUserId: string | null = null;

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -537,7 +537,7 @@ export class GiveawayCommand {
     interaction: CommandInteraction,
   ): Promise<void> {
     const ephemeral = !showInChat;
-    await safeDeferReply(interaction, { flags: ephemeral ? MessageFlags.Ephemeral : undefined });
+    await deferWithShowInChat(interaction, showInChat);
 
     const sessionId = `giveaway-${Date.now()}-${Math.floor(Math.random() * 100000)}`;
     const payload = await buildKeyListPayload(

--- a/src/commands/hltb.command.ts
+++ b/src/commands/hltb.command.ts
@@ -6,8 +6,8 @@ import { searchHltb, type HltbSearchResult } from "../scripts/SearchHltb.js";
 import Game from "../classes/Game.js";
 import { getHltbCacheByGameId, upsertHltbCache } from "../classes/HltbCache.js";
 import {
+  deferWithShowInChat,
   ephemeralFlag,
-  safeDeferReply,
   safeReply,
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
@@ -71,7 +71,7 @@ export class hltb {
   ): Promise<void> {
     title = sanitizeUserInput(title, { preserveNewlines: false });
     const ephemeral = !showInChat;
-    await safeDeferReply(interaction, { flags: ephemeralFlag(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     try {
       const result = await resolveHltbResult(title);

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -22,9 +22,9 @@ import {
 } from "discordx";
 import Member, { type IMemberPlatformRecord } from "../classes/Member.js";
 import {
+  deferWithShowInChat,
   ephemeralFlag,
   extractErrorMessage,
-  safeDeferReply,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
@@ -310,7 +310,7 @@ export class MultiplayerInfoCommand {
           nsw: nsw ?? true,
         };
     const ephemeral = !showInChat;
-    await safeDeferReply(interaction, { flags: ephemeralFlag(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     const anyIncluded = filters.steam || filters.xbl || filters.psn || filters.nsw;
     if (!anyIncluded) {

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -31,6 +31,7 @@ import {
   getUpcomingNominationWindow,
 } from "../functions/NominationWindow.js";
 import {
+  deferWithShowInChat,
   safeDeferReply,
   safeReply,
   sanitizeUserInput,
@@ -303,7 +304,7 @@ export class NominateCommand {
       return;
     }
 
-    await safeDeferReply(interaction, { flags: buildComponentsV2Flags(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     try {
       const window = await getUpcomingNominationWindow();

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -25,6 +25,7 @@ import Member, {
   type IMemberSearchFilters,
 } from "../classes/Member.js";
 import {
+  deferWithShowInChat,
   ephemeralFlag,
   extractErrorMessage,
   safeDeferReply,
@@ -331,7 +332,7 @@ export class ProfileCommand {
   ): Promise<void> {
     const target = member ?? interaction.user;
     const ephemeral = !showInChat;
-    await safeDeferReply(interaction, { flags: buildComponentsV2Flags(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     const result = await buildProfileViewPayload(target);
 
@@ -588,7 +589,7 @@ export class ProfileCommand {
     interaction: CommandInteraction,
   ): Promise<void> {
     const ephemeral = !showInChat;
-    await safeDeferReply(interaction, { flags: ephemeralFlag(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     userId = userId ? sanitizeUserInput(userId, { preserveNewlines: false }) : undefined;
     username = username ? sanitizeUserInput(username, { preserveNewlines: false }) : undefined;

--- a/src/commands/round.command.ts
+++ b/src/commands/round.command.ts
@@ -1,6 +1,10 @@
 import { type CommandInteraction, ApplicationCommandOptionType } from "discord.js";
 import { Discord, Slash, SlashOption } from "discordx";
-import { extractErrorMessage, safeDeferReply, safeReply } from "../functions/InteractionUtils.js";
+import {
+  deferWithShowInChat,
+  extractErrorMessage,
+  safeReply,
+} from "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import BotVotingInfo from "../classes/BotVotingInfo.js";
 import Gotm from "../classes/Gotm.js";
@@ -28,7 +32,7 @@ export class CurrentRoundCommand {
     interaction: CommandInteraction,
   ): Promise<void> {
     const ephemeral = !showInChat;
-    await safeDeferReply(interaction, { flags: buildComponentsV2Flags(ephemeral) });
+    await deferWithShowInChat(interaction, showInChat);
 
     try {
       const current = await BotVotingInfo.getCurrentRound();

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -7,7 +7,7 @@ import type {
 } from "discord.js";
 import { BOT_DEV_CHANNEL_ID } from "../config/channels.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
-import { buildTextReply, safeV2TextContent } from "./ComponentsV2Utils.js";
+import { buildComponentsV2Flags, buildTextReply, safeV2TextContent } from "./ComponentsV2Utils.js";
 
 export type AnyRepliable = RepliableInteraction | CommandInteraction;
 
@@ -478,6 +478,14 @@ export async function safeUpdate(interaction: AnyRepliable, options: any): Promi
 
 export function ephemeralFlag(isEphemeral: boolean | undefined): number | undefined {
   return isEphemeral ? MessageFlags.Ephemeral : undefined;
+}
+
+/** Defers reply with ephemeral controlled by the showInChat option. */
+export async function deferWithShowInChat(
+  interaction: AnyRepliable,
+  showInChat: boolean | null | undefined,
+): Promise<void> {
+  await safeDeferReply(interaction, { flags: buildComponentsV2Flags(!showInChat) });
 }
 
 export function extractErrorMessage(err: unknown): string {


### PR DESCRIPTION
## Summary
- Adds `deferWithShowInChat(interaction, showInChat)` to `src/functions/InteractionUtils.ts` that encapsulates `safeDeferReply` with `buildComponentsV2Flags(!showInChat)`
- Replaces the repeated two-call pattern across 8 command files with the new helper
- Normalizes `ephemeralFlag(ephemeral)` variant usages to `buildComponentsV2Flags` at all replaced call sites

Closes #559

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npx eslint src/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)