### PR TITLE
refactor: complete parseCustomIdSegments() migration sweep (#606)

### DIFF
--- a/src/commands/admin/gotm-audit-handlers.ts
+++ b/src/commands/admin/gotm-audit-handlers.ts
@@ -41,10 +41,13 @@ import {
   buildGotmAuditPromptComponents,
 } from "./gotm-audit-ui.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export async function handleGotmAuditSelect(
   interaction: StringSelectMenuInteraction): Promise<void> {
-  const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 3);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId, importIdRaw, itemIdRaw] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This audit prompt is not for you.", true));
     return;
@@ -117,7 +120,9 @@ export async function handleGotmAuditSelect(
 }
 
 export async function handleGotmAuditAction(interaction: ButtonInteraction): Promise<void> {
-  const [, ownerId, importIdRaw, itemIdRaw, action] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 4);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId, importIdRaw, itemIdRaw, action] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This audit prompt is not for you.", true));
     return;
@@ -262,7 +267,9 @@ export async function handleGotmAuditAction(interaction: ButtonInteraction): Pro
 export async function handleGotmAuditManualModal(
   interaction: ModalSubmitInteraction,
 ): Promise<void> {
-  const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 3);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId, importIdRaw, itemIdRaw] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This audit prompt is not for you.", true));
     return;
@@ -338,7 +345,9 @@ export async function handleGotmAuditManualModal(
 export async function handleGotmAuditQueryModal(
   interaction: ModalSubmitInteraction,
 ): Promise<void> {
-  const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 3);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId, importIdRaw, itemIdRaw] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This audit prompt is not for you.", true));
     return;

