### PR TITLE
refactor: centralize embed colors into src/config/colors.ts

### DIFF
--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -1,4 +1,5 @@
 import type { CommandInteraction, StringSelectMenuInteraction } from "discord.js";
+import { COLOR_PRIMARY } from "../../config/colors.js";
 import {
   ActionRowBuilder,
   AttachmentBuilder,
@@ -281,7 +282,7 @@ export async function handleNextRoundSetup(
 
   const embed = new EmbedBuilder()
     .setTitle("Round Setup Wizard")
-    .setColor(0x0099ff)
+    .setColor(COLOR_PRIMARY)
     .setDescription("Initializing...");
   if (testMode) {
     embed.setFooter({ text: "TEST MODE ENABLED" });

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -64,6 +64,7 @@ import { igdbService } from "../services/IGDB/IgdbService.js";
 import { shouldRenderPrevNextButtons } from "../functions/PaginationUtils.js";
 import { parseSynonymQuickAddTerms } from "./gamedb-synonym.utils.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { COLOR_PRIMARY, COLOR_SUCCESS, COLOR_HIGHLIGHT } from "../config/colors.js";
 
 const AUDIT_PAGE_SIZE = 20;
 const AUDIT_VIDEO_MODAL_ID = "audit-video-modal";
@@ -1143,7 +1144,7 @@ export class GameDbAdmin {
     const embed = new EmbedBuilder()
       .setTitle(`Audit: ${game.title}`)
       .setDescription(`Game ID: ${game.id}\nIGDB ID: ${game.igdbId ?? "N/A"}`)
-      .setColor(0xFFA500); // Orange for audit
+      .setColor(COLOR_HIGHLIGHT);
 
     const files: AttachmentBuilder[] = [];
 
@@ -1315,7 +1316,7 @@ export class GameDbAdmin {
     let currentEmbed = new EmbedBuilder()
       .setTitle(title)
       .setDescription("Starting auto accept run...")
-      .setColor(0x0099ff);
+      .setColor(COLOR_PRIMARY);
     const stopRow = this.buildAutoAcceptStopRow(runId, false);
 
     const followUpPayload = buildAutoAcceptFollowUpPayload([currentEmbed], [stopRow], isPublic);
@@ -1349,7 +1350,7 @@ export class GameDbAdmin {
           currentEmbed = new EmbedBuilder()
             .setTitle(title)
             .setDescription("Processing...")
-            .setColor(0x0099ff);
+            .setColor(COLOR_PRIMARY);
           logLines.length = 0;
           try {
             currentMessage = await safeReply(interaction, {
@@ -1399,7 +1400,7 @@ export class GameDbAdmin {
       `\n**Run Complete**\n✅ Updated: ${updated}\n` +
       `⏭️ Skipped: ${skipped}\n❌ Failed: ${failed}`;
     await updateEmbed(summary);
-    currentEmbed.setColor(0x2ecc71);
+    currentEmbed.setColor(COLOR_SUCCESS);
     const stopped = shouldStop();
     const finalStopRow = this.buildAutoAcceptStopRow(runId, true, stopped ? "Stopped" : "Stop");
     if (currentMessage?.edit) {
@@ -1423,7 +1424,7 @@ export class GameDbAdmin {
     let currentEmbed = new EmbedBuilder()
       .setTitle(title)
       .setDescription("Starting sweep...")
-      .setColor(0x0099ff);
+      .setColor(COLOR_PRIMARY);
     const stopRow = this.buildAutoAcceptStopRow(runId, false);
 
     let currentMessage: any = null;
@@ -1448,7 +1449,7 @@ export class GameDbAdmin {
           currentEmbed = new EmbedBuilder()
             .setTitle(title)
             .setDescription("Processing...")
-            .setColor(0x0099ff);
+            .setColor(COLOR_PRIMARY);
           logLines.length = 0;
           try {
             currentMessage = await safeReply(interaction, {
@@ -1505,7 +1506,7 @@ export class GameDbAdmin {
         ` | ❌ ${stats.releases.failed}`,
     ].join("\n");
     await updateEmbed(summary);
-    currentEmbed.setColor(0x2ecc71);
+    currentEmbed.setColor(COLOR_SUCCESS);
     const stopped = shouldStop();
     const finalStopRow = this.buildAutoAcceptStopRow(runId, true, stopped ? "Stopped" : "Stop");
     if (currentMessage?.edit) {

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -52,6 +52,7 @@ import {
 } from "../services/GiveawayHubService.js";
 import { GIVEAWAY_HUB_CHANNEL_ID, GIVEAWAY_LOG_CHANNEL_ID } from "../config/channels.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { COLOR_SUCCESS } from "../config/colors.js";
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_PLATFORM_LENGTH = 50;
@@ -127,7 +128,7 @@ async function logGiveawayClaim(
     const embed = new EmbedBuilder()
       .setTitle("Giveaway claim")
       .setDescription(message)
-      .setColor(0x2ecc71)
+      .setColor(COLOR_SUCCESS)
       .setTimestamp(new Date());
     await channel.send({ embeds: [embed] }).catch(() => {});
   }

--- a/src/commands/hltb.command.ts
+++ b/src/commands/hltb.command.ts
@@ -3,6 +3,7 @@ import { ApplicationCommandOptionType } from "discord.js";
 import { Discord, Slash, SlashOption } from "discordx";
 import { EmbedBuilder } from "discord.js";
 import { searchHltb, type HltbSearchResult } from "../scripts/SearchHltb.js";
+import { COLOR_PRIMARY } from "../config/colors.js";
 import Game from "../classes/Game.js";
 import { getHltbCacheByGameId, upsertHltbCache } from "../classes/HltbCache.js";
 import {
@@ -146,7 +147,7 @@ async function outputHltbResultsAsEmbed(
     }
 
     const hltbEmbed = new EmbedBuilder()
-      .setColor(0x0099ff)
+      .setColor(COLOR_PRIMARY)
       .setTitle(`How Long to Beat ${hltb_result.name}`)
       .setAuthor({
         name: 'HowLongToBeat™',

--- a/src/config/colors.ts
+++ b/src/config/colors.ts
@@ -1,0 +1,6 @@
+export const COLOR_PRIMARY = 0x0099ff;
+export const COLOR_SUCCESS = 0x2ecc71;
+export const COLOR_INFO = 0x3498db;
+export const COLOR_WARNING = 0xf39c12;
+export const COLOR_ERROR = 0xe74c3c;
+export const COLOR_HIGHLIGHT = 0xffa500;

--- a/src/events/GuildBanLog.command.ts
+++ b/src/events/GuildBanLog.command.ts
@@ -3,6 +3,7 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { BAN_LOG_CHANNEL_ID, UNBAN_LOG_CHANNEL_ID } from "../config/channels.js";
+import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
 
 async function resolveLogChannel(client: Client, channelId: string): Promise<any | null> {
   const channel = await client.channels.fetch(channelId).catch(() => null);
@@ -56,7 +57,7 @@ export class GuildBanLog {
       username,
       user.displayAvatarURL?.() ?? null,
       user.createdAt ?? new Date(),
-      0xe74c3c,
+      COLOR_ERROR,
     );
 
     await (logChannel as any).send({ embeds: [embed] });
@@ -77,7 +78,7 @@ export class GuildBanLog {
       username,
       user.displayAvatarURL?.() ?? null,
       user.createdAt ?? new Date(),
-      0x3498db,
+      COLOR_INFO,
     );
 
     await (logChannel as any).send({ embeds: [embed] });

--- a/src/events/GuildMemberAdd.command.ts
+++ b/src/events/GuildMemberAdd.command.ts
@@ -4,6 +4,7 @@ import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
+import { COLOR_SUCCESS } from "../config/colors.js";
 
 function formatDiscordDateTime(date: Date): string {
   return `<t:${Math.floor(date.getTime() / 1000)}:F>`;
@@ -31,7 +32,7 @@ export class GuildMemberAdd {
         const username = member.user.tag ?? member.user.username ?? member.user.id;
         const embed = new EmbedBuilder()
           .setTitle("User Joined")
-          .setColor(0x2ecc71)
+          .setColor(COLOR_SUCCESS)
           .addFields(
             { name: "User", value: `<@${member.user.id}>\n${username}` },
             {

--- a/src/events/GuildMemberRemove.command.ts
+++ b/src/events/GuildMemberRemove.command.ts
@@ -3,6 +3,7 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
+import { COLOR_WARNING } from "../config/colors.js";
 const KICK_LOG_WINDOW_MS = 30_000;
 const KICK_LOG_RETRY_COUNT = 3;
 const KICK_LOG_RETRY_DELAY_MS = 750;
@@ -68,7 +69,7 @@ export class GuildMemberRemove {
     if (kickAudit) {
       const embed = new EmbedBuilder()
         .setTitle("User Kicked")
-        .setColor(0xf39c12)
+        .setColor(COLOR_WARNING)
         .addFields(
           { name: "User", value: `<@${member.user.id}>\n${username}` },
           {

--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -15,6 +15,7 @@ import {
   MODERATOR_ROLE_ID,
   REGULARS_ROLE_ID,
 } from "../config/roles.js";
+import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
 
 const QUALIFYING_ROLE_IDS_SET = new Set(
   [REGULARS_ROLE_ID, ADMIN_ROLE_ID, MODERATOR_ROLE_ID, MEMBER_ROLE_ID].filter(
@@ -68,11 +69,11 @@ export class GuildMemberUpdate {
         };
 
         for (const role of addedRoles.values()) {
-          await sendRoleLog("Role added", role.id, 0x3498db);
+          await sendRoleLog("Role added", role.id, COLOR_INFO);
         }
 
         for (const role of removedRoles.values()) {
-          await sendRoleLog("Role removed", role.id, 0xe74c3c);
+          await sendRoleLog("Role removed", role.id, COLOR_ERROR);
         }
       }
     }
@@ -136,7 +137,7 @@ export class GuildMemberUpdate {
             ? "Nickname added"
             : "Nickname changed";
         const nicknameColor =
-          oldMember.nickname && !newMember.nickname ? 0xe74c3c : 0x3498db;
+          oldMember.nickname && !newMember.nickname ? COLOR_ERROR : COLOR_INFO;
         await sendNameLog(
           nicknameTitle,
           oldNicknameValue,

--- a/src/events/MessageLog.command.ts
+++ b/src/events/MessageLog.command.ts
@@ -3,6 +3,7 @@ import type { Message } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
+import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
 const MAX_FIELD_LENGTH = 1000;
 const MAX_DESCRIPTION_LENGTH = 3500;
 
@@ -64,7 +65,7 @@ export class MessageLog {
     const embed = buildAuthorEmbed(
       resolved,
       `Message deleted in ${channelMention}`,
-      0xe74c3c,
+      COLOR_ERROR,
     );
     embed.setDescription(truncate(formatMessageContent(resolved)));
 
@@ -103,7 +104,7 @@ export class MessageLog {
     const embed = buildAuthorEmbed(
       resolvedNew,
       title,
-      0x3498db,
+      COLOR_INFO,
     );
     embed.setFields([]);
     const beforeValue = truncate(beforeText || "No text content.");

--- a/src/events/ServerChangeLog.command.ts
+++ b/src/events/ServerChangeLog.command.ts
@@ -9,8 +9,9 @@ import {
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
+import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
 
-function buildBaseEmbed(title: string, color = 0x3498db): EmbedBuilder {
+function buildBaseEmbed(title: string, color = COLOR_INFO): EmbedBuilder {
   return new EmbedBuilder()
     .setTitle(title)
     .setColor(color)
@@ -70,7 +71,7 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Channel deleted", 0xe74c3c);
+    const embed = buildBaseEmbed("Channel deleted", COLOR_ERROR);
     embed.setDescription(`${channel.name ?? channel.id} (${channel.id})`);
 
     await (logChannel as any).send({ embeds: [embed] });
@@ -133,7 +134,7 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Role deleted", 0xe74c3c);
+    const embed = buildBaseEmbed("Role deleted", COLOR_ERROR);
     embed.setDescription(`${role.name ?? role.id} (${role.id})`);
     await (logChannel as any).send({ embeds: [embed] });
   }
@@ -173,7 +174,7 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Emoji deleted", 0xe74c3c);
+    const embed = buildBaseEmbed("Emoji deleted", COLOR_ERROR);
     embed.setDescription(`${emoji.name ?? "emoji"} (${emoji.id})`);
     await (logChannel as any).send({ embeds: [embed] });
   }

--- a/src/events/ThreadCreated.command.ts
+++ b/src/events/ThreadCreated.command.ts
@@ -3,6 +3,7 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { joinThreadIfTarget } from "../services/ForumThreadJoinService.js";
 import { NOW_PLAYING_FORUM_ID, WHATCHA_PLAYING_CHANNEL_ID } from "../config/channels.js";
+import { COLOR_PRIMARY } from "../config/colors.js";
 
 @Discord()
 export class ThreadCreated {
@@ -130,7 +131,7 @@ export class ThreadCreated {
       }
 
       const nowPlayingEmbed = new EmbedBuilder()
-        .setColor(0x0099ff)
+        .setColor(COLOR_PRIMARY)
         .setTitle(`${thread.name}`)
         .setURL(`https://discord.com/channels/${thread.guildId}/${thread.id}`)
         .setDescription(`New "Now Playing" Forum Post`)

--- a/src/events/UserUpdate.command.ts
+++ b/src/events/UserUpdate.command.ts
@@ -4,6 +4,7 @@ import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { logAvatarChange, updateAvatarRecordFromUrl } from "../utilities/AvatarLogUtils.js";
 import { syncUserEmojiFromAvatarChange } from "../services/UserEmojiService.js";
+import { COLOR_INFO } from "../config/colors.js";
 
 @Discord()
 export class UserUpdate {
@@ -64,7 +65,7 @@ export class UserUpdate {
         })
         .setTitle(title)
         .setDescription(`**Before:** ${beforeValue}\n**+After:** ${afterValue}`)
-        .setColor(0x3498db)
+        .setColor(COLOR_INFO)
         .setFooter({ text: `ID: ${newUser.id} • ${timestamp}` });
       await (logChannel as any).send({ embeds: [embed] });
     };

--- a/src/functions/GotmEntryEmbeds.ts
+++ b/src/functions/GotmEntryEmbeds.ts
@@ -2,6 +2,7 @@ import { AttachmentBuilder, EmbedBuilder, type Client } from "discord.js";
 import type { IGotmEntry, IGotmGame } from "../classes/Gotm.js";
 import type { INrGotmEntry, INrGotmGame } from "../classes/NrGotm.js";
 import Game from "../classes/Game.js";
+import { COLOR_PRIMARY } from "../config/colors.js";
 
 const ANNOUNCEMENTS_CHANNEL_ID: string | undefined = process.env.ANNOUNCEMENTS_CHANNEL_ID;
 
@@ -164,7 +165,7 @@ export async function buildGotmEntryEmbed(
 ): Promise<IEmbedWithAttachments> {
   const desc = await formatGamesWithJump(entry as AnyEntry, guildId);
   const embed = new EmbedBuilder()
-    .setColor(0x0099ff)
+    .setColor(COLOR_PRIMARY)
     .setTitle(`Round ${entry.round} - ${entry.monthYear}`)
     .setDescription(desc);
 
@@ -186,7 +187,7 @@ export async function buildNrGotmEntryEmbed(
 ): Promise<IEmbedWithAttachments> {
   const desc = await formatGamesWithJump(entry as AnyEntry, guildId);
   const embed = new EmbedBuilder()
-    .setColor(0x0099ff)
+    .setColor(COLOR_PRIMARY)
     .setTitle(`NR-GOTM Round ${entry.round} - ${entry.monthYear}`)
     .setDescription(desc);
 

--- a/src/services/GamedbAuditService.ts
+++ b/src/services/GamedbAuditService.ts
@@ -3,6 +3,7 @@ import type { Client, TextBasedChannel } from "discord.js";
 import axios from "axios";
 import Game from "../classes/Game.js";
 import { igdbService } from "./IGDB/IgdbService.js";
+import { COLOR_PRIMARY, COLOR_SUCCESS } from "../config/colors.js";
 
 export type AutoAcceptResult = {
   updated: number;
@@ -510,7 +511,7 @@ export async function runAutoAcceptImagesAudit(
   let currentEmbed = new EmbedBuilder()
     .setTitle("GameDB Auto Accept Images")
     .setDescription("Starting auto accept run...")
-    .setColor(0x0099ff);
+    .setColor(COLOR_PRIMARY);
 
   let message = await (channel as any).send({ embeds: [currentEmbed] });
   let currentChunk = 0;
@@ -524,7 +525,7 @@ export async function runAutoAcceptImagesAudit(
         currentEmbed = new EmbedBuilder()
           .setTitle("GameDB Auto Accept Images")
           .setDescription("Processing...")
-          .setColor(0x0099ff);
+          .setColor(COLOR_PRIMARY);
         message = await (channel as any).send({ embeds: [currentEmbed] });
         logLines = [];
       }
@@ -545,7 +546,7 @@ export async function runAutoAcceptImagesAudit(
   if (!logs.length) {
     currentEmbed
       .setDescription("No games found with missing images and valid IGDB IDs.")
-      .setColor(0x2ecc71);
+      .setColor(COLOR_SUCCESS);
     await message.edit({ embeds: [currentEmbed] }).catch(() => {});
     return;
   }
@@ -554,7 +555,7 @@ export async function runAutoAcceptImagesAudit(
     `\n**Run Complete**\n✅ Updated: ${updated}\n` +
     `⏭️ Skipped: ${skipped}\n❌ Failed: ${failed}`;
   await updateEmbed(summary);
-  currentEmbed.setColor(0x2ecc71);
+  currentEmbed.setColor(COLOR_SUCCESS);
   await message.edit({ embeds: [currentEmbed] }).catch(() => {});
 }
 

--- a/src/utilities/AvatarLogUtils.ts
+++ b/src/utilities/AvatarLogUtils.ts
@@ -3,6 +3,7 @@ import { AttachmentBuilder, EmbedBuilder } from "discord.js";
 import type { GuildMember, User } from "discord.js";
 import Member, { type IMemberRecord } from "../classes/Member.js";
 import { formatTimestampWithDay, resolveLogChannel } from "./DiscordLogUtils.js";
+import { COLOR_INFO } from "../config/colors.js";
 
 type AvatarHistoryRecord = Awaited<ReturnType<typeof Member.getAvatarHistory>>[number];
 
@@ -118,7 +119,7 @@ export async function logAvatarChange(
     })
     .setTitle(title)
     .setDescription(`**Before:** ${beforeLabel}\n**+After:** ${afterLabel}`)
-    .setColor(0x3498db)
+    .setColor(COLOR_INFO)
     .setFooter({
       text: `ID: ${user.id} • ${formatTimestampWithDay(afterRecord.changedAt.getTime())}`,
     })

--- a/src/utilities/DiscordConsoleLogger.ts
+++ b/src/utilities/DiscordConsoleLogger.ts
@@ -6,12 +6,13 @@ import { DISCORD_CONSOLE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { BOT_DEV_PING_USER_ID } from "../config/users.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { safeV2TextContent } from "../functions/ComponentsV2Utils.js";
+import { COLOR_INFO, COLOR_WARNING, COLOR_ERROR } from "../config/colors.js";
 const MAX_DESCRIPTION_LENGTH = 3900;
 const LEVEL_COLORS: Record<string, number> = {
   log: 0x95a5a6,
-  info: 0x3498db,
-  warn: 0xf39c12,
-  error: 0xe74c3c,
+  info: COLOR_INFO,
+  warn: COLOR_WARNING,
+  error: COLOR_ERROR,
   debug: 0x9b59b6,
 };
 const LOG_BATCH_INTERVAL_MS = 5 * 1000;


### PR DESCRIPTION
Closes #573

## Summary
- Creates `src/config/colors.ts` with 6 named color constants: `COLOR_PRIMARY`, `COLOR_SUCCESS`, `COLOR_INFO`, `COLOR_WARNING`, `COLOR_ERROR`, `COLOR_HIGHLIGHT`
- Replaces all matching hardcoded hex literals across 16 source files
- Verification: `grep -rn "0x0099ff\|0x2ecc71\|0x3498db\|0xf39c12\|0xFFA500\|0xe74c3c" src/` returns zero hits outside of `colors.ts`

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Embed colors render correctly in Discord (primary/success/info/warning/error/highlight)

🤖 Generated with [Claude Code](https://claude.com/claude-code)