### PR TITLE
refactor: extract inline row mappers to module-level functions (#563)

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -257,6 +257,58 @@ function buildParams(record: IMemberRecord) {
   };
 }
 
+type MemberRow = {
+  USER_ID: string; IS_BOT: number; USERNAME: string | null; GLOBAL_NAME: string | null;
+  AVATAR_BLOB: Buffer | null; SERVER_JOINED_AT: Date | null; SERVER_LEFT_AT: Date | null;
+  LAST_SEEN_AT: Date | null; ROLE_ADMIN: number; ROLE_MODERATOR: number;
+  ROLE_REGULAR: number; ROLE_MEMBER: number; ROLE_NEWCOMER: number;
+  MESSAGE_COUNT: number | null; COMPLETIONATOR_URL: string | null;
+  PSN_USERNAME: string | null; XBL_USERNAME: string | null; NSW_FRIEND_CODE: string | null;
+  STEAM_URL: string | null; PROFILE_IMAGE: Buffer | null; PROFILE_IMAGE_AT: Date | null;
+};
+
+function mapMemberRow(row: MemberRow): IMemberRecord {
+  return {
+    userId: row.USER_ID,
+    isBot: row.IS_BOT,
+    username: row.USERNAME ?? null,
+    globalName: row.GLOBAL_NAME ?? null,
+    avatarBlob: row.AVATAR_BLOB ?? null,
+    serverJoinedAt: row.SERVER_JOINED_AT ?? null,
+    serverLeftAt: row.SERVER_LEFT_AT ?? null,
+    lastSeenAt: row.LAST_SEEN_AT ?? null,
+    roleAdmin: row.ROLE_ADMIN,
+    roleModerator: row.ROLE_MODERATOR,
+    roleRegular: row.ROLE_REGULAR,
+    roleMember: row.ROLE_MEMBER,
+    roleNewcomer: row.ROLE_NEWCOMER,
+    messageCount: row.MESSAGE_COUNT ?? null,
+    completionatorUrl: row.COMPLETIONATOR_URL ?? null,
+    psnUsername: row.PSN_USERNAME ?? null,
+    xblUsername: row.XBL_USERNAME ?? null,
+    nswFriendCode: row.NSW_FRIEND_CODE ?? null,
+    steamUrl: row.STEAM_URL ?? null,
+    profileImage: row.PROFILE_IMAGE ?? null,
+    profileImageAt: row.PROFILE_IMAGE_AT ?? null,
+  };
+}
+
+type AvatarHistoryRow = {
+  EVENT_ID: number; USER_ID: string; AVATAR_HASH: string | null;
+  AVATAR_URL: string | null; AVATAR_BLOB: Buffer | null; CHANGED_AT: Date | string;
+};
+
+function mapAvatarHistoryRow(row: AvatarHistoryRow): IAvatarHistoryRecord {
+  return {
+    eventId: Number(row.EVENT_ID),
+    userId: String(row.USER_ID),
+    avatarHash: row.AVATAR_HASH ?? null,
+    avatarUrl: row.AVATAR_URL ?? null,
+    avatarBlob: row.AVATAR_BLOB ?? null,
+    changedAt: row.CHANGED_AT instanceof Date ? row.CHANGED_AT : new Date(row.CHANGED_AT as any),
+  };
+}
+
 export default class Member {
   static async touchLastSeen(userId: string, when: Date = new Date()): Promise<void> {
     try {
@@ -1389,38 +1441,6 @@ export default class Member {
   }
 
   static async getByUserId(userId: string): Promise<IMemberRecord | null> {
-    type MemberRow = {
-      USER_ID: string; IS_BOT: number; USERNAME: string | null; GLOBAL_NAME: string | null;
-      AVATAR_BLOB: Buffer | null; SERVER_JOINED_AT: Date | null; SERVER_LEFT_AT: Date | null;
-      LAST_SEEN_AT: Date | null; ROLE_ADMIN: number; ROLE_MODERATOR: number;
-      ROLE_REGULAR: number; ROLE_MEMBER: number; ROLE_NEWCOMER: number;
-      MESSAGE_COUNT: number | null; COMPLETIONATOR_URL: string | null;
-      PSN_USERNAME: string | null; XBL_USERNAME: string | null; NSW_FRIEND_CODE: string | null;
-      STEAM_URL: string | null; PROFILE_IMAGE: Buffer | null; PROFILE_IMAGE_AT: Date | null;
-    };
-    const mapRow = (row: MemberRow): IMemberRecord => ({
-      userId: row.USER_ID,
-      isBot: row.IS_BOT,
-      username: row.USERNAME ?? null,
-      globalName: row.GLOBAL_NAME ?? null,
-      avatarBlob: row.AVATAR_BLOB ?? null,
-      serverJoinedAt: row.SERVER_JOINED_AT ?? null,
-      serverLeftAt: row.SERVER_LEFT_AT ?? null,
-      lastSeenAt: row.LAST_SEEN_AT ?? null,
-      roleAdmin: row.ROLE_ADMIN,
-      roleModerator: row.ROLE_MODERATOR,
-      roleRegular: row.ROLE_REGULAR,
-      roleMember: row.ROLE_MEMBER,
-      roleNewcomer: row.ROLE_NEWCOMER,
-      messageCount: row.MESSAGE_COUNT ?? null,
-      completionatorUrl: row.COMPLETIONATOR_URL ?? null,
-      psnUsername: row.PSN_USERNAME ?? null,
-      xblUsername: row.XBL_USERNAME ?? null,
-      nswFriendCode: row.NSW_FRIEND_CODE ?? null,
-      steamUrl: row.STEAM_URL ?? null,
-      profileImage: row.PROFILE_IMAGE ?? null,
-      profileImageAt: row.PROFILE_IMAGE_AT ?? null,
-    });
     return dbWithConnection(async (conn) => {
       if (dialect === "oracle") {
         const result = await (conn as oracledb.Connection).execute<MemberRow>(
@@ -1435,10 +1455,10 @@ export default class Member {
           },
         );
         const row = (result.rows ?? [])[0];
-        return row ? mapRow(row) : null;
+        return row ? mapMemberRow(row) : null;
       }
       const rows = await dbQueryConn<MemberRow, IMemberRecord>(
-        conn, MemberSql.getByUserId, { userId }, mapRow,
+        conn, MemberSql.getByUserId, { userId }, mapMemberRow,
       );
       return rows[0] ?? null;
     });
@@ -1465,18 +1485,6 @@ export default class Member {
   ): Promise<IAvatarHistoryRecord[]> {
     const safeLimit = Math.min(Math.max(limit, 1), 50);
     const safeOffset = Math.max(offset, 0);
-    type AvatarHistoryRow = {
-      EVENT_ID: number; USER_ID: string; AVATAR_HASH: string | null;
-      AVATAR_URL: string | null; AVATAR_BLOB: Buffer | null; CHANGED_AT: Date | string;
-    };
-    const mapRow = (row: AvatarHistoryRow): IAvatarHistoryRecord => ({
-      eventId: Number(row.EVENT_ID),
-      userId: String(row.USER_ID),
-      avatarHash: row.AVATAR_HASH ?? null,
-      avatarUrl: row.AVATAR_URL ?? null,
-      avatarBlob: row.AVATAR_BLOB ?? null,
-      changedAt: row.CHANGED_AT instanceof Date ? row.CHANGED_AT : new Date(row.CHANGED_AT as any),
-    });
     return dbWithConnection(async (conn) => {
       if (dialect === "oracle") {
         const result = await (conn as oracledb.Connection).execute<AvatarHistoryRow>(
@@ -1487,13 +1495,13 @@ export default class Member {
             fetchInfo: { AVATAR_BLOB: { type: oracledb.BUFFER } },
           },
         );
-        return (result.rows ?? []).map(mapRow);
+        return (result.rows ?? []).map(mapAvatarHistoryRow);
       }
       return dbQueryConn<AvatarHistoryRow, IAvatarHistoryRecord>(
         conn,
         MemberSql.getAvatarHistory,
         { userId, limit: safeLimit, offset: safeOffset },
-        mapRow,
+        mapAvatarHistoryRow,
       );
     });
   }

--- a/src/classes/RssFeed.ts
+++ b/src/classes/RssFeed.ts
@@ -27,6 +27,9 @@ export interface IRssFeedItem {
   publishedAt: Date | null;
 }
 
+function mapIsItemSeenRow(row: { FOUND: number }) { return row; }
+function mapSeenItemHashRow(row: { ITEM_ID_HASH: string }) { return row; }
+
 export function normalizeKeywords(
   input: string | (string | null | undefined)[] | null | undefined): string[] {
   if (!input) return [];
@@ -158,12 +161,11 @@ export async function isItemSeen(
   itemIdHash: string,
   existingConnection?: AnyConn,
 ): Promise<boolean> {
-  const mapper = (row: { FOUND: number }) => row;
   const rows = existingConnection
     ? await dbQueryConn(
-        existingConnection, RssFeedSql.isItemSeen, { feedId, hash: itemIdHash }, mapper,
+        existingConnection, RssFeedSql.isItemSeen, { feedId, hash: itemIdHash }, mapIsItemSeenRow,
       )
-    : await dbQuery(RssFeedSql.isItemSeen, { feedId, hash: itemIdHash }, mapper);
+    : await dbQuery(RssFeedSql.isItemSeen, { feedId, hash: itemIdHash }, mapIsItemSeenRow);
   return rows.length > 0;
 }
 
@@ -176,8 +178,6 @@ export async function getSeenItemHashes(
 
   const CHUNK_SIZE = 900;
   const foundHashes = new Set<string>();
-  const mapper = (row: { ITEM_ID_HASH: string }) => row;
-
   for (let i = 0; i < itemIdHashes.length; i += CHUNK_SIZE) {
     const chunk = itemIdHashes.slice(i, i + CHUNK_SIZE);
     const bindVars: Record<string, string | number> = { feedId };
@@ -191,8 +191,8 @@ export async function getSeenItemHashes(
 
     const entry = RssFeedSql.getSeenItemHashes(bindPlaceholders.join(", "));
     const rows = existingConnection
-      ? await dbQueryConn(existingConnection, entry, bindVars, mapper)
-      : await dbQuery(entry, bindVars, mapper);
+      ? await dbQueryConn(existingConnection, entry, bindVars, mapSeenItemHashRow)
+      : await dbQuery(entry, bindVars, mapSeenItemHashRow);
     rows.forEach((row) => foundHashes.add(row.ITEM_ID_HASH));
   }
 


### PR DESCRIPTION
## Summary
- Extracted `MemberRow` type and `mapMemberRow` function to module scope in `Member.ts` (was inline inside `getByUserId`)
- Extracted `AvatarHistoryRow` type and `mapAvatarHistoryRow` function to module scope in `Member.ts` (was inline inside `getAvatarHistory`)
- Extracted `mapIsItemSeenRow` and `mapSeenItemHashRow` to module scope in `RssFeed.ts` (were inline lambdas)

No SQL changes, no behavior changes -- purely lifting anonymous functions to module scope with descriptive names, consistent with the pattern in `Game.ts` and `Nomination.ts`.

Closes #563

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)