--- a/src/commands/admin/live-stream-admin.service.ts
+++ b/src/commands/admin/live-stream-admin.service.ts
@@ -24,6 +24,7 @@ import {
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const LIVE_STREAM_MODAL_PREFIX = "admin-live-stream-create";
 const LIVE_STREAM_TOPIC_ID = "live-stream-topic";
@@ -229,13 +230,11 @@ export async function openLiveStreamCreateModal(interaction: CommandInteraction)
 
 export async function handleLiveStreamCreateModal(interaction: ModalSubmitInteraction):
   Promise<void> {
-  const customIdParts = interaction.customId.split(":");
-  if (customIdParts.length !== 2 || customIdParts[0] !== LIVE_STREAM_MODAL_PREFIX) {
-    await safeReply(interaction, buildTextReply("This modal is invalid.", true));
-    return;
-  }
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [userId] = segs;
 
-  if (customIdParts[1] !== interaction.user.id) {
+  if (userId !== interaction.user.id) {
     await safeReply(interaction, buildTextReply("This modal is not for you.", true));
     return;
   }

--- a/src/commands/collection/collection-csv-import.service.ts
+++ b/src/commands/collection/collection-csv-import.service.ts
@@ -16,6 +16,7 @@ import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { resolveGameCompletionPlatformId } from "../game-completion/completion-autocomplete.utils.js";
 import { buildImportReasonSummary } from "./collection-import-ui.utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export type CollectionCsvImportButtonAction = "skip" | "remap" | "game-id" | "pause";
 
@@ -66,24 +67,25 @@ export function parseCollectionCsvImportActionId(customId: string): {
   itemId: number;
   action: CollectionCsvImportButtonAction;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 5) return null;
-  if (parts[0] !== CSV_IMPORT_ACTION_PREFIX) return null;
-  const importId = Number(parts[2]);
-  const itemId = Number(parts[3]);
+  if (!customId.startsWith(`${CSV_IMPORT_ACTION_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [ownerId, importIdStr, itemIdStr, actionCode] = segs;
+  const importId = Number(importIdStr);
+  const itemId = Number(itemIdStr);
   if (!Number.isInteger(importId) || !Number.isInteger(itemId)) return null;
-  if (!parts[1]) return null;
-  const action = parts[4] === "s"
+  if (!ownerId) return null;
+  const action = actionCode === "s"
     ? "skip"
-    : parts[4] === "r"
+    : actionCode === "r"
       ? "remap"
-      : parts[4] === "i"
+      : actionCode === "i"
         ? "game-id"
-      : parts[4] === "p"
+      : actionCode === "p"
         ? "pause"
         : null;
   if (!action) return null;
-  return { ownerId: parts[1], importId, itemId, action };
+  return { ownerId, importId, itemId, action };
 }
 
 export function buildCollectionCsvChooseId(params: {
@@ -107,16 +109,17 @@ export function parseCollectionCsvChooseId(customId: string): {
   itemId: number;
   gameId: number;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 5) return null;
-  if (parts[0] !== CSV_CHOOSE_PREFIX) return null;
-  const importId = Number(parts[2]);
-  const itemId = Number(parts[3]);
-  const gameId = Number(parts[4]);
+  if (!customId.startsWith(`${CSV_CHOOSE_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [ownerId, importIdStr, itemIdStr, gameIdStr] = segs;
+  const importId = Number(importIdStr);
+  const itemId = Number(itemIdStr);
+  const gameId = Number(gameIdStr);
   if (!Number.isInteger(importId) || !Number.isInteger(itemId)) return null;
   if (!isPositiveInt(gameId)) return null;
-  if (!parts[1]) return null;
-  return { ownerId: parts[1], importId, itemId, gameId };
+  if (!ownerId) return null;
+  return { ownerId, importId, itemId, gameId };
 }
 
 export function buildCollectionCsvRemapModalId(params: {
@@ -137,14 +140,15 @@ export function parseCollectionCsvRemapModalId(customId: string): {
   importId: number;
   itemId: number;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4) return null;
-  if (parts[0] !== CSV_REMAP_MODAL_PREFIX) return null;
-  const importId = Number(parts[2]);
-  const itemId = Number(parts[3]);
+  if (!customId.startsWith(`${CSV_REMAP_MODAL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 3);
+  if (!segs) return null;
+  const [ownerId, importIdStr, itemIdStr] = segs;
+  const importId = Number(importIdStr);
+  const itemId = Number(itemIdStr);
   if (!Number.isInteger(importId) || !Number.isInteger(itemId)) return null;
-  if (!parts[1]) return null;
-  return { ownerId: parts[1], importId, itemId };
+  if (!ownerId) return null;
+  return { ownerId, importId, itemId };
 }
 
 export function buildCollectionCsvGameIdModalId(params: {
@@ -165,14 +169,15 @@ export function parseCollectionCsvGameIdModalId(customId: string): {
   importId: number;
   itemId: number;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4) return null;
-  if (parts[0] !== CSV_GAME_ID_MODAL_PREFIX) return null;
-  const importId = Number(parts[2]);
-  const itemId = Number(parts[3]);
+  if (!customId.startsWith(`${CSV_GAME_ID_MODAL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 3);
+  if (!segs) return null;
+  const [ownerId, importIdStr, itemIdStr] = segs;
+  const importId = Number(importIdStr);
+  const itemId = Number(itemIdStr);
   if (!Number.isInteger(importId) || !Number.isInteger(itemId)) return null;
-  if (!parts[1]) return null;
-  return { ownerId: parts[1], importId, itemId };
+  if (!ownerId) return null;
+  return { ownerId, importId, itemId };
 }
 
 export function buildCsvImportItemMessage(params: {

--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -16,6 +16,7 @@ import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { safeDeferUpdate } from "../../functions/InteractionUtils.js";
 import { buildUserHeaderContainer } from "../../functions/uiComponents.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const COLLECTION_LIST_PAGE_SIZE = 20;
 const COLLECTION_LIST_NAV_PREFIX = "collection-list-nav-v2";
@@ -72,15 +73,11 @@ export function parseCollectionListNavId(customId: string): {
   isEphemeral: boolean;
   direction: "prev" | "next";
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 6) return null;
-  if (parts[0] !== COLLECTION_LIST_NAV_PREFIX) return null;
-
-  const viewerUserId = parts[1];
-  const targetUserId = parts[2];
-  const page = Number(parts[3]);
-  const visibility = parts[4];
-  const direction = parts[5] as "prev" | "next";
+  if (!customId.startsWith(`${COLLECTION_LIST_NAV_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 5);
+  if (!segs) return null;
+  const [viewerUserId, targetUserId, pageStr, visibility, direction] = segs;
+  const page = Number(pageStr);
   if (!Number.isInteger(page) || page < 0) return null;
   if (visibility !== "e" && visibility !== "p") return null;
   if (direction !== "prev" && direction !== "next") return null;
@@ -90,7 +87,7 @@ export function parseCollectionListNavId(customId: string): {
     targetUserId,
     page,
     isEphemeral: visibility === "e",
-    direction,
+    direction: direction as "prev" | "next",
   };
 }
 
@@ -115,17 +112,16 @@ export function parseCollectionFilterActionId(customId: string): {
   isEphemeral: boolean;
   action: "open";
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 5) return null;
-  if (parts[0] !== COLLECTION_LIST_FILTER_PREFIX) return null;
-  const visibility = parts[3];
-  const action = parts[4] as "open";
+  if (!customId.startsWith(`${COLLECTION_LIST_FILTER_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [viewerUserId, targetUserId, visibility, action] = segs;
   if (visibility !== "e" && visibility !== "p") return null;
   if (action !== "open") return null;
 
   return {
-    viewerUserId: parts[1],
-    targetUserId: parts[2],
+    viewerUserId,
+    targetUserId,
     isEphemeral: visibility === "e",
     action,
   };
@@ -176,18 +172,18 @@ export function parseCollectionFilterPanelActionId(customId: string): {
   isEphemeral: boolean;
   action: "text" | "ownership" | "apply" | "clear" | "cancel";
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 6) return null;
-  if (parts[0] !== COLLECTION_LIST_FILTER_PANEL_PREFIX) return null;
-  const visibility = parts[4];
-  const action = decodeFilterPanelAction(parts[5]);
+  if (!customId.startsWith(`${COLLECTION_LIST_FILTER_PANEL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 5);
+  if (!segs) return null;
+  const [viewerUserId, targetUserId, sourceMessageId, visibility, actionCode] = segs;
+  const action = decodeFilterPanelAction(actionCode);
   if (visibility !== "e" && visibility !== "p") return null;
   if (!action) return null;
 
   return {
-    viewerUserId: parts[1],
-    targetUserId: parts[2],
-    sourceMessageId: parts[3],
+    viewerUserId,
+    targetUserId,
+    sourceMessageId,
     isEphemeral: visibility === "e",
     action,
   };
@@ -217,17 +213,17 @@ export function parseCollectionFilterModalId(customId: string): {
   isEphemeral: boolean;
   ownershipType: CollectionOwnershipType | undefined;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 6) return null;
-  if (parts[0] !== COLLECTION_LIST_FILTER_MODAL_PREFIX) return null;
-  const visibility = parts[4];
+  if (!customId.startsWith(`${COLLECTION_LIST_FILTER_MODAL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 5);
+  if (!segs) return null;
+  const [viewerUserId, targetUserId, sourceMessageId, visibility, ownershipCode] = segs;
   if (visibility !== "e" && visibility !== "p") return null;
   return {
-    viewerUserId: parts[1],
-    targetUserId: parts[2],
-    sourceMessageId: parts[3],
+    viewerUserId,
+    targetUserId,
+    sourceMessageId,
     isEphemeral: visibility === "e",
-    ownershipType: ownershipCodeToType(parts[5]),
+    ownershipType: ownershipCodeToType(ownershipCode),
   };
 }
 

--- a/src/commands/collection/collection-overview.service.ts
+++ b/src/commands/collection/collection-overview.service.ts
@@ -10,6 +10,7 @@ import { COLLECTION_OVERVIEW_EMOJIS } from "../../config/emojis.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export const COLLECTION_OVERVIEW_SELECT_PREFIX = "collection-overview-select-v1";
 const COLLECTION_OVERVIEW_SELECT_OVERVIEW = "overview";
@@ -164,15 +165,15 @@ export function parseCollectionOverviewSelectId(customId: string): {
   targetUserId: string;
   isEphemeral: boolean;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4) return null;
-  if (parts[0] !== COLLECTION_OVERVIEW_SELECT_PREFIX) return null;
-  const visibility = parts[3];
+  if (!customId.startsWith(`${COLLECTION_OVERVIEW_SELECT_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 3);
+  if (!segs) return null;
+  const [viewerUserId, targetUserId, visibility] = segs;
   if (visibility !== "e" && visibility !== "p") return null;
 
   return {
-    viewerUserId: parts[1],
-    targetUserId: parts[2],
+    viewerUserId,
+    targetUserId,
     isEphemeral: visibility === "e",
   };
 }

--- a/src/commands/collection/collection-steam-import.service.ts
+++ b/src/commands/collection/collection-steam-import.service.ts
@@ -1,6 +1,7 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
 import { buildImportReasonSummary } from "./collection-import-ui.utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export type CollectionSteamImportButtonAction = "skip" | "remap" | "game-id" | "pause";
 
@@ -49,16 +50,16 @@ export function parseCollectionSteamImportActionId(customId: string): {
   itemId: number;
   action: CollectionSteamImportButtonAction;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 5) return null;
-  if (parts[0] !== STEAM_IMPORT_ACTION_PREFIX) return null;
+  if (!customId.startsWith(`${STEAM_IMPORT_ACTION_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [ownerId, importIdStr, itemIdStr, actionCode] = segs;
 
-  const importId = Number(parts[2]);
-  const itemId = Number(parts[3]);
+  const importId = Number(importIdStr);
+  const itemId = Number(itemIdStr);
   if (!isPositiveInt(importId)) return null;
   if (!isPositiveInt(itemId)) return null;
 
-  const actionCode = parts[4];
   const action = actionCode === "s"
     ? "skip"
     : actionCode === "r"
@@ -70,7 +71,7 @@ export function parseCollectionSteamImportActionId(customId: string): {
         : null;
   if (!action) return null;
 
-  return { ownerId: parts[1], importId, itemId, action };
+  return { ownerId, importId, itemId, action };
 }
 
 export function buildCollectionSteamChooseId(params: {
@@ -94,16 +95,17 @@ export function parseCollectionSteamChooseId(customId: string): {
   itemId: number;
   gameId: number;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 5) return null;
-  if (parts[0] !== STEAM_CHOOSE_PREFIX) return null;
-  const importId = Number(parts[2]);
-  const itemId = Number(parts[3]);
-  const gameId = Number(parts[4]);
+  if (!customId.startsWith(`${STEAM_CHOOSE_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [ownerId, importIdStr, itemIdStr, gameIdStr] = segs;
+  const importId = Number(importIdStr);
+  const itemId = Number(itemIdStr);
+  const gameId = Number(gameIdStr);
   if (!isPositiveInt(importId)) return null;
   if (!isPositiveInt(itemId)) return null;
   if (!isPositiveInt(gameId)) return null;
-  return { ownerId: parts[1], importId, itemId, gameId };
+  return { ownerId, importId, itemId, gameId };
 }
 
 export function buildCollectionSteamRemapModalId(params: {
@@ -124,16 +126,16 @@ export function parseCollectionSteamRemapModalId(customId: string): {
   importId: number;
   itemId: number;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4) return null;
-  if (parts[0] !== STEAM_REMAP_MODAL_PREFIX) return null;
-
-  const importId = Number(parts[2]);
-  const itemId = Number(parts[3]);
+  if (!customId.startsWith(`${STEAM_REMAP_MODAL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 3);
+  if (!segs) return null;
+  const [ownerId, importIdStr, itemIdStr] = segs;
+  const importId = Number(importIdStr);
+  const itemId = Number(itemIdStr);
   if (!isPositiveInt(importId)) return null;
   if (!isPositiveInt(itemId)) return null;
 
-  return { ownerId: parts[1], importId, itemId };
+  return { ownerId, importId, itemId };
 }
 
 export function buildCollectionSteamGameIdModalId(params: {
@@ -154,14 +156,15 @@ export function parseCollectionSteamGameIdModalId(customId: string): {
   importId: number;
   itemId: number;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4) return null;
-  if (parts[0] !== STEAM_GAME_ID_MODAL_PREFIX) return null;
-  const importId = Number(parts[2]);
-  const itemId = Number(parts[3]);
+  if (!customId.startsWith(`${STEAM_GAME_ID_MODAL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 3);
+  if (!segs) return null;
+  const [ownerId, importIdStr, itemIdStr] = segs;
+  const importId = Number(importIdStr);
+  const itemId = Number(itemIdStr);
   if (!isPositiveInt(importId)) return null;
   if (!isPositiveInt(itemId)) return null;
-  return { ownerId: parts[1], importId, itemId };
+  return { ownerId, importId, itemId };
 }
 
 export function buildSteamImportItemMessage(params: {

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -38,6 +38,7 @@ import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
 } from "../../config/textLimits.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 /**
  * Creates a completion session and returns the session ID
@@ -370,7 +371,9 @@ export async function processCompletionSelection(
 export async function handleCompletionAddSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const [, sessionId] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [sessionId] = segs;
   const ctx = completionAddSessions.get(sessionId);
 
   if (!ctx) {

--- a/src/commands/game-completion/completion-common.service.ts
+++ b/src/commands/game-completion/completion-common.service.ts
@@ -15,6 +15,7 @@ import { safeDeferUpdate, safeReply } from "../../functions/InteractionUtils.js"
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { buildComponentsV2Flags, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { decodeBase64Url, encodeWithMaxLength } from "../../functions/CustomIdUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 import {
   COMPLETION_PAGE_SIZE,
@@ -132,20 +133,22 @@ function buildCommonNavCustomId(
 function parseCommonBackCustomId(
   customId: string,
 ): { state: ICommonCompletionState; page: number } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 8 || parts[0] !== "comp-common-back") return null;
-  const page = Number(parts[6]);
+  if (!customId.startsWith("comp-common-back:")) return null;
+  const segs = parseCustomIdSegments(customId, 7);
+  if (!segs) return null;
+  const [leftId, rightId, sortTok, yearTok, platformTok, pageStr, queryTok] = segs;
+  const page = Number(pageStr);
   if (!Number.isInteger(page) || page < 0) return null;
 
   return {
     page,
     state: {
-      leftId: parts[1],
-      rightId: parts[2],
-      sort: normalizeSort(parts[3]),
-      year: parseYearToken(parts[4]),
-      platformId: parsePlatformToken(parts[5]),
-      query: decodeQueryToken(parts[7]),
+      leftId,
+      rightId,
+      sort: normalizeSort(sortTok),
+      year: parseYearToken(yearTok),
+      platformId: parsePlatformToken(platformTok),
+      query: decodeQueryToken(queryTok),
     },
   };
 }
@@ -153,22 +156,22 @@ function parseCommonBackCustomId(
 function parseCommonNavCustomId(
   customId: string,
 ): { state: ICommonCompletionState; page: number; direction: "prev" | "next" } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 9 || parts[0] !== "comp-common-nav") return null;
-
-  const page = Number(parts[6]);
-  const direction = parts[7];
+  if (!customId.startsWith("comp-common-nav:")) return null;
+  const segs = parseCustomIdSegments(customId, 8);
+  if (!segs) return null;
+  const [leftId, rightId, sortTok, yearTok, platformTok, pageStr, direction, queryTok] = segs;
+  const page = Number(pageStr);
   if (!Number.isInteger(page) || page < 0) return null;
   if (direction !== "prev" && direction !== "next") return null;
 
   return {
     state: {
-      leftId: parts[1],
-      rightId: parts[2],
-      sort: normalizeSort(parts[3]),
-      year: parseYearToken(parts[4]),
-      platformId: parsePlatformToken(parts[5]),
-      query: decodeQueryToken(parts[8]),
+      leftId,
+      rightId,
+      sort: normalizeSort(sortTok),
+      year: parseYearToken(yearTok),
+      platformId: parsePlatformToken(platformTok),
+      query: decodeQueryToken(queryTok),
     },
     page,
     direction,

--- a/src/commands/game-completion/completion-delete.service.ts
+++ b/src/commands/game-completion/completion-delete.service.ts
@@ -4,6 +4,7 @@ import { safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 /**
  * Handles completion deletion from the selection menu
@@ -11,7 +12,9 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 export async function handleCompletionDeleteMenu(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const [, ownerId] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This delete prompt isn't for you.", true));
     return;

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -30,6 +30,7 @@ import {
   safeUpdate,
 } from "../../functions/InteractionUtils.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const MAX_NOTE_LENGTH = 500;
 type CompletionEditField = "type" | "date" | "platform" | "playtime" | "note";
@@ -45,7 +46,9 @@ type EditPromptPayload = {
 export async function handleCompletionEditMenu(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const [, ownerId] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId] = segs;
   if (await replyIfNotOwner(interaction, ownerId)) return;
 
   const completionId = Number(interaction.values[0]);
@@ -72,7 +75,9 @@ export async function handleCompletionEditMenu(
  * Handles the "Done" button when finishing editing
  */
 export async function handleCompletionEditDone(interaction: ButtonInteraction): Promise<void> {
-  const [, ownerId] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId] = segs;
   if (await replyIfNotOwner(interaction, ownerId)) return;
 
   await safeUpdate(interaction, {
@@ -89,7 +94,9 @@ export async function handleCompletionEditDone(interaction: ButtonInteraction): 
  * Handles editing individual completion fields (type, date, playtime, note)
  */
 export async function handleCompletionFieldEdit(interaction: ButtonInteraction): Promise<void> {
-  const [, ownerId, completionIdRaw, field] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 3);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId, completionIdRaw, field] = segs;
   if (await replyIfNotOwner(interaction, ownerId)) return;
 
   const completionId = Number(completionIdRaw);
@@ -248,7 +255,9 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
 export async function handleCompletionTypeSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const [, ownerId, completionIdRaw] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 2);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId, completionIdRaw] = segs;
   if (await replyIfNotOwner(interaction, ownerId)) return;
 
   const completionId = Number(completionIdRaw);

--- a/src/commands/game-completion/completion-helpers.ts
+++ b/src/commands/game-completion/completion-helpers.ts
@@ -8,6 +8,7 @@ import type {
 } from "discord.js";
 import Member from "../../classes/Member.js";
 import { promptRemoveFromNowPlaying } from "../../functions/CompletionHelpers.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 function shouldPromptNowPlayingRemoval(
   addedAt: Date | null,
@@ -77,10 +78,10 @@ export function parseCompletionatorChooseId(customId: string): {
   itemId: number;
   gameId: number;
 } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 5) return null;
-  const [prefix, ownerId, importIdRaw, itemIdRaw, gameIdRaw] = parts;
-  if (prefix !== "comp-import-choose-v1") return null;
+  if (!customId.startsWith("comp-import-choose-v1:")) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [ownerId, importIdRaw, itemIdRaw, gameIdRaw] = segs;
   const importId = Number(importIdRaw);
   const itemId = Number(itemIdRaw);
   const gameId = Number(gameIdRaw);

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -20,6 +20,7 @@ import {
   buildTextReply,
   safeV2TextContent,
 } from "../../functions/ComponentsV2Utils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 /**
  * Parses a year filter string into a number, "unknown", or null
@@ -137,8 +138,9 @@ async function openCompletionJournalView(
 export async function handleCompletionJournalViewSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const parts = interaction.customId.split(":");
-  const ownerId = parts[1];
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId] = segs;
   const gameId = Number(interaction.values[0]);
   if (!gameId) return;
   const firstPage = 1;
@@ -151,7 +153,9 @@ export async function handleCompletionJournalViewSelect(
 export async function handleCompletionJournalPage(
   interaction: ButtonInteraction,
 ): Promise<void> {
-  const [, ownerId, gameIdRaw, , pageRaw] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 4);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId, gameIdRaw, , pageRaw] = segs;
   const gameId = Number(gameIdRaw);
   const page = Number(pageRaw);
   if (!gameId || Number.isNaN(page)) return;
@@ -174,8 +178,9 @@ const COMPLETION_HELP_TEXT = [
 export async function handleCompletionListHeader(
   interaction: ButtonInteraction,
 ): Promise<void> {
-  const parts = interaction.customId.split(":");
-  const ownerId = parts[1];
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [ownerId] = segs;
   if (interaction.user.id !== ownerId) {
     await safeDeferUpdate(interaction).catch(() => {});
     return;
@@ -196,8 +201,9 @@ export async function handleCompletionListHeader(
 export async function handleCompletionClearYearFilter(
   interaction: ButtonInteraction,
 ): Promise<void> {
-  const parts = interaction.customId.split(":");
-  const userId = parts[1];
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [userId] = segs;
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
 
   if (!await safeDeferUpdateOrBail(interaction)) return;
@@ -213,8 +219,9 @@ export async function handleCompletionClearYearFilter(
 export async function handleCompletionYearSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const parts = interaction.customId.split(":");
-  const userId = parts[1];
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [userId] = segs;
   const selectedYear = interaction.values[0];
   const year = parseCompletionYearFilter(selectedYear);
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;

--- a/src/commands/game-completion/completion-platform.service.ts
+++ b/src/commands/game-completion/completion-platform.service.ts
@@ -20,6 +20,7 @@ import {
   type CompletionPlatformContext,
 } from "./completion.types.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export function createCompletionPlatformSession(
   ctx: CompletionPlatformContext,
@@ -78,7 +79,9 @@ export async function promptCompletionPlatformSelection(
 export async function handleCompletionPlatformSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const [, sessionId] = interaction.customId.split(":");
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const [sessionId] = segs;
   const ctx = completionPlatformSessions.get(sessionId);
 
   if (!ctx) {

--- a/src/commands/game-completion/completionator-handlers.service.ts
+++ b/src/commands/game-completion/completionator-handlers.service.ts
@@ -32,6 +32,7 @@ import { COMPLETIONATOR_SKIP_SENTINEL } from "./completion.types.js";
 import { parseCompletionDateInput } from "../profile.command.js";
 import { searchGameDbWithFallback, importGameFromIgdb } from "./completionator-parser.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export class CompletionatorHandlersService {
   private workflowService: CompletionatorWorkflowService;
@@ -43,7 +44,9 @@ export class CompletionatorHandlersService {
   }
 
   async handleCompletionatorSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt isn't for you.", true));
       return;
@@ -165,7 +168,9 @@ export class CompletionatorHandlersService {
   }
 
   async handleCompletionatorUpdateFields(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt isn't for you.", true));
       return;
@@ -241,7 +246,9 @@ export class CompletionatorHandlersService {
   }
 
   async handleCompletionatorAction(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw, action] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw, action] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt isn't for you.", true));
       return;
@@ -487,7 +494,9 @@ export class CompletionatorHandlersService {
   }
 
   async handleCompletionatorFormSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw, field] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw, field] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
       return;
@@ -586,7 +595,9 @@ export class CompletionatorHandlersService {
   }
 
   async handleCompletionatorDateModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
       return;
@@ -656,11 +667,12 @@ export class CompletionatorHandlersService {
   }
 
   async handleCompletionatorInputModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const kind = parts[1] as CompletionatorModalKind;
-    const ownerId = parts[2];
-    const importId = Number(parts[3]);
-    const itemId = Number(parts[4]);
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [kindRaw, ownerId, importIdRaw2, itemIdRaw2] = segs;
+    const kind = kindRaw as CompletionatorModalKind;
+    const importId = Number(importIdRaw2);
+    const itemId = Number(itemIdRaw2);
 
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -66,6 +66,7 @@ import { parseSynonymQuickAddTerms } from "./gamedb-synonym.utils.js";
 import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { COLOR_PRIMARY, COLOR_SUCCESS, COLOR_HIGHLIGHT } from "../config/colors.js";
 import { AUDIT_PAGE_SIZE, SYNONYM_LIST_PAGE_SIZE } from "../config/pagination.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 const AUDIT_VIDEO_MODAL_ID = "audit-video-modal";
 const AUDIT_VIDEO_INPUT_ID = "audit-video-url";
@@ -218,11 +219,10 @@ function buildAutoAcceptStopId(runId: string): string {
 }
 
 function parseAutoAcceptStopId(id: string): string | null {
-  const parts = id.split(":");
-  if (parts.length !== 2 || parts[0] !== AUDIT_AUTO_STOP_PREFIX) {
-    return null;
-  }
-  return parts[1] || null;
+  if (!id.startsWith(`${AUDIT_AUTO_STOP_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(id, 1);
+  if (!segs) return null;
+  return segs[0] || null;
 }
 
 function buildAutoAcceptFollowUpPayload(
@@ -638,9 +638,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-page:[^:]+:(next|prev)$/ })
   async handleAuditPage(interaction: ButtonInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const sessionId = parts[1];
-    const direction = parts[2];
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, direction] = segs;
 
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session) {
@@ -663,8 +663,9 @@ export class GameDbAdmin {
 
   @SelectMenuComponent({ id: /^audit-select:[^:]+$/ })
   async handleAuditSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const sessionId = parts[1];
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
 
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session) {
@@ -688,7 +689,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-back:[^:]+$/ })
   async handleAuditBack(interaction: ButtonInteraction): Promise<void> {
-    const sessionId = interaction.customId.split(":")[1];
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session) {
       await safeUpdate(interaction, { content: "Session expired.", components: [] });
@@ -700,7 +703,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-next:[^:]+:\d+$/ })
   async handleAuditNext(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, gameIdStr] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session || session.userId !== interaction.user.id) return;
@@ -720,7 +725,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-accept-igdb:[^:]+:\d+$/ })
   async handleAuditAcceptIgdb(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, gameIdStr] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
 
     const session = AUDIT_SESSIONS.get(sessionId);
@@ -765,7 +772,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-img:[^:]+:\d+$/ })
   async handleAuditImage(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, gameIdStr] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
     
     // We need to use a collector in the channel to get the image
@@ -842,7 +851,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-accept-video:[^:]+:\d+$/ })
   async handleAuditAcceptVideo(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, gameIdStr] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
 
     const session = AUDIT_SESSIONS.get(sessionId);
@@ -887,7 +898,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-video:[^:]+:\d+$/ })
   async handleAuditVideo(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, gameIdStr] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdStr] = segs;
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session || session.userId !== interaction.user.id) return;
 
@@ -910,7 +923,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-description:[^:]+:\d+$/ })
   async handleAuditDescription(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, gameIdStr] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdStr] = segs;
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session || session.userId !== interaction.user.id) return;
 
@@ -933,7 +948,9 @@ export class GameDbAdmin {
 
   @ModalComponent({ id: /^audit-video-modal:[^:]+:\d+$/ })
   async handleAuditVideoModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, sessionId, gameIdStr] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session || session.userId !== interaction.user.id) return;
@@ -968,7 +985,9 @@ export class GameDbAdmin {
 
   @ModalComponent({ id: /^audit-description-modal:[^:]+:\d+$/ })
   async handleAuditDescriptionModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, sessionId, gameIdStr] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session || session.userId !== interaction.user.id) return;
@@ -1619,8 +1638,9 @@ export class GameDbAdmin {
 
   @ModalComponent({ id: /^gamedb-syn-add:\d+$/ })
   async synonymAddModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const draftId = Number(parts[1]);
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const draftId = Number(segs[0]);
     if (!isPositiveInt(draftId)) {
       await safeReply(interaction, buildTextReply("This synonym draft is no longer valid.", true));
       return;
@@ -1687,8 +1707,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^gamedb-syn-more:\d+$/ })
   async synonymAddMore(interaction: ButtonInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const draftId = Number(parts[1]);
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const draftId = Number(segs[0]);
     if (!isPositiveInt(draftId)) {
       await safeReply(interaction, buildTextReply("This synonym draft is no longer valid.", true));
       return;
@@ -1705,8 +1726,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^gamedb-syn-done:\d+$/ })
   async synonymAddDone(interaction: ButtonInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const draftId = Number(parts[1]);
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const draftId = Number(segs[0]);
     if (!isPositiveInt(draftId)) {
       await safeReply(interaction, buildTextReply("This synonym draft is no longer valid.", true));
       return;
@@ -1726,8 +1748,9 @@ export class GameDbAdmin {
   async synonymGroupEditSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const ownerId = parts[1];
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const groupId = Number(interaction.values[0]);
@@ -1758,10 +1781,10 @@ export class GameDbAdmin {
   async synonymGroupDeleteSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const ownerId = parts[1];
-    const page = Number(parts[2]);
-    const encodedQuery = parts[3] ?? "";
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, pageRaw, encodedQuery] = segs;
+    const page = Number(pageRaw);
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const groupId = Number(interaction.values[0]);
@@ -1789,8 +1812,9 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^gamedb-syn-add-from-list:\d+:\d+:[A-Za-z0-9_-]*$/ })
   async synonymAddFromList(interaction: ButtonInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const ownerId = parts[1];
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const draft = await GameSearchSynonymDraft.createDraft(interaction.user.id);
@@ -1805,9 +1829,10 @@ export class GameDbAdmin {
   async synonymGroupEditModal(
     interaction: ModalSubmitInteraction,
   ): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const ownerId = parts[1];
-    const groupId = Number(parts[2]);
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, groupIdRaw] = segs;
+    const groupId = Number(groupIdRaw);
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This edit request isn't for you.", true));
       return;
@@ -1854,11 +1879,10 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^gamedb-syn-page:\d+:\d+:[A-Za-z0-9_-]*:(next|prev)$/ })
   async synonymListPage(interaction: ButtonInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const ownerId = parts[1];
-    const page = Number(parts[2]);
-    const encodedQuery = parts[3] ?? "";
-    const direction = parts[4];
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, pageRaw, encodedQuery, direction] = segs;
+    const page = Number(pageRaw);
 
     if (await replyIfNotOwner(interaction, ownerId)) return;
 

--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -27,6 +27,7 @@ import {
   safeUpdate,
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import {
   notifyUnknownCompletionPlatform,
   validateCompletionPlaytimeInput,
@@ -302,9 +303,9 @@ export class GameDbCompletionCommand {
    
   @SelectMenuComponent({ id: /^gamedb-completion-select:\d+:(type|date|platform|remove)$/ })
   async handleCompletionWizardSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const sessionId = parts[1];
-    const field = parts[2];
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, field] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
     if (!session) {
       await safeReply(interaction, buildTextReply("This completion request has expired.", true)).catch(() => {});
@@ -346,8 +347,9 @@ export class GameDbCompletionCommand {
    
   @ButtonComponent({ id: /^gamedb-completion-next:\d+$/ })
   async handleCompletionWizardNext(interaction: ButtonInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const sessionId = parts[1];
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
     if (!session) {
       await safeReply(interaction, buildTextReply("This completion request has expired.", true)).catch(() => {});
@@ -420,8 +422,9 @@ export class GameDbCompletionCommand {
    
   @ModalComponent({ id: /^gamedb-completion-modal:\d+$/ })
   async handleCompletionWizardModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const sessionId = parts[1];
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral }).catch(() => {});
     if (!session) {
@@ -513,7 +516,9 @@ export class GameDbCompletionCommand {
    
   @ModalComponent({ id: /^gamedb-nowplaying-modal:\d+$/ })
   async handleGameDbNowPlayingModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, gameIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [gameIdRaw] = segs;
     const gameId = Number(gameIdRaw);
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
     if (!isPositiveInt(gameId)) {

--- a/src/commands/gamedb/gamedb-csv-import.command.ts
+++ b/src/commands/gamedb/gamedb-csv-import.command.ts
@@ -74,6 +74,7 @@ import {
 import { processReleaseDates } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const GAMEDB_CSV_ACTIONS = ["start", "resume", "status", "pause", "cancel"] as const;
 type GameDbCsvAction = (typeof GAMEDB_CSV_ACTIONS)[number];
@@ -484,7 +485,9 @@ export class GameDbCsvImportCommand {
 
   @SelectMenuComponent({ id: /^gamedb-csv-select:\d+:\d+:\d+$/ })
   async handleGameDbCsvSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
       return;
@@ -553,7 +556,9 @@ export class GameDbCsvImportCommand {
     id: /^gamedb-csv-action:\d+:\d+:\d+:(manual|query|accept|skip|pause)$/,
   })
   async handleGameDbCsvAction(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw, action] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw, action] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
       return;
@@ -702,7 +707,9 @@ export class GameDbCsvImportCommand {
 
   @ModalComponent({ id: /^gamedb-csv-manual:\d+:\d+:\d+$/ })
   async handleGameDbCsvManualModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
       return;
@@ -769,7 +776,9 @@ export class GameDbCsvImportCommand {
 
   @ModalComponent({ id: /^gamedb-csv-query:\d+:\d+:\d+$/ })
   async handleGameDbCsvQueryModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, ownerId, importIdRaw, itemIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
       return;

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -51,6 +51,7 @@ import {
 import { handleNoResults } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { MAX_CONTAINER_TEXT } from "../../config/textLimits.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 function formatUpcomingDate(date: Date | null | undefined): string {
   if (!date) return "";
@@ -337,10 +338,10 @@ export class GameDbSearchCommand {
 
   @SelectMenuComponent({ id: /^gamedb-search-select:\d+:\d+:[A-Za-z0-9_-]*$/ })
   async handleSearchSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const ownerId = parts[1];
-    const page = Number(parts[2]);
-    const encodedQuery = parts[3] ?? "";
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, pageRaw, encodedQuery] = segs;
+    const page = Number(pageRaw);
 
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This menu isn't for you.", true));
@@ -412,11 +413,10 @@ export class GameDbSearchCommand {
 
   @ButtonComponent({ id: /^gamedb-search-page:\d+:\d+:[A-Za-z0-9_-]*:(next|prev)$/ })
   async handleSearchPage(interaction: ButtonInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const ownerId = parts[1];
-    const page = Number(parts[2]);
-    const encodedQuery = parts[3] ?? "";
-    const direction = parts[4];
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, pageRaw, encodedQuery, direction] = segs;
+    const page = Number(pageRaw);
 
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This menu isn't for you.", true));
@@ -473,9 +473,9 @@ export class GameDbSearchCommand {
 
   @ButtonComponent({ id: /^gamedb-search-refresh:\d+:[A-Za-z0-9_-]*$/ })
   async handleSearchRefresh(interaction: ButtonInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const ownerId = parts[1];
-    const encodedQuery = parts[2] ?? "";
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, encodedQuery] = segs;
 
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, {

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -28,6 +28,7 @@ import { NOW_PLAYING_SIDEGAME_TAG_ID } from "../../config/tags.js";
 import Game from "../../classes/Game.js";
 import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const GAMEDB_THREAD_MODAL_PREFIX = "gamedb-thread-modal";
 const GAMEDB_THREAD_TITLE_INPUT_ID = "gamedb-thread-title";
@@ -226,10 +227,10 @@ export class GameDbThreadCommand {
    
   @ModalComponent({ id: /^gamedb-thread-modal:\d+:\d+:\d+$/ })
   async handleGameDbThreadModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const parts = interaction.customId.split(":");
-    const gameId = Number(parts[1]);
-    const sourceChannelId = parts[2] ?? "";
-    const sourceMessageId = parts[3] ?? "";
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [gameIdRaw, sourceChannelId, sourceMessageId] = segs;
+    const gameId = Number(gameIdRaw);
 
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
 

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -42,6 +42,7 @@ import { runSearchFlow } from "./gamedb-search.command.js";
 import { startCompletionWizard } from "./gamedb-completion.command.js";
 import { showNowPlayingThreadModal } from "./gamedb-thread.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 @Discord()
 @SlashGroup("gamedb")
@@ -98,7 +99,9 @@ export class GameDbViewCommand {
     id: /^gamedb-action:(nowplaying|completion|thread|video|hltb-import):\d+$/,
   })
   async handleGameDbAction(interaction: ButtonInteraction): Promise<void> {
-    const [, action, gameIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [action, gameIdRaw] = segs;
     const gameId = Number(gameIdRaw);
     if (!isPositiveInt(gameId)) {
       await safeReply(interaction, buildTextReply("Invalid GameDB id.", true));

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -56,6 +56,7 @@ import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { COLOR_SUCCESS } from "../config/colors.js";
 import { CLAIM_MENU_CHUNK_SIZE } from "../config/pagination.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 const MAX_TITLE_LENGTH = 200;
 const MAX_PLATFORM_LENGTH = 50;
@@ -611,7 +612,9 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-page:[^:]+:\d+:\d+:(prev|next)$/ })
   async handlePage(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, ownerId, pageRaw, dir] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, ownerId, pageRaw, dir] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const parsed = parseDirAndPage(pageRaw, dir);
@@ -621,7 +624,9 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-page-public:[^:]+:\d+:(prev|next)$/ })
   async handlePublicPage(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, pageRaw, dir] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, pageRaw, dir] = segs;
     const parsed = parseDirAndPage(pageRaw, dir);
     if (!parsed) return;
     await updateKeyListInteraction(
@@ -630,7 +635,9 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-hub-claim:\d+$/ })
   async handleHubClaim(interaction: ButtonInteraction): Promise<void> {
-    const [, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [pageRaw] = segs;
     const page = Number(pageRaw);
     if (Number.isNaN(page)) return;
 
@@ -689,7 +696,9 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-donor-notify:\d+:(yes|no)$/ })
   async handleDonorNotifyUpdate(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, choice] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, choice] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const enabled = choice === "yes";
@@ -711,7 +720,9 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-claim-button:[^:]+:\d+$/ })
   async handleClaimButton(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, pageRaw] = segs;
     const page = Number(pageRaw);
     if (Number.isNaN(page)) return;
 
@@ -742,7 +753,9 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-claim:[^:]+:\d+:\d+:\d+$/ })
   async handleClaim(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, sessionId, ownerId, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, ownerId, pageRaw] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
     if (!hasMemberRole(interaction.member)) {
@@ -780,7 +793,9 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-hub-claim-select:\d+:\d+$/ })
   async handleHubClaimSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, userId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [userId] = segs;
     if (interaction.user.id !== userId) {
       await safeReply(interaction, buildTextReply("This giveaway claim isn't for you.", true));
       return;
@@ -820,7 +835,9 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-claim-public:[^:]+:\d+:\d+:\d+:\d+$/ })
   async handlePublicClaim(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, sessionId, pageRaw, messageId, userId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, pageRaw, messageId, userId] = segs;
     if (interaction.user.id !== userId) {
       await safeReply(interaction, buildTextReply("This giveaway claim isn't for you.", true));
       return;
@@ -955,7 +972,9 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-claim-cancel:\d+$/ })
   async handleClaimCancel(interaction: ButtonInteraction): Promise<void> {
-    const [, userId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [userId] = segs;
     if (interaction.user.id !== userId) {
       await safeReply(interaction, buildTextReply("This giveaway claim isn't for you.", true));
       return;

--- a/src/commands/help.command.ts
+++ b/src/commands/help.command.ts
@@ -20,6 +20,7 @@ import { buildSuperAdminHelpResponse, isSuperAdmin } from "./superadmin.command.
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { safeDeferReply, safeReply, safeUpdate } from "../functions/InteractionUtils.js";
 import { decodeBase64Url, encodeBase64Url } from "../functions/CustomIdUtils.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { GIVEAWAY_HUB_CHANNEL_ID } from "../config/channels.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
 
@@ -392,9 +393,11 @@ function buildHelpCustomId(view: HelpMenuView, state: HelpStatePayload = {}): st
 function parseHelpCustomId(
   customId: string,
 ): { view: HelpMenuView; state: HelpStatePayload } | null {
-  const [prefix, view, encodedState] = customId.split(":");
-  if (prefix !== HELP_CUSTOM_ID_PREFIX || !view || !encodedState) return null;
-  if (!isHelpView(view)) return null;
+  if (!customId.startsWith(`${HELP_CUSTOM_ID_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 2);
+  if (!segs) return null;
+  const [view, encodedState] = segs;
+  if (!view || !encodedState || !isHelpView(view)) return null;
 
   try {
     const state = JSON.parse(decodeBase64Url(encodedState)) as HelpStatePayload;

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -103,6 +103,7 @@ import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { formatStructuredLog } from "../utilities/LogUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 const MAX_NOW_PLAYING_NOTE_LEN = 500;
 const NOW_PLAYING_SEARCH_LIMIT = 10;
@@ -1368,7 +1369,9 @@ export class NowPlayingCommand {
     interaction: ModalSubmitInteraction,
   ): Promise<void> {
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(true) });
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = nowPlayingCompletionWizardSessions.get(sessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -1514,7 +1517,9 @@ export class NowPlayingCommand {
   async handleNowPlayingCompletionPlatformSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, platformSessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [platformSessionId] = segs;
     const session = nowPlayingCompletionPlatformSessions.get(platformSessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -1774,7 +1779,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^np-complete-pick:[^:]+:\d+$/ })
   async handleNowPlayingCompletionPick(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId, gameIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId, gameIdRaw] = segs;
     const session = nowPlayingCompletionWizardSessions.get(sessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -1818,7 +1825,9 @@ export class NowPlayingCommand {
   async handleNowPlayingCompletionTypeSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = nowPlayingCompletionWizardSessions.get(sessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -1862,7 +1871,9 @@ export class NowPlayingCommand {
   async handleNowPlayingCompletionRemoveSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = nowPlayingCompletionWizardSessions.get(sessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -1906,7 +1917,9 @@ export class NowPlayingCommand {
   async handleNowPlayingCompletionAnnounceSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = nowPlayingCompletionWizardSessions.get(sessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -1950,7 +1963,9 @@ export class NowPlayingCommand {
   async handleNowPlayingCompletionNoteSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = nowPlayingCompletionWizardSessions.get(sessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -1992,7 +2007,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^np-complete-details:[^:]+$/ })
   async handleNowPlayingCompletionDetails(interaction: ButtonInteraction): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = nowPlayingCompletionWizardSessions.get(sessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -2069,7 +2086,9 @@ export class NowPlayingCommand {
 
   @SelectMenuComponent({ id: /^nowplaying-add-select:.+$/ })
   async handleAddNowPlayingSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = nowPlayingAddSessions.get(sessionId);
     const ownerId = session?.userId;
 
@@ -2128,7 +2147,9 @@ export class NowPlayingCommand {
 
   @SelectMenuComponent({ id: /^nowplaying-add-platform-select:[^:]+$/ })
   async handleAddNowPlayingPlatformSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, platformSessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [platformSessionId] = segs;
     const session = nowPlayingAddPlatformSessions.get(platformSessionId);
     if (!session) {
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -2693,7 +2714,9 @@ export class NowPlayingCommand {
   async handleNowPlayingEditPlatformSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This platform prompt isn't for you.", true));
       return;
@@ -2719,7 +2742,9 @@ export class NowPlayingCommand {
   @SelectMenuComponent({ id: /^nowplaying-edit-platform-slot:\d+:\d+:[a-z0-9_]+$/ })
   async handleEditPlatformSlot(interaction: StringSelectMenuInteraction): Promise<void> {
     const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
-    const [, ownerId, slotRaw, stateToken] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, slotRaw, stateToken] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This platform prompt isn't for you.", true));
       return;
@@ -2765,7 +2790,9 @@ export class NowPlayingCommand {
 
   @SelectMenuComponent({ id: /^nowplaying-edit-note-select:\d+$/ })
   async handleEditNoteSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This note prompt isn't for you.", true));
       return;
@@ -2798,7 +2825,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-edit-note-direct:\d+:\d+$/ })
   async handleEditNoteDirect(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This note prompt isn't for you.", true));
       return;
@@ -2834,7 +2863,9 @@ export class NowPlayingCommand {
   @SelectMenuComponent({ id: /^nowplaying-sort-slot:\d+:\d+:[a-z0-9_]+$/ })
   async handleNowPlayingSortSlot(interaction: StringSelectMenuInteraction): Promise<void> {
     const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
-    const [, ownerId, slotRaw, stateToken] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, slotRaw, stateToken] = segs;
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("This sort prompt isn't for you."),
@@ -2911,7 +2942,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-sort-save:\d+:[a-z0-9_]+$/ })
   async handleNowPlayingSortSave(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, stateToken] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, stateToken] = segs;
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("This sort prompt isn't for you."),
@@ -2991,7 +3024,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-sort-reset:\d+$/ })
   async handleNowPlayingSortReset(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This sort prompt isn't for you.", true));
       return;
@@ -3103,7 +3138,9 @@ export class NowPlayingCommand {
 
   @SelectMenuComponent({ id: /^nowplaying-delete-note-select:\d+$/ })
   async handleDeleteNoteSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This note prompt isn't for you.", true));
       return;
@@ -3147,7 +3184,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-delete-note-confirm:\d+:\d+:(yes|no)$/ })
   async handleDeleteNoteConfirm(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, choice] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, choice] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This note prompt isn't for you.", true));
       return;
@@ -3177,7 +3216,9 @@ export class NowPlayingCommand {
   @ButtonComponent({ id: /^np-remove:[^:]+:\d+$/ })
   async handleRemoveNowPlayingButton(interaction: ButtonInteraction): Promise<void> {
     const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("This remove prompt isn't for you."),
@@ -3266,7 +3307,9 @@ export class NowPlayingCommand {
   async handleNowPlayingListNotesToggle(interaction: ButtonInteraction): Promise<void> {
     await safeDeferUpdate(interaction);
 
-    const [, ownerId, action] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, action] = segs;
     const showNotes = action === "show";
     const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
     const contextKey = buildNowPlayingContextKey(
@@ -3355,7 +3398,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-journal-header:\d+:\d+:\d+$/ })
   async handleNowPlayingJournalHeader(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, pageRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeDeferUpdate(interaction);
       return;
@@ -3368,7 +3413,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-journal-open:\d+:\d+:\d+$/ })
   async handleNowPlayingJournalOpen(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, pageRaw] = segs;
     const gameId = Number(gameIdRaw);
     const nowPlayingEntries = getDisplayNowPlayingEntries(await Member.getNowPlaying(ownerId));
     const selected = nowPlayingEntries.find((entry) => entry.gameId === Number(gameIdRaw));
@@ -3407,7 +3454,9 @@ export class NowPlayingCommand {
   async handleNowPlayingJournalViewSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     const gameId = Number(interaction.values?.[0]);
     if (!gameId) return;
     const nowPlayingEntries = getDisplayNowPlayingEntries(await Member.getNowPlaying(ownerId));
@@ -3441,7 +3490,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-journal-page:\d+:\d+:(prev|next):\d+$/ })
   async handleNowPlayingJournalPage(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, , pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, , pageRaw] = segs;
     const gameId = Number(gameIdRaw);
     const nowPlayingEntries = getDisplayNowPlayingEntries(await Member.getNowPlaying(ownerId));
     const selected = nowPlayingEntries.find((entry) => entry.gameId === Number(gameIdRaw));
@@ -3478,7 +3529,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-journal-add:\d+:\d+:\d+$/ })
   async handleNowPlayingJournalAdd(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, pageRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can add journal entries.", false));
       return;
@@ -3510,7 +3563,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-journal-edit:\d+:\d+:\d+$/ })
   async handleNowPlayingJournalEdit(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, pageRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can edit journal entries.", false));
       return;
@@ -3552,7 +3607,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-journal-delete:\d+:\d+:\d+$/ })
   async handleNowPlayingJournalDelete(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, pageRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can delete journal entries.", false));
       return;
@@ -3596,7 +3653,9 @@ export class NowPlayingCommand {
   async handleNowPlayingJournalDeleteSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, pageRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can delete journal entries.", false));
       return;
@@ -3644,7 +3703,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-journal-delete-confirm:(yes|no):\d+:\d+:\d+:\d+$/ })
   async handleNowPlayingJournalDeleteConfirm(interaction: ButtonInteraction): Promise<void> {
-    const [, action, ownerId, gameIdRaw, pageRaw, entryIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 5);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [action, ownerId, gameIdRaw, pageRaw, entryIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can delete journal entries.", false));
       return;
@@ -3672,7 +3733,9 @@ export class NowPlayingCommand {
 
   @ModalComponent({ id: /^nowplaying-journal-modal:\d+:\d+:\d+$/ })
   async handleNowPlayingJournalModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 3);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, pageRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can submit journal entries.", false));
       return;
@@ -3730,7 +3793,9 @@ export class NowPlayingCommand {
 
   @ModalComponent({ id: /^nowplaying-journal-edit-modal:\d+:\d+:\d+:\d+$/ })
   async handleNowPlayingJournalEditModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw, pageRaw, entryIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 4);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw, pageRaw, entryIdRaw] = segs;
     const gameId = Number(gameIdRaw);
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("Only the owner can edit journal entries.", false));
@@ -3764,7 +3829,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-list-edit:\d+$/ })
   async handleNowPlayingListEdit(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent(
@@ -3788,7 +3855,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-help:[a-z-]+:\d+$/ })
   async handleNowPlayingHelp(interaction: ButtonInteraction): Promise<void> {
-    const [, screenType, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [screenType, ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This help button isn't for you.", true));
       return;
@@ -3806,7 +3875,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-edit-menu-sort:\d+$/ })
   async handleNowPlayingEditMenuSort(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This edit menu isn't for you.", true));
       return;
@@ -3816,7 +3887,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-edit-menu-platform:\d+$/ })
   async handleNowPlayingEditMenuPlatform(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This edit menu isn't for you.", true));
       return;
@@ -3826,7 +3899,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-edit-menu-complete:\d+$/ })
   async handleNowPlayingEditMenuComplete(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This edit menu isn't for you.", true));
       return;
@@ -3837,7 +3912,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-edit-menu-remove:\d+$/ })
   async handleNowPlayingEditMenuRemove(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This edit menu isn't for you.", true));
       return;
@@ -3847,7 +3924,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-edit-menu-start-journal:\d+$/ })
   async handleNowPlayingEditMenuStartJournal(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This edit menu isn't for you.", true));
       return;
@@ -3885,7 +3964,9 @@ export class NowPlayingCommand {
   async handleNowPlayingEditMenuStartJournalSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This edit menu isn't for you.", true));
       return;
@@ -3928,7 +4009,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-list-add:\d+$/ })
   async handleNowPlayingListAdd(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("This add prompt isn't for you."),
@@ -3945,7 +4028,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-list-edit-platform:\d+$/ })
   async handleNowPlayingListEditPlatform(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This platform prompt isn't for you.", true));
       return;
@@ -3956,7 +4041,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^np-edit-platform:\d+:\d+$/ })
   async handleNowPlayingEditPlatformPick(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, gameIdRaw] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, gameIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This platform prompt isn't for you.", true));
       return;
@@ -3971,7 +4058,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-edit-platform-save:\d+:[a-z0-9_]+$/ })
   async handleNowPlayingEditPlatformSave(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId, stateToken] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 2);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId, stateToken] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This platform prompt isn't for you.", true));
       return;
@@ -4037,7 +4126,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-edit-platform-reset:\d+$/ })
   async handleNowPlayingEditPlatformReset(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This platform prompt isn't for you.", true));
       return;
@@ -4060,7 +4151,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-list-sort:\d+$/ })
   async handleNowPlayingListSort(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This sort prompt isn't for you.", true));
       return;
@@ -4071,7 +4164,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-list-complete:\d+$/ })
   async handleNowPlayingListComplete(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This completion prompt isn't for you.", true));
       return;
@@ -4083,7 +4178,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-complete-done:\d+$/ })
   async handleNowPlayingCompleteDone(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This completion prompt isn't for you.", true));
       return;
@@ -4093,7 +4190,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-list-remove:\d+$/ })
   async handleNowPlayingListRemove(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("This remove prompt isn't for you."),
@@ -4110,7 +4209,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-remove-done:\d+$/ })
   async handleNowPlayingRemoveDone(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This remove prompt isn't for you.", true));
       return;
@@ -4120,7 +4221,9 @@ export class NowPlayingCommand {
 
   @ButtonComponent({ id: /^nowplaying-list-cancel:\d+$/ })
   async handleNowPlayingListCancel(interaction: ButtonInteraction): Promise<void> {
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This prompt isn't for you.", true));
       return;
@@ -4836,7 +4939,9 @@ export class NowPlayingCommand {
   @SelectMenuComponent({ id: /^nowplaying-remove-select:\d+$/ })
   async handleNowPlayingRemoveSelect(interaction: StringSelectMenuInteraction): Promise<void> {
     const isEphemeral = interaction.message.flags?.has(MessageFlags.Ephemeral) ?? false;
-    const [, ownerId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [ownerId] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This remove prompt isn't for you.", true));
       return;

--- a/src/commands/round-history.command.ts
+++ b/src/commands/round-history.command.ts
@@ -38,6 +38,7 @@ import {
 } from "../functions/InteractionUtils.js";
 import { buildComponentsV2Flags, buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { decodeBase64Url, encodeBase64Url } from "../functions/CustomIdUtils.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import {
   buildRawModalCustomId,
   parseRawModalCustomId,
@@ -300,17 +301,13 @@ function buildRoundHistoryPageCustomId(state: IRoundHistoryFilterState): string 
 }
 
 function parseRoundHistoryPageCustomId(customId: string): IRoundHistoryFilterState | null {
-  const parts = customId.split(":");
-  if (parts.length !== 7 || parts[0] !== "round-history-page") {
-    return null;
-  }
-
-  const ownerUserId = parts[1];
-  const kindToken = parts[2];
-  const year = Number(parts[3]);
-  const sortToken = parts[4];
-  const page = Number(parts[5]);
-  const query = decodeQueryToken(parts[6] ?? "");
+  if (!customId.startsWith("round-history-page:")) return null;
+  const segs = parseCustomIdSegments(customId, 6);
+  if (!segs) return null;
+  const [ownerUserId, kindToken, yearStr, sortToken, pageStr, queryStr] = segs;
+  const year = Number(yearStr);
+  const page = Number(pageStr);
+  const query = decodeQueryToken(queryStr ?? "");
   if (
     !ownerUserId || !Number.isInteger(year) || !Number.isInteger(page) || page < 0 || query === null
   ) {

--- a/src/commands/suggestion.command.ts
+++ b/src/commands/suggestion.command.ts
@@ -48,6 +48,7 @@ import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { buildTextReply, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import { logRawModal } from "../services/raw-modal/RawModalLogging.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 const SUGGESTION_APPROVE_PREFIX = "suggestion-approve";
 const SUGGESTION_CREATE_MODAL_ID = "suggestion-create-modal";
@@ -105,11 +106,10 @@ function buildComponentsV2Flags(isEphemeral: boolean): number {
 function parseSuggestionReviewActionId(
   customId: string,
 ): { action: string; sessionId: string; reviewerId: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== SUGGESTION_REVIEW_PREFIX) {
-    return null;
-  }
-  const [, action, sessionId, reviewerId] = parts;
+  if (!customId.startsWith(`${SUGGESTION_REVIEW_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 3);
+  if (!segs) return null;
+  const [action, sessionId, reviewerId] = segs;
   return action && sessionId && reviewerId ? { action, sessionId, reviewerId } : null;
 }
 
@@ -123,15 +123,12 @@ function buildSuggestionReviewDecisionModalId(
 function parseSuggestionReviewDecisionModalId(
   customId: string,
 ): { reviewerId: string; suggestionId: number } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 3 || parts[0] !== SUGGESTION_REVIEW_DECISION_MODAL_PREFIX) {
-    return null;
-  }
-  const suggestionId = Number(parts[2]);
-  if (!isPositiveInt(suggestionId)) {
-    return null;
-  }
-  const reviewerId = parts[1];
+  if (!customId.startsWith(`${SUGGESTION_REVIEW_DECISION_MODAL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 2);
+  if (!segs) return null;
+  const [reviewerId, suggestionIdStr] = segs;
+  const suggestionId = Number(suggestionIdStr);
+  if (!isPositiveInt(suggestionId)) return null;
   return reviewerId ? { reviewerId, suggestionId } : null;
 }
 
@@ -436,11 +433,10 @@ function buildSuggestionApproveId(suggestionId: number): string {
 }
 
 function parseSuggestionApproveId(id: string): number | null {
-  const parts = id.split(":");
-  if (parts.length !== 2 || parts[0] !== SUGGESTION_APPROVE_PREFIX) {
-    return null;
-  }
-  const suggestionId = Number(parts[1]);
+  if (!id.startsWith(`${SUGGESTION_APPROVE_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(id, 1);
+  if (!segs) return null;
+  const suggestionId = Number(segs[0]);
   return isPositiveInt(suggestionId) ? suggestionId : null;
 }
 

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -51,6 +51,7 @@ import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { sleep } from "../utilities/DelayUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 type CompletionAddContext = {
   targetUserId: string;
@@ -263,7 +264,9 @@ export class SuperAdmin {
 
   @SelectMenuComponent({ id: /^sa-comp-add-select:.+/ })
   async handleSuperAdminCompletionSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const ctx = superadminCompletionAddSessions.get(sessionId);
 
     if (!ctx) {
@@ -300,7 +303,9 @@ export class SuperAdmin {
   async handleSuperAdminCompletionPlatformSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const ctx = superadminCompletionPlatformSessions.get(sessionId);
 
     if (!ctx) {

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -60,6 +60,7 @@ import {
   buildTextReply,
 } from "../functions/ComponentsV2Utils.js";
 import { decodeBase64Url, encodeWithMaxLength } from "../functions/CustomIdUtils.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import { formatDiscordTimestamp } from "../functions/DateFormatUtils.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
@@ -767,32 +768,22 @@ function buildTodoViewId(payloadToken: string, page: number, issueNumber: number
 }
 
 function parseTodoListCustomId(id: string): { payloadToken: string; page: number } | null {
-  const parts = id.split(":");
-  if (parts.length !== 3 || parts[0] !== TODO_LIST_ID_PREFIX) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  if (!payloadToken || !page) {
-    return null;
-  }
-
+  if (!id.startsWith(`${TODO_LIST_ID_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(id, 2);
+  if (!segs) return null;
+  const [payloadToken, pageStr] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page) return null;
   return { payloadToken, page };
 }
 
 function parseTodoListBackId(id: string): { payloadToken: string; page: number } | null {
-  const parts = id.split(":");
-  if (parts.length !== 3 || parts[0] !== TODO_LIST_BACK_ID_PREFIX) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  if (!payloadToken || !page) {
-    return null;
-  }
-
+  if (!id.startsWith(`${TODO_LIST_BACK_ID_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(id, 2);
+  if (!segs) return null;
+  const [payloadToken, pageStr] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page) return null;
   return { payloadToken, page };
 }
 
@@ -800,17 +791,12 @@ function parseTodoCreateButtonId(
   id: string,
   prefix: string,
 ): { payloadToken: string; page: number } | null {
-  const parts = id.split(":");
-  if (parts.length !== 3 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  if (!payloadToken || !page) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 2);
+  if (!segs) return null;
+  const [payloadToken, pageStr] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page) return null;
   return { payloadToken, page };
 }
 
@@ -818,19 +804,12 @@ function parseTodoCreateModalId(
   id: string,
   prefix: string,
 ): { payloadToken: string; page: number; channelId: string; messageId: string } | null {
-  const parts = id.split(":");
-  if (parts.length !== 5 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  const channelId = parts[3];
-  const messageId = parts[4];
-  if (!payloadToken || !page || !channelId || !messageId) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 4);
+  if (!segs) return null;
+  const [payloadToken, pageStr, channelId, messageId] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page || !channelId || !messageId) return null;
   return { payloadToken, page, channelId, messageId };
 }
 
@@ -838,17 +817,12 @@ function parseTodoCloseId(
   id: string,
   prefix: string,
 ): { payloadToken: string; page: number } | null {
-  const parts = id.split(":");
-  if (parts.length !== 3 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  if (!payloadToken || !page) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 2);
+  if (!segs) return null;
+  const [payloadToken, pageStr] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page) return null;
   return { payloadToken, page };
 }
 
@@ -856,37 +830,25 @@ function parseTodoCloseSelectId(
   id: string,
   prefix: string,
 ): { payloadToken: string; page: number; channelId: string; messageId: string } | null {
-  const parts = id.split(":");
-  if (parts.length !== 5 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  const channelId = parts[3];
-  const messageId = parts[4];
-  if (!payloadToken || !page || !channelId || !messageId) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 4);
+  if (!segs) return null;
+  const [payloadToken, pageStr, channelId, messageId] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page || !channelId || !messageId) return null;
   return { payloadToken, page, channelId, messageId };
 }
 
 function parseTodoViewId(
   id: string,
 ): { payloadToken: string; page: number; issueNumber: number } | null {
-  const parts = id.split(":");
-  if (parts.length !== 4 || parts[0] !== TODO_VIEW_ID_PREFIX) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  const issueNumber = Number(parts[3]);
-  if (!payloadToken || !page || !issueNumber) {
-    return null;
-  }
-
+  if (!id.startsWith(`${TODO_VIEW_ID_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(id, 3);
+  if (!segs) return null;
+  const [payloadToken, pageStr, issueStr] = segs;
+  const page = Number(pageStr);
+  const issueNumber = Number(issueStr);
+  if (!payloadToken || !page || !issueNumber) return null;
   return { payloadToken, page, issueNumber };
 }
 
@@ -894,18 +856,13 @@ function parseTodoIssueActionId(
   id: string,
   prefix: string,
 ): { payloadToken: string; page: number; issueNumber: number } | null {
-  const parts = id.split(":");
-  if (parts.length !== 4 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  const issueNumber = Number(parts[3]);
-  if (!payloadToken || !page || !issueNumber) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 3);
+  if (!segs) return null;
+  const [payloadToken, pageStr, issueStr] = segs;
+  const page = Number(pageStr);
+  const issueNumber = Number(issueStr);
+  if (!payloadToken || !page || !issueNumber) return null;
   return { payloadToken, page, issueNumber };
 }
 
@@ -919,20 +876,13 @@ function parseTodoIssueModalId(
   channelId: string;
   messageId: string;
 } | null {
-  const parts = id.split(":");
-  if (parts.length !== 6 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  const issueNumber = Number(parts[3]);
-  const channelId = parts[4];
-  const messageId = parts[5];
-  if (!payloadToken || !page || !issueNumber || !channelId || !messageId) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 5);
+  if (!segs) return null;
+  const [payloadToken, pageStr, issueStr, channelId, messageId] = segs;
+  const page = Number(pageStr);
+  const issueNumber = Number(issueStr);
+  if (!payloadToken || !page || !issueNumber || !channelId || !messageId) return null;
   return { payloadToken, page, issueNumber, channelId, messageId };
 }
 
@@ -974,17 +924,12 @@ function parseTodoQueryId(
   id: string,
   prefix: string,
 ): { payloadToken: string; page: number } | null {
-  const parts = id.split(":");
-  if (parts.length !== 3 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  if (!payloadToken || !page) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 2);
+  if (!segs) return null;
+  const [payloadToken, pageStr] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page) return null;
   return { payloadToken, page };
 }
 
@@ -992,19 +937,12 @@ function parseTodoQueryModalId(
   id: string,
   prefix: string,
 ): { payloadToken: string; page: number; channelId: string; messageId: string } | null {
-  const parts = id.split(":");
-  if (parts.length !== 5 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  const channelId = parts[3];
-  const messageId = parts[4];
-  if (!payloadToken || !page || !channelId || !messageId) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 4);
+  if (!segs) return null;
+  const [payloadToken, pageStr, channelId, messageId] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page || !channelId || !messageId) return null;
   return { payloadToken, page, channelId, messageId };
 }
 
@@ -1012,17 +950,12 @@ function parseTodoFilterId(
   id: string,
   prefix: string,
 ): { payloadToken: string; page: number } | null {
-  const parts = id.split(":");
-  if (parts.length !== 3 || parts[0] !== prefix) {
-    return null;
-  }
-
-  const payloadToken = parts[1];
-  const page = Number(parts[2]);
-  if (!payloadToken || !page) {
-    return null;
-  }
-
+  if (!id.startsWith(`${prefix}:`)) return null;
+  const segs = parseCustomIdSegments(id, 2);
+  if (!segs) return null;
+  const [payloadToken, pageStr] = segs;
+  const page = Number(pageStr);
+  if (!payloadToken || !page) return null;
   return { payloadToken, page };
 }
 

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -33,6 +33,7 @@ import { notifyUnknownCompletionPlatform } from "../functions/CompletionHelpers.
 import { COMPLETION_REACTION_DEV_CHANNEL_ID } from "../config/channels.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 const PUSH_PIN_EMOJI = "📌";
 const PLUS_EMOJI = "➕";
@@ -264,7 +265,9 @@ export class MessageReactionAdd {
   async handleCompletionReactionType(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
       await safeUpdate(interaction, {
@@ -320,7 +323,9 @@ export class MessageReactionAdd {
   async handleCompletionReactionGame(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
       await safeUpdate(interaction, {
@@ -354,7 +359,9 @@ export class MessageReactionAdd {
   async handleCompletionReactionPlatform(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = completionReactionPlatformSessions.get(sessionId);
     if (!session) {
       await safeUpdate(interaction, {
@@ -451,7 +458,9 @@ export class MessageReactionAdd {
   async handleCompletionReactionTitle(
     interaction: ButtonInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
       await safeReply(interaction, buildTextReply("This completion prompt has expired.", false))
@@ -492,7 +501,9 @@ export class MessageReactionAdd {
   async handleCompletionReactionTitleModal(
     interaction: ModalSubmitInteraction,
   ): Promise<void> {
-    const [, sessionId] = interaction.customId.split(":");
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
       await safeReply(interaction, buildTextReply("This completion prompt has expired.", true))

--- a/src/services/IGDB/IgdbSelectService.ts
+++ b/src/services/IGDB/IgdbSelectService.ts
@@ -15,6 +15,7 @@ import {
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export type IgdbSelectOption = { id: number; label: string; description?: string };
 
@@ -153,8 +154,9 @@ export function deleteIgdbSession(sessionId: string): void {
 export async function handleIgdbSelectInteraction(
   interaction: StringSelectMenuInteraction,
 ): Promise<boolean> {
-  const [, sessionId, pageRaw] = interaction.customId.split(":");
-  if (!sessionId) return false;
+  const segs = parseCustomIdSegments(interaction.customId, 2);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return false; }
+  const [sessionId, pageRaw] = segs;
   const session = getSessionStore().get(sessionId);
   if (!session) {
     await safeReply(interaction, buildTextReply("This selection session has expired.", true));
@@ -210,8 +212,9 @@ export async function handleIgdbSelectInteraction(
 export async function handleIgdbFirstMatchInteraction(
   interaction: ButtonInteraction,
 ): Promise<boolean> {
-  const [, sessionId] = interaction.customId.split(":");
-  if (!sessionId) return false;
+  const segs = parseCustomIdSegments(interaction.customId, 1);
+  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return false; }
+  const [sessionId] = segs;
   const session = getSessionStore().get(sessionId);
   if (!session) {
     await safeReply(interaction, buildTextReply("This selection session has expired.", true));

--- a/src/services/ThreadLinkPromptService.ts
+++ b/src/services/ThreadLinkPromptService.ts
@@ -31,6 +31,7 @@ import {
 import { shouldPrompt, markPrompted, getGameReleaseYear } from "./ThreadLinkPromptCache.js";
 import { COLOR_BLUE_INFO } from "../config/colors.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
+import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 function hasIgdbConfig(): boolean {
   return Boolean(process.env.IGDB_CLIENT_ID && process.env.IGDB_CLIENT_SECRET);
@@ -91,8 +92,9 @@ async function promptThread(thread: ThreadChannel): Promise<void> {
 export class ThreadLinkButtonHandlers {
   @ButtonComponent({ id: /^thread-link:.+$/ })
   async handleLinkButton(interaction: ButtonInteraction): Promise<void> {
-    const threadId = interaction.customId.split(":")[1];
-    if (!threadId) return;
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [threadId] = segs;
     if (!interaction.guild || !interaction.channel) return;
 
     if (!hasIgdbConfig()) {
@@ -226,8 +228,9 @@ export class ThreadLinkButtonHandlers {
 
   @ButtonComponent({ id: /^thread-skip:.+$/ })
   async handleSkipButton(interaction: ButtonInteraction): Promise<void> {
-    const threadId = interaction.customId.split(":")[1];
-    if (!threadId) return;
+    const segs = parseCustomIdSegments(interaction.customId, 1);
+    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const [threadId] = segs;
     try {
       await setThreadSkipLinking(threadId, true);
       await safeReply(interaction, buildTextReply(

--- a/src/services/raw-modal/RawModalCustomId.ts
+++ b/src/services/raw-modal/RawModalCustomId.ts
@@ -1,3 +1,4 @@
+import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import {
   RAW_MODAL_ADMIN_FLOWS,
   RAW_MODAL_CUSTOM_ID_PREFIX,
@@ -70,12 +71,11 @@ export function buildRawModalCustomId(parts: IRawModalCustomIdParts): string {
 }
 
 export function parseRawModalCustomId(customId: string): IRawModalParsedCustomId | null {
-  const [prefix, feature, versionPart, flow, sessionId] = customId.split(":");
-
-  if (!prefix || !feature || !versionPart || !flow || !sessionId) {
-    return null;
-  }
-  if (prefix !== RAW_MODAL_CUSTOM_ID_PREFIX) {
+  if (!customId.startsWith(`${RAW_MODAL_CUSTOM_ID_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [feature, versionPart, flow, sessionId] = segs;
+  if (!feature || !versionPart || !flow || !sessionId) {
     return null;
   }
   if (!isSupportedFeature(feature) || !isSupportedFlow(flow)) {


### PR DESCRIPTION
## Summary

Closes #606

- Migrated 150+ inline `customId.split(":")` calls to `parseCustomIdSegments()` across 31 files
- Component/modal handlers now return early with `console.error` when segment count doesn't match, catching typos in custom ID templates at runtime rather than silently producing `undefined`
- Standalone parser functions migrated via `startsWith()` prefix guard + `parseCustomIdSegments()` for the count check, eliminating duplicate length/index logic

**Intentionally left as inline splits (6 sites across 4 files):**
- `completion-pagination.service.ts`: `parts.slice(n).join(":")` — variable-length query segment that can contain colons
- `giveaway.command.ts`: scope-based variable segment count (`hub` vs `private`/`public`)
- `game-journal.command.ts`: rest spread `...queryParts` — variable last segment
- `now-playing.command.ts`: optional 2nd segment (`nowplaying-note-modal:\d+(?::\d+)?`)
- `completion-add.service.ts` / `collection-overview.service.ts`: split on select menu `value`, not `customId`

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run lint` passes with no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)