### PR TITLE
refactor: extract truncateWithEllipsis() shared utility (#605)

### DIFF
--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -63,7 +63,7 @@ import axios from "axios";
 import { igdbService } from "../services/IGDB/IgdbService.js";
 import { shouldRenderPrevNextButtons } from "../functions/PaginationUtils.js";
 import { parseSynonymQuickAddTerms } from "./gamedb-synonym.utils.js";
-import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { COLOR_PRIMARY, COLOR_SUCCESS, COLOR_HIGHLIGHT } from "../config/colors.js";
 import { AUDIT_PAGE_SIZE, SYNONYM_LIST_PAGE_SIZE } from "../config/pagination.js";
 
@@ -93,8 +93,7 @@ function decodeSynonymQuery(encoded: string): string {
 }
 
 function clampSynonymOptionText(value: string, maxLength = 100): string {
-  if (value.length <= maxLength) return value;
-  return value.slice(0, Math.max(0, maxLength - 3)) + "...";
+  return truncateWithEllipsis(value, maxLength);
 }
 
 function buildSynonymGroupEditModal(ownerId: string, groupId: number, terms: string): ModalBuilder {

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -62,6 +62,7 @@ import {
 import { decodeBase64Url, encodeWithMaxLength } from "../functions/CustomIdUtils.js";
 import { safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import { formatDiscordTimestamp } from "../functions/DateFormatUtils.js";
+import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
 const TODO_LABELS = [
   "New Feature",
@@ -456,8 +457,7 @@ function formatIssueTitle(issue: IGithubIssue): string {
 function formatIssueSelectLabel(issue: IGithubIssue): string {
   const labelText = issue.labels.length ? ` [${issue.labels.join(", ")}]` : "";
   const text = `#${issue.number} ${issue.title}${labelText}`;
-  if (text.length <= 100) return text;
-  return `${text.slice(0, 97)}...`;
+  return truncateWithEllipsis(text, 100);
 }
 
 function sanitizeTodoText(value: string, preserveNewlines: boolean): string {
@@ -537,10 +537,7 @@ function renderTodoContent(rawValue: string, maxTextLength: number): {
 }
 
 function clampTextDisplayContent(value: string): string {
-  if (value.length <= MAX_TEXT_DISPLAY_CONTENT) {
-    return value;
-  }
-  return `${value.slice(0, MAX_TEXT_DISPLAY_CONTENT - 3)}...`;
+  return truncateWithEllipsis(value, MAX_TEXT_DISPLAY_CONTENT);
 }
 
 function trimToBudget(value: string, maxLength: number): string {

--- a/src/functions/GotmEntryEmbeds.ts
+++ b/src/functions/GotmEntryEmbeds.ts
@@ -3,6 +3,7 @@ import type { IGotmEntry, IGotmGame } from "../classes/Gotm.js";
 import type { INrGotmEntry, INrGotmGame } from "../classes/NrGotm.js";
 import Game from "../classes/Game.js";
 import { COLOR_PRIMARY } from "../config/colors.js";
+import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
 const ANNOUNCEMENTS_CHANNEL_ID: string | undefined = process.env.ANNOUNCEMENTS_CHANNEL_ID;
 
@@ -55,9 +56,7 @@ async function formatGames(games: AnyGame[]): Promise<string> {
 }
 
 function truncateField(value: string): string {
-  const MAX = 1024;
-  if (value.length <= MAX) return value;
-  return value.slice(0, MAX - 3) + "...";
+  return truncateWithEllipsis(value, 1024);
 }
 
 function appendWithTailTruncate(body: string, tail: string): string {
@@ -67,7 +66,7 @@ function appendWithTailTruncate(body: string, tail: string): string {
   if (total <= MAX) return body + sep + tail;
   const availForBody = MAX - tail.length - sep.length;
   if (availForBody <= 0) return tail.slice(0, MAX);
-  const trimmedBody = body.slice(0, Math.max(0, availForBody - 3)) + "...";
+  const trimmedBody = truncateWithEllipsis(body, availForBody);
   return trimmedBody + sep + tail;
 }
 

--- a/src/utilities/ValidationUtils.ts
+++ b/src/utilities/ValidationUtils.ts
@@ -18,3 +18,8 @@ export function parsePageNumber(raw: string | null | undefined): number | null {
 export function isValidPlaytimeHours(value: unknown): value is number {
   return typeof value === "number" && !Number.isNaN(value) && value >= 0;
 }
+
+export function truncateWithEllipsis(text: string, maxLength: number): string {
+  if (text.length <= maxLength) return text;
+  return text.slice(0, Math.max(0, maxLength - 3)) + "...";
+}


### PR DESCRIPTION
## Summary

- Adds `truncateWithEllipsis(text, maxLength)` to `src/utilities/ValidationUtils.ts`
- Replaces 5 independent inline truncation implementations across `gamedb-admin.command.ts`, `GotmEntryEmbeds.ts`, and `todo.command.ts`
- Verification: `grep -rn '+ "\.\.\."' src/` returns only the canonical definition in `ValidationUtils.ts`

Closes #605

## Test plan

- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npm run lint` passes (verified)
- [ ] Synonym autocomplete labels still truncate correctly in gamedb-admin flows
- [ ] GOTM embed fields and body truncation still render correctly
- [ ] Todo text display and issue select label truncation still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)