### PR TITLE
refactor: add isInteractionSettled() / canSafeReply() guards to InteractionUtils

### DIFF
--- a/src/commands/collection/collection-csv-import.command.ts
+++ b/src/commands/collection/collection-csv-import.command.ts
@@ -42,6 +42,7 @@ import {
   resolveGameCompletionPlatformLabel,
 } from "../game-completion/completion-autocomplete.utils.js";
 import {
+  canSafeReply,
   safeDeferReply,
   safeDeferUpdate,
   safeReply,
@@ -153,10 +154,9 @@ export class CollectionCsvImportCommand {
     importId: number,
     ownerId: string,
   ): Promise<void> {
-    const shouldUseInteractionUpdate = 
+    const shouldUseInteractionUpdate =
       (interaction.isButton() || interaction.isStringSelectMenu()) &&
-      !interaction.deferred &&
-      !interaction.replied;
+      canSafeReply(interaction);
     const shouldUseModalUpdate = interaction.isModalSubmit();
 
     const session = await getCollectionCsvImportById(importId);

--- a/src/commands/collection/collection-steam-import.command.ts
+++ b/src/commands/collection/collection-steam-import.command.ts
@@ -44,6 +44,7 @@ import {
   resolveGameCompletionPlatformId,
 } from "../game-completion/completion-autocomplete.utils.js";
 import {
+  canSafeReply,
   safeDeferReply,
   safeDeferUpdate,
   safeReply,
@@ -164,8 +165,7 @@ export class CollectionSteamImportCommand {
   ): Promise<void> {
     const shouldUseInteractionUpdate =
       (interaction.isButton() || interaction.isStringSelectMenu()) &&
-      !interaction.deferred &&
-      !interaction.replied;
+      canSafeReply(interaction);
     const shouldUseModalUpdate = interaction.isModalSubmit();
 
     const session = await getSteamCollectionImportById(importId);

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -14,7 +14,9 @@ import Game from "../../classes/Game.js";
 import Member from "../../classes/Member.js";
 import { saveCompletion } from "../../functions/CompletionHelpers.js";
 import {
+  canSafeReply,
   extractErrorMessage,
+  isInteractionSettled,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
@@ -94,7 +96,7 @@ export async function promptIgdbSelection(
 ): Promise<void> {
   if (interaction.isMessageComponent()) {
     const loadingComponents = [buildTextContainer(`Searching IGDB for "${searchTerm}"...`)];
-    if (interaction.deferred || interaction.replied) {
+    if (isInteractionSettled(interaction)) {
       await safeReply(interaction, {
         components: loadingComponents,
         flags: COMPONENTS_V2_FLAG,
@@ -236,7 +238,7 @@ export async function processCompletionSelection(
     return true;
   }
 
-  if (!interaction.deferred && !interaction.replied) {
+  if (canSafeReply(interaction)) {
     try {
       await safeDeferUpdate(interaction);
     } catch {
@@ -439,7 +441,7 @@ async function confirmDuplicateCompletion(
   try {
     const reply = await safeReply(interaction, {
       ...payload,
-      __forceFollowUp: interaction.deferred || interaction.replied,
+      __forceFollowUp: isInteractionSettled(interaction),
     });
     message = (reply as any)?.resource?.message ?? (reply as Message) ?? null;
   } catch {

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -24,7 +24,12 @@ import {
 } from "./completion-autocomplete.utils.js";
 import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
-import { replyIfNotOwner, safeReply, safeUpdate } from "../../functions/InteractionUtils.js";
+import {
+  isInteractionSettled,
+  replyIfNotOwner,
+  safeReply,
+  safeUpdate,
+} from "../../functions/InteractionUtils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 
 const MAX_NOTE_LENGTH = 500;
@@ -57,7 +62,7 @@ export async function handleCompletionEditMenu(
   }
 
   const response = buildCompletionEditPrompt(ownerId, completionId, completion);
-  if (interaction.deferred || interaction.replied) {
+  if (isInteractionSettled(interaction)) {
     await safeReply(interaction, response);
   } else {
     await safeUpdate(interaction, response);

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -37,7 +37,7 @@ import { GAMEDB_CSV_PLATFORM_MAP } from "../../config/gamedbCsvPlatformMap.js";
 import { formatTableDate } from "../profile.command.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { COMPLETIONATOR_MATCH_THUMBNAIL_NAME } from "./completion.types.js";
-import { safeReply, safeUpdate } from "../../functions/InteractionUtils.js";
+import { isInteractionSettled, safeReply, safeUpdate } from "../../functions/InteractionUtils.js";
 import { buildComponentsV2Flags } from "../../functions/NominationListComponents.js";
 import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
 import {
@@ -658,7 +658,7 @@ export class CompletionatorUiService {
     }
 
     if ("isMessageComponent" in interaction && interaction.isMessageComponent()) {
-      if (interaction.deferred || interaction.replied) {
+      if (isInteractionSettled(interaction)) {
         await safeReply(interaction, { ...payload, files, flags });
       } else {
         await safeUpdate(interaction, { ...payload, files, flags });

--- a/src/commands/game-completion/completionator-workflow.service.ts
+++ b/src/commands/game-completion/completionator-workflow.service.ts
@@ -35,7 +35,7 @@ import { importGameFromIgdb } from "./completionator-parser.service.js";
 import { searchGameDbWithFallback } from "./completionator-parser.service.js";
 import { runDockerVolumeBackup } from "../../services/DockerVolumeBackupService.js";
 import { buildImportTextContainer } from "../imports/import-scaffold.service.js";
-import { safeDeferReply, safeDeferUpdate } from "../../functions/InteractionUtils.js";
+import { canSafeReply, safeDeferReply, safeDeferUpdate } from "../../functions/InteractionUtils.js";
 
 export class CompletionatorWorkflowService {
   private uiService: CompletionatorUiService;
@@ -533,7 +533,7 @@ export class CompletionatorWorkflowService {
   ): Promise<void> {
     const isComponent =
       "isMessageComponent" in interaction && interaction.isMessageComponent();
-    if (!interaction.deferred && !interaction.replied) {
+    if (canSafeReply(interaction)) {
       if (isComponent) {
         await safeDeferUpdate(interaction);
       } else {

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -17,6 +17,7 @@ import {
 } from "discordx";
 import {
   getModalField,
+  isInteractionSettled,
   safeDeferReply,
   safeReply,
 } from "../../functions/InteractionUtils.js";
@@ -121,7 +122,7 @@ async function runNowPlayingThreadWizard(
     typeof interaction.isModalSubmit === "function" &&
     interaction.isModalSubmit();
   const sendStatus = async (content: string): Promise<void> => {
-    if (isModalInteraction && (interaction.deferred || interaction.replied)) {
+    if (isModalInteraction && isInteractionSettled(interaction)) {
       await safeReply(interaction, buildTextReply(content, false)).catch(() => {});
       return;
     }

--- a/src/commands/igdb-select.handler.ts
+++ b/src/commands/igdb-select.handler.ts
@@ -1,6 +1,6 @@
 import { ButtonComponent, Discord, SelectMenuComponent } from "discordx";
 import { type ButtonInteraction, type StringSelectMenuInteraction } from "discord.js";
-import { safeReply } from "../functions/InteractionUtils.js";
+import { canSafeReply, safeReply } from "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import {
   handleIgdbFirstMatchInteraction,
@@ -12,7 +12,7 @@ export class IgdbSelectHandler {
   @SelectMenuComponent({ id: /^igdb-select:.+/ })
   async handleIgdbSelect(interaction: StringSelectMenuInteraction): Promise<void> {
     const handled = await handleIgdbSelectInteraction(interaction);
-    if (!handled && !interaction.replied && !interaction.deferred) {
+    if (!handled && canSafeReply(interaction)) {
       await safeReply(interaction, buildTextReply("This IGDB selection is no longer valid.", true));
     }
   }
@@ -20,7 +20,7 @@ export class IgdbSelectHandler {
   @ButtonComponent({ id: /^igdb-first:.+/ })
   async handleIgdbFirstMatch(interaction: ButtonInteraction): Promise<void> {
     const handled = await handleIgdbFirstMatchInteraction(interaction);
-    if (!handled && !interaction.replied && !interaction.deferred) {
+    if (!handled && canSafeReply(interaction)) {
       await safeReply(interaction, buildTextReply("This IGDB selection is no longer valid.", true));
     }
   }

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -48,6 +48,7 @@ import Member, { type IMemberNowPlayingEntry } from "../classes/Member.js";
 import {
   extractErrorMessage,
   getModalField,
+  isInteractionSettled,
   safeDeferReply,
   safeDeferUpdate,
   safeReply,
@@ -358,7 +359,7 @@ async function confirmDuplicateCompletion(
 
   let message: Message | null = null;
   try {
-    if (interaction.deferred || interaction.replied) {
+    if (isInteractionSettled(interaction)) {
       const reply = await safeReply(interaction, { ...payload, __forceFollowUp: true } as any);
       message = reply as Message;
     } else {

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -20,7 +20,9 @@ import {
 } from "discordx";
 import {
   AnyRepliable,
+  canSafeReply,
   extractErrorMessage,
+  isInteractionSettled,
   safeDeferReply,
   safeDeferUpdate,
   safeReply,
@@ -464,7 +466,7 @@ export class SuperAdmin {
   ): Promise<void> {
     if ("isMessageComponent" in interaction && interaction.isMessageComponent()) {
       const loading = { content: `Searching IGDB for "${searchTerm}"...`, components: [] };
-      if (interaction.deferred || interaction.replied) {
+      if (isInteractionSettled(interaction)) {
         await safeReply(interaction, loading).catch(() => {});
       } else {
         await safeUpdate(interaction, loading).catch(() => {});
@@ -717,7 +719,7 @@ export class SuperAdmin {
 
   @ButtonComponent({ id: /^(gotm|nr-gotm)-audit(img)?-(stop|skip|novalue).*-/ })
   async handleAuditButtons(interaction: ButtonInteraction): Promise<void> {
-    if (!interaction.deferred && !interaction.replied) {
+    if (canSafeReply(interaction)) {
       await safeDeferUpdate(interaction);
     }
   }

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -27,7 +27,7 @@ import Member from "../classes/Member.js";
 import { ANNOUNCEMENT_CHANNEL_ID, BOT_DEV_CHANNEL_ID } from "../config/channels.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { buildComponentsV2Flags, buildTextContainer } from "./ComponentsV2Utils.js";
-import { safeReply, safeUpdate } from "./InteractionUtils.js";
+import { isInteractionSettled, safeReply, safeUpdate } from "./InteractionUtils.js";
 
 const MAX_PLAYTIME_HOURS = 999999.99;
 const COMPLETION_COVER_ATTACHMENT_PREFIX = "completion-cover";
@@ -272,7 +272,7 @@ export async function promptRemoveFromNowPlaying(
 
   let message: Message | null = null;
   try {
-    if (interaction.deferred || interaction.replied) {
+    if (isInteractionSettled(interaction)) {
       const reply = await safeReply(interaction, { ...payload, __forceFollowUp: true } as any);
       message = reply as Message;
     } else {

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -12,6 +12,16 @@ import { buildComponentsV2Flags, buildTextReply, safeV2TextContent } from "./Com
 
 export type AnyRepliable = RepliableInteraction | CommandInteraction;
 
+/** True if the interaction has already been deferred or replied to. */
+export function isInteractionSettled(interaction: AnyRepliable): boolean {
+  return interaction.deferred || interaction.replied;
+}
+
+/** True if the interaction can still receive an initial reply or deferral. */
+export function canSafeReply(interaction: AnyRepliable): boolean {
+  return !interaction.deferred && !interaction.replied;
+}
+
 type SanitizeOptions = {
   maxLength?: number;
   preserveNewlines?: boolean;

--- a/src/services/IGDB/IgdbSelectService.ts
+++ b/src/services/IGDB/IgdbSelectService.ts
@@ -6,7 +6,12 @@ import {
   type ButtonInteraction,
   type StringSelectMenuInteraction,
 } from "discord.js";
-import { safeDeferUpdate, safeReply, safeUpdate } from "../../functions/InteractionUtils.js";
+import {
+  canSafeReply,
+  safeDeferUpdate,
+  safeReply,
+  safeUpdate,
+} from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 
@@ -191,7 +196,7 @@ export async function handleIgdbSelectInteraction(
   }
 
   try {
-    if (!interaction.deferred && !interaction.replied) {
+    if (canSafeReply(interaction)) {
       await safeDeferUpdate(interaction);
     }
     await session.onSelect(interaction, selected.gameId);
@@ -226,7 +231,7 @@ export async function handleIgdbFirstMatchInteraction(
   }
 
   try {
-    if (!interaction.deferred && !interaction.replied) {
+    if (canSafeReply(interaction)) {
       await safeDeferUpdate(interaction);
     }
     await session.onSelect(interaction as unknown as StringSelectMenuInteraction, firstOption.id);


### PR DESCRIPTION
Closes #575

## Summary
- Added `isInteractionSettled(interaction)` and `canSafeReply(interaction)` to `src/functions/InteractionUtils.ts`
- Replaced 13+ manual `interaction.deferred || interaction.replied` / `!interaction.deferred && !interaction.replied` expressions across 12 files with the named predicates
- Updated all affected import statements

## Verification
`grep -rn "interaction.deferred || interaction.replied" src/` returns zero hits (only the canonical definitions in InteractionUtils.ts remain).

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run lint` passes with no violations

Part of shared-utilities-standardization-pass-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)