### PR TITLE
refactor: centralize sleep/delay into DelayUtils.ts

### DIFF
--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -48,6 +48,7 @@ import {
 } from "../functions/CompletionHelpers.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { sleep } from "../utilities/DelayUtils.js";
 
 type CompletionAddContext = {
   targetUserId: string;
@@ -755,7 +756,6 @@ export class SuperAdmin {
     let successCount = 0;
     let failCount = 0;
 
-    const delay = async (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
     const avatarBuffersDifferent = (a: Buffer | null, b: Buffer | null): boolean => {
       if (!a && !b) return false;
       if (!!a !== !!b) return true;
@@ -833,12 +833,12 @@ export class SuperAdmin {
           try {
             await Member.upsert({ ...baseRecord, avatarBlob: null });
             successCount++;
-            await delay(1000);
+            await sleep(1000);
             continue;
           } catch (retryErr) {
             failCount++;
             console.error(`Failed to upsert user ${user.id} after stripping avatar`, retryErr);
-            await delay(1000);
+            await sleep(1000);
             continue;
           }
         }
@@ -846,7 +846,7 @@ export class SuperAdmin {
         console.error(`Failed to upsert user ${user.id}`, err);
       }
 
-      await delay(1000);
+      await sleep(1000);
     }
 
     await safeReply(interaction, buildTextReply(`Member scan complete. Upserts succeeded: ${successCount}. Failed: ${failCount}. ` +
@@ -906,9 +906,6 @@ export class SuperAdmin {
     });
   }
 
-  private async delay(ms: number): Promise<void> {
-    await new Promise((resolve) => setTimeout(resolve, ms));
-  }
 }
 
 export const AUDIT_NO_VALUE_SENTINEL = "__NO_VALUE__";

--- a/src/events/GuildMemberRemove.command.ts
+++ b/src/events/GuildMemberRemove.command.ts
@@ -4,6 +4,7 @@ import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { COLOR_WARNING } from "../config/colors.js";
+import { sleep } from "../utilities/DelayUtils.js";
 const KICK_LOG_WINDOW_MS = 30_000;
 const KICK_LOG_RETRY_COUNT = 3;
 const KICK_LOG_RETRY_DELAY_MS = 750;
@@ -45,7 +46,7 @@ async function getKickAudit(
       }
     }
 
-    await new Promise((resolve) => setTimeout(resolve, KICK_LOG_RETRY_DELAY_MS));
+    await sleep(KICK_LOG_RETRY_DELAY_MS);
   }
 
   return null;

--- a/src/events/ThreadCreated.command.ts
+++ b/src/events/ThreadCreated.command.ts
@@ -4,6 +4,7 @@ import { Discord, On } from "discordx";
 import { joinThreadIfTarget } from "../services/ForumThreadJoinService.js";
 import { NOW_PLAYING_FORUM_ID, WHATCHA_PLAYING_CHANNEL_ID } from "../config/channels.js";
 import { COLOR_PRIMARY } from "../config/colors.js";
