### PR TITLE
refactor: add safeIgnore() utility and migrate top .catch(() => {}) sites

### DIFF
--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -40,6 +40,7 @@ import {
 } from "../../functions/ComponentsV2Utils.js";
 import { flattenErrorMessages } from "../imports/import-scaffold.service.js";
 import { formatStructuredLog } from "../../utilities/LogUtils.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import {
   buildAllCollectionsOverviewMessages,
   buildCollectionOverviewResponse,
@@ -287,18 +288,18 @@ export class CollectionViewCommand {
   ): Promise<void> {
     const parsed = parseCollectionOverviewSelectId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply("This collection overview control is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This collection overview control is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.viewerUserId) {
-      await safeReply(interaction, buildTextReply("This collection overview is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This collection overview is not for you.", true)));
       return;
     }
 
     const selection = parseCollectionOverviewSelectValue(interaction.values?.[0] ?? "");
     if (!selection) {
-      await safeReply(interaction, buildTextReply("That collection selection is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("That collection selection is invalid.", true)));
       return;
     }
 
@@ -319,10 +320,10 @@ export class CollectionViewCommand {
         titleOverride: overviewTitle ?? undefined,
       });
 
-      await safeReply(interaction, {
+      safeIgnore(safeReply(interaction, {
         components,
         flags: buildComponentsV2EditFlags(),
-      }).catch(() => {});
+      }));
       return;
     }
 
@@ -341,17 +342,17 @@ export class CollectionViewCommand {
       });
 
       if (response.content) {
-        await safeReply(interaction, {
+        safeIgnore(safeReply(interaction, {
           content: response.content,
           components: [],
-        }).catch(() => {});
+        }));
         return;
       }
 
-      await safeReply(interaction, {
+      safeIgnore(safeReply(interaction, {
         components: response.components,
         flags: buildComponentsV2EditFlags(),
-      }).catch(() => {});
+      }));
       return;
     }
 
@@ -376,17 +377,17 @@ export class CollectionViewCommand {
     });
 
     if (response.content) {
-      await safeReply(interaction, {
+      safeIgnore(safeReply(interaction, {
         content: response.content,
         components: [],
-      }).catch(() => {});
+      }));
       return;
     }
 
