### PR TITLE
refactor: unify isAdmin/isModerator imports to single canonical module

### DIFF
--- a/src/commands/admin.command.ts
+++ b/src/commands/admin.command.ts
@@ -423,6 +423,3 @@ export class Admin {
     });
   }
 }
-
-// Export isAdmin for external use
-export { isAdmin };

--- a/src/commands/admin/admin-auth.utils.ts
+++ b/src/commands/admin/admin-auth.utils.ts
@@ -1,5 +1,10 @@
-import { PermissionsBitField } from "discord.js";
-import { ACCESS_DENIED_ADMIN, AnyRepliable, safeReply } from "../../functions/InteractionUtils.js";
+import { MessageFlags, PermissionsBitField } from "discord.js";
+import {
+  ACCESS_DENIED_ADMIN,
+  ACCESS_DENIED_MOD,
+  AnyRepliable,
+  safeReply,
+} from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 
 export async function isAdmin(interaction: AnyRepliable): Promise<boolean> {
@@ -19,4 +24,31 @@ export async function isAdmin(interaction: AnyRepliable): Promise<boolean> {
   }
 
   return isAdmin;
+}
+
+export async function isModerator(interaction: AnyRepliable): Promise<boolean> {
+  const member: any = (interaction as any).member;
+  const canCheck =
+    member && typeof member.permissionsIn === "function" && interaction.channel;
+  let isMod = canCheck
+    ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.ManageMessages)
+    : false;
+
+  if (!isMod) {
+    const isAdminCheck = canCheck
+      ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.Administrator)
+      : false;
+
+    if (!isAdminCheck) {
+      const denial = {
+        content: ACCESS_DENIED_MOD,
+        flags: MessageFlags.Ephemeral,
+      };
+      await safeReply(interaction, denial as any);
+    } else {
+      isMod = true;
+    }
+  }
+
+  return isMod;
 }

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -53,7 +53,7 @@ import {
   type AutoAcceptResult,
   type AllAcceptStats,
 } from "../services/GamedbAuditService.js";
-import { isAdmin } from "./admin.command.js";
+import { isAdmin } from "./admin/admin-auth.utils.js";
 import Game, { IGame } from "../classes/Game.js";
 import GameSearchSynonym from "../classes/GameSearchSynonym.js";
 import GameSearchSynonymDraft, {

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -43,7 +43,7 @@ import {
   revokeGameKey,
 } from "../classes/GameKey.js";
 import Member from "../classes/Member.js";
-import { isAdmin } from "./admin.command.js";
+import { isAdmin } from "./admin/admin-auth.utils.js";
 import {
   buildKeyListEmbed,
   getAvailableKeysPage,

--- a/src/commands/help.command.ts
+++ b/src/commands/help.command.ts
@@ -13,9 +13,9 @@ import {
   MessageFlags,
 } from "discord.js";
 import { ButtonComponent, Discord, SelectMenuComponent, Slash } from "discordx";
-import { isAdmin } from "./admin.command.js";
+import { isAdmin, isModerator } from "./admin/admin-auth.utils.js";
 import { buildAdminHelpResponse } from "./admin/admin-help.service.js";
-import { buildModHelpResponse, isModerator } from "./mod.command.js";
+import { buildModHelpResponse } from "./mod.command.js";
 import { buildSuperAdminHelpResponse, isSuperAdmin } from "./superadmin.command.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { safeDeferReply, safeReply, safeUpdate } from "../functions/InteractionUtils.js";

--- a/src/commands/mod.command.ts
+++ b/src/commands/mod.command.ts
@@ -3,16 +3,14 @@ import {
   ApplicationCommandOptionType,
   EmbedBuilder,
   MessageFlags,
-  PermissionsBitField,
   StringSelectMenuBuilder,
   type StringSelectMenuInteraction,
 } from "discord.js";
 import type { CommandInteraction } from "discord.js";
 import { Discord, SelectMenuComponent, Slash, SlashGroup, SlashOption } from "discordx";
 import { getPresenceHistory, setPresence } from "../functions/SetPresence.js";
+import { isModerator } from "./admin/admin-auth.utils.js";
 import {
-  AnyRepliable,
-  ACCESS_DENIED_MOD,
   safeDeferReply,
   safeReply,
   safeUpdate,
@@ -200,33 +198,6 @@ export class Mod {
   }
 }
 
-export async function isModerator(interaction: AnyRepliable) {
-  const member: any = (interaction as any).member;
-  const canCheck =
-    member && typeof member.permissionsIn === "function" && interaction.channel;
-  let isMod = canCheck
-    ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.ManageMessages)
-    : false;
-
-  if (!isMod) {
-    const isAdmin = canCheck
-      ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.Administrator)
-      : false;
-
-    if (!isAdmin) {
-      const denial = {
-        content: ACCESS_DENIED_MOD,
-        flags: MessageFlags.Ephemeral,
-      };
-
-      await safeReply(interaction, denial as any);
-    } else {
-      isMod = true;
-    }
-  }
-
-  return isMod;
-}
 export function buildModHelpResponse(
   activeTopicId?: ModHelpTopicId,
 ): {

--- a/src/commands/moderator-live-event.command.ts
+++ b/src/commands/moderator-live-event.command.ts
@@ -1,6 +1,6 @@
 import type { CommandInteraction, ModalSubmitInteraction } from "discord.js";
 import { Discord, ModalComponent, Slash, SlashGroup } from "discordx";
-import { isModerator } from "./mod.command.js";
+import { isModerator } from "./admin/admin-auth.utils.js";
 import {
   handleLiveStreamCreateModal,
   openLiveStreamCreateModal,

--- a/src/commands/publicreminder.command.ts
+++ b/src/commands/publicreminder.command.ts
@@ -8,7 +8,7 @@ import {
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
-import { isAdmin } from "./admin.command.js";
+import { isAdmin } from "./admin/admin-auth.utils.js";
 import {
   createReminder,
   deleteReminder,

--- a/src/commands/rss.command.ts
+++ b/src/commands/rss.command.ts
@@ -8,7 +8,7 @@ import {
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
-import { isAdmin } from "./admin.command.js";
+import { isAdmin } from "./admin/admin-auth.utils.js";
 import { addFeed, listFeeds, removeFeed, updateFeed } from "../classes/RssFeed.js";
 import { buildRssHelpResponse } from "./help.command.js";
 


### PR DESCRIPTION
## Summary

- Moved `isModerator` from `src/commands/mod.command.ts` into `src/commands/admin/admin-auth.utils.ts` alongside `isAdmin`
- Updated all `isAdmin` import sites that were using the `admin.command.ts` re-export to point directly to `admin-auth.utils.ts`
- Updated all `isModerator` import sites (`mod.command.ts`, `moderator-live-event.command.ts`, `help.command.ts`) to import from `admin-auth.utils.ts`
- Removed the `isAdmin` re-export from `admin.command.ts`
- Cleaned up `mod.command.ts` unused imports (`AnyRepliable`, `PermissionsBitField`) left over after the move

Verification: `grep -rn "from.*admin\.command.*isAdmin" src/` returns zero hits.

Closes #593

## Test plan

- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] All permission-gated commands still deny non-admins/non-mods
- [ ] All permission-gated commands still allow admins/mods

🤖 Generated with [Claude Code](https://claude.com/claude-code)