### PR TITLE
refactor: replace all .slice(0, 100) literals with DISCORD_SELECT_LABEL_MAX

### DIFF
--- a/src/commands/admin/gotm-audit-ui.service.ts
+++ b/src/commands/admin/gotm-audit-ui.service.ts
@@ -12,6 +12,7 @@ import {
   GOTM_AUDIT_RESULT_LIMIT,
 } from "./admin.types.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export function buildGotmAuditPromptContent(
   session: IGotmAuditImport,
@@ -67,9 +68,9 @@ export function buildGotmAuditPromptComponents(
       .setPlaceholder("Select a GameDB match")
       .addOptions(
         options.slice(0, GOTM_AUDIT_RESULT_LIMIT).map((opt, idx) => ({
-          label: opt.label.slice(0, 100),
+          label: opt.label.slice(0, DISCORD_SELECT_LABEL_MAX),
           value: String(opt.id),
-          description: opt.description?.slice(0, 100),
+          description: opt.description?.slice(0, DISCORD_SELECT_LABEL_MAX),
           default: idx === 0,
         })),
       );

--- a/src/commands/admin/live-stream-admin.service.ts
+++ b/src/commands/admin/live-stream-admin.service.ts
@@ -23,6 +23,7 @@ import {
   sanitizeUserInput,
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 const LIVE_STREAM_MODAL_PREFIX = "admin-live-stream-create";
 const LIVE_STREAM_TOPIC_ID = "live-stream-topic";
@@ -281,7 +282,7 @@ export async function handleLiveStreamCreateModal(interaction: ModalSubmitIntera
         content: `Live event discussion for **${topic}**`,
         embeds: imageUrl ? [new EmbedBuilder().setImage(imageUrl)] : [],
       },
-      name: topic.slice(0, 100),
+      name: topic.slice(0, DISCORD_SELECT_LABEL_MAX),
     });
     threadUrl = thread.url;
     threadId = thread.id;

--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -46,6 +46,7 @@ import {
   type WizardNominationOption,
 } from "./round-setup-wizard.utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 const NEXT_ROUND_SETUP_COMMAND_KEY = "nextround-setup";
 const MAX_SELECT_OPTIONS = 25;