-    await safeReply(interaction, {
+    safeIgnore(safeReply(interaction, {
       components: response.components,
       flags: buildComponentsV2EditFlags(),
-    }).catch(() => {});
+    }));
   }
 
   @ButtonComponent({
@@ -395,12 +396,12 @@ export class CollectionViewCommand {
   async onCollectionListNav(interaction: ButtonInteraction): Promise<void> {
     const parsed = parseCollectionListNavId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply("This collection view control is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This collection view control is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.viewerUserId) {
-      await safeReply(interaction, buildTextReply("This collection view is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This collection view is not for you.", true)));
       return;
     }
 
@@ -472,12 +473,12 @@ export class CollectionViewCommand {
   async onCollectionFilterOpen(interaction: ButtonInteraction): Promise<void> {
     const parsed = parseCollectionFilterActionId(interaction.customId);
     if (!parsed || parsed.action !== "open") {
-      await safeReply(interaction, buildTextReply("This filter control is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This filter control is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.viewerUserId) {
-      await safeReply(interaction, buildTextReply("This collection view is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This collection view is not for you.", true)));
       return;
     }
 
@@ -491,7 +492,7 @@ export class CollectionViewCommand {
       }),
       true,
     );
-    await safeReply(interaction, {
+    safeIgnore(safeReply(interaction, {
       ...filterPanelReply,
       components: [
         ...filterPanelReply.components,
@@ -503,7 +504,7 @@ export class CollectionViewCommand {
           ownershipType: currentFilters.ownershipType,
         }),
       ],
-    }).catch(() => {});
+    }));
   }
 
   @ButtonComponent({
@@ -512,12 +513,12 @@ export class CollectionViewCommand {
   async onCollectionFilterAction(interaction: ButtonInteraction): Promise<void> {
     const parsed = parseCollectionFilterPanelActionId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply("This filter control is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This filter control is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.viewerUserId) {
-      await safeReply(interaction, buildTextReply("This filter control is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This filter control is not for you.", true)));
       return;
     }
 
@@ -560,7 +561,7 @@ export class CollectionViewCommand {
         new ActionRowBuilder<TextInputBuilder>().addComponents(titleInput),
         new ActionRowBuilder<TextInputBuilder>().addComponents(platformInput),
       );
-      await interaction.showModal(modal).catch(() => {});
+      safeIgnore(interaction.showModal(modal));
       return;
     }
 
@@ -594,7 +595,7 @@ export class CollectionViewCommand {
         platform: nextState.platform,
         ownershipType: nextState.ownershipType,
       });
-      await (interaction.message as any)?.delete?.().catch(() => {});
+      safeIgnore((interaction.message as any)?.delete?.() ?? Promise.resolve());
       if (!applied) {
         await safeReply(interaction, { ...buildTextReply("Could not update that collection message.", true), __forceFollowUp: true });
         return;
@@ -624,12 +625,12 @@ export class CollectionViewCommand {
   async onCollectionFilterTextModal(interaction: ModalSubmitInteraction): Promise<void> {
     const parsed = parseCollectionFilterModalId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply("This filter modal is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This filter modal is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.viewerUserId) {
-      await safeReply(interaction, buildTextReply("This filter modal is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This filter modal is not for you.", true)));
       return;
     }
 

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -104,6 +104,7 @@ import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtil
 import { formatStructuredLog } from "../utilities/LogUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
 
 const MAX_NOW_PLAYING_NOTE_LEN = 500;
 const NOW_PLAYING_SEARCH_LIMIT = 10;
@@ -812,7 +813,7 @@ export class NowPlayingCommand {
     const replacedCurrentChannelMessage = !ephemeral && interaction.channelId
       ? await this.replaceNowPlayingMessageInCurrentChannel(interaction, interaction.user.id)
       : false;
-    await this.refreshNowPlayingListFromContext(interaction, interaction.user.id).catch(() => {});
+    safeIgnore(this.refreshNowPlayingListFromContext(interaction, interaction.user.id));
     if (replacedCurrentChannelMessage) {
       return;
     }
@@ -1698,7 +1699,7 @@ export class NowPlayingCommand {
     }
 
     if (session.removeFromNowPlaying) {
-      await Member.removeNowPlaying(session.userId, game.id).catch(() => {});
+      safeIgnore(Member.removeNowPlaying(session.userId, game.id));
     }
 
     if (session.announce) {
@@ -1713,7 +1714,7 @@ export class NowPlayingCommand {
     }
 
     if (session.removeFromNowPlaying) {
-      await this.refreshNowPlayingListFromContext(interaction, session.userId).catch(() => {});
+      safeIgnore(this.refreshNowPlayingListFromContext(interaction, session.userId));
     }
 
     if (session.returnToList) {
@@ -2081,7 +2082,7 @@ export class NowPlayingCommand {
       modalRows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(noteInput));
     }
     modal.addComponents(...modalRows);
-    await interaction.showModal(modal).catch(() => {});
+    safeIgnore(interaction.showModal(modal));
   }
 
   @SelectMenuComponent({ id: /^nowplaying-add-select:.+$/ })
@@ -2735,7 +2736,7 @@ export class NowPlayingCommand {
       return;
     }
 
-    await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
+    safeIgnore(this.refreshNowPlayingListFromContext(interaction, ownerId));
     await this.returnToNowPlayingEditMenu(interaction, ownerId);
   }
 
@@ -2933,10 +2934,10 @@ export class NowPlayingCommand {
       const container = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent("Could not update the sort form right now."),
       );
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         components: [container],
         flags: buildComponentsV2Flags(isEphemeral),
-      }).catch(() => {});
+      }));
     }
   }
 
@@ -3018,7 +3019,7 @@ export class NowPlayingCommand {
       return;
     }
 
-    await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
+    safeIgnore(this.refreshNowPlayingListFromContext(interaction, ownerId));
     await this.returnToNowPlayingEditMenu(interaction, ownerId);
   }
 
@@ -3103,14 +3104,14 @@ export class NowPlayingCommand {
             components: dmComponents,
             flags: buildComponentsV2Flags(false),
           });
