### PR TITLE
refactor: move raw SQL out of SetPresence.ts into BotPresenceHistory class

### DIFF
--- a/src/classes/BotPresenceHistory.ts
+++ b/src/classes/BotPresenceHistory.ts
@@ -1,0 +1,52 @@
+import { dbQuery, dbMutate } from "../db/SqlManager.js";
+import { BotPresenceHistorySql } from "../db/sql/index.js";
+import { isPositiveInt } from "../utilities/ValidationUtils.js";
+
+export interface IPresenceHistoryEntry {
+  activityName: string;
+  setAt: Date | null;
+  setByUserId: string | null;
+  setByUsername: string | null;
+}
+
+export default class BotPresenceHistory {
+  static async savePresence(
+    activityName: string,
+    userId: string | null,
+    username: string | null,
+  ): Promise<void> {
+    await dbMutate(BotPresenceHistorySql.savePresence, { activityName, userId, username });
+  }
+
+  static async getLatestPresenceActivity(): Promise<string | null> {
+    const rows = await dbQuery(
+      BotPresenceHistorySql.getLatest,
+      {},
+      (row: { ACTIVITY_NAME: string }) => row.ACTIVITY_NAME,
+    );
+    const activityName = rows[0] ?? null;
+    if (typeof activityName === "string" && activityName.trim().length > 0) {
+      return activityName;
+    }
+    return null;
+  }
+
+  static async getPresenceHistory(limit: number): Promise<IPresenceHistoryEntry[]> {
+    const safeLimit: number = isPositiveInt(limit) ? Math.min(limit, 50) : 5;
+    return dbQuery(
+      BotPresenceHistorySql.getHistory,
+      { limit: safeLimit },
+      (row: {
+        ACTIVITY_NAME: string;
+        SET_AT: Date;
+        SET_BY_USER_ID: string | null;
+        SET_BY_USERNAME: string | null;
+      }) => ({
+        activityName: row.ACTIVITY_NAME,
+        setAt: row.SET_AT ?? null,
+        setByUserId: row.SET_BY_USER_ID ?? null,
+        setByUsername: row.SET_BY_USERNAME ?? null,
+      }),
+    );
+  }
+}

--- a/src/db/sql/botPresenceHistory.sql.ts
+++ b/src/db/sql/botPresenceHistory.sql.ts
@@ -1,0 +1,40 @@
+import type { ISqlEntry } from "./types.js";
+
+export const BotPresenceHistorySql = {
+  savePresence: {
+    oracle: `INSERT INTO BOT_PRESENCE_HISTORY
+        (ACTIVITY_NAME, SET_AT, SET_BY_USER_ID, SET_BY_USERNAME)
+       VALUES (:activityName, SYSTIMESTAMP, :userId, :username)`,
+    postgres: `INSERT INTO bot_presence_history
+        (activity_name, set_at, set_by_user_id, set_by_username)
+       VALUES (:activityName, NOW(), :userId, :username)`,
+  } satisfies ISqlEntry,
+
+  getLatest: {
+    oracle: `SELECT ACTIVITY_NAME
+         FROM BOT_PRESENCE_HISTORY
+        ORDER BY SET_AT DESC
+        FETCH FIRST 1 ROWS ONLY`,
+    postgres: `SELECT activity_name
+         FROM bot_presence_history
+        ORDER BY set_at DESC
+        LIMIT 1`,
+  } satisfies ISqlEntry,
+
+  getHistory: {
+    oracle: `SELECT ACTIVITY_NAME,
+              SET_AT,
+              SET_BY_USER_ID,
+              SET_BY_USERNAME
+         FROM BOT_PRESENCE_HISTORY
+        ORDER BY SET_AT DESC
+        FETCH FIRST :limit ROWS ONLY`,
+    postgres: `SELECT activity_name,
+              set_at,
+              set_by_user_id,
+              set_by_username
+         FROM bot_presence_history
+        ORDER BY set_at DESC
+        LIMIT :limit`,
+  } satisfies ISqlEntry,
+};

--- a/src/db/sql/index.ts
+++ b/src/db/sql/index.ts
@@ -3,6 +3,7 @@ import type { Dialect, ISqlEntry } from "./types.js";
 export type { Dialect, ISqlEntry };
 
 export { AdminWizardSessionSql } from "./adminWizardSession.sql.js";
+export { BotPresenceHistorySql } from "./botPresenceHistory.sql.js";
 export { BotVotingInfoSql } from "./botVotingInfo.sql.js";
 export { CollectionCsvImportSql } from "./collectionCsvImport.sql.js";
 export { CompletionatorImportSql } from "./completionatorImport.sql.js";

--- a/src/functions/SetPresence.ts
+++ b/src/functions/SetPresence.ts
@@ -1,26 +1,8 @@
 import { ActivityType, Client } from "discord.js";
 import type { AnyRepliable } from "./InteractionUtils.js";
