### PR TITLE
refactor: extract getModalField() helper (#574)

### DIFF
--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -21,10 +21,10 @@ import {
 import { ModalBuilder } from "discord.js";
 import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import {
+  getModalField,
   safeDeferReply,
   safeReply,
   safeUpdate,
-  stripModalInput,
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import {
@@ -438,9 +438,7 @@ export class GameDbCompletionCommand {
     } else if (session.dateChoice === "unknown") {
       completedAt = null;
     } else if (session.dateChoice === "date") {
-      const dateInput = stripModalInput(
-        interaction.fields.getTextInputValue("completion-date"),
-      );
+      const dateInput = getModalField(interaction, "completion-date");
       try {
         completedAt = parseCompletionDateInput(dateInput);
       } catch (err: any) {
@@ -449,9 +447,7 @@ export class GameDbCompletionCommand {
       }
     }
 
-    const playtimeInput = stripModalInput(
-      interaction.fields.getTextInputValue("completion-playtime"),
-    );
+    const playtimeInput = getModalField(interaction, "completion-playtime");
     const playtimeCheck = validateCompletionPlaytimeInput(playtimeInput);
     if (playtimeCheck.error) {
       await safeReply(interaction, buildTextReply(playtimeCheck.error, false)).catch(() => {});
@@ -459,9 +455,7 @@ export class GameDbCompletionCommand {
     }
     const playtime = playtimeCheck.value;
 
-    const noteInput = stripModalInput(
-      interaction.fields.getTextInputValue("completion-note"),
-    );
+    const noteInput = getModalField(interaction, "completion-note");
     const note = noteInput ? noteInput : null;
     if (note && note.length > MAX_COMPLETION_NOTE_LEN) {
       await safeReply(interaction, buildTextReply(`Note must be ${MAX_COMPLETION_NOTE_LEN} characters or fewer.`, false)).catch(() => {});
@@ -532,9 +526,7 @@ export class GameDbCompletionCommand {
       return;
     }
 
-    const noteRaw = stripModalInput(
-      interaction.fields.getTextInputValue("gamedb-nowplaying-note"),
-    );
+    const noteRaw = getModalField(interaction, "gamedb-nowplaying-note");
     if (noteRaw.length > MAX_NOW_PLAYING_NOTE_LEN) {
       await safeReply(interaction, buildTextReply(`Note must be ${MAX_NOW_PLAYING_NOTE_LEN} characters or fewer.`, false)).catch(() => {});
       return;

--- a/src/commands/gamedb/gamedb-csv-import.command.ts
+++ b/src/commands/gamedb/gamedb-csv-import.command.ts
@@ -25,10 +25,10 @@ import {
 import axios from "axios";
 import {
   safeDeferReply,
+  getModalField,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
-  stripModalInput,
 } from "../../functions/InteractionUtils.js";
 import {
   normalizeCsvHeader,
@@ -713,8 +713,7 @@ export class GameDbCsvImportCommand {
       return;
     }
 
-    const raw = interaction.fields.getTextInputValue(GAMEDB_CSV_MANUAL_INPUT_ID);
-    const cleaned = stripModalInput(raw);
+    const cleaned = getModalField(interaction, GAMEDB_CSV_MANUAL_INPUT_ID);
     const igdbId = Number(cleaned);
     if (!isPositiveInt(igdbId)) {
       await safeReply(interaction, buildTextReply("Please provide a valid IGDB id.", true));
@@ -781,8 +780,7 @@ export class GameDbCsvImportCommand {
       return;
     }
 
-    const raw = interaction.fields.getTextInputValue(GAMEDB_CSV_QUERY_INPUT_ID);
-    const query = stripModalInput(raw).trim();
+    const query = getModalField(interaction, GAMEDB_CSV_QUERY_INPUT_ID);
     if (!query) {
       await safeReply(interaction, buildTextReply("Please provide a search query.", true));
       return;

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -16,9 +16,9 @@ import {
   SlashGroup,
 } from "discordx";
 import {
+  getModalField,
   safeDeferReply,
   safeReply,
-  stripModalInput,
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { getThreadsByGameId, setThreadGameLink, upsertThreadRecord } from "../../classes/Thread.js";
@@ -250,12 +250,8 @@ export class GameDbThreadCommand {
     const defaultTitle = buildDefaultNowPlayingThreadTitle(game.title);
     const defaultBody = buildDefaultNowPlayingThreadBody(memberDisplayName);
 
-    const titleInput = stripModalInput(
-      interaction.fields.getTextInputValue(GAMEDB_THREAD_TITLE_INPUT_ID),
-    );
-    const bodyInput = stripModalInput(
-      interaction.fields.getTextInputValue(GAMEDB_THREAD_BODY_INPUT_ID),
-    );
+    const titleInput = getModalField(interaction, GAMEDB_THREAD_TITLE_INPUT_ID);
+    const bodyInput = getModalField(interaction, GAMEDB_THREAD_BODY_INPUT_ID);
     const threadTitle = titleInput || defaultTitle;
     const threadBody = bodyInput || defaultBody;
 

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -27,7 +27,7 @@ import {
   replyIfNotOwner,
   safeReply,
   safeUpdate,
-  stripModalInput,
+  getModalField,
 } from "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import {
@@ -971,11 +971,9 @@ export class GiveawayCommand {
   @ModalComponent({ id: GIVEAWAY_DONATE_MODAL_ID })
   async handleDonateModal(interaction: ModalSubmitInteraction): Promise<void> {
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
-    const title = stripModalInput(interaction.fields.getTextInputValue(GIVEAWAY_DONATE_TITLE_ID));
-    const platform = stripModalInput(
-      interaction.fields.getTextInputValue(GIVEAWAY_DONATE_PLATFORM_ID),
-    );
-    const keyValue = stripModalInput(interaction.fields.getTextInputValue(GIVEAWAY_DONATE_KEY_ID));
+    const title = getModalField(interaction, GIVEAWAY_DONATE_TITLE_ID);
+    const platform = getModalField(interaction, GIVEAWAY_DONATE_PLATFORM_ID);
+    const keyValue = getModalField(interaction, GIVEAWAY_DONATE_KEY_ID);
 
     const created = await handleDonation(interaction, title, platform, keyValue);
     if (created) {
@@ -986,9 +984,7 @@ export class GiveawayCommand {
   @ModalComponent({ id: GIVEAWAY_REVOKE_MODAL_ID })
   async handleRevokeModal(interaction: ModalSubmitInteraction): Promise<void> {
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
-    const keyIdInput = stripModalInput(
-      interaction.fields.getTextInputValue(GIVEAWAY_REVOKE_KEY_ID),
-    );
+    const keyIdInput = getModalField(interaction, GIVEAWAY_REVOKE_KEY_ID);
     const keyId = Number(keyIdInput);
     if (Number.isNaN(keyId)) {
       await safeReply(interaction, buildTextReply("Invalid key id.", true));

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -47,12 +47,12 @@ import crypto from "node:crypto";
 import Member, { type IMemberNowPlayingEntry } from "../classes/Member.js";
 import {
   extractErrorMessage,
+  getModalField,
   safeDeferReply,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
   sanitizeUserInput,
-  stripModalInput,
   type AnyRepliable,
 } from "../functions/InteractionUtils.js";
 import Game, { type IGame } from "../classes/Game.js";
@@ -929,12 +929,8 @@ export class NowPlayingCommand {
 
   @ModalComponent({ id: NOW_PLAYING_ADD_MODAL_ID })
   async handleAddNowPlayingModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const query = stripModalInput(
-      interaction.fields.getTextInputValue(NOW_PLAYING_ADD_TITLE_INPUT_ID),
-    );
-    const noteRaw = stripModalInput(
-      interaction.fields.getTextInputValue(NOW_PLAYING_ADD_NOTE_INPUT_ID),
-    );
+    const query = getModalField(interaction, NOW_PLAYING_ADD_TITLE_INPUT_ID);
+    const noteRaw = getModalField(interaction, NOW_PLAYING_ADD_NOTE_INPUT_ID);
     if (!query) {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("Please provide a title to search."),
@@ -1378,16 +1374,10 @@ export class NowPlayingCommand {
       return;
     }
 
-    const completionDateInput = stripModalInput(
-      interaction.fields.getTextInputValue(NOW_PLAYING_COMPLETE_DATE_INPUT_ID),
-    );
-    const finalPlaytimeRaw = stripModalInput(
-      interaction.fields.getTextInputValue(NOW_PLAYING_COMPLETE_HOURS_INPUT_ID),
-    );
+    const completionDateInput = getModalField(interaction, NOW_PLAYING_COMPLETE_DATE_INPUT_ID);
+    const finalPlaytimeRaw = getModalField(interaction, NOW_PLAYING_COMPLETE_HOURS_INPUT_ID);
     const noteInput = session.addCompletionNote
-      ? stripModalInput(
-        interaction.fields.getTextInputValue(NOW_PLAYING_COMPLETE_NOTE_INPUT_ID),
-      )
+      ? getModalField(interaction, NOW_PLAYING_COMPLETE_NOTE_INPUT_ID)
       : "";
 
     let completedAt: Date | null = null;
@@ -3009,9 +2999,7 @@ export class NowPlayingCommand {
         return;
       }
 
-      const noteInput = stripModalInput(
-        interaction.fields.getTextInputValue(NOW_PLAYING_NOTE_INPUT_ID),
-      );
+      const noteInput = getModalField(interaction, NOW_PLAYING_NOTE_INPUT_ID);
       const note = noteInput.trim();
       const nextNote = note ? note : null;
       if (note && note.length > MAX_NOW_PLAYING_NOTE_LEN) {
@@ -3031,7 +3019,7 @@ export class NowPlayingCommand {
         const fieldId = `${NOW_PLAYING_NOTE_INPUT_ID}:${entry.gameId}`;
         let noteInput = "";
         try {
-          noteInput = stripModalInput(interaction.fields.getTextInputValue(fieldId));
+          noteInput = getModalField(interaction, fieldId);
         } catch {
           noteInput = "";
         }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -3,6 +3,7 @@ import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import type {
   CommandInteraction,
   InteractionDeferReplyOptions,
+  ModalSubmitInteraction,
   RepliableInteraction,
 } from "discord.js";
 import { BOT_DEV_CHANNEL_ID } from "../config/channels.js";
@@ -115,6 +116,13 @@ export function sanitizeOptionalInput(
 
 export function stripModalInput(value: string): string {
   return sanitizeUserInput(value);
+}
+
+export function getModalField(
+  interaction: ModalSubmitInteraction,
+  customId: string,
+): string {
+  return stripModalInput(interaction.fields.getTextInputValue(customId));
 }
 
 function normalizeOptions(options: any): any {


### PR DESCRIPTION
## Summary

- Adds `getModalField(interaction, customId)` to `src/functions/InteractionUtils.ts` as a drop-in replacement for `stripModalInput(interaction.fields.getTextInputValue(id))`
- Replaces all call sites across `giveaway.command.ts`, `now-playing.command.ts`, `gamedb/gamedb-thread.command.ts`, `gamedb/gamedb-csv-import.command.ts`, and `gamedb/gamedb-completion.command.ts`
- `grep -rn "stripModalInput(interaction.fields" src/` returns zero hits (only occurrence is inside the helper itself)

## Test plan

- [ ] Type-check passes: `npx tsc --noEmit`
- [ ] Lint passes: `npm run lint`
- [ ] Modal submissions for giveaway donate/revoke, now-playing add/complete/note, gamedb thread create, csv import, and completion still work correctly

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)