### PR TITLE
refactor: add navigation button row factories to PaginationUtils.ts (#633)

### DIFF
--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -17,6 +17,7 @@ import { safeDeferUpdate } from "../../functions/InteractionUtils.js";
 import { buildUserHeaderContainer } from "../../functions/uiComponents.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { buildDisabledPrevNextRowWithIds } from "../../functions/PaginationUtils.js";
 
 const COLLECTION_LIST_PAGE_SIZE = 20;
 const COLLECTION_LIST_NAV_PREFIX = "collection-list-nav-v2";
@@ -516,37 +517,24 @@ async function buildCollectionListResponse(params: {
     ),
   );
 
-  const row = new ActionRowBuilder<ButtonBuilder>();
-  if (pageCount > 1) {
-    row.addComponents(
-      new ButtonBuilder()
-        .setCustomId(
-          buildCollectionListNavId({
-            viewerUserId: params.viewerUserId,
-            targetUserId: params.targetUserId,
-            page: safePage,
-            isEphemeral: params.isEphemeral,
-            direction: "prev",
-          }),
-        )
-        .setLabel("Previous")
-        .setStyle(ButtonStyle.Secondary)
-        .setDisabled(safePage <= 0),
-      new ButtonBuilder()
-        .setCustomId(
-          buildCollectionListNavId({
-            viewerUserId: params.viewerUserId,
-            targetUserId: params.targetUserId,
-            page: safePage,
-            isEphemeral: params.isEphemeral,
-            direction: "next",
-          }),
-        )
-        .setLabel("Next")
-        .setStyle(ButtonStyle.Secondary)
-        .setDisabled(safePage >= pageCount - 1),
-    );
-  }
+  const row = buildDisabledPrevNextRowWithIds(
+    buildCollectionListNavId({
+      viewerUserId: params.viewerUserId,
+      targetUserId: params.targetUserId,
+      page: safePage,
+      isEphemeral: params.isEphemeral,
+      direction: "prev",
+    }),
+    buildCollectionListNavId({
+      viewerUserId: params.viewerUserId,
+      targetUserId: params.targetUserId,
+      page: safePage,
+      isEphemeral: params.isEphemeral,
+      direction: "next",
+    }),
+    safePage,
+    pageCount,
+  ) ?? new ActionRowBuilder<ButtonBuilder>();
 
   row.addComponents(
     new ButtonBuilder()

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -68,6 +68,7 @@ import { NOW_PLAYING_HELP_PREFIX } from "./now-playing-help.js";
 import { EphemeralOwnerMenu } from "../functions/EphemeralOwnerMenu.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { buildOptionalPrevNextRowWithIds } from "../functions/PaginationUtils.js";
 import {
   JOURNAL_LIST_PAGE_SIZE as LIST_PAGE_SIZE,
   JOURNAL_ALL_PAGE_SIZE as ALL_PAGE_SIZE,
@@ -231,28 +232,12 @@ function buildListPageRow(
   page: number,
   totalPages: number,
 ): ActionRowBuilder<ButtonBuilder> | null {
-  if (totalPages <= 1) return null;
-
-  const row = new ActionRowBuilder<ButtonBuilder>();
-  if (page > 0) {
-    row.addComponents(
-      new ButtonBuilder()
-        // eslint-disable-next-line local/custom-id-has-matching-handler
-        .setCustomId(`${GJ_LIST_PAGE_PREFIX}:${callerId}:${targetUserId}:${page - 1}`)
-        .setLabel("Previous")
-        .setStyle(ButtonStyle.Secondary),
-    );
-  }
-  if (page < totalPages - 1) {
-    row.addComponents(
-      new ButtonBuilder()
-        // eslint-disable-next-line local/custom-id-has-matching-handler
-        .setCustomId(`${GJ_LIST_PAGE_PREFIX}:${callerId}:${targetUserId}:${page + 1}`)
-        .setLabel("Next")
-        .setStyle(ButtonStyle.Secondary),
-    );
-  }
-  return row.components.length > 0 ? row : null;
+  return buildOptionalPrevNextRowWithIds(
+    `${GJ_LIST_PAGE_PREFIX}:${callerId}:${targetUserId}:${page - 1}`,
+    `${GJ_LIST_PAGE_PREFIX}:${callerId}:${targetUserId}:${page + 1}`,
+    page,
+    totalPages,
+  );
 }
 
 function buildJournalViewPayload(
@@ -329,27 +314,12 @@ function buildAllPageRow(
   page: number,
   totalPages: number,
 ): ActionRowBuilder<ButtonBuilder> | null {
-  if (totalPages <= 1) return null;
-  const row = new ActionRowBuilder<ButtonBuilder>();
-  if (page > 0) {
-    row.addComponents(
-      new ButtonBuilder()
-        // eslint-disable-next-line local/custom-id-has-matching-handler
-        .setCustomId(`${GJ_ALL_PAGE_PREFIX}:${callerId}:${page - 1}`)
-        .setLabel("Previous")
-        .setStyle(ButtonStyle.Secondary),
-    );
-  }
-  if (page < totalPages - 1) {
-    row.addComponents(
-      new ButtonBuilder()
-        // eslint-disable-next-line local/custom-id-has-matching-handler
-        .setCustomId(`${GJ_ALL_PAGE_PREFIX}:${callerId}:${page + 1}`)
-        .setLabel("Next")
-        .setStyle(ButtonStyle.Secondary),
-    );
-  }
-  return row.components.length > 0 ? row : null;
+  return buildOptionalPrevNextRowWithIds(
+    `${GJ_ALL_PAGE_PREFIX}:${callerId}:${page - 1}`,
+    `${GJ_ALL_PAGE_PREFIX}:${callerId}:${page + 1}`,
+    page,
+    totalPages,
+  );
 }
 
 async function autocompleteJournalSearchGame(
@@ -438,25 +408,13 @@ function buildSearchPageRow(
   page: number,
   totalPages: number,
 ): ActionRowBuilder<ButtonBuilder> | null {
-  if (totalPages <= 1) return null;
-  const row = new ActionRowBuilder<ButtonBuilder>();
-  if (page > 0) {
-    row.addComponents(
-      new ButtonBuilder()
-        .setCustomId(buildSearchCustomId(callerId, targetUserId, gameId, page - 1, query))
-        .setLabel("Previous Result")
-        .setStyle(ButtonStyle.Secondary),
-    );
-  }
-  if (page < totalPages - 1) {
-    row.addComponents(
-      new ButtonBuilder()
-        .setCustomId(buildSearchCustomId(callerId, targetUserId, gameId, page + 1, query))
-        .setLabel("Next Result")
-        .setStyle(ButtonStyle.Secondary),
-    );
-  }
-  return row.components.length > 0 ? row : null;
+  return buildOptionalPrevNextRowWithIds(
+    buildSearchCustomId(callerId, targetUserId, gameId, page - 1, query),
+    buildSearchCustomId(callerId, targetUserId, gameId, page + 1, query),
+    page,
+    totalPages,
+    { prev: "Previous Result", next: "Next Result" },
+  );
 }
 
 @Discord()

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -35,7 +35,7 @@ import {
   buildTextReply,
   safeV2TextContent,
 } from "../functions/ComponentsV2Utils.js";
-import { shouldRenderPrevNextButtons } from "../functions/PaginationUtils.js";
+import { buildDisabledPrevNextRow } from "../functions/PaginationUtils.js";
 import {
   GUILD_FETCH_CHUNK_SIZE,
   MP_INFO_PAGE_SIZE as PAGE_SIZE,
@@ -191,23 +191,14 @@ function buildPageComponents(
     .setMaxValues(1);
   components.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
 
-  if (totalPages > 1) {
-    const prevDisabled = page <= 0;
-    const nextDisabled = page >= totalPages - 1;
-    const prev = new ButtonBuilder()
-      .setCustomId(`mpinfo-page:${ownerId}:${filterKey}:${page}:prev`)
-      .setLabel("Previous Page")
-      .setStyle(ButtonStyle.Secondary)
-      .setDisabled(prevDisabled);
-    const next = new ButtonBuilder()
-      .setCustomId(`mpinfo-page:${ownerId}:${filterKey}:${page}:next`)
-      .setLabel("Next Page")
-      .setStyle(ButtonStyle.Secondary)
-      .setDisabled(nextDisabled);
-
-    if (shouldRenderPrevNextButtons(prevDisabled, nextDisabled)) {
-      components.push(new ActionRowBuilder<ButtonBuilder>().addComponents(prev, next));
-    }
+  const navRow = buildDisabledPrevNextRow(
+    `mpinfo-page:${ownerId}:${filterKey}`,
+    page,
+    totalPages,
+    { prev: "Previous Page", next: "Next Page" },
+  );
+  if (navRow) {
+    components.push(navRow);
   }
 
   return components;

--- a/src/commands/round-history.command.ts
+++ b/src/commands/round-history.command.ts
@@ -44,6 +44,7 @@ import {
   parseRawModalCustomId,
 } from "../services/raw-modal/RawModalCustomId.js";
 import { ROUND_HISTORY_PAGE_SIZE } from "../config/pagination.js";
+import { buildDisabledPrevNextRowWithIds } from "../functions/PaginationUtils.js";
 
 const ROUND_HISTORY_MODAL_TITLE = "Round History";
 const ROUND_HISTORY_HELP_ID = "round-history-help";
@@ -418,26 +419,15 @@ function buildRoundHistoryPaginationRow(
   state: IRoundHistoryFilterState,
   totalPages: number,
 ): ActionRowBuilder<ButtonBuilder> | null {
-  if (totalPages <= 1) {
-    return null;
-  }
-
   const prevPage = Math.max(0, state.page - 1);
   const nextPage = Math.min(totalPages - 1, state.page + 1);
-
-  const prevButton = new ButtonBuilder()
-    .setCustomId(buildRoundHistoryPageCustomId({ ...state, page: prevPage }))
-    .setLabel("Previous")
-    .setStyle(ButtonStyle.Secondary)
-    .setDisabled(state.page <= 0);
-
-  const nextButton = new ButtonBuilder()
-    .setCustomId(buildRoundHistoryPageCustomId({ ...state, page: nextPage }))
-    .setLabel("Next")
-    .setStyle(ButtonStyle.Primary)
-    .setDisabled(state.page >= totalPages - 1);
-
-  return new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton);
+  return buildDisabledPrevNextRowWithIds(
+    buildRoundHistoryPageCustomId({ ...state, page: prevPage }),
+    buildRoundHistoryPageCustomId({ ...state, page: nextPage }),
+    state.page,
+    totalPages,
+    { styles: { next: ButtonStyle.Primary } },
+  );
 }
 
 async function buildRoundHistoryResponse(

--- a/src/functions/PaginationUtils.ts
+++ b/src/functions/PaginationUtils.ts
@@ -55,3 +55,99 @@ export function buildOptionalPrevNextRow(
   if (!buttons.length) return null;
   return new ActionRowBuilder<ButtonBuilder>().addComponents(buttons);
 }
+
+/**
+ * Builds a Previous / Next button row using explicit customIds, omitting
+ * whichever buttons are disabled. Returns null when there is only one page
+ * or neither button would be shown.
+ */
+export function buildOptionalPrevNextRowWithIds(
+  prevCustomId: string,
+  nextCustomId: string,
+  page: number,
+  totalPages: number,
+  labels?: { prev?: string; next?: string },
+): ActionRowBuilder<ButtonBuilder> | null {
+  if (totalPages <= 1) return null;
+  const buttons: ButtonBuilder[] = [];
+  if (page > 0) {
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(prevCustomId)
+        .setLabel(labels?.prev ?? "Previous")
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+  if (page < totalPages - 1) {
+    buttons.push(
+      new ButtonBuilder()
+        .setCustomId(nextCustomId)
+        .setLabel(labels?.next ?? "Next")
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+  if (!buttons.length) return null;
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(buttons);
+}
+
+/**
+ * Builds a Previous / Next button row where both buttons are always included
+ * but disabled at the boundary pages. Uses the customIdBase+`:${page}:prev|next`
+ * suffix convention. Returns null when there is only one page.
+ */
+export function buildDisabledPrevNextRow(
+  customIdBase: string,
+  page: number,
+  totalPages: number,
+  labels?: { prev?: string; next?: string },
+): ActionRowBuilder<ButtonBuilder> | null {
+  if (totalPages <= 1) return null;
+  const prevDisabled = page <= 0;
+  const nextDisabled = page >= totalPages - 1;
+  if (!shouldRenderPrevNextButtons(prevDisabled, nextDisabled)) return null;
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${customIdBase}:${page}:prev`)
+      .setLabel(labels?.prev ?? "Previous")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(prevDisabled),
+    new ButtonBuilder()
+      .setCustomId(`${customIdBase}:${page}:next`)
+      .setLabel(labels?.next ?? "Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(nextDisabled),
+  );
+}
+
+/**
+ * Builds a Previous / Next button row using explicit customIds where both
+ * buttons are always included but disabled at the boundary pages. Returns null
+ * when there is only one page.
+ */
+export function buildDisabledPrevNextRowWithIds(
+  prevCustomId: string,
+  nextCustomId: string,
+  page: number,
+  totalPages: number,
+  options?: {
+    labels?: { prev?: string; next?: string };
+    styles?: { prev?: ButtonStyle; next?: ButtonStyle };
+  },
+): ActionRowBuilder<ButtonBuilder> | null {
+  if (totalPages <= 1) return null;
+  const prevDisabled = page <= 0;
+  const nextDisabled = page >= totalPages - 1;
+  if (!shouldRenderPrevNextButtons(prevDisabled, nextDisabled)) return null;
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(prevCustomId)
+      .setLabel(options?.labels?.prev ?? "Previous")
+      .setStyle(options?.styles?.prev ?? ButtonStyle.Secondary)
+      .setDisabled(prevDisabled),
+    new ButtonBuilder()
+      .setCustomId(nextCustomId)
+      .setLabel(options?.labels?.next ?? "Next")
+      .setStyle(options?.styles?.next ?? ButtonStyle.Secondary)
+      .setDisabled(nextDisabled),
+  );
+}


### PR DESCRIPTION
Closes #633

## Summary

- Adds three new factories to `src/functions/PaginationUtils.ts`:
  - `buildOptionalPrevNextRowWithIds` -- omit-disabled variant with explicit prev/next customIds
  - `buildDisabledPrevNextRow` -- always-show-both variant using the `customIdBase:page:dir` suffix convention
  - `buildDisabledPrevNextRowWithIds` -- always-show-both variant with explicit prev/next customIds and optional label/style overrides
- Migrates all inline `ButtonBuilder` nav chains to the shared factories:
  - `game-journal.command.ts`: `buildListPageRow`, `buildAllPageRow`, `buildSearchPageRow`
  - `mp-info.command.ts`: inline prev/next construction in `buildPageComponents`
  - `round-history.command.ts`: `buildRoundHistoryPaginationRow`
  - `collection-list.service.ts`: inline prev/next in the nav+filter row

## Verification

- `npx tsc --noEmit` passes with zero errors
- `npm run lint` passes with zero violations
- No `ButtonBuilder` chains for prev/next navigation remain in the migrated files -- only `PaginationUtils` factory calls

Part of shared-utilities-standardization-pass-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)