+import { sleep } from "../utilities/DelayUtils.js";
 
 @Discord()
 export class ThreadCreated {
@@ -17,10 +18,6 @@ export class ThreadCreated {
     // New Threads in Now Playing forum channel get announced in the Whatcha Playing channel
     if (thread.parentId === NOW_PLAYING_FORUM_ID) {
       // Always wait 10 seconds before fetching the starter message
-      const sleep = (ms: number): Promise<void> =>
-        new Promise<void>((resolve): void => {
-          setTimeout(resolve, ms);
-        });
       await sleep(10_000);
       // Resolve thread author (prefer starter message author; fallback to thread.ownerId)
       let authorName: string = 'Unknown';

--- a/src/scripts/import-igdb-platforms.ts
+++ b/src/scripts/import-igdb-platforms.ts
@@ -3,15 +3,13 @@ import oracledb from "oracledb";
 import { initOraclePool, getOraclePool } from "../db/oracleClient.js";
 import { oraQuery, oraMutate, oraWithConnection } from "../db/SqlManager.js";
 import { igdbService, type IGDBPlatform } from "../services/IGDB/IgdbService.js";
+import { sleep } from "../utilities/DelayUtils.js";
 
 type UpsertResult = "inserted" | "updated" | "unchanged";
 type WriteMode = "write" | "dry-run";
 
 const DEFAULT_LIMIT: number = 500;
 const RATE_LIMIT_DELAY_MS: number = 300;
-
-const sleep = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
 
 const normalizeCode = (input: string): string =>
   input.replace(/[^A-Za-z0-9]/g, "").toUpperCase();

--- a/src/services/BackblazeB2Service.ts
+++ b/src/services/BackblazeB2Service.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import crypto from "node:crypto";
+import { sleep } from "../utilities/DelayUtils.js";
 
 const BACKBLAZE_AUTH_URL = "https://api.backblazeb2.com/b2api/v2/b2_authorize_account";
 
@@ -100,7 +101,7 @@ async function withRetry<T>(fn: () => Promise<T>, label: string): Promise<T> {
         `[Backblaze] ${label} failed (attempt ${attempt}/${RETRY_MAX_ATTEMPTS}), ` +
         `retrying in ${delay}ms...`,
       );
-      await new Promise((resolve) => setTimeout(resolve, delay));
+      await sleep(delay);
     }
   }
   throw lastError;

--- a/src/services/GamedbAuditService.ts
+++ b/src/services/GamedbAuditService.ts
@@ -4,6 +4,7 @@ import axios from "axios";
 import Game from "../classes/Game.js";
 import { igdbService } from "./IGDB/IgdbService.js";
 import { COLOR_PRIMARY, COLOR_SUCCESS } from "../config/colors.js";
+import { sleep, AUDIT_STEP_DELAY_MS } from "../utilities/DelayUtils.js";
 
 export type AutoAcceptResult = {
   updated: number;
@@ -83,7 +84,7 @@ async function performAutoAcceptImages(
       break;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await sleep(AUDIT_STEP_DELAY_MS);
   }
 
   return { updated, skipped, failed, logs };
@@ -162,7 +163,7 @@ async function performAutoAcceptVideos(
       break;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await sleep(AUDIT_STEP_DELAY_MS);
   }
 
   return { updated, skipped, failed, logs };
@@ -234,7 +235,7 @@ async function performAutoAcceptReleaseData(
       break;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await sleep(AUDIT_STEP_DELAY_MS);
   }
 
   return { updated, skipped, failed, logs };
@@ -305,7 +306,7 @@ async function performAutoAcceptDescriptions(
       break;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await sleep(AUDIT_STEP_DELAY_MS);
   }
 
   return { updated, skipped, failed, logs };
@@ -373,7 +374,7 @@ async function performAutoAcceptAll(
         `❌ Failed **${game.title}**: IGDB fetch error: ${err?.message ?? String(err)}`,
       );
       if (shouldStop?.()) break;
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await sleep(AUDIT_STEP_DELAY_MS);
       continue;
     }
 
@@ -383,7 +384,7 @@ async function performAutoAcceptAll(
       stats.descriptions.skipped++;
       stats.releases.skipped++;
       if (shouldStop?.()) break;
-      await new Promise((resolve) => setTimeout(resolve, 1000));
+      await sleep(AUDIT_STEP_DELAY_MS);
       continue;
     }
 
@@ -471,7 +472,7 @@ async function performAutoAcceptAll(
     }
 
     if (shouldStop?.()) break;
-    await new Promise((resolve) => setTimeout(resolve, 1000));
+    await sleep(AUDIT_STEP_DELAY_MS);
   }
 
   return stats;

--- a/src/services/IGDB/IgdbScanService.ts
+++ b/src/services/IGDB/IgdbScanService.ts
@@ -2,6 +2,7 @@ import oracledb from "oracledb";
 import { oraWithConnection } from "../../db/SqlManager.js";
 import Game from "../../classes/Game.js";
 import { igdbService } from "./IgdbService.js";
