### PR TITLE
refactor: move MEMBER_ROLE_ID from giveaway.command.ts into src/config/roles.ts

### DIFF
--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -51,6 +51,7 @@ import {
   refreshGiveawayHubMessage,
 } from "../services/GiveawayHubService.js";
 import { GIVEAWAY_HUB_CHANNEL_ID, GIVEAWAY_LOG_CHANNEL_ID } from "../config/channels.js";
+import { MEMBER_ROLE_ID } from "../config/roles.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { COLOR_SUCCESS } from "../config/colors.js";
 import { CLAIM_MENU_CHUNK_SIZE } from "../config/pagination.js";
@@ -58,7 +59,6 @@ import { CLAIM_MENU_CHUNK_SIZE } from "../config/pagination.js";
 const MAX_TITLE_LENGTH = 200;
 const MAX_PLATFORM_LENGTH = 50;
 const MAX_KEY_LENGTH = 200;
-const MEMBER_ROLE_ID = "747520789003239530";
 const GIVEAWAY_DONATE_MODAL_ID = "giveaway-donate-modal";
 const GIVEAWAY_REVOKE_MODAL_ID = "giveaway-revoke-modal";
 const GIVEAWAY_DONATE_TITLE_ID = "giveaway-donate-title";

--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -4,5 +4,4 @@ export const ADMIN_ROLE_ID =
   process.env.ADMIN_ROLE_ID?.replace(/[<@&>]/g, "").trim() ?? null;
 export const MODERATOR_ROLE_ID =
   process.env.MODERATOR_ROLE_ID?.replace(/[<@&>]/g, "").trim() ?? null;
-export const MEMBER_ROLE_ID =
-  process.env.MEMBER_ROLE_ID?.replace(/[<@&>]/g, "").trim() ?? null;
+export const MEMBER_ROLE_ID = "747520789003239530";


### PR DESCRIPTION
## Summary
- Moved hardcoded `MEMBER_ROLE_ID = "747520789003239530"` from `src/commands/giveaway.command.ts` into `src/config/roles.ts`
- Updated the existing env-var-based `MEMBER_ROLE_ID` in `roles.ts` to use the hardcoded value (consistent with `REGULARS_ROLE_ID`/`NEWCOMERS_ROLE_ID` pattern)
- Added import of `MEMBER_ROLE_ID` from `src/config/roles.js` in `giveaway.command.ts`

Closes #578

## Verification
`grep -rn "747520789003239530" src/` returns exactly one hit: `src/config/roles.ts:7`

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Giveaway commands still correctly gate on member role

🤖 Generated with [Claude Code](https://claude.com/claude-code)