### PR TITLE
refactor: add parseCustomIdSegments() and migrate highest-traffic handlers

### DIFF
--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -39,6 +39,7 @@ import { getUserEmojiData, renderUsernameWithEmoji } from "../services/UserEmoji
 import { buildTitleHeaderContainer, buildUserHeaderContainer } from "../functions/uiComponents.js";
 import { safeDeferUpdate } from "../functions/InteractionUtils.js";
 import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { isAdmin } from "./admin/admin-auth.utils.js";
 import {
   AVATAR_HISTORY_PAGE_SIZE,
@@ -336,7 +337,9 @@ export class AvatarHistoryCommand {
 
   @ButtonComponent({ id: /^avatar-history-page:\d+:\d+:\d+:(prev|next)$/ })
   async handlePage(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, targetId, pageRaw, dir] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 4);
+    if (!segments) return;
+    const [ownerId, targetId, pageRaw, dir] = segments;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const parsed = parseDirAndPage(pageRaw, dir);
@@ -372,7 +375,9 @@ export class AvatarHistoryCommand {
 
   @ButtonComponent({ id: /^avatar-history-all-page:\d+:\d+:(prev|next)$/ })
   async handleAllPage(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, pageRaw, dir] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 3);
+    if (!segments) return;
+    const [ownerId, pageRaw, dir] = segments;
     if (await replyIfNotOwner(interaction, ownerId)) return;
     const parsed = parseDirAndPage(pageRaw, dir);
     if (!parsed) return;
@@ -402,7 +407,9 @@ export class AvatarHistoryCommand {
 
   @SelectMenuComponent({ id: /^avatar-history-all-select:\d+$/ })
   async handleAllSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 1);
+    if (!segments) return;
+    const [ownerId] = segments;
     if (await replyIfNotOwner(interaction, ownerId)) return;
     const targetId = interaction.values[0];
     if (!targetId) return;

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -67,6 +67,7 @@ import {
 import { NOW_PLAYING_HELP_PREFIX } from "./now-playing-help.js";
 import { EphemeralOwnerMenu } from "../functions/EphemeralOwnerMenu.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import {
   JOURNAL_LIST_PAGE_SIZE as LIST_PAGE_SIZE,
   JOURNAL_ALL_PAGE_SIZE as ALL_PAGE_SIZE,
@@ -603,7 +604,9 @@ export class GameJournalCommand {
 
   @SelectMenuComponent({ id: new RegExp(`^${GJ_LIST_SELECT_PREFIX}:\\d+:\\d+:\\d+$`) })
   async handleListSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, callerId, targetUserId] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 3);
+    if (!segments) return;
+    const [callerId, targetUserId] = segments;
     if (interaction.user.id !== callerId) {
       await safeReply(interaction, buildTextReply("This journal list isn't yours to navigate.", true));
       return;
@@ -634,7 +637,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: new RegExp(`^${GJ_LIST_PAGE_PREFIX}:\\d+:\\d+:\\d+$`) })
   async handleListPage(interaction: ButtonInteraction): Promise<void> {
-    const [, callerId, targetUserId, pageRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 3);
+    if (!segments) return;
+    const [callerId, targetUserId, pageRaw] = segments;
     if (interaction.user.id !== callerId) {
       await safeReply(interaction, buildTextReply("This journal list isn't yours to navigate.", true));
       return;
@@ -664,7 +669,9 @@ export class GameJournalCommand {
 
   @SelectMenuComponent({ id: new RegExp(`^${GJ_ALL_SELECT_PREFIX}:\\d+:\\d+$`) })
   async handleAllSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, callerId] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 2);
+    if (!segments) return;
+    const [callerId] = segments;
     if (interaction.user.id !== callerId) {
       await safeReply(interaction, buildTextReply("This member list isn't yours to navigate.", true));
       return;
@@ -701,7 +708,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: new RegExp(`^${GJ_ALL_PAGE_PREFIX}:\\d+:\\d+$`) })
   async handleAllPage(interaction: ButtonInteraction): Promise<void> {
-    const [, callerId, pageRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 2);
+    if (!segments) return;
+    const [callerId, pageRaw] = segments;
     if (interaction.user.id !== callerId) {
       await safeReply(interaction, buildTextReply("This member list isn't yours to navigate.", true));
       return;
@@ -789,7 +798,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: new RegExp(`^${GJ_VIEW_PAGE_PREFIX}:\\d+:\\d+:\\d+:\\d+$`) })
   async handleViewPage(interaction: ButtonInteraction): Promise<void> {
-    const [, callerId, targetUserId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 4);
+    if (!segments) return;
+    const [callerId, targetUserId, gameIdRaw, pageRaw] = segments;
     if (interaction.user.id !== callerId) {
       await safeReply(interaction, buildTextReply("This journal isn't yours to navigate.", true));
       return;
@@ -819,7 +830,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: /^game-journal-header-add:\d+:\d+:\d+$/ })
   async handleHeaderAdd(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 3);
+    if (!segments) return;
+    const [ownerId, gameIdRaw, pageRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
@@ -835,7 +848,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: /^game-journal-hmenu-add:\d+:\d+$/ })
   async handleGjHmenuAdd(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 2);
