### PR TITLE
fix: RSS feed repeating entries (#571)

### DIFF
--- a/src/services/RssFeedService.ts
+++ b/src/services/RssFeedService.ts
@@ -104,7 +104,7 @@ async function processFeed(
 
   if (!newItems.length) return;
 
-  await markItemsSeen(newItems, connection);
+  await markItemsSeen(newItems);
 
   try {
     const channel = await client.channels.fetch(feed.channelId).catch(() => null);


### PR DESCRIPTION
## Root Cause

`startRssFeedService` acquires a single Oracle connection via `dbWithConnection` and passes it down to `processFeed`, which then passed it to `markItemsSeen`.

Inside `oraMutate`, when an `existingConn` is supplied the driver runs with `autoCommit: false`. When `oraWithConnection` closes the connection at the end of the poll tick (with no explicit `COMMIT`), Oracle silently rolls back every INSERT that `markItemsSeen` attempted.

On the next poll the seen-item table is still empty, so the same recent entries look unseen again, get re-posted to Discord, and get rolled back again -- forever.

## Fix

Remove the shared connection argument from the `markItemsSeen` call in `processFeed`. Without a connection, `markItemsSeen` falls through to its own `dbTransaction` path, which issues a `COMMIT` on Oracle after all rows are inserted.

The read path (`getSeenItemHashes`) retains the shared connection because reads don't need to be committed and there is no correctness impact.

## Test plan

- [ ] Confirm the bot polls the backloggd feed and does not re-post entries on the second tick
- [ ] Confirm new entries still appear on first poll

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)