### PR TITLE
refactor: centralize access-denied error message strings (#591)

### DIFF
--- a/src/commands/admin/admin-auth.utils.ts
+++ b/src/commands/admin/admin-auth.utils.ts
@@ -1,5 +1,5 @@
 import { PermissionsBitField } from "discord.js";
-import { AnyRepliable, safeReply } from "../../functions/InteractionUtils.js";
+import { ACCESS_DENIED_ADMIN, AnyRepliable, safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 
 export async function isAdmin(interaction: AnyRepliable): Promise<boolean> {
@@ -12,7 +12,7 @@ export async function isAdmin(interaction: AnyRepliable): Promise<boolean> {
 
   if (!isAdmin) {
     try {
-      await safeReply(interaction, buildTextReply("Access denied. Command requires Administrator role.", true));
+      await safeReply(interaction, buildTextReply(ACCESS_DENIED_ADMIN, true));
     } catch {
       // swallow to avoid leaking
     }

--- a/src/commands/gamedb/gamedb-csv-import.command.ts
+++ b/src/commands/gamedb/gamedb-csv-import.command.ts
@@ -26,6 +26,7 @@ import axios from "axios";
 import {
   safeDeferReply,
   getModalField,
+  ACCESS_DENIED_SERVER_OWNER,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
@@ -365,7 +366,7 @@ export class GameDbCsvImportCommand {
     }
 
     await safeReply(interaction,
-      buildTextReply("Access denied. Command requires server owner.", true));
+      buildTextReply(ACCESS_DENIED_SERVER_OWNER, true));
     return false;
   }
 

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -7,7 +7,12 @@ import {
   type MessageActionRowComponent,
   type AutocompleteInteraction,
 } from "discord.js";
-import { AnyRepliable, safeReply, sanitizeUserInput } from "../../functions/InteractionUtils.js";
+import {
+  ACCESS_DENIED_MOD_ADMIN,
+  AnyRepliable,
+  safeReply,
+  sanitizeUserInput,
+} from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { decodeBase64Url, encodeBase64Url } from "../../functions/CustomIdUtils.js";
@@ -129,10 +134,7 @@ export async function requireModeratorOrAdminOrOwner(
     return true;
   }
 
-  await safeReply(interaction, buildTextReply(
-    "Access denied. Action requires Moderator, Administrator, or server owner.",
-    true,
-  ));
+  await safeReply(interaction, buildTextReply(ACCESS_DENIED_MOD_ADMIN, true));
   return false;
 }
 

--- a/src/commands/mod.command.ts
+++ b/src/commands/mod.command.ts
@@ -12,6 +12,7 @@ import { Discord, SelectMenuComponent, Slash, SlashGroup, SlashOption } from "di
 import { getPresenceHistory, setPresence } from "../functions/SetPresence.js";
 import {
   AnyRepliable,
+  ACCESS_DENIED_MOD,
   safeDeferReply,
   safeReply,
   safeUpdate,
@@ -214,7 +215,7 @@ export async function isModerator(interaction: AnyRepliable) {
 
     if (!isAdmin) {
       const denial = {
-        content: "Access denied. Command requires Moderator role or above.",
+        content: ACCESS_DENIED_MOD,
         flags: MessageFlags.Ephemeral,
       };
 

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -19,6 +19,7 @@ import {
   SlashChoice,
 } from "discordx";
 import {
+  ACCESS_DENIED_OWNER,
   AnyRepliable,
   canSafeReply,
   extractErrorMessage,
@@ -924,7 +925,7 @@ export async function isSuperAdmin(interaction: AnyRepliable): Promise<boolean> 
 
   if (!isOwner) {
     const denial = {
-      content: "Access denied. Command is restricted to the server owner.",
+      content: ACCESS_DENIED_OWNER,
       flags: MessageFlags.Ephemeral,
     };
 

--- a/src/commands/thread-admin.command.ts
+++ b/src/commands/thread-admin.command.ts
@@ -5,7 +5,11 @@ import {
 import { Discord, Slash, SlashGroup, SlashOption } from "discordx";
 import { removeThreadGameLink, setThreadGameLink } from "../classes/Thread.js";
 import { REGULARS_ROLE_ID } from "../config/roles.js";
-import { safeReply, sanitizeUserInput } from "../functions/InteractionUtils.js";
+import {
+  ACCESS_DENIED_REGULARS,
+  safeReply,
+  sanitizeUserInput,
+} from "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 
 @Discord()
@@ -32,7 +36,7 @@ export class ThreadAdminCommands {
   ): Promise<void> {
     threadId = sanitizeUserInput(threadId, { preserveNewlines: false });
     if (!this.hasRegularsRole(interaction)) {
-      await safeReply(interaction, buildTextReply("Access denied. Command requires the Regulars role.", true));
+      await safeReply(interaction, buildTextReply(ACCESS_DENIED_REGULARS, true));
       return;
     }
 
@@ -60,7 +64,7 @@ export class ThreadAdminCommands {
   ): Promise<void> {
     threadId = sanitizeUserInput(threadId, { preserveNewlines: false });
     if (!this.hasRegularsRole(interaction)) {
-      await safeReply(interaction, buildTextReply("Access denied. Command requires the Regulars role.", true));
+      await safeReply(interaction, buildTextReply(ACCESS_DENIED_REGULARS, true));
       return;
     }
 

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -31,6 +31,8 @@ import {
   SlashOption,
 } from "discordx";
 import {
+  ACCESS_DENIED_MOD_ADMIN,
+  ACCESS_DENIED_SERVER_OWNER,
   AnyRepliable,
   safeDeferReply,
   safeDeferUpdate,
@@ -388,7 +390,7 @@ async function requireModeratorOrAdminOrOwner(
   await safeReply(
     interaction,
     buildTodoTextReply(
-      "Access denied. Command requires Moderator, Administrator, or server owner.",
+      ACCESS_DENIED_MOD_ADMIN,
       true,
     ),
   );
@@ -411,7 +413,7 @@ async function requireOwner(interaction: AnyRepliable): Promise<boolean> {
 
   await safeReply(
     interaction,
-    buildTodoTextReply("Access denied. Command requires server owner.", true),
+    buildTodoTextReply(ACCESS_DENIED_SERVER_OWNER, true),
   );
   return false;
 }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -512,6 +512,13 @@ export function extractErrorMessage(err: unknown): string {
 }
 
 export const OWNER_ONLY_MESSAGE = "This list isn't for you.";
+export const ACCESS_DENIED_ADMIN = "Access denied. Command requires Administrator role.";
+export const ACCESS_DENIED_MOD = "Access denied. Command requires Moderator role or above.";
+export const ACCESS_DENIED_MOD_ADMIN =
+  "Access denied. Command requires Moderator, Administrator, or server owner.";
+export const ACCESS_DENIED_OWNER = "Access denied. Command is restricted to the server owner.";
+export const ACCESS_DENIED_SERVER_OWNER = "Access denied. Command requires server owner.";
+export const ACCESS_DENIED_REGULARS = "Access denied. Command requires the Regulars role.";
 export const SHOW_IN_CHAT_DESCRIPTION = "Show in chat (public) instead of ephemeral";
 
 /** Returns true and replies ephemerally if user is not the owner. */


### PR DESCRIPTION
## Summary

- Adds six `ACCESS_DENIED_*` constants to `src/functions/InteractionUtils.ts` near the existing `OWNER_ONLY_MESSAGE`
- Replaces all eight hardcoded `"Access denied."` strings across 7 files with the new shared constants
- Standardizes the "Action requires" wording in `gamedb-utils.ts` to match the "Command requires" convention used elsewhere

## Files changed

| File | Constant used |
|---|---|
| `admin/admin-auth.utils.ts` | `ACCESS_DENIED_ADMIN` |
| `thread-admin.command.ts` | `ACCESS_DENIED_REGULARS` (x2) |
| `mod.command.ts` | `ACCESS_DENIED_MOD` |
| `gamedb/gamedb-utils.ts` | `ACCESS_DENIED_MOD_ADMIN` |
| `gamedb/gamedb-csv-import.command.ts` | `ACCESS_DENIED_SERVER_OWNER` |
| `todo.command.ts` | `ACCESS_DENIED_MOD_ADMIN`, `ACCESS_DENIED_SERVER_OWNER` |
| `superadmin.command.ts` | `ACCESS_DENIED_OWNER` |

## Verification

```
grep -rn '"Access denied\.' src/
```
Returns zero hits outside of `InteractionUtils.ts`.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npm run lint` passes (verified)
- [ ] Access-denied replies still display correctly for each guarded command

Closes #591

🤖 Generated with [Claude Code](https://claude.com/claude-code)