-          await interaction.deleteReply().catch(() => {});
+          safeIgnore(interaction.deleteReply());
           return;
         } catch {
           // Fall through to existing fallback response if DM message edit fails.
         }
       }
       if (refreshed) {
-        await interaction.deleteReply().catch(() => {});
+        safeIgnore(interaction.deleteReply());
         return;
       }
       const list = await Member.getNowPlaying(ownerId);
@@ -3193,10 +3194,10 @@ export class NowPlayingCommand {
     }
 
     if (choice === "no") {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: "Cancelled.",
         components: [],
-      }).catch(() => {});
+      }));
       return;
     }
 
@@ -3207,10 +3208,10 @@ export class NowPlayingCommand {
     }
 
     const updated = await Member.updateNowPlayingNote(ownerId, gameId, null);
-    await safeUpdate(interaction, {
+    safeIgnore(safeUpdate(interaction, {
       content: updated ? "Note deleted." : "Could not update that entry.",
       components: [],
-    }).catch(() => {});
+    }));
   }
 
   @ButtonComponent({ id: /^np-remove:[^:]+:\d+$/ })
@@ -3256,7 +3257,7 @@ export class NowPlayingCommand {
         });
         return;
       }
-      await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
+      safeIgnore(this.refreshNowPlayingListFromContext(interaction, ownerId));
 
       const entries = getDisplayNowPlayingEntries(await Member.getNowPlaying(ownerId));
       if (!entries.length) {
@@ -4023,7 +4024,7 @@ export class NowPlayingCommand {
       return;
     }
     setNowPlayingListContext(ownerId, interaction.message);
-    await interaction.showModal(this.buildNowPlayingAddModal()).catch(() => {});
+    safeIgnore(interaction.showModal(this.buildNowPlayingAddModal()));
   }
 
   @ButtonComponent({ id: /^nowplaying-list-edit-platform:\d+$/ })
@@ -4120,7 +4121,7 @@ export class NowPlayingCommand {
         return;
       }
     }
-    await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
+    safeIgnore(this.refreshNowPlayingListFromContext(interaction, ownerId));
     await this.returnToNowPlayingEditMenu(interaction, ownerId);
   }
 
@@ -4784,9 +4785,9 @@ export class NowPlayingCommand {
       anyInteraction.deferred ?? anyInteraction.replied,
     );
     if (isAcked) {
-      await safeReply(interaction, { components: [row], flags }).catch(() => {});
+      safeIgnore(safeReply(interaction, { components: [row], flags }));
     } else {
-      await safeUpdate(interaction, { components: [row], flags }).catch(() => {});
+      safeIgnore(safeUpdate(interaction, { components: [row], flags }));
     }
   }
 
@@ -4973,13 +4974,13 @@ export class NowPlayingCommand {
             "Failed to remove that game (it may have been removed already).",
           ),
         );
-        await safeReply(interaction, {
+        safeIgnore(safeReply(interaction, {
           components: [container],
           flags: buildComponentsV2Flags(isEphemeral),
-        }).catch(() => {});
+        }));
         return;
       }
-      await this.refreshNowPlayingListFromContext(interaction, ownerId).catch(() => {});
+      safeIgnore(this.refreshNowPlayingListFromContext(interaction, ownerId));
       const entries = getDisplayNowPlayingEntries(await Member.getNowPlaying(ownerId));
       if (!entries.length) {
         const container = new ContainerBuilder().addTextDisplayComponents(
@@ -4990,10 +4991,10 @@ export class NowPlayingCommand {
           interaction.guildId,
           [container],
         );
-        await safeReply(interaction, {
+        safeIgnore(safeReply(interaction, {
           components: pmComponents,
           flags: buildComponentsV2Flags(isEphemeral),
-        }).catch(() => {});
+        }));
         return;
       }
       const includeImages = interaction.guildId != null;
@@ -5012,10 +5013,10 @@ export class NowPlayingCommand {
         interaction.guildId,
         components,
       );
-      await safeReply(interaction, {
+      safeIgnore(safeReply(interaction, {
         ...this.buildComponentPayload(pmComponents as any, files),
         flags: buildComponentsV2Flags(isEphemeral),
-      }).catch(() => {});
+      }));
     } catch (err: any) {
       const msg = extractErrorMessage(err);
       const container = new ContainerBuilder().addTextDisplayComponents(
@@ -5023,10 +5024,10 @@ export class NowPlayingCommand {
           safeV2TextContent(`Could not remove from Now Playing: ${msg}`, 1000),
         ),
       );
-      await safeReply(interaction, {
+      safeIgnore(safeReply(interaction, {
         components: [container],
         flags: buildComponentsV2Flags(isEphemeral),
-      }).catch(() => {});
+      }));
     }
   }
 