+    if (!segments) return;
+    const [ownerId, gameIdRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
@@ -849,7 +864,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: /^game-journal-hmenu-edit:\d+:\d+:\d+$/ })
   async handleGjHmenuEdit(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 3);
+    if (!segments) return;
+    const [ownerId, gameIdRaw, pageRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
@@ -888,7 +905,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: /^game-journal-hmenu-delete:\d+:\d+$/ })
   async handleGjHmenuDelete(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 2);
+    if (!segments) return;
+    const [ownerId, gameIdRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
@@ -946,7 +965,9 @@ export class GameJournalCommand {
   async handleGjHmenuDeleteSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 2);
+    if (!segments) return;
+    const [ownerId, gameIdRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
@@ -992,7 +1013,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: /^game-journal-hmenu-delete-confirm:(yes|no):\d+:\d+:\d+$/ })
   async handleGjHmenuDeleteConfirm(interaction: ButtonInteraction): Promise<void> {
-    const [, action, ownerId, gameIdRaw, entryIdRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 4);
+    if (!segments) return;
+    const [action, ownerId, gameIdRaw, entryIdRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
@@ -1020,7 +1043,9 @@ export class GameJournalCommand {
 
   @ModalComponent({ id: /^game-journal-hmenu-add-modal:\d+:\d+$/ })
   async handleGjHmenuAddModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 2);
+    if (!segments) return;
+    const [ownerId, gameIdRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can submit journal entries.", false));
       return;
@@ -1049,7 +1074,9 @@ export class GameJournalCommand {
 
   @ModalComponent({ id: /^game-journal-hmenu-edit-modal:\d+:\d+:\d+$/ })
   async handleGjHmenuEditModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, entryIdRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 3);
+    if (!segments) return;
+    const [ownerId, gameIdRaw, entryIdRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can edit journal entries.", false));
       return;
@@ -1083,7 +1110,9 @@ export class GameJournalCommand {
 
   @ButtonComponent({ id: new RegExp(`^${GJ_CLOSE_PREFIX}:\\d+$`) })
   async handlePublicClose(interaction: ButtonInteraction): Promise<void> {
-    const [, callerId] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 1);
+    if (!segments) return;
+    const [callerId] = segments;
     if (interaction.user.id !== callerId) {
       await safeReply(
         interaction,

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -40,6 +40,7 @@ import {
   GUILD_FETCH_CHUNK_SIZE,
   MP_INFO_PAGE_SIZE as PAGE_SIZE,
 } from "../config/pagination.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 const MAX_OPTIONS = 25;
 
@@ -325,7 +326,9 @@ export class MultiplayerInfoCommand {
 
   @SelectMenuComponent({ id: /^mpinfo-select:\d+:[01]{4}:\d+$/ })
   async handleProfileSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId, filterKey, pageRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 3);
+    if (!segments) return;
+    const [ownerId, filterKey, pageRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This menu isn't for you.", true));
       return;
@@ -396,7 +399,9 @@ export class MultiplayerInfoCommand {
 
   @ButtonComponent({ id: /^mpinfo-back:\d+:[01]{4}:\d+$/ })
   async handleBackToList(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, filterKey, pageRaw] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 3);
+    if (!segments) return;
+    const [ownerId, filterKey, pageRaw] = segments;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This menu isn't for you.", true));
       return;
@@ -411,7 +416,9 @@ export class MultiplayerInfoCommand {
 
   @ButtonComponent({ id: /^mpinfo-page:\d+:[01]{4}:\d+:(prev|next)$/ })
   async handlePageButton(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, filterKey, pageRaw, dir] = interaction.customId.split(":");
+    const segments = parseCustomIdSegments(interaction.customId, 4);
+    if (!segments) return;
+    const [ownerId, filterKey, pageRaw, dir] = segments;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This menu isn't for you.", true));
       return;

--- a/src/utilities/CustomIdUtils.ts
+++ b/src/utilities/CustomIdUtils.ts
@@ -1,0 +1,13 @@
+/**
+ * Splits a colon-delimited custom ID and returns the segments after the prefix.
+ * Returns null if the segment count does not match expectedCount.
+ */
+export function parseCustomIdSegments(
+  customId: string,
+  expectedCount: number,
+): string[] | null {
+  const parts = customId.split(":");
+  const segments = parts.slice(1);
+  if (segments.length !== expectedCount) return null;
+  return segments;
+}


### PR DESCRIPTION
Closes #594

## Summary
- Adds `src/utilities/CustomIdUtils.ts` with `parseCustomIdSegments(customId, expectedCount)` -- splits on `:`, slices off the prefix, and returns `null` if the segment count doesn't match
- Migrates all `customId.split(":")` destructuring in `mp-info.command.ts` (3 sites), `avatar-history.command.ts` (3 sites), and `game-journal.command.ts` (13 sites)
- The `handleSearchPage` handler in `game-journal.command.ts` is intentionally left as-is -- it uses a rest spread because the search query can itself contain colons

## Test plan
- [ ] Type-check passes: `npx tsc --noEmit`
- [ ] Lint passes: `npm run lint`
- [ ] Pagination and select menus in mp-info, avatar-history, and game-journal work as before on the bot
- [ ] Interactions still resume correctly after a bot restart (stable customId format unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)