+import { sleep } from "../../utilities/DelayUtils.js";
 
 type IgdbScanConfig = {
   enabled: boolean;
@@ -22,8 +23,6 @@ const DEFAULT_SCAN_INTERVAL_MINUTES = 15;
 const DEFAULT_SCAN_BATCH_SIZE = 25;
 const DEFAULT_SCAN_MIN_AGE_DAYS = 30;
 const DEFAULT_SCAN_THROTTLE_MS = 300;
-
-const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
 function parseNumberEnv(name: string, fallback: number, min?: number): number {
   const raw = process.env[name];

--- a/src/services/SteamApiService.ts
+++ b/src/services/SteamApiService.ts
@@ -1,4 +1,5 @@
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { sleep } from "../utilities/DelayUtils.js";
 
 type SteamIdentifierKind = "steamid64" | "profiles-url" | "vanity-url" | "vanity";
 export type SteamApiErrorCode =
@@ -92,10 +93,6 @@ const APP_STORE_METADATA_CACHE_TTL_MS = 24 * 60 * 60 * 1000;
 
 function getSteamApiKey(): string {
   return process.env.STEAM_WEB_API_KEY ?? process.env.STEAM_API_KEY ?? "";
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function jitter(maxMs: number): number {

--- a/src/services/UserEmojiService.ts
+++ b/src/services/UserEmojiService.ts
@@ -1,6 +1,7 @@
 import sharp from "sharp";
 import type { Client, GuildMember } from "discord.js";
 import Member from "../classes/Member.js";
+import { sleep } from "../utilities/DelayUtils.js";
 import {
   ADMIN_ROLE_ID,
   MEMBER_ROLE_ID,
@@ -186,7 +187,7 @@ async function syncAllUserEmoji(client: Client, forceRefresh = false): Promise<v
           emojiCache.set(userId, { emojiId: emoji.id, emojiName: storedName });
           claimedNames.add(storedName);
           created++;
-          await new Promise((resolve) => setTimeout(resolve, CREATION_THROTTLE_MS));
+          await sleep(CREATION_THROTTLE_MS);
         }
       } catch (err) {
         console.error(`[UserEmojiService] Failed to recreate emoji for ${member.displayName}:`, err);
@@ -200,7 +201,7 @@ async function syncAllUserEmoji(client: Client, forceRefresh = false): Promise<v
     const success = await createEmojiForMember(app, member);
     if (success) {
       created++;
-      await new Promise((resolve) => setTimeout(resolve, CREATION_THROTTLE_MS));
+      await sleep(CREATION_THROTTLE_MS);
     }
   }
 

--- a/src/utilities/DelayUtils.ts
+++ b/src/utilities/DelayUtils.ts
@@ -1,0 +1,6 @@
+export const AUDIT_STEP_DELAY_MS = 1000;
+export const IGDB_RATE_LIMIT_DELAY_MS = 250;
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
Closes #576

## Summary
- Created `src/utilities/DelayUtils.ts` with `sleep()`, `AUDIT_STEP_DELAY_MS = 1000`, and `IGDB_RATE_LIMIT_DELAY_MS = 250`
- Removed 7 hardcoded `new Promise((resolve) => setTimeout(resolve, 1000))` calls in `GamedbAuditService.ts`, replaced with `await sleep(AUDIT_STEP_DELAY_MS)`
- Removed local `sleep()` definitions from `IgdbScanService.ts`, `SteamApiService.ts`, `import-igdb-platforms.ts`, `ThreadCreated.command.ts`
- Replaced inline `new Promise/setTimeout` patterns in `UserEmojiService.ts`, `GuildMemberRemove.command.ts`, `BackblazeB2Service.ts`
- Removed local `const delay` and `private async delay()` from `superadmin.command.ts`

## Verification
`grep -rn "new Promise.*setTimeout" src/` now returns zero hits (only the canonical definition in `DelayUtils.ts`).

## Test plan
- [ ] Type-check passes: `npx tsc --noEmit`
- [ ] Lint passes: `npm run lint`
- [ ] Audit service batch delays still fire between IGDB/axios calls
- [ ] IgdbScanService throttle still applies between game scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)