### PR TITLE
refactor: add parsePageNumber/isValidPlaytimeHours and migrate playtime guards (#595)

### DIFF
--- a/src/commands/collection/collection-crud.command.ts
+++ b/src/commands/collection/collection-crud.command.ts
@@ -39,6 +39,7 @@ import {
 } from "./collection-autocomplete.utils.js";
 import { resolveCollectionGameForAdd } from "./collection-game-resolve.utils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
+import { isValidPlaytimeHours } from "../../utilities/ValidationUtils.js";
 
 @Discord()
 @SlashGroup({ description: "Manage your game collection", name: "collection" })
@@ -454,10 +455,7 @@ export class CollectionCrudCommand {
       return;
     }
 
-    if (
-      finalPlaytimeHours !== undefined &&
-      (Number.isNaN(finalPlaytimeHours) || finalPlaytimeHours < 0)
-    ) {
+    if (finalPlaytimeHours !== undefined && !isValidPlaytimeHours(finalPlaytimeHours)) {
       await safeReply(interaction, "Final playtime must be a non-negative number.");
       return;
     }

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -92,7 +92,7 @@ import {
 } from "./game-completion/completion.types.js";
 import Game from "../classes/Game.js";
 import Member from "../classes/Member.js";
-import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 
 // Note: This is a simplified working version that delegates complex Completionator logic
 // to service files. The full implementation would import and delegate all handlers.
@@ -185,10 +185,7 @@ export class GameCompletionCommands {
       return;
     }
 
-    if (
-      finalPlaytimeHours !== undefined &&
-      (Number.isNaN(finalPlaytimeHours) || finalPlaytimeHours < 0)
-    ) {
+    if (finalPlaytimeHours !== undefined && !isValidPlaytimeHours(finalPlaytimeHours)) {
       await safeReply(interaction, "Final playtime must be a non-negative number of hours.");
       return;
     }
@@ -630,7 +627,7 @@ export class GameCompletionCommands {
     if (clearFinalPlaytime) {
       updates.finalPlaytimeHours = null;
     } else if (finalPlaytimeHours !== undefined) {
-      if (Number.isNaN(finalPlaytimeHours) || finalPlaytimeHours < 0) {
+      if (!isValidPlaytimeHours(finalPlaytimeHours)) {
         await safeReply(interaction, "Final playtime must be a non-negative number of hours.");
         return;
       }

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -29,7 +29,7 @@ import {
   safeReply,
   safeUpdate,
 } from "../../functions/InteractionUtils.js";
-import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { isPositiveInt, isValidPlaytimeHours } from "../../utilities/ValidationUtils.js";
 
 const MAX_NOTE_LENGTH = 500;
 type CompletionEditField = "type" | "date" | "platform" | "playtime" | "note";
@@ -200,7 +200,7 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
       }
     } else if (field === "playtime") {
       const num = Number(value);
-      if (Number.isNaN(num) || num < 0)
+      if (!isValidPlaytimeHours(num))
         throw new Error("Playtime must be a non-negative number.");
       await Member.updateCompletion(ownerId, completionId, { finalPlaytimeHours: num });
     } else if (field === "note") {

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -100,7 +100,7 @@ import {
 } from "./now-playing-help.js";
 
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
-import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { formatStructuredLog } from "../utilities/LogUtils.js";
 
 const MAX_NOW_PLAYING_NOTE_LEN = 500;
@@ -1427,10 +1427,7 @@ export class NowPlayingCommand {
     const finalPlaytimeHours = finalPlaytimeRaw
       ? Number(finalPlaytimeRaw)
       : null;
-    if (
-      finalPlaytimeHours !== null &&
-      (Number.isNaN(finalPlaytimeHours) || finalPlaytimeHours < 0)
-    ) {
+    if (finalPlaytimeHours !== null && !isValidPlaytimeHours(finalPlaytimeHours)) {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent(
           "Final playtime must be a non-negative number of hours.",

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -48,7 +48,7 @@ import {
   saveCompletion,
 } from "../functions/CompletionHelpers.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
-import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { sleep } from "../utilities/DelayUtils.js";
 
 type CompletionAddContext = {
@@ -242,10 +242,7 @@ export class SuperAdmin {
       return;
     }
 
-    if (
-      finalPlaytimeHours !== undefined &&
-      (Number.isNaN(finalPlaytimeHours) || finalPlaytimeHours < 0)
-    ) {
+    if (finalPlaytimeHours !== undefined && !isValidPlaytimeHours(finalPlaytimeHours)) {
       await safeReply(interaction, buildTextReply("Final playtime must be a non-negative number of hours.", true));
       return;
     }

--- a/src/utilities/ValidationUtils.ts
+++ b/src/utilities/ValidationUtils.ts
@@ -7,3 +7,14 @@ export function requirePositiveInt(value: unknown, label = "ID"): number {
   if (!isPositiveInt(value)) throw new Error(`Invalid ${label}.`);
   return value as number;
 }
+
+/** Returns the parsed page number, or null if not a valid positive integer. */
+export function parsePageNumber(raw: string | null | undefined): number | null {
+  const n = parseInt(raw ?? "", 10);
+  return Number.isNaN(n) || n < 1 ? null : n;
+}
+
+/** Returns true if value is a valid non-negative playtime in hours. */
+export function isValidPlaytimeHours(value: unknown): value is number {
+  return typeof value === "number" && !Number.isNaN(value) && value >= 0;
+}


### PR DESCRIPTION
## Summary
- Adds `parsePageNumber(raw)` and `isValidPlaytimeHours(value)` to `src/utilities/ValidationUtils.ts`
- Migrates all five inline `(Number.isNaN(finalPlaytimeHours) || finalPlaytimeHours < 0)` guards to `!isValidPlaytimeHours()` across: `game-completion.command.ts` (2 sites), `collection-crud.command.ts`, `now-playing.command.ts`, `superadmin.command.ts`, and `completion-edit.service.ts`

## Notes
- `Member.ts:892` uses `Number.isFinite` (stricter than `isNaN`) at the model layer with additional max-value and decimal-precision checks; intentionally left alone to avoid silently accepting `Infinity` at the DB layer
- `parsePageNumber` is added per spec; page-handler patterns in the codebase use 0-indexed pages so those were not migrated (page=0 is a valid first page and `parsePageNumber` rejects n < 1)

## Test plan
- [ ] `npm run lint` -- passes clean
- [ ] `npx tsc --noEmit` -- passes clean
- [ ] `grep -rn "Number.isNaN.*PlaytimeHours" src/` returns zero hits

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)