-import { oraQuery, oraMutate } from "../db/SqlManager.js";
-import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import BotPresenceHistory, { type IPresenceHistoryEntry } from "../classes/BotPresenceHistory.js";
 
-const PRESENCE_TABLE: string = "BOT_PRESENCE_HISTORY";
-
-async function savePresenceToDatabase(
-  activityName: string,
-  userId: string | null,
-  username: string | null,
-): Promise<void> {
-  try {
-    await oraMutate(
-      `INSERT INTO ${PRESENCE_TABLE} (ACTIVITY_NAME, SET_AT, SET_BY_USER_ID, SET_BY_USERNAME)
-       VALUES (:activityName, SYSTIMESTAMP, :userId, :username)`,
-      { activityName, userId, username },
-    );
-    console.log("Presence saved to database.");
-  } catch (error) {
-    console.error("Error saving presence to database:", error);
-  }
-}
+export type { IPresenceHistoryEntry };
 
 async function internalSetPresence(
   client: Client,
@@ -40,63 +22,18 @@ async function internalSetPresence(
   });
 
   if (saveToDb) {
-    await savePresenceToDatabase(activityName, userId, username);
-  }
-}
-
-async function readLatestPresenceFromDatabase(): Promise<string | null> {
-  try {
-    const rows = await oraQuery(
-      `SELECT ACTIVITY_NAME
-         FROM ${PRESENCE_TABLE}
-        ORDER BY SET_AT DESC
-        FETCH FIRST 1 ROWS ONLY`,
-      {},
-      (row: { ACTIVITY_NAME: string }) => row.ACTIVITY_NAME,
-    );
-    const activityName = rows[0] ?? null;
-    if (typeof activityName === "string" && activityName.trim().length > 0) {
-      return activityName;
+    try {
+      await BotPresenceHistory.savePresence(activityName, userId, username);
+      console.log("Presence saved to database.");
+    } catch (error) {
+      console.error("Error saving presence to database:", error);
     }
-    return null;
-  } catch (error) {
-    console.error("Error reading presence from database:", error);
-    return null;
   }
-}
-
-export interface IPresenceHistoryEntry {
-  activityName: string;
-  setAt: Date | null;
-  setByUserId: string | null;
-  setByUsername: string | null;
 }
 
 export async function getPresenceHistory(limit: number): Promise<IPresenceHistoryEntry[]> {
-  const safeLimit: number = isPositiveInt(limit) ? Math.min(limit, 50) : 5;
-
   try {
-    return oraQuery(
-      `SELECT ACTIVITY_NAME,
-              SET_AT,
-              SET_BY_USER_ID,
-              SET_BY_USERNAME
-         FROM ${PRESENCE_TABLE}
-        ORDER BY SET_AT DESC
-        FETCH FIRST :limit ROWS ONLY`,
-      { limit: safeLimit },
-      (row: {
-        ACTIVITY_NAME: string;
-        SET_AT: Date;
-        SET_BY_USER_ID: string | null;
-        SET_BY_USERNAME: string | null;
-      }) => ({
-        activityName: row.ACTIVITY_NAME,
-        setAt: row.SET_AT ?? null,
-        setByUserId: row.SET_BY_USER_ID ?? null,
-        setByUsername: row.SET_BY_USERNAME ?? null,
-      }),
-    );
+    return BotPresenceHistory.getPresenceHistory(limit);
   } catch (error) {
     console.error("Error loading presence history from database:", error);
     return [];
@@ -117,10 +54,14 @@ export async function setPresence(
 }
 
 export async function updateBotPresence(bot: Client): Promise<void> {
-  const activityName: string | null = await readLatestPresenceFromDatabase();
-  if (activityName) {
-    await internalSetPresence(bot, activityName);
-  } else {
-    console.log("No presence data found in database.");
+  try {
+    const activityName: string | null = await BotPresenceHistory.getLatestPresenceActivity();
+    if (activityName) {
+      await internalSetPresence(bot, activityName);
+    } else {
+      console.log("No presence data found in database.");
+    }
+  } catch (error) {
+    console.error("Error reading presence from database:", error);
   }
 }


### PR DESCRIPTION
Closes #562

## Summary
- Created `src/db/sql/botPresenceHistory.sql.ts` with `savePresence`, `getLatest`, and `getHistory` SQL entries using `ISqlEntry` pattern (Oracle + Postgres)
- Created `src/classes/BotPresenceHistory.ts` with `savePresence()`, `getLatestPresenceActivity()`, and `getPresenceHistory()` static methods
- Updated `src/functions/SetPresence.ts` to delegate all DB calls to `BotPresenceHistory`; no behavior changes

## Verification
- `npx tsc --noEmit` passes
- `npm run lint` passes
- `grep -rn "oraMutate\|oraQuery" src/functions/` returns no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)