### PR TITLE
refactor: create textLimits.ts and replace magic-number truncations (#592)

### DIFF
--- a/src/commands/game-completion/completion-common.service.ts
+++ b/src/commands/game-completion/completion-common.service.ts
@@ -20,6 +20,7 @@ import {
   COMPLETION_PAGE_SIZE,
 } from "../profile.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { MAX_CONTAINER_TEXT, MAX_SECTION_TEXT } from "../../config/textLimits.js";
 
 export type CommonCompletionSort =
   | "title_asc"
@@ -331,7 +332,7 @@ function buildV2Flags(ephemeral: boolean): number {
   return buildComponentsV2Flags(ephemeral);
 }
 
-const CHUNK_LIMIT = 3500;
+const CHUNK_LIMIT = MAX_CONTAINER_TEXT;
 
 function pushChunked(containers: ContainerBuilder[], lines: string[]): void {
   let buffer = "";
@@ -417,7 +418,7 @@ export async function renderCommonCompletionPage(
   containers.push(
     new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent(
-        safeV2TextContent(`## Shared Completions\n### ${leftDisplay} & ${rightDisplay}`, 3500),
+        safeV2TextContent(`## Shared Completions\n### ${leftDisplay} & ${rightDisplay}`, MAX_CONTAINER_TEXT),
       ),
     ),
   );
@@ -443,7 +444,7 @@ export async function renderCommonCompletionPage(
   }
   containers.push(
     new ContainerBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(safeV2TextContent(footerLines.join("\n"), 1000)),
+      new TextDisplayBuilder().setContent(safeV2TextContent(footerLines.join("\n"), MAX_SECTION_TEXT)),
     ),
   );
 

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -21,6 +21,11 @@ import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2U
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import {
+  DISCORD_SELECT_LABEL_MAX,
+  DISCORD_SELECT_OPTIONS_MAX,
+  MAX_QUERY_LENGTH,
+} from "../../config/textLimits.js";
+import {
   buildJournalSelectRow,
   buildUserHeaderContainer,
   type IJournalSelectEntry,
@@ -71,7 +76,7 @@ export async function renderCompletionLeaderboard(
   );
 
   const options = leaderboard.map((m) => ({
-    label: (m.globalName ?? m.username ?? m.userId).slice(0, 100),
+    label: (m.globalName ?? m.username ?? m.userId).slice(0, DISCORD_SELECT_LABEL_MAX),
     value: m.userId,
     description: `${m.count} ${m.count === 1 ? "completion" : "completions"}`,
   }));
@@ -79,7 +84,7 @@ export async function renderCompletionLeaderboard(
   const select = new StringSelectMenuBuilder()
     .setCustomId(
       // eslint-disable-next-line local/custom-id-has-matching-handler
-      `comp-leaderboard-select${trimmedQuery ? `:${trimmedQuery.slice(0, 50)}` : ""}`,
+      `comp-leaderboard-select${trimmedQuery ? `:${trimmedQuery.slice(0, MAX_QUERY_LENGTH)}` : ""}`,
     )
     .setPlaceholder("View completions for a member")
     .addOptions(options);
@@ -145,7 +150,7 @@ export async function renderCompletionPage(
 
   const { containers, totalPages, safePage, sortedYears, yearCounts, journalEntries } = result;
   const yearPart = year == null ? "" : String(year);
-  const queryPart = query ? `:${query.slice(0, 50)}` : "";
+  const queryPart = query ? `:${query.slice(0, MAX_QUERY_LENGTH)}` : "";
   const clearFilterCustomId = year !== null ? `comp-clear-year-filter:${userId}` : undefined;
   const paginationRows = buildPaginationRows(
     totalPages,
@@ -207,11 +212,11 @@ export async function renderSelectionPage(
   const { containers, totalPages, safePage, pageCompletions } = result;
 
   const selectOptions = pageCompletions.map((c) => ({
-    label: c.title.slice(0, 100),
+    label: c.title.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(c.completionId),
     description: `${c.completionType} (${
       c.completedAt ? formatDiscordTimestamp(c.completedAt) : "No date"
-    })`.slice(0, 100),
+    })`.slice(0, DISCORD_SELECT_LABEL_MAX),
   }));
 
   const selectId = mode === "edit" ? "comp-edit-menu" : "comp-del-menu";
@@ -223,7 +228,7 @@ export async function renderSelectionPage(
   const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
 
   const yearPart = year == null ? "" : String(year);
-  const queryPart = query ? `:${query.slice(0, 50)}` : "";
+  const queryPart = query ? `:${query.slice(0, MAX_QUERY_LENGTH)}` : "";
   const paginationRows = buildPaginationRows(
     totalPages,
     safePage,
@@ -255,7 +260,7 @@ function buildYearJumpRow(
 ): ActionRowBuilder<StringSelectMenuBuilder> | null {
   if (activeYear !== null || query || totalPages <= 5 || sortedYears.length <= 3) return null;
 
-  const options = sortedYears.slice(0, 25).map((yr) => {
+  const options = sortedYears.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((yr) => {
     const count = yearCounts[yr] ?? 0;
     const label = yr === "Unknown" ? "Unknown Date" : yr;
     const gameWord = count === 1 ? "game" : "games";

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -50,6 +50,7 @@ import {
 } from "./gamedb-profile.service.js";
 import { handleNoResults } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { MAX_CONTAINER_TEXT } from "../../config/textLimits.js";
 
 function formatUpcomingDate(date: Date | null | undefined): string {
   if (!date) return "";
@@ -220,7 +221,7 @@ function buildSearchResponse(
       `## ${title}\n\n${listText}\n\n*${results.length} results total*${filterNote}`,
     );
     const container = new ContainerBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(safeV2TextContent(content, 3500)),
+      new TextDisplayBuilder().setContent(safeV2TextContent(content, MAX_CONTAINER_TEXT)),
     );
     components.push(container);
   }

--- a/src/config/textLimits.ts
+++ b/src/config/textLimits.ts
@@ -1,0 +1,13 @@
+// Discord API hard limits
+export const DISCORD_SELECT_LABEL_MAX = 100;
+export const DISCORD_SELECT_OPTIONS_MAX = 25;
+export const DISCORD_EMBED_TITLE_MAX = 256;
+export const DISCORD_EMBED_DESCRIPTION_MAX = 4096;
+export const DISCORD_BUTTON_LABEL_MAX = 80;
+export const DISCORD_MODAL_TITLE_MAX = 45;
+export const DISCORD_TEXT_INPUT_MAX = 4000;
+
+// Application-defined limits
+export const MAX_QUERY_LENGTH = 50;
+export const MAX_CONTAINER_TEXT = 3500;
+export const MAX_SECTION_TEXT = 1000;

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -11,6 +11,7 @@ import {
 } from "../services/UserEmojiService.js";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
 import { formatTableDate } from "./DateFormatUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 export interface IJournalSelectEntry {
   gameId: number;
@@ -27,10 +28,13 @@ export function buildJournalSelectRow(
   const sorted = [...entries].sort((a, b) => a.title.localeCompare(b.title));
   const options = sorted.map((e) => {
     const rawLabel = `${e.title} Game Journal`;
-    const label = rawLabel.length > 100 ? `${rawLabel.slice(0, 97)}...` : rawLabel;
+    const label =
+      rawLabel.length > DISCORD_SELECT_LABEL_MAX
+        ? `${rawLabel.slice(0, DISCORD_SELECT_LABEL_MAX - 3)}...`
+        : rawLabel;
     const countText = e.journalCount === 1 ? "1 entry" : `${e.journalCount} entries`;
     const lastPart = e.lastJournalAt ? ` · Last entry ${formatTableDate(e.lastJournalAt)}` : "";
-    const description = `${countText}${lastPart}`.slice(0, 100);
+    const description = `${countText}${lastPart}`.slice(0, DISCORD_SELECT_LABEL_MAX);
     return { label, description, value: String(e.gameId) };
   });
   const select = new StringSelectMenuBuilder()


### PR DESCRIPTION
## Summary
- Creates `src/config/textLimits.ts` with named constants for Discord API hard limits and application-defined limits
- Replaces bare `.slice(0, N)` and `safeV2TextContent(..., N)` literals in the four priority files from issue #592: `completion-list.service.ts`, `completion-common.service.ts`, `gamedb-search.command.ts`, and `uiComponents.ts`
- Full sweep of remaining ~80 sites is a follow-on PR as noted in the issue

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Completion leaderboard and pagination still render correctly
- [ ] Game search results still display correctly

Closes #592

🤖 Generated with [Claude Code](https://claude.com/claude-code)