@@ -5850,10 +5851,10 @@ export class NowPlayingCommand {
           const container = new ContainerBuilder().addTextDisplayComponents(
             new TextDisplayBuilder().setContent(safeV2TextContent(msg, 1000)),
           );
-          await safeReply(sel, {
+          safeIgnore(safeReply(sel, {
             components: [container],
             flags: buildComponentsV2Flags(true),
-          }).catch(() => {});
+          }));
         }
       });
 

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -34,6 +34,7 @@ import { COMPLETION_REACTION_DEV_CHANNEL_ID } from "../config/channels.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
 
 const PUSH_PIN_EMOJI = "📌";
 const PLUS_EMOJI = "➕";
@@ -190,9 +191,9 @@ export class MessageReactionAdd {
       const content = message.content ?? "";
       const query = parseCompletionQuery(content);
       if (!query) {
-        await user.send({
+        safeIgnore(user.send({
           content: "That message has no text to use as a game title.",
-        }).catch(() => {});
+        }));
         return;
       }
 
@@ -215,9 +216,9 @@ export class MessageReactionAdd {
         .fetch(COMPLETION_REACTION_DEV_CHANNEL_ID)
         .catch(() => null);
       if (!targetChannel || !("send" in targetChannel)) {
-        await user.send({
+        safeIgnore(user.send({
           content: "Bot dev channel not found. Cannot start completion flow.",
-        }).catch(() => {});
+        }));
         return;
       }
       const prompt = await targetChannel.send({
@@ -233,7 +234,7 @@ export class MessageReactionAdd {
           promptChannelId: null,
         }, user.id),
         components: [row, titleRow],
-      }).catch(() => {});
+      }).catch(() => null);
       const session = completionReactionSessions.get(sessionId);
       if (session) {
         session.promptMessageId = prompt?.id ?? null;
@@ -254,9 +255,9 @@ export class MessageReactionAdd {
       if (!limitReached) return;
       const channel: any = message.channel;
       if (channel && typeof channel.send === "function") {
-        await channel.send({
+        safeIgnore(channel.send({
           content: "Pin limit reached for this channel. Unpin something to pin this message.",
-        }).catch(() => {});
+        }));
       }
     }
   }
@@ -270,25 +271,24 @@ export class MessageReactionAdd {
     const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: "This completion prompt has expired.",
         components: [],
-      }).catch(() => {});
+      }));
       return;
     }
 
     if (interaction.user.id !== session.requesterId) {
-      await safeReply(interaction, buildTextReply("This completion prompt is not for you.", false))
-        .catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion prompt is not for you.", false)));
       return;
     }
 
     const value = interaction.values?.[0];
     if (!value || !COMPLETION_TYPES.includes(value as CompletionType)) {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: "Invalid completion type.",
         components: [],
-      }).catch(() => {});
+      }));
       completionReactionSessions.delete(sessionId);
       return;
     }
@@ -313,10 +313,10 @@ export class MessageReactionAdd {
       description: `GameDB #${game.id}`,
     }));
     const row = buildCompletionGameRow(sessionId, options);
-    await safeUpdate(interaction, {
+    safeIgnore(safeUpdate(interaction, {
       content: `Select the game for "${session.query}".`,
       components: [row, buildCompletionTitleRow(sessionId)],
-    }).catch(() => {});
+    }));
   }
    
   @SelectMenuComponent({ id: /^completion-react-game:.+$/ })
@@ -328,26 +328,25 @@ export class MessageReactionAdd {
     const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: "This completion prompt has expired.",
         components: [],
-      }).catch(() => {});
+      }));
       return;
     }
 
     if (interaction.user.id !== session.requesterId) {
-      await safeReply(interaction, buildTextReply("This completion prompt is not for you.", false))
-        .catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion prompt is not for you.", false)));
       return;
     }
 
     const value = interaction.values?.[0];
     const gameId = value ? Number(value) : Number.NaN;
     if (!isPositiveInt(gameId)) {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: "Invalid game selection.",
         components: [],
-      }).catch(() => {});
+      }));
       completionReactionSessions.delete(sessionId);
       return;
     }
