### PR TITLE
refactor: move formatStructuredLog() to LogUtils.ts and begin error logging standardization

### DIFF
--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -39,6 +39,7 @@ import {
   buildComponentsV2EditFlags,
 } from "../../functions/ComponentsV2Utils.js";
 import { flattenErrorMessages } from "../imports/import-scaffold.service.js";
+import { formatStructuredLog } from "../../utilities/LogUtils.js";
 import {
   buildAllCollectionsOverviewMessages,
   buildCollectionOverviewResponse,
@@ -164,7 +165,11 @@ export class CollectionViewCommand {
         ),
       ]);
     } catch (err) {
-      console.error("[collection list] Failed to build response:", err);
+      console.error(formatStructuredLog({
+        context: "collection list",
+        event: "build_response_failed",
+        error: err instanceof Error ? err.message : String(err),
+      }));
       await safeReply(
         interaction,
         buildTextReply("Failed to load your collection. Please try again.", isEphemeral),
@@ -186,14 +191,22 @@ export class CollectionViewCommand {
         flags: buildComponentsV2Flags(isEphemeral),
       });
     } catch (err) {
-      console.error("[collection list] safeReply failed:", err);
+      console.error(formatStructuredLog({
+        context: "collection list",
+        event: "safe_reply_failed",
+        error: err instanceof Error ? err.message : String(err),
+      }));
       try {
         await safeReply(
           interaction,
           buildTextReply("Failed to display collection. Please try again.", isEphemeral),
         );
       } catch (fallbackErr) {
-        console.error("[collection list] fallback safeReply also failed:", fallbackErr);
+        console.error(formatStructuredLog({
+          context: "collection list",
+          event: "fallback_safe_reply_failed",
+          error: fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr),
+        }));
       }
     }
     console.log("[collection list] step: reply sent");

--- a/src/commands/generate-vote-image.command.ts
+++ b/src/commands/generate-vote-image.command.ts
@@ -12,6 +12,7 @@ import { getUpcomingNominationWindow } from "../functions/NominationWindow.js";
 import { isAdmin } from "./admin/admin-auth.utils.js";
 import { composeVoteImage, type VoteImageType } from "../services/collageGenerator.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { formatStructuredLog } from "../utilities/LogUtils.js";
 
 const GENERATION_LOCK_TTL_MS = 2 * 60 * 1000;
 
@@ -49,10 +50,6 @@ function toVoteKind(value: string):
     return { nominationKind: "nr-gotm", label: "NR-GOTM" };
   }
   return null;
-}
-
-function formatStructuredLog(fields: Record<string, unknown>): string {
-  return JSON.stringify(fields);
 }
 
 @Discord()

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -99,6 +99,7 @@ import {
 
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { formatStructuredLog } from "../utilities/LogUtils.js";
 
 const MAX_NOW_PLAYING_NOTE_LEN = 500;
 const NOW_PLAYING_SEARCH_LIMIT = 10;
@@ -226,7 +227,11 @@ export async function restoreJournalMessageContextsFromDb(): Promise<void> {
     }
     console.log(`[Journal] Restored ${rows.length} message context(s) from DB.`);
   } catch (err) {
-    console.error("[Journal] Failed to restore message contexts from DB:", err);
+    console.error(formatStructuredLog({
+      context: "Journal",
+      event: "restore_contexts_failed",
+      error: err instanceof Error ? err.message : String(err),
+    }));
   }
 }
 
