### PR TITLE
refactor: extract date-formatting utilities into DateFormatUtils.ts (#590)

### DIFF
--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -44,11 +44,7 @@ import {
   AVATAR_HISTORY_PAGE_SIZE,
   AVATAR_ALL_VIEW_PAGE_SIZE as ALL_VIEW_PAGE_SIZE,
 } from "../config/pagination.js";
-
-function formatTimestamp(date: Date): string {
-  const seconds = Math.floor(date.getTime() / 1000);
-  return `<t:${seconds}:F>`;
-}
+import { formatDiscordTimestamp } from "../functions/DateFormatUtils.js";
 
 type AvatarHistoryV2Page = {
   containers: ContainerBuilder[];
@@ -77,7 +73,7 @@ async function buildAvatarHistoryV2Page(
 
   history.forEach((entry, idx) => {
     const number = offset + idx + 1;
-    const description = `#${number} of ${totalCount} - ${formatTimestamp(entry.changedAt)}`;
+    const description = `#${number} of ${totalCount} - ${formatDiscordTimestamp(entry.changedAt)}`;
     if (entry.avatarUrl) {
       gallery.addItems(
         new MediaGalleryItemBuilder().setURL(entry.avatarUrl).setDescription(description),

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -21,7 +21,7 @@ import {
   safeReply,
   safeUpdate,
 } from "../../functions/InteractionUtils.js";
-import { formatDiscordTimestamp, formatPlaytimeHours } from "../profile.command.js";
+import { formatDiscordTimestamp, formatPlaytimeHours } from "../../functions/DateFormatUtils.js";
 import { igdbService } from "../../services/IGDB/IgdbService.js";
 import { createIgdbSession, type IgdbSelectOption } from "../../services/IGDB/IgdbSelectService.js";
 import { resolveNowPlayingRemoval } from "./completion-helpers.js";

--- a/src/commands/game-completion/completion-autocomplete.utils.ts
+++ b/src/commands/game-completion/completion-autocomplete.utils.ts
@@ -5,7 +5,7 @@ import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import Game, { type IPlatformDef } from "../../classes/Game.js";
 import Member from "../../classes/Member.js";
-import { formatTableDate } from "../profile.command.js";
+import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -14,10 +14,9 @@ import {
 import Member from "../../classes/Member.js";
 import {
   COMPLETION_TYPES,
-  formatDiscordTimestamp,
-  formatPlaytimeHours,
   parseCompletionDateInput,
 } from "../profile.command.js";
+import { formatDiscordTimestamp, formatPlaytimeHours } from "../../functions/DateFormatUtils.js";
 import {
   resolveGameCompletionPlatformId,
   resolveGameCompletionPlatformLabel,

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -13,11 +13,8 @@ import {
 import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import Member from "../../classes/Member.js";
 import Game from "../../classes/Game.js";
-import {
-  COMPLETION_PAGE_SIZE,
-  formatDiscordTimestamp,
-  formatTableDate,
-} from "../profile.command.js";
+import { COMPLETION_PAGE_SIZE } from "../profile.command.js";
+import { formatDiscordTimestamp, formatTableDate } from "../../functions/DateFormatUtils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { safeReply, safeUpdate } from "../../functions/InteractionUtils.js";
 import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -34,7 +34,7 @@ import type {
 } from "./completion.types.js";
 import { COMPLETION_TYPES } from "../profile.command.js";
 import { GAMEDB_CSV_PLATFORM_MAP } from "../../config/gamedbCsvPlatformMap.js";
-import { formatTableDate } from "../profile.command.js";
+import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { COMPLETIONATOR_MATCH_THUMBNAIL_NAME } from "./completion.types.js";
 import { isInteractionSettled, safeReply, safeUpdate } from "../../functions/InteractionUtils.js";

--- a/src/commands/game-completion/completionator-workflow.service.ts
+++ b/src/commands/game-completion/completionator-workflow.service.ts
@@ -27,8 +27,8 @@ import {
   resolveNowPlayingRemoval,
 } from "./completion-helpers.js";
 import { notifyUnknownCompletionPlatform } from "../../functions/CompletionHelpers.js";
-import { formatTableDate } from "../profile.command.js";
 import { COMPLETION_TYPES, type CompletionType } from "../profile.command.js";
+import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import { igdbService } from "../../services/IGDB/IgdbService.js";
 import { importGameFromIgdb } from "./completionator-parser.service.js";

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -59,7 +59,7 @@ import {
   JOURNAL_TITLE_INPUT_ID,
   JOURNAL_BODY_INPUT_ID,
 } from "../config/journalConstants.js";
-import { formatTableDate } from "./profile.command.js";
+import { formatTableDate } from "../functions/DateFormatUtils.js";
 import {
   trackNowPlayingJournalContext,
   refreshJournalMessages,

--- a/src/commands/gamedb/gamedb-csv-import.service.ts
+++ b/src/commands/gamedb/gamedb-csv-import.service.ts
@@ -15,7 +15,7 @@ import {
 } from "../../functions/CsvUtils.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
-import { formatTableDate } from "../profile.command.js";
+import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { igdbService, type IGDBGame } from "../../services/IGDB/IgdbService.js";
 import { type IgdbSelectOption } from "../../services/IGDB/IgdbSelectService.js";
 import Game from "../../classes/Game.js";

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -20,7 +20,7 @@ import { SeparatorSpacingSize } from "discord-api-types/v10";
 import { safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
-import { formatTableDate } from "../profile.command.js";
+import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { getHltbCacheByGameId } from "../../classes/HltbCache.js";
 import { getThreadsByGameId } from "../../classes/Thread.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -79,11 +79,13 @@ import {
 import {
   COMPLETION_TYPES,
   type CompletionType,
+  parseCompletionDateInput,
+} from "../commands/profile.command.js";
+import {
   formatDiscordTimestamp,
   formatPlaytimeHours,
   formatTableDate,
-  parseCompletionDateInput,
-} from "../commands/profile.command.js";
+} from "../functions/DateFormatUtils.js";
 import { parseTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { STANDARD_PLATFORM_IDS } from "../config/standardPlatforms.js";

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -35,6 +35,13 @@ import {
 import { buildTextReply, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import { buildUserHeaderContainer } from "../functions/uiComponents.js";
 import { buildComponentsV2Flags } from "../functions/NominationListComponents.js";
+import {
+  formatDiscordTimestamp,
+  formatPlaytimeHours,
+  formatTableDate,
+} from "../functions/DateFormatUtils.js";
+
+export { formatDiscordTimestamp, formatPlaytimeHours, formatTableDate };
 
 export const COMPLETION_TYPES = [
   "Main Story",
@@ -101,20 +108,6 @@ export function parseCompletionDateInput(value: string | undefined): Date | null
   return parsed;
 }
 
-export function formatPlaytimeHours(val: number | null | undefined): string | null {
-  if (val === null || val === undefined) return null;
-  const rounded = Math.round(val * 100) / 100;
-  return `${rounded} hours`;
-}
-
-export function formatTableDate(date: Date | null): string {
-  if (!date) return "No date";
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-  const year = date.getFullYear();
-  return `${month}/${day}/${year}`;
-}
-
 function summarizeFilters(filters: IMemberSearchFilters): string {
   const parts: string[] = [];
   if (filters.userId) parts.push(`userId~${filters.userId}`);
@@ -146,12 +139,6 @@ function chunkOptions<T>(items: T[], size: number): T[][] {
     chunks.push(items.slice(i, i + size));
   }
   return chunks;
-}
-
-export function formatDiscordTimestamp(value: Date | null): string {
-  if (!value) return "Unknown";
-  const seconds = Math.floor(value.getTime() / 1000);
-  return `<t:${seconds}:F>`;
 }
 
 function buildProfileContentContainer(

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -59,6 +59,7 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import { decodeBase64Url, encodeWithMaxLength } from "../functions/CustomIdUtils.js";
 import { safeV2TextContent } from "../functions/ComponentsV2Utils.js";
+import { formatDiscordTimestamp } from "../functions/DateFormatUtils.js";
 
 const TODO_LABELS = [
   "New Feature",
@@ -345,13 +346,6 @@ function toIssueState(filters: ListState[]): ListState {
   const normalized = normalizeStateFilters(filters);
   if (normalized.length > 1) return "all";
   return normalized[0] ?? "open";
-}
-
-function formatDiscordTimestamp(value: string | null | undefined): string {
-  if (!value) return "Unknown";
-  const ms = Date.parse(value);
-  if (Number.isNaN(ms)) return "Unknown";
-  return `<t:${Math.floor(ms / 1000)}:f>`;
 }
 
 function getTodoPermissionFlags(interaction: AnyRepliable): {

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -17,11 +17,8 @@ import {
   ThumbnailBuilder,
 } from "@discordjs/builders";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
-import {
-  type CompletionType,
-  formatPlaytimeHours,
-  formatTableDate,
-} from "../commands/profile.command.js";
+import { type CompletionType } from "../commands/profile.command.js";
+import { formatPlaytimeHours, formatTableDate } from "./DateFormatUtils.js";
 import Game, { type IGame } from "../classes/Game.js";
 import Member from "../classes/Member.js";
 import { ANNOUNCEMENT_CHANNEL_ID, BOT_DEV_CHANNEL_ID } from "../config/channels.js";

--- a/src/functions/DateFormatUtils.ts
+++ b/src/functions/DateFormatUtils.ts
@@ -1,0 +1,21 @@
+export function formatPlaytimeHours(val: number | null | undefined): string | null {
+  if (val === null || val === undefined) return null;
+  const rounded = Math.round(val * 100) / 100;
+  return `${rounded} hours`;
+}
+
+export function formatTableDate(date: Date | null): string {
+  if (!date) return "No date";
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const year = date.getFullYear();
+  return `${month}/${day}/${year}`;
+}
+
+export function formatDiscordTimestamp(value: Date | string | null | undefined): string {
+  if (!value) return "Unknown";
+  const date = value instanceof Date ? value : new Date(value);
+  if (isNaN(date.getTime())) return "Unknown";
+  const seconds = Math.floor(date.getTime() / 1000);
+  return `<t:${seconds}:F>`;
+}

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -13,7 +13,7 @@ import {
 import Member, { type ICompletionRecord } from "../classes/Member.js";
 import Game from "../classes/Game.js";
 import { getThreadsByGameId } from "../classes/Thread.js";
-import { formatTableDate, formatPlaytimeHours } from "../commands/profile.command.js";
+import { formatTableDate, formatPlaytimeHours } from "./DateFormatUtils.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
 import { buildUserHeaderContainer } from "./uiComponents.js";

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -10,7 +10,7 @@ import {
   renderUsernameWithEmoji,
 } from "../services/UserEmojiService.js";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
-import { formatTableDate } from "../commands/profile.command.js";
+import { formatTableDate } from "./DateFormatUtils.js";
 
 export interface IJournalSelectEntry {
   gameId: number;


### PR DESCRIPTION
## Summary
- Creates `src/functions/DateFormatUtils.ts` with the three canonical functions: `formatTableDate()`, `formatDiscordTimestamp()`, and `formatPlaytimeHours()`
- Removes the definitions from `profile.command.ts` (re-exported for any remaining imports that still pull from there)
- Deletes two divergent local reimplementations: `formatDiscordTimestamp()` in `todo.command.ts` (used `:f` format instead of canonical `:F`) and `formatTimestamp()` in `avatar-history.command.ts`
- Updates all 14 import sites across commands and functions directories

The new `formatDiscordTimestamp` accepts `Date | string | null | undefined` to cover both the `Date`-typed fields (profile, completions) and `string`-typed fields (GitHub issue timestamps in todo.command.ts).

## Verification
```
grep -rn "from.*profile.command.*formatTable\|from.*profile.command.*formatDiscord" src/
```
Returns zero hits.

## Test plan
- [ ] `npx tsc --noEmit` passes with no errors
- [ ] `npm run lint` passes with no violations
- [ ] Discord timestamps render correctly in profile, completion, and todo embeds

Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)