@@ -364,16 +363,15 @@ export class MessageReactionAdd {
     const [sessionId] = segs;
     const session = completionReactionPlatformSessions.get(sessionId);
     if (!session) {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: "This completion prompt has expired.",
         components: [],
-      }).catch(() => {});
+      }));
       return;
     }
 
     if (interaction.user.id !== session.requesterId) {
-      await safeReply(interaction, buildTextReply("This completion prompt is not for you.", false))
-        .catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion prompt is not for you.", false)));
       return;
     }
 
@@ -391,10 +389,10 @@ export class MessageReactionAdd {
       session.platforms.some((platform) => platform.id === platformId)
     );
     if (!valid) {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: "Invalid platform selection.",
         components: [],
-      }).catch(() => {});
+      }));
       completionReactionPlatformSessions.delete(sessionId);
       completionReactionSessions.delete(sessionId);
       return;
@@ -403,10 +401,10 @@ export class MessageReactionAdd {
     const completionType = session.completionType ?? (COMPLETION_TYPES[0] as CompletionType);
     const game = await Game.getGameById(session.gameId);
     if (!game) {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: "Selected game was not found in GameDB.",
         components: [],
-      }).catch(() => {});
+      }));
       completionReactionPlatformSessions.delete(sessionId);
       completionReactionSessions.delete(sessionId);
       return;
@@ -428,17 +426,17 @@ export class MessageReactionAdd {
       });
     } catch (err: any) {
       const msg = err?.message ?? "Failed to save completion.";
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: `Could not save completion: ${msg}`,
         components: [],
-      }).catch(() => {});
+      }));
       completionReactionPlatformSessions.delete(sessionId);
       completionReactionSessions.delete(sessionId);
       return;
     }
 
     const completedAtUnix = Math.floor(session.completedAt.getTime() / 1000);
-    await safeUpdate(interaction, {
+    safeIgnore(safeUpdate(interaction, {
       content: [
         "Completion added.",
         `Member: <@${session.targetUserId}>`,
@@ -448,7 +446,7 @@ export class MessageReactionAdd {
         `Message: ${session.messageUrl}`,
       ].join("\n"),
       components: [],
-    }).catch(() => {});
+    }));
 
     completionReactionPlatformSessions.delete(sessionId);
     completionReactionSessions.delete(sessionId);
@@ -463,14 +461,12 @@ export class MessageReactionAdd {
     const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
-      await safeReply(interaction, buildTextReply("This completion prompt has expired.", false))
-        .catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply("This completion prompt has expired.", false)));
       return;
     }
 
     if (interaction.user.id !== session.requesterId) {
-      await safeReply(interaction, buildTextReply("This completion prompt is not for you.", false))
-        .catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply("This completion prompt is not for you.", false)));
       return;
     }
 
@@ -494,7 +490,7 @@ export class MessageReactionAdd {
         ),
       );
 
-    await interaction.showModal(modal).catch(() => {});
+    safeIgnore(interaction.showModal(modal));
   }
    
   @ModalComponent({ id: /^completion-react-title-modal:.+$/ })
@@ -506,14 +502,12 @@ export class MessageReactionAdd {
     const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
-      await safeReply(interaction, buildTextReply("This completion prompt has expired.", true))
-        .catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply("This completion prompt has expired.", true)));
       return;
     }
 
     if (interaction.user.id !== session.requesterId) {
-      await safeReply(interaction, buildTextReply("This completion prompt is not for you.", true))
-        .catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply("This completion prompt is not for you.", true)));
       return;
     }
 
@@ -521,27 +515,26 @@ export class MessageReactionAdd {
       interaction.fields.getTextInputValue("completion-react-title-input"),
     );
     if (!newTitle) {
-      await safeReply(interaction, buildTextReply("Game title is required.", true))
-        .catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply("Game title is required.", true)));
       return;
     }
 
     session.query = newTitle;
-    await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral }).catch(() => {});
+    safeIgnore(safeDeferReply(interaction, { flags: MessageFlags.Ephemeral }));
     const channelId = session.promptChannelId;
     const messageId = session.promptMessageId;
     if (channelId && messageId) {
       const channel = await interaction.client.channels.fetch(channelId).catch(() => null);
       if (channel?.isTextBased()) {
-        await channel.messages.fetch(messageId)
-          .then((message) => message.edit({
+        safeIgnore(
+          channel.messages.fetch(messageId).then((message) => message.edit({
             content: buildCompletionPromptContent(session, session.requesterId),
             components: [buildCompletionTypeRow(sessionId), buildCompletionTitleRow(sessionId)],
-          }))
-          .catch(() => {});
+          })),
+        );
       }
     }
-    await interaction.deleteReply().catch(() => {});
+    safeIgnore(interaction.deleteReply());
   }
 
   private async saveCompletionFromReaction(
@@ -553,7 +546,7 @@ export class MessageReactionAdd {
       content: string,
       components: ActionRowBuilder<StringSelectMenuBuilder>[] = [],
     ): Promise<void> => {
-      await safeUpdate(interaction, { content, components }).catch(() => {});
+      safeIgnore(safeUpdate(interaction, { content, components }));
     };
 
     const game = await Game.getGameById(gameId);
@@ -599,19 +592,19 @@ export class MessageReactionAdd {
       searchRes = await igdbService.searchGames(session.query);
     } catch (err: any) {
       const msg = err?.message ?? "Failed to search IGDB.";
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: `IGDB search failed: ${msg}`,
         components: [],
-      }).catch(() => {});
+      }));
       completionReactionSessions.delete(session.sessionId);
       return;
     }
 
     if (!searchRes.results.length) {
-      await safeUpdate(interaction, {
+      safeIgnore(safeUpdate(interaction, {
         content: `No IGDB results found for "${session.query}".`,
         components: [],
-      }).catch(() => {});
+      }));
       completionReactionSessions.delete(session.sessionId);
       return;
     }
@@ -622,27 +615,27 @@ export class MessageReactionAdd {
         if (!sel.deferred && !sel.replied) {
           await safeDeferUpdate(sel);
         }
-        await safeReply(sel, {
+        safeIgnore(safeReply(sel, {
           content: "Importing game details from IGDB...",
           components: [],
-        }).catch(() => {});
+        }));
         const imported = await this.importGameFromIgdb(igdbId);
         await this.saveCompletionFromReaction(sel, session, imported.gameId);
         completionReactionSessions.delete(session.sessionId);
       } catch (err: any) {
         const msg = err?.message ?? "Failed to import from IGDB.";
-        await safeReply(sel, {
+        safeIgnore(safeReply(sel, {
           content: msg,
           components: [],
-        }).catch(() => {});
+        }));
         completionReactionSessions.delete(session.sessionId);
       }
     });
 
-    await safeUpdate(interaction, {
+    safeIgnore(safeUpdate(interaction, {
       content: `No GameDB match. Select an IGDB result for "${session.query}".`,
       components: [...components, buildCompletionTitleRow(session.sessionId)],
-    }).catch(() => {});
+    }));
     session.promptMessageId = interaction.message?.id ?? session.promptMessageId;
     session.promptChannelId = interaction.channelId ?? session.promptChannelId;
   }

--- a/src/utilities/AsyncUtils.ts
+++ b/src/utilities/AsyncUtils.ts
@@ -1,0 +1,3 @@
+export function safeIgnore(promise: Promise<unknown>): void {
+  promise.catch(() => {});
+}


### PR DESCRIPTION
## Summary
- Creates `src/utilities/AsyncUtils.ts` with a `safeIgnore()` helper that explicitly marks fire-and-forget promises (replaces silent `.catch(() => {})` noise)
- Migrates the three highest-density files (73 total instances):
  - `src/events/MessageReactionAdd.command.ts` (32 instances)
  - `src/commands/now-playing.command.ts` (22 instances)
  - `src/commands/collection/collection-view.command.ts` (19 instances)

Closes #610

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] `grep -n "\.catch(() => {})" src/events/MessageReactionAdd.command.ts src/commands/now-playing.command.ts src/commands/collection/collection-view.command.ts` returns zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)