@@ -487,7 +492,11 @@ export async function trackNowPlayingJournalContext(
     createdAt,
     ownerUserId,
     gameId,
-  ).catch((err) => console.error("[Journal] Failed to persist message context:", err));
+  ).catch((err) => console.error(formatStructuredLog({
+    context: "Journal",
+    event: "persist_context_failed",
+    error: err instanceof Error ? err.message : String(err),
+  })));
 }
 
 export async function refreshJournalMessages(
@@ -506,7 +515,11 @@ export async function refreshJournalMessages(
     if (now - ctx.createdAt > NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS) {
       nowPlayingJournalContexts.delete(key);
       await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
-        .catch((err) => console.error("[Journal] Failed to delete expired context:", err));
+        .catch((err) => console.error(formatStructuredLog({
+          context: "Journal",
+          event: "delete_expired_context_failed",
+          error: err instanceof Error ? err.message : String(err),
+        })));
       continue;
     }
     const existing = latestByChannel.get(ctx.channelId);
@@ -522,7 +535,11 @@ export async function refreshJournalMessages(
       const key = `${ctx.channelId}:${ctx.messageId}`;
       nowPlayingJournalContexts.delete(key);
       await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
-        .catch((err) => console.error("[Journal] Failed to delete unreachable context:", err));
+        .catch((err) => console.error(formatStructuredLog({
+          context: "Journal",
+          event: "delete_unreachable_context_failed",
+          error: err instanceof Error ? err.message : String(err),
+        })));
       continue;
     }
     const message = await channel.messages.fetch(ctx.messageId).catch(() => null);
@@ -530,7 +547,11 @@ export async function refreshJournalMessages(
       const key = `${ctx.channelId}:${ctx.messageId}`;
       nowPlayingJournalContexts.delete(key);
       await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
-        .catch((err) => console.error("[Journal] Failed to delete missing context:", err));
+        .catch((err) => console.error(formatStructuredLog({
+          context: "Journal",
+          event: "delete_missing_context_failed",
+          error: err instanceof Error ? err.message : String(err),
+        })));
       continue;
     }
     const guildId = channel.isDMBased() ? null : (channel as any).guildId as string;
@@ -551,7 +572,11 @@ export async function refreshJournalMessages(
     await message.edit({
       components: payload.components as any[],
       files: payload.files,
-    }).catch((err) => console.error("[Journal] Failed to refresh public message:", err));
+    }).catch((err) => console.error(formatStructuredLog({
+      context: "Journal",
+      event: "refresh_public_message_failed",
+      error: err instanceof Error ? err.message : String(err),
+    })));
   }
 }
 
@@ -5338,7 +5363,11 @@ export class NowPlayingCommand {
       if (now - context.createdAt > NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS) {
         nowPlayingJournalContexts.delete(key);
         await Member.deleteJournalMessageContext(context.channelId, context.messageId)
-          .catch((err) => console.error("[Journal] Failed to delete expired context from DB:", err));
+          .catch((err) => console.error(formatStructuredLog({
+            context: "Journal",
+            event: "delete_expired_context_from_db_failed",
+            error: err instanceof Error ? err.message : String(err),
+          })));
         continue;
       }
       if (context.channelId !== channelId) continue;
@@ -5357,7 +5386,11 @@ export class NowPlayingCommand {
     if (!channel?.isTextBased()) {
       nowPlayingJournalContexts.delete(latestKey);
       await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
-        .catch((err) => console.error("[Journal] Failed to delete unreachable context from DB:", err));
+        .catch((err) => console.error(formatStructuredLog({
+          context: "Journal",
+          event: "delete_unreachable_context_from_db_failed",
+          error: err instanceof Error ? err.message : String(err),
+        })));
       return;
     }
 
@@ -5365,14 +5398,22 @@ export class NowPlayingCommand {
     if (!message) {
       nowPlayingJournalContexts.delete(latestKey);
       await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
-        .catch((err) => console.error("[Journal] Failed to delete missing context from DB:", err));
+        .catch((err) => console.error(formatStructuredLog({
+          context: "Journal",
+          event: "delete_missing_context_from_db_failed",
+          error: err instanceof Error ? err.message : String(err),
+        })));
       return;
     }
 
     await message.delete().catch(() => null);
     nowPlayingJournalContexts.delete(latestKey);
     await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
-      .catch((err) => console.error("[Journal] Failed to delete context from DB after message delete:", err));
+      .catch((err) => console.error(formatStructuredLog({
+        context: "Journal",
+        event: "delete_context_from_db_after_message_delete_failed",
+        error: err instanceof Error ? err.message : String(err),
+      })));
   }
 
   private async trackJournalReply(

--- a/src/utilities/LogUtils.ts
+++ b/src/utilities/LogUtils.ts
@@ -1,0 +1,3 @@
+export function formatStructuredLog(fields: Record<string, unknown>): string {
+  return JSON.stringify(fields);
+}


### PR DESCRIPTION
Closes #579

## Summary
- Creates `src/utilities/LogUtils.ts` exporting `formatStructuredLog(fields: Record<string, unknown>): string`
- Removes the local `formatStructuredLog()` definition from `generate-vote-image.command.ts` and imports from `LogUtils`
- Replaces ad-hoc `[collection list]`-prefixed `console.error()` calls in `collection-view.command.ts` with structured log calls
- Replaces all `[Journal]`-prefixed `console.error()` calls in `now-playing.command.ts` with structured log calls

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npm run lint` passes with no violations
- [ ] `grep -rn "formatStructuredLog" src/commands/generate-vote-image.command.ts` shows an import, not a definition
- [ ] No `[collection list]` or `[Journal]` string prefixes remain in console.error calls in the updated files

Part of shared-utilities-standardization-pass-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)