@@ -69,7 +70,7 @@ function buildSelectionOptions(
     .filter((option) => !pickedIds.includes(option.nominationId))
     .slice(0, MAX_SELECT_OPTIONS)
     .map((option) => ({
-      label: option.gameTitle.slice(0, 100),
+      label: option.gameTitle.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(option.nominationId),
       description: `GameDB ${option.gamedbGameId} | ${option.userIds.length} nominee(s)`,
     }));
@@ -244,7 +245,7 @@ async function promptOrderNomination(
 ): Promise<number | null> {
   const remainingOptions = options.filter((option) => remainingIds.includes(option.nominationId));
   const selectOptions = remainingOptions.slice(0, MAX_SELECT_OPTIONS).map((option) => ({
-    label: option.gameTitle.slice(0, 100),
+    label: option.gameTitle.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(option.nominationId),
     description: `GameDB ${option.gamedbGameId}`,
   }));

--- a/src/commands/collection/collection-autocomplete.utils.ts
+++ b/src/commands/collection/collection-autocomplete.utils.ts
@@ -6,6 +6,7 @@ import UserGameCollection, {
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export const COLLECTION_ENTRY_VALUE_PREFIX = "collection";
 
@@ -28,7 +29,7 @@ export function formatCollectionEntryAutocompleteName(entry: {
   ownershipType: CollectionOwnershipType;
 }): string {
   const platform = entry.platformName ?? "Unknown platform";
-  return `${entry.title} | ${platform} | ${entry.ownershipType}`.slice(0, 100);
+  return `${entry.title} | ${platform} | ${entry.ownershipType}`.slice(0, DISCORD_SELECT_LABEL_MAX);
 }
 
 export async function autocompleteCollectionGameTitle(
@@ -45,7 +46,7 @@ export async function autocompleteCollectionGameTitle(
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, 25).map((game) => ({
-      name: formatGameTitleWithYear(game).slice(0, 100),
+      name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
     })),
   );

--- a/src/commands/collection/collection-game-resolve.utils.ts
+++ b/src/commands/collection/collection-game-resolve.utils.ts
@@ -3,6 +3,7 @@ import { igdbService, type IGDBGame } from "../../services/IGDB/IgdbService.js";
 import type { IgdbSelectOption } from "../../services/IGDB/IgdbSelectService.js";
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export type ResolvedCollectionGame =
   | { kind: "resolved"; gameId: number; title: string }
@@ -33,11 +34,11 @@ export async function buildCollectionIgdbSelectOptions(
       .join(", ");
     const summary = (game.summary ?? "No summary").replace(/\s+/g, " ").trim();
     const description = platformText
-      ? `${platformText} | ${summary}`.slice(0, 100)
-      : summary.slice(0, 100);
+      ? `${platformText} | ${summary}`.slice(0, DISCORD_SELECT_LABEL_MAX)
+      : summary.slice(0, DISCORD_SELECT_LABEL_MAX);
     return {
       id: game.id,
-      label: `${game.name} (${year})`.slice(0, 100),
+      label: `${game.name} (${year})`.slice(0, DISCORD_SELECT_LABEL_MAX),
       description,
     };
   });

--- a/src/commands/create-thread.command.ts
+++ b/src/commands/create-thread.command.ts
@@ -13,6 +13,7 @@ import { safeDeferReply, safeReply, sanitizeOptionalInput, sanitizeUserInput } f
   "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { formatGameTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 const DEFAULT_FIRST_POST_PREFIX = "Thread created by";
 
@@ -34,7 +35,7 @@ async function autocompleteCreateThreadTitle(
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, 25).map((game) => ({
-      name: formatGameTitleWithYear(game).slice(0, 100),
+      name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
     })),
   );
@@ -58,8 +59,8 @@ async function autocompleteCreateThreadTag(
     .filter((tag) => !query || tag.name.toLowerCase().includes(query))
     .slice(0, 25)
     .map((tag) => ({
-      name: tag.name.slice(0, 100),
-      value: tag.name.slice(0, 100),
+      name: tag.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+      value: tag.name.slice(0, DISCORD_SELECT_LABEL_MAX),
     }));
   await interaction.respond(filtered);
 }
@@ -166,7 +167,7 @@ export class CreateThreadCommand {
     const thread = await forum.threads.create({
       appliedTags: [selectedTag.id],
       message: messagePayload,
-      name: game.title.slice(0, 100),
+      name: game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
     });
     await upsertThreadRecord({
       createdAt: thread.createdAt ?? new Date(),
@@ -175,7 +176,7 @@ export class CreateThreadCommand {
       lastSeenAt: null,
       skipLinking: "Y",
       threadId: thread.id,
-      threadName: thread.name ?? game.title.slice(0, 100),
+      threadName: thread.name ?? game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
     });
     await setThreadGameLink(thread.id, game.id);
 

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -34,6 +34,7 @@ import {
 } from "../../functions/ComponentsV2Utils.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 /**
  * Creates a completion session and returns the session ID
@@ -56,7 +57,7 @@ export async function promptCompletionSelection(
   if (localResults.length) {
     const sessionId = createCompletionSession(ctx);
     const options = localResults.slice(0, 24).map((game) => ({
-      label: game.title.slice(0, 100),
+      label: game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
       description: `GameDB #${game.id}`,
     }));

--- a/src/commands/game-completion/completion-autocomplete.utils.ts
+++ b/src/commands/game-completion/completion-autocomplete.utils.ts
@@ -8,6 +8,7 @@ import Member from "../../classes/Member.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 const PLATFORM_CACHE_TTL_MS = 5 * 60 * 1000;
 const COMPLETION_TITLE_VALUE_PREFIX = "completion";
@@ -34,7 +35,7 @@ function normalizePlatformSearchText(value: string): string {
 
 function buildPlatformAutocompleteLabel(platform: IPlatformDef): string {
   const detail = platform.abbreviation ? `${platform.name} (${platform.abbreviation})` : platform.name;
-  return detail.slice(0, 100);
+  return detail.slice(0, DISCORD_SELECT_LABEL_MAX);
 }
 
 function sortPlatformsForAutocomplete(
@@ -55,7 +56,7 @@ function sortPlatformsForAutocomplete(
 export function buildKeepTypingOption(query: string): { name: string; value: string } {
   const label = `Keep typing: "${query}"`;
   return {
-    name: label.slice(0, 100),
+    name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: query,
   };
 }
@@ -72,7 +73,7 @@ export async function autocompleteGameCompletionTitle(
   }
   const results = await Game.searchGamesAutocomplete(query);
   const resultOptions = results.slice(0, 24).map((game) => ({
-    name: formatGameTitleWithYear(game).slice(0, 100),
+    name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
     value: game.title,
   }));
   const options = [buildKeepTypingOption(query), ...resultOptions];
@@ -86,7 +87,7 @@ function buildCompletionTitleAutocompleteName(completion: {
 }): string {
   const dateLabel = completion.completedAt ? formatTableDate(completion.completedAt) : "No date";
   const line = `${completion.title} | ${completion.completionType} | ${dateLabel}`;
-  return line.slice(0, 100);
+  return line.slice(0, DISCORD_SELECT_LABEL_MAX);
 }
 
 function buildCompletionTitleAutocompleteValue(completionId: number): string {

--- a/src/commands/game-completion/completion-platform.service.ts
+++ b/src/commands/game-completion/completion-platform.service.ts
@@ -19,6 +19,7 @@ import {
   completionPlatformSessions,
   type CompletionPlatformContext,
 } from "./completion.types.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export function createCompletionPlatformSession(
   ctx: CompletionPlatformContext,
@@ -57,7 +58,7 @@ export async function promptCompletionPlatformSelection(
   }, interaction.user.id);
 
   const baseOptions = platformOptions.map((platform) => ({
-    label: platform.name.slice(0, 100),
+    label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(platform.id),
   }));
   const options = [

--- a/src/commands/game-completion/completionator-thread.service.ts
+++ b/src/commands/game-completion/completionator-thread.service.ts
@@ -6,6 +6,7 @@ import { CompletionatorUiService } from "./completionator-ui.service.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { BOT_DEV_CHANNEL_ID } from "../../config/channels.js";
 import { safeReply } from "../../functions/InteractionUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export class CompletionatorThreadService {
   private uiService: CompletionatorUiService;
@@ -94,7 +95,7 @@ export class CompletionatorThreadService {
 
     const threadName: string = `Completionator Import #${session.importId}`;
     const thread: ThreadChannel = await parentMessage.startThread({
-      name: threadName.slice(0, 100),
+      name: threadName.slice(0, DISCORD_SELECT_LABEL_MAX),
       autoArchiveDuration: 60,
     });
 

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -46,6 +46,7 @@ import {
 } from "../imports/import-scaffold.service.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { buildCompletionatorChooseId } from "./completion-helpers.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export class CompletionatorUiService {
   buildCompletionatorBaseLines(
@@ -367,7 +368,7 @@ export class CompletionatorUiService {
       .setPlaceholder("Completion type")
       .addOptions(
         COMPLETION_TYPES.map((value: string) => ({
-          label: value.slice(0, 100),
+          label: value.slice(0, DISCORD_SELECT_LABEL_MAX),
           value,
           default: state.completionType === value,
         })),
@@ -415,7 +416,7 @@ export class CompletionatorUiService {
       a.name.localeCompare(b.name, "en", { sensitivity: "base" }),
     );
     const platformOptions = sortedPlatforms.map((platform) => ({
-      label: platform.name.slice(0, 100),
+      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(platform.id),
       default: state.platformId === platform.id,
     }));
@@ -719,7 +720,7 @@ export class CompletionatorUiService {
        
       .setCustomId("completionator-input")
       .setLabel(label.slice(0, 45))
-      .setPlaceholder((itemTitle ?? placeholder).slice(0, 100))
+      .setPlaceholder((itemTitle ?? placeholder).slice(0, DISCORD_SELECT_LABEL_MAX))
       .setStyle(TextInputStyle.Short)
       .setRequired(true);
     modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -73,6 +73,7 @@ import {
   JOURNAL_ALL_PAGE_SIZE as ALL_PAGE_SIZE,
   JOURNAL_SEARCH_PAGE_SIZE as SEARCH_PAGE_SIZE,
 } from "../config/pagination.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 const gjHmenu = new EphemeralOwnerMenu();
 
@@ -210,7 +211,7 @@ function buildListSelectRow(
   const pageEntries = entries.slice(start, start + LIST_PAGE_SIZE);
 
   const options = pageEntries.map((e) => ({
-    label: e.title.slice(0, 100),
+    label: e.title.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(e.gameId),
     description: `${e.totalEntries} ${entryLabel(e.totalEntries)}`,
   }));
@@ -311,7 +312,7 @@ function buildAllSelectRow(
   const start = page * ALL_PAGE_SIZE;
   const pageSummaries = summaries.slice(start, start + ALL_PAGE_SIZE);
   const options = pageSummaries.map((s) => ({
-    label: (s.globalName ?? s.username ?? s.userId).slice(0, 100),
+    label: (s.globalName ?? s.username ?? s.userId).slice(0, DISCORD_SELECT_LABEL_MAX),
     value: s.userId,
     description: `${s.gameCount} ${gameLabel(s.gameCount)}`,
   }));
@@ -364,7 +365,7 @@ async function autocompleteJournalSearchGame(
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, 25).map((game) => ({
-      name: formatGameTitleWithYear(game).slice(0, 100),
+      name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
     })),
   );
@@ -935,7 +936,7 @@ export class GameJournalCommand {
       return;
     }
     const options = entries.map((e) => ({
-      label: (e.title ?? `Entry #${e.entryNumber}`).slice(0, 100),
+      label: (e.title ?? `Entry #${e.entryNumber}`).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(e.entryId),
       description: formatTableDate(e.createdAt),
     }));

--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -50,6 +50,7 @@ import {
 import { trimTextDisplayContent } from "./gamedb-profile.service.js";
 import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 const COMPLETION_WIZARD_SESSIONS = new Map<string, CompletionWizardSession>();
 
@@ -129,7 +130,7 @@ function buildCompletionPlatformOptions(
     a.name.localeCompare(b.name, "en", { sensitivity: "base" }),
   );
   const baseOptions = sortedPlatforms.map((platform) => ({
-    label: platform.name.slice(0, 100),
+    label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(platform.id),
   }));
   return [
@@ -148,7 +149,7 @@ function buildCompletionWizardComponents(
     .setPlaceholder("Completion type")
     .addOptions(
       COMPLETION_TYPES.map((value) => ({
-        label: value.slice(0, 100),
+        label: value.slice(0, DISCORD_SELECT_LABEL_MAX),
         value,
         default: session.completionType === value,
       })),

--- a/src/commands/gamedb/gamedb-csv-import.service.ts
+++ b/src/commands/gamedb/gamedb-csv-import.service.ts
@@ -24,6 +24,7 @@ import { GAMEDB_CSV_PLATFORM_MAP } from "../../config/gamedbCsvPlatformMap.js";
 import { buildIgdbSearchLink } from "./gamedb-utils.js";
 import { type IGameDbCsvImport } from "../../classes/GameDbCsvImport.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export const GAMEDB_CSV_RESULT_LIMIT = 15;
 
@@ -124,9 +125,9 @@ export function buildCsvPromptComponents(
       .setPlaceholder("Select a match from IGDB")
       .addOptions(
         options.slice(0, GAMEDB_CSV_RESULT_LIMIT).map((opt, idx) => ({
-          label: opt.label.slice(0, 100),
+          label: opt.label.slice(0, DISCORD_SELECT_LABEL_MAX),
           value: String(opt.id),
-          description: opt.description?.slice(0, 100),
+          description: opt.description?.slice(0, DISCORD_SELECT_LABEL_MAX),
           default: idx === 0,
         })),
       );

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -17,6 +17,7 @@ import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUt
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { decodeBase64Url, encodeBase64Url } from "../../functions/CustomIdUtils.js";
 import Game from "../../classes/Game.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export interface ISearchFilters {
   upcomingRelease?: boolean;
@@ -230,7 +231,7 @@ export function getSearchRowsFromComponents(
 export function buildKeepTypingOption(query: string): { name: string; value: string } {
   const label = `Keep typing: "${query}"`;
   return {
-    name: label.slice(0, 100),
+    name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: query,
   };
 }
@@ -250,7 +251,7 @@ export async function autocompleteSearchPlatform(
     )
     : platforms;
   const options = filtered.slice(0, 25).map((p) => ({
-    name: (p.abbreviation ? `${p.name} (${p.abbreviation})` : p.name).slice(0, 100),
+    name: (p.abbreviation ? `${p.name} (${p.abbreviation})` : p.name).slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(p.id),
   }));
   await interaction.respond(options);
@@ -267,7 +268,7 @@ export async function autocompleteSearchCompany(
     ? companies.filter((c) => c.name.toLowerCase().includes(query))
     : companies;
   const options = filtered.slice(0, 25).map((c) => ({
-    name: c.name.slice(0, 100),
+    name: c.name.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(c.id),
   }));
   await interaction.respond(options);
@@ -287,7 +288,7 @@ export async function autocompleteGameDbViewTitle(
   const resultOptions = results.slice(0, 24).map((game) => {
     const label = formatGameTitleWithYear(game);
     return {
-      name: label.slice(0, 100),
+      name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
     };
   });

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -55,6 +55,7 @@ import { MEMBER_ROLE_ID } from "../config/roles.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { COLOR_SUCCESS } from "../config/colors.js";
 import { CLAIM_MENU_CHUNK_SIZE } from "../config/pagination.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_PLATFORM_LENGTH = 50;
@@ -93,7 +94,7 @@ function buildKeySelectMenus(
       continue;
     }
     const options = chunk.map((key) => ({
-      label: key.gameTitle.slice(0, 100),
+      label: key.gameTitle.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(key.keyId),
     }));
     const range = getKeyRangeLabel(chunk);

--- a/src/commands/hltb.command.ts
+++ b/src/commands/hltb.command.ts
@@ -18,11 +18,12 @@ import {
   getReleaseYear,
   parseTitleWithYear,
 } from "../functions/GameTitleAutocompleteUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 function buildKeepTypingOption(query: string): { name: string; value: string } {
   const label = `Keep typing: "${query}"`;
   return {
-    name: label.slice(0, 100),
+    name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: query,
   };
 }
@@ -41,7 +42,7 @@ async function autocompleteHltbTitle(
   const resultOptions = results.slice(0, 24).map((game) => {
     const label = formatGameTitleWithYear(game);
     return {
-      name: label.slice(0, 100),
+      name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: label,
     };
   });

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -41,6 +41,7 @@ import {
   MP_INFO_PAGE_SIZE as PAGE_SIZE,
 } from "../config/pagination.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 const MAX_OPTIONS = 25;
 
@@ -174,9 +175,9 @@ function buildPageComponents(
     const name = member.globalName ?? member.username ?? "Unknown member";
     const platforms = formatPlatforms(member, filters) || "Platforms not listed";
     return {
-      label: name.slice(0, 100),
+      label: name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: member.userId,
-      description: platforms.slice(0, 100),
+      description: platforms.slice(0, DISCORD_SELECT_LABEL_MAX),
     };
   });
 

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -44,6 +44,7 @@ import {
 } from "../config/nominationChannels.js";
 import { showGameProfileFromNomination } from "./gamedb.command.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 const NOMINATE_REASON_MAX_LENGTH = 1500;
 
@@ -61,8 +62,8 @@ async function autocompleteNominationTitle(
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, 25).map((game) => ({
-      name: formatGameTitleWithYear(game).slice(0, 100),
-      value: formatGameTitleWithYear(game).slice(0, 100),
+      name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
+      value: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
     })),
   );
 }

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -102,6 +102,7 @@ import {
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { formatStructuredLog } from "../utilities/LogUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 const MAX_NOW_PLAYING_NOTE_LEN = 500;
 const NOW_PLAYING_SEARCH_LIMIT = 10;
@@ -1630,7 +1631,7 @@ export class NowPlayingCommand {
     });
 
     const baseOptions = platformOptions.map((platform) => ({
-      label: platform.name.slice(0, 100),
+      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(platform.id),
     }));
     const options = [
@@ -2249,7 +2250,7 @@ export class NowPlayingCommand {
       sourceSessionId,
     });
     const options = platforms.slice(0, 25).map((platform) => ({
-      label: platform.name.slice(0, 100),
+      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(platform.id),
     }));
     const select = new StringSelectMenuBuilder()
@@ -2606,7 +2607,7 @@ export class NowPlayingCommand {
           });
         }
         return deduped.map((platform, optionIndex) => ({
-          label: platform.name.slice(0, 100),
+          label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
           value: String(optionIndex),
           platformId: platform.id,
         }));
@@ -2656,7 +2657,7 @@ export class NowPlayingCommand {
     }
 
     const options = platforms.slice(0, 25).map((platform) => ({
-      label: platform.name.slice(0, 100),
+      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(platform.id),
     }));
     const select = new StringSelectMenuBuilder()
@@ -3565,7 +3566,7 @@ export class NowPlayingCommand {
       return;
     }
     const options = entries.map((entry) => ({
-      label: (entry.title ?? `Entry #${entry.entryNumber}`).slice(0, 100),
+      label: (entry.title ?? `Entry #${entry.entryNumber}`).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(entry.entryId),
       description: formatTableDate(entry.createdAt),
     }));
@@ -3861,7 +3862,7 @@ export class NowPlayingCommand {
       return;
     }
     const options = gamesWithoutJournal.map((e) => ({
-      label: e.title.slice(0, 100),
+      label: e.title.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(e.gameId),
     }));
     const select = new StringSelectMenuBuilder()
@@ -4810,7 +4811,7 @@ export class NowPlayingCommand {
       .filter((entry) => isPositiveInt(entry.gameId))
       .slice(0, 25)
       .map((entry) => ({
-        label: formatEntryTitleWithPlatform(entry).slice(0, 100),
+        label: formatEntryTitleWithPlatform(entry).slice(0, DISCORD_SELECT_LABEL_MAX),
         value: String(entry.gameId),
       }));
     const removeSelect = new StringSelectMenuBuilder()
@@ -4963,8 +4964,8 @@ export class NowPlayingCommand {
       const currentPlatformName =
         selectedIndex >= 0 ? (options[selectedIndex]?.label ?? null) : null;
       const placeholder = currentPlatformName
-        ? `${entry.title.slice(0, 50)} - ${currentPlatformName}`.slice(0, 100)
-        : entry.title.slice(0, 100);
+        ? `${entry.title.slice(0, 50)} - ${currentPlatformName}`.slice(0, DISCORD_SELECT_LABEL_MAX)
+        : entry.title.slice(0, DISCORD_SELECT_LABEL_MAX);
       const select = new StringSelectMenuBuilder()
         .setCustomId(`${NOW_PLAYING_EDIT_PLATFORM_SLOT_PREFIX}:${ownerId}:${slotIndex}:${stateToken}`)
         .setPlaceholder(placeholder)
@@ -4972,7 +4973,7 @@ export class NowPlayingCommand {
         .setMaxValues(1)
         .addOptions(options.map((option, optionIndex) => ({
           label: optionIndex === selectedIndex
-            ? `${entry.title.slice(0, 50)} - ${option.label}`.slice(0, 100)
+            ? `${entry.title.slice(0, 50)} - ${option.label}`.slice(0, DISCORD_SELECT_LABEL_MAX)
             : option.label,
           value: option.value,
           default: selectedIndex === optionIndex,
@@ -5039,7 +5040,7 @@ export class NowPlayingCommand {
         .setMinValues(1)
         .setMaxValues(1)
         .addOptions(entries.map((entry, entryIndex) => ({
-          label: formatEntryTitleWithPlatform(entry).slice(0, 100),
+          label: formatEntryTitleWithPlatform(entry).slice(0, DISCORD_SELECT_LABEL_MAX),
           value: String(entryIndex),
           default: selectedIndex === entryIndex,
         })));
@@ -5665,7 +5666,7 @@ export class NowPlayingCommand {
     const options = sorted.slice(0, 25).map((record) => {
       const displayName = record.globalName ?? record.username ?? record.userId;
       return {
-        label: displayName.slice(0, 100),
+        label: displayName.slice(0, DISCORD_SELECT_LABEL_MAX),
         value: record.userId,
         description: `${record.entries.length} ${record.entries.length === 1 ? "game" : "games"}`,
         default: record.userId === selectedUserId,

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -40,6 +40,7 @@ import {
   formatPlaytimeHours,
   formatTableDate,
 } from "../functions/DateFormatUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 export { formatDiscordTimestamp, formatPlaytimeHours, formatTableDate };
 
@@ -668,12 +669,12 @@ export class ProfileCommand {
     const description = `Filters: ${filterSummary}\n\n${lines.join("\n")}`;
 
     const selectOptions = results.map((record, idx) => {
-      const label = (record.globalName ?? record.username ?? `Member ${idx + 1}`).slice(0, 100);
+      const label = (record.globalName ?? record.username ?? `Member ${idx + 1}`).slice(0, DISCORD_SELECT_LABEL_MAX);
       const descriptionText = `ID: ${record.userId}${record.isBot ? " | Bot" : ""}`;
       return {
         label,
         value: record.userId,
-        description: descriptionText.slice(0, 100),
+        description: descriptionText.slice(0, DISCORD_SELECT_LABEL_MAX),
       };
     });
 

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -50,6 +50,7 @@ import {
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { sleep } from "../utilities/DelayUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 type CompletionAddContext = {
   targetUserId: string;
@@ -365,7 +366,7 @@ export class SuperAdmin {
       superadminCompletionAddSessions.set(sessionId, ctx);
 
       const options = localResults.slice(0, 24).map((game) => ({
-        label: game.title.slice(0, 100),
+        label: game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
         value: String(game.id),
         description: `GameDB #${game.id}`,
       }));
@@ -437,7 +438,7 @@ export class SuperAdmin {
       interaction.id,
     );
     const baseOptions = platformOptions.map((platform) => ({
-      label: platform.name.slice(0, 100),
+      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(platform.id),
     }));
     const options = [

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -32,6 +32,7 @@ import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { notifyUnknownCompletionPlatform } from "../functions/CompletionHelpers.js";
 import { COMPLETION_REACTION_DEV_CHANNEL_ID } from "../config/channels.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 
 const PUSH_PIN_EMOJI = "📌";
 const PLUS_EMOJI = "➕";
@@ -304,7 +305,7 @@ export class MessageReactionAdd {
     }
 
     const options = matches.slice(0, 24).map((game) => ({
-      label: game.title.slice(0, 100),
+      label: game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
       description: `GameDB #${game.id}`,
     }));
@@ -480,7 +481,7 @@ export class MessageReactionAdd {
             .setStyle(TextInputStyle.Short)
             .setRequired(true)
             .setMaxLength(100)
-            .setValue(session.query.slice(0, 100)),
+            .setValue(session.query.slice(0, DISCORD_SELECT_LABEL_MAX)),
         ),
       );
 
@@ -557,7 +558,7 @@ export class MessageReactionAdd {
     }
 
     const baseOptions = platforms.map((platform) => ({
-      label: platform.name.slice(0, 100),
+      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(platform.id),
     }));
     const platformOptions = [

--- a/src/services/IGDB/IgdbSelectService.ts
+++ b/src/services/IGDB/IgdbSelectService.ts
@@ -14,6 +14,7 @@ import {
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export type IgdbSelectOption = { id: number; label: string; description?: string };
 
@@ -94,9 +95,9 @@ export function buildIgdbComponents(
     .addOptions(
       hasOptions
         ? pageOptions.map((opt, index) => ({
-          label: opt.label.slice(0, 100),
+          label: opt.label.slice(0, DISCORD_SELECT_LABEL_MAX),
           value: String(opt.id),
-          description: opt.description?.slice(0, 100),
+          description: opt.description?.slice(0, DISCORD_SELECT_LABEL_MAX),
           default: page === 0 && index === 0,
         }))
         : [{


### PR DESCRIPTION
Closes #603

## Summary

- Replaced every remaining `.slice(0, 100)` bare literal across 24 files with `DISCORD_SELECT_LABEL_MAX` imported from `src/config/textLimits.ts`
- Zero bare `.slice(0, 100)` calls remain in `src/`
- Covers all files listed in issue #603 plus additional call sites found in `collection/`, `admin/`, `gamedb/`, `services/IGDB/`, and `events/`

## Verification

```
grep -rn ".slice(0, 100)" src/
```
Returns zero hits.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] Zero remaining `.slice(0, 100)` literals in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)