### PR TITLE
refactor: migrate all parseCustomIdSegments+inline-error to assertCustomIdSegments (#631)

### DIFF
--- a/src/commands/admin/gotm-audit-handlers.ts
+++ b/src/commands/admin/gotm-audit-handlers.ts
@@ -41,12 +41,12 @@ import {
   buildGotmAuditPromptComponents,
 } from "./gotm-audit-ui.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export async function handleGotmAuditSelect(
   interaction: StringSelectMenuInteraction): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 3);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 3);
+  if (!segs) return;
   const [ownerId, importIdRaw, itemIdRaw] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This audit prompt is not for you.", true));
@@ -120,8 +120,8 @@ export async function handleGotmAuditSelect(
 }
 
 export async function handleGotmAuditAction(interaction: ButtonInteraction): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 4);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 4);
+  if (!segs) return;
   const [ownerId, importIdRaw, itemIdRaw, action] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This audit prompt is not for you.", true));
@@ -267,8 +267,8 @@ export async function handleGotmAuditAction(interaction: ButtonInteraction): Pro
 export async function handleGotmAuditManualModal(
   interaction: ModalSubmitInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 3);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 3);
+  if (!segs) return;
   const [ownerId, importIdRaw, itemIdRaw] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This audit prompt is not for you.", true));
@@ -345,8 +345,8 @@ export async function handleGotmAuditManualModal(
 export async function handleGotmAuditQueryModal(
   interaction: ModalSubmitInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 3);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 3);
+  if (!segs) return;
   const [ownerId, importIdRaw, itemIdRaw] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This audit prompt is not for you.", true));

--- a/src/commands/admin/live-stream-admin.service.ts
+++ b/src/commands/admin/live-stream-admin.service.ts
@@ -24,7 +24,7 @@ import {
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const LIVE_STREAM_MODAL_PREFIX = "admin-live-stream-create";
 const LIVE_STREAM_TOPIC_ID = "live-stream-topic";
@@ -230,8 +230,8 @@ export async function openLiveStreamCreateModal(interaction: CommandInteraction)
 
 export async function handleLiveStreamCreateModal(interaction: ModalSubmitInteraction):
   Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [userId] = segs;
 
   if (userId !== interaction.user.id) {

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -38,7 +38,7 @@ import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
 } from "../../config/textLimits.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 /**
  * Creates a completion session and returns the session ID
@@ -371,8 +371,8 @@ export async function processCompletionSelection(
 export async function handleCompletionAddSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [sessionId] = segs;
   const ctx = completionAddSessions.get(sessionId);
 

--- a/src/commands/game-completion/completion-delete.service.ts
+++ b/src/commands/game-completion/completion-delete.service.ts
@@ -4,7 +4,7 @@ import { safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 /**
  * Handles completion deletion from the selection menu
@@ -12,8 +12,8 @@ import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 export async function handleCompletionDeleteMenu(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [ownerId] = segs;
   if (interaction.user.id !== ownerId) {
     await safeReply(interaction, buildTextReply("This delete prompt isn't for you.", true));

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -30,7 +30,7 @@ import {
   safeUpdate,
 } from "../../functions/InteractionUtils.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../../utilities/ValidationUtils.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const MAX_NOTE_LENGTH = 500;
 type CompletionEditField = "type" | "date" | "platform" | "playtime" | "note";
@@ -46,8 +46,8 @@ type EditPromptPayload = {
 export async function handleCompletionEditMenu(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [ownerId] = segs;
   if (await replyIfNotOwner(interaction, ownerId)) return;
 
@@ -75,8 +75,8 @@ export async function handleCompletionEditMenu(
  * Handles the "Done" button when finishing editing
  */
 export async function handleCompletionEditDone(interaction: ButtonInteraction): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [ownerId] = segs;
   if (await replyIfNotOwner(interaction, ownerId)) return;
 
@@ -94,8 +94,8 @@ export async function handleCompletionEditDone(interaction: ButtonInteraction): 
  * Handles editing individual completion fields (type, date, playtime, note)
  */
 export async function handleCompletionFieldEdit(interaction: ButtonInteraction): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 3);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 3);
+  if (!segs) return;
   const [ownerId, completionIdRaw, field] = segs;
   if (await replyIfNotOwner(interaction, ownerId)) return;
 
@@ -255,8 +255,8 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
 export async function handleCompletionTypeSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 2);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 2);
+  if (!segs) return;
   const [ownerId, completionIdRaw] = segs;
   if (await replyIfNotOwner(interaction, ownerId)) return;
 

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -20,7 +20,7 @@ import {
   buildTextReply,
   safeV2TextContent,
 } from "../../functions/ComponentsV2Utils.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 /**
  * Parses a year filter string into a number, "unknown", or null
@@ -138,8 +138,8 @@ async function openCompletionJournalView(
 export async function handleCompletionJournalViewSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [ownerId] = segs;
   const gameId = Number(interaction.values[0]);
   if (!gameId) return;
@@ -153,8 +153,8 @@ export async function handleCompletionJournalViewSelect(
 export async function handleCompletionJournalPage(
   interaction: ButtonInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 4);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 4);
+  if (!segs) return;
   const [ownerId, gameIdRaw, , pageRaw] = segs;
   const gameId = Number(gameIdRaw);
   const page = Number(pageRaw);
@@ -178,8 +178,8 @@ const COMPLETION_HELP_TEXT = [
 export async function handleCompletionListHeader(
   interaction: ButtonInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [ownerId] = segs;
   if (interaction.user.id !== ownerId) {
     await safeDeferUpdate(interaction).catch(() => {});
@@ -201,8 +201,8 @@ export async function handleCompletionListHeader(
 export async function handleCompletionClearYearFilter(
   interaction: ButtonInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [userId] = segs;
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
 
@@ -219,8 +219,8 @@ export async function handleCompletionClearYearFilter(
 export async function handleCompletionYearSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [userId] = segs;
   const selectedYear = interaction.values[0];
   const year = parseCompletionYearFilter(selectedYear);

--- a/src/commands/game-completion/completion-platform.service.ts
+++ b/src/commands/game-completion/completion-platform.service.ts
@@ -20,7 +20,7 @@ import {
   type CompletionPlatformContext,
 } from "./completion.types.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export function createCompletionPlatformSession(
   ctx: CompletionPlatformContext,
@@ -79,8 +79,8 @@ export async function promptCompletionPlatformSelection(
 export async function handleCompletionPlatformSelect(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return;
   const [sessionId] = segs;
   const ctx = completionPlatformSessions.get(sessionId);
 

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -66,7 +66,7 @@ import { parseSynonymQuickAddTerms } from "./gamedb-synonym.utils.js";
 import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { COLOR_PRIMARY, COLOR_SUCCESS, COLOR_HIGHLIGHT } from "../config/colors.js";
 import { AUDIT_PAGE_SIZE, SYNONYM_LIST_PAGE_SIZE } from "../config/pagination.js";
-import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments, parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 const AUDIT_VIDEO_MODAL_ID = "audit-video-modal";
 const AUDIT_VIDEO_INPUT_ID = "audit-video-url";
@@ -638,8 +638,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-page:[^:]+:(next|prev)$/ })
   async handleAuditPage(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, direction] = segs;
 
     const session = AUDIT_SESSIONS.get(sessionId);
@@ -663,8 +663,8 @@ export class GameDbAdmin {
 
   @SelectMenuComponent({ id: /^audit-select:[^:]+$/ })
   async handleAuditSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
 
     const session = AUDIT_SESSIONS.get(sessionId);
@@ -689,8 +689,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-back:[^:]+$/ })
   async handleAuditBack(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session) {
@@ -703,8 +703,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-next:[^:]+:\d+$/ })
   async handleAuditNext(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
     const session = AUDIT_SESSIONS.get(sessionId);
@@ -725,8 +725,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-accept-igdb:[^:]+:\d+$/ })
   async handleAuditAcceptIgdb(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
 
@@ -772,8 +772,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-img:[^:]+:\d+$/ })
   async handleAuditImage(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
     
@@ -851,8 +851,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-accept-video:[^:]+:\d+$/ })
   async handleAuditAcceptVideo(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
 
@@ -898,8 +898,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-video:[^:]+:\d+$/ })
   async handleAuditVideo(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, gameIdStr] = segs;
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session || session.userId !== interaction.user.id) return;
@@ -923,8 +923,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^audit-description:[^:]+:\d+$/ })
   async handleAuditDescription(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, gameIdStr] = segs;
     const session = AUDIT_SESSIONS.get(sessionId);
     if (!session || session.userId !== interaction.user.id) return;
@@ -948,8 +948,8 @@ export class GameDbAdmin {
 
   @ModalComponent({ id: /^audit-video-modal:[^:]+:\d+$/ })
   async handleAuditVideoModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
     const session = AUDIT_SESSIONS.get(sessionId);
@@ -985,8 +985,8 @@ export class GameDbAdmin {
 
   @ModalComponent({ id: /^audit-description-modal:[^:]+:\d+$/ })
   async handleAuditDescriptionModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, gameIdStr] = segs;
     const gameId = Number(gameIdStr);
     const session = AUDIT_SESSIONS.get(sessionId);
@@ -1638,8 +1638,8 @@ export class GameDbAdmin {
 
   @ModalComponent({ id: /^gamedb-syn-add:\d+$/ })
   async synonymAddModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const draftId = Number(segs[0]);
     if (!isPositiveInt(draftId)) {
       await safeReply(interaction, buildTextReply("This synonym draft is no longer valid.", true));
@@ -1707,8 +1707,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^gamedb-syn-more:\d+$/ })
   async synonymAddMore(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const draftId = Number(segs[0]);
     if (!isPositiveInt(draftId)) {
       await safeReply(interaction, buildTextReply("This synonym draft is no longer valid.", true));
@@ -1726,8 +1726,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^gamedb-syn-done:\d+$/ })
   async synonymAddDone(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const draftId = Number(segs[0]);
     if (!isPositiveInt(draftId)) {
       await safeReply(interaction, buildTextReply("This synonym draft is no longer valid.", true));
@@ -1748,8 +1748,8 @@ export class GameDbAdmin {
   async synonymGroupEditSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [ownerId] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
@@ -1781,8 +1781,8 @@ export class GameDbAdmin {
   async synonymGroupDeleteSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [ownerId, pageRaw, encodedQuery] = segs;
     const page = Number(pageRaw);
     if (await replyIfNotOwner(interaction, ownerId)) return;
@@ -1812,8 +1812,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^gamedb-syn-add-from-list:\d+:\d+:[A-Za-z0-9_-]*$/ })
   async synonymAddFromList(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [ownerId] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
@@ -1829,8 +1829,8 @@ export class GameDbAdmin {
   async synonymGroupEditModal(
     interaction: ModalSubmitInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [ownerId, groupIdRaw] = segs;
     const groupId = Number(groupIdRaw);
     if (interaction.user.id !== ownerId) {
@@ -1879,8 +1879,8 @@ export class GameDbAdmin {
 
   @ButtonComponent({ id: /^gamedb-syn-page:\d+:\d+:[A-Za-z0-9_-]*:(next|prev)$/ })
   async synonymListPage(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 4);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 4);
+    if (!segs) return;
     const [ownerId, pageRaw, encodedQuery, direction] = segs;
     const page = Number(pageRaw);
 

--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -27,7 +27,7 @@ import {
   safeUpdate,
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import {
   notifyUnknownCompletionPlatform,
   validateCompletionPlaytimeInput,
@@ -303,8 +303,8 @@ export class GameDbCompletionCommand {
    
   @SelectMenuComponent({ id: /^gamedb-completion-select:\d+:(type|date|platform|remove)$/ })
   async handleCompletionWizardSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, field] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
     if (!session) {
@@ -347,8 +347,8 @@ export class GameDbCompletionCommand {
    
   @ButtonComponent({ id: /^gamedb-completion-next:\d+$/ })
   async handleCompletionWizardNext(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
     if (!session) {
@@ -422,8 +422,8 @@ export class GameDbCompletionCommand {
    
   @ModalComponent({ id: /^gamedb-completion-modal:\d+$/ })
   async handleCompletionWizardModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral }).catch(() => {});
@@ -516,8 +516,8 @@ export class GameDbCompletionCommand {
    
   @ModalComponent({ id: /^gamedb-nowplaying-modal:\d+$/ })
   async handleGameDbNowPlayingModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [gameIdRaw] = segs;
     const gameId = Number(gameIdRaw);
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });

--- a/src/commands/gamedb/gamedb-csv-import.command.ts
+++ b/src/commands/gamedb/gamedb-csv-import.command.ts
@@ -74,7 +74,7 @@ import {
 import { processReleaseDates } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const GAMEDB_CSV_ACTIONS = ["start", "resume", "status", "pause", "cancel"] as const;
 type GameDbCsvAction = (typeof GAMEDB_CSV_ACTIONS)[number];
@@ -485,8 +485,8 @@ export class GameDbCsvImportCommand {
 
   @SelectMenuComponent({ id: /^gamedb-csv-select:\d+:\d+:\d+$/ })
   async handleGameDbCsvSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
@@ -556,8 +556,8 @@ export class GameDbCsvImportCommand {
     id: /^gamedb-csv-action:\d+:\d+:\d+:(manual|query|accept|skip|pause)$/,
   })
   async handleGameDbCsvAction(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 4);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 4);
+    if (!segs) return;
     const [ownerId, importIdRaw, itemIdRaw, action] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
@@ -707,8 +707,8 @@ export class GameDbCsvImportCommand {
 
   @ModalComponent({ id: /^gamedb-csv-manual:\d+:\d+:\d+$/ })
   async handleGameDbCsvManualModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));
@@ -776,8 +776,8 @@ export class GameDbCsvImportCommand {
 
   @ModalComponent({ id: /^gamedb-csv-query:\d+:\d+:\d+$/ })
   async handleGameDbCsvQueryModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [ownerId, importIdRaw, itemIdRaw] = segs;
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, buildTextReply("This import prompt is not for you.", true));

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -51,7 +51,7 @@ import {
 import { handleNoResults } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { MAX_CONTAINER_TEXT } from "../../config/textLimits.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 function formatUpcomingDate(date: Date | null | undefined): string {
   if (!date) return "";
@@ -338,8 +338,8 @@ export class GameDbSearchCommand {
 
   @SelectMenuComponent({ id: /^gamedb-search-select:\d+:\d+:[A-Za-z0-9_-]*$/ })
   async handleSearchSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [ownerId, pageRaw, encodedQuery] = segs;
     const page = Number(pageRaw);
 
@@ -413,8 +413,8 @@ export class GameDbSearchCommand {
 
   @ButtonComponent({ id: /^gamedb-search-page:\d+:\d+:[A-Za-z0-9_-]*:(next|prev)$/ })
   async handleSearchPage(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 4);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 4);
+    if (!segs) return;
     const [ownerId, pageRaw, encodedQuery, direction] = segs;
     const page = Number(pageRaw);
 
@@ -473,8 +473,8 @@ export class GameDbSearchCommand {
 
   @ButtonComponent({ id: /^gamedb-search-refresh:\d+:[A-Za-z0-9_-]*$/ })
   async handleSearchRefresh(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [ownerId, encodedQuery] = segs;
 
     if (interaction.user.id !== ownerId) {

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -28,7 +28,7 @@ import { NOW_PLAYING_SIDEGAME_TAG_ID } from "../../config/tags.js";
 import Game from "../../classes/Game.js";
 import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const GAMEDB_THREAD_MODAL_PREFIX = "gamedb-thread-modal";
 const GAMEDB_THREAD_TITLE_INPUT_ID = "gamedb-thread-title";
@@ -227,8 +227,8 @@ export class GameDbThreadCommand {
    
   @ModalComponent({ id: /^gamedb-thread-modal:\d+:\d+:\d+$/ })
   async handleGameDbThreadModal(interaction: ModalSubmitInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [gameIdRaw, sourceChannelId, sourceMessageId] = segs;
     const gameId = Number(gameIdRaw);
 

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -42,7 +42,7 @@ import { runSearchFlow } from "./gamedb-search.command.js";
 import { startCompletionWizard } from "./gamedb-completion.command.js";
 import { showNowPlayingThreadModal } from "./gamedb-thread.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 @Discord()
 @SlashGroup("gamedb")
@@ -99,8 +99,8 @@ export class GameDbViewCommand {
     id: /^gamedb-action:(nowplaying|completion|thread|video|hltb-import):\d+$/,
   })
   async handleGameDbAction(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [action, gameIdRaw] = segs;
     const gameId = Number(gameIdRaw);
     if (!isPositiveInt(gameId)) {

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -61,7 +61,7 @@ import {
   GIVEAWAY_MAX_PLATFORM_LENGTH,
   GIVEAWAY_MAX_KEY_LENGTH,
 } from "../config/textLimits.js";
-import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 const GIVEAWAY_DONATE_MODAL_ID = "giveaway-donate-modal";
 const GIVEAWAY_REVOKE_MODAL_ID = "giveaway-revoke-modal";
 const GIVEAWAY_DONATE_TITLE_ID = "giveaway-donate-title";
@@ -613,8 +613,8 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-page:[^:]+:\d+:\d+:(prev|next)$/ })
   async handlePage(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 4);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 4);
+    if (!segs) return;
     const [sessionId, ownerId, pageRaw, dir] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
@@ -625,8 +625,8 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-page-public:[^:]+:\d+:(prev|next)$/ })
   async handlePublicPage(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [sessionId, pageRaw, dir] = segs;
     const parsed = parseDirAndPage(pageRaw, dir);
     if (!parsed) return;
@@ -636,8 +636,8 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-hub-claim:\d+$/ })
   async handleHubClaim(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [pageRaw] = segs;
     const page = Number(pageRaw);
     if (Number.isNaN(page)) return;
@@ -697,8 +697,8 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-donor-notify:\d+:(yes|no)$/ })
   async handleDonorNotifyUpdate(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [ownerId, choice] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
@@ -721,8 +721,8 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-claim-button:[^:]+:\d+$/ })
   async handleClaimButton(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 2);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 2);
+    if (!segs) return;
     const [sessionId, pageRaw] = segs;
     const page = Number(pageRaw);
     if (Number.isNaN(page)) return;
@@ -754,8 +754,8 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-claim:[^:]+:\d+:\d+:\d+$/ })
   async handleClaim(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 3);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 3);
+    if (!segs) return;
     const [sessionId, ownerId, pageRaw] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
 
@@ -794,8 +794,8 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-hub-claim-select:\d+:\d+$/ })
   async handleHubClaimSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [userId] = segs;
     if (interaction.user.id !== userId) {
       await safeReply(interaction, buildTextReply("This giveaway claim isn't for you.", true));
@@ -836,8 +836,8 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-claim-public:[^:]+:\d+:\d+:\d+:\d+$/ })
   async handlePublicClaim(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 4);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 4);
+    if (!segs) return;
     const [sessionId, pageRaw, messageId, userId] = segs;
     if (interaction.user.id !== userId) {
       await safeReply(interaction, buildTextReply("This giveaway claim isn't for you.", true));
@@ -973,8 +973,8 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: /^giveaway-claim-cancel:\d+$/ })
   async handleClaimCancel(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [userId] = segs;
     if (interaction.user.id !== userId) {
       await safeReply(interaction, buildTextReply("This giveaway claim isn't for you.", true));

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -51,7 +51,7 @@ import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { sleep } from "../utilities/DelayUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
-import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 type CompletionAddContext = {
   targetUserId: string;
@@ -264,8 +264,8 @@ export class SuperAdmin {
 
   @SelectMenuComponent({ id: /^sa-comp-add-select:.+/ })
   async handleSuperAdminCompletionSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const ctx = superadminCompletionAddSessions.get(sessionId);
 
@@ -303,8 +303,8 @@ export class SuperAdmin {
   async handleSuperAdminCompletionPlatformSelect(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const ctx = superadminCompletionPlatformSessions.get(sessionId);
 

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -33,7 +33,7 @@ import { notifyUnknownCompletionPlatform } from "../functions/CompletionHelpers.
 import { COMPLETION_REACTION_DEV_CHANNEL_ID } from "../config/channels.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
-import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 
 const PUSH_PIN_EMOJI = "📌";
@@ -266,8 +266,8 @@ export class MessageReactionAdd {
   async handleCompletionReactionType(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
@@ -323,8 +323,8 @@ export class MessageReactionAdd {
   async handleCompletionReactionGame(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
@@ -358,8 +358,8 @@ export class MessageReactionAdd {
   async handleCompletionReactionPlatform(
     interaction: StringSelectMenuInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const session = completionReactionPlatformSessions.get(sessionId);
     if (!session) {
@@ -456,8 +456,8 @@ export class MessageReactionAdd {
   async handleCompletionReactionTitle(
     interaction: ButtonInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {
@@ -497,8 +497,8 @@ export class MessageReactionAdd {
   async handleCompletionReactionTitleModal(
     interaction: ModalSubmitInteraction,
   ): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [sessionId] = segs;
     const session = completionReactionSessions.get(sessionId);
     if (!session) {

--- a/src/services/IGDB/IgdbSelectService.ts
+++ b/src/services/IGDB/IgdbSelectService.ts
@@ -15,7 +15,7 @@ import {
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
-import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 export type IgdbSelectOption = { id: number; label: string; description?: string };
 
@@ -154,8 +154,8 @@ export function deleteIgdbSession(sessionId: string): void {
 export async function handleIgdbSelectInteraction(
   interaction: StringSelectMenuInteraction,
 ): Promise<boolean> {
-  const segs = parseCustomIdSegments(interaction.customId, 2);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return false; }
+  const segs = assertCustomIdSegments(interaction, 2);
+  if (!segs) return false;
   const [sessionId, pageRaw] = segs;
   const session = getSessionStore().get(sessionId);
   if (!session) {
@@ -212,8 +212,8 @@ export async function handleIgdbSelectInteraction(
 export async function handleIgdbFirstMatchInteraction(
   interaction: ButtonInteraction,
 ): Promise<boolean> {
-  const segs = parseCustomIdSegments(interaction.customId, 1);
-  if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return false; }
+  const segs = assertCustomIdSegments(interaction, 1);
+  if (!segs) return false;
   const [sessionId] = segs;
   const session = getSessionStore().get(sessionId);
   if (!session) {

--- a/src/services/ThreadLinkPromptService.ts
+++ b/src/services/ThreadLinkPromptService.ts
@@ -31,7 +31,7 @@ import {
 import { shouldPrompt, markPrompted, getGameReleaseYear } from "./ThreadLinkPromptCache.js";
 import { COLOR_BLUE_INFO } from "../config/colors.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
-import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 function hasIgdbConfig(): boolean {
   return Boolean(process.env.IGDB_CLIENT_ID && process.env.IGDB_CLIENT_SECRET);
@@ -92,8 +92,8 @@ async function promptThread(thread: ThreadChannel): Promise<void> {
 export class ThreadLinkButtonHandlers {
   @ButtonComponent({ id: /^thread-link:.+$/ })
   async handleLinkButton(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [threadId] = segs;
     if (!interaction.guild || !interaction.channel) return;
 
@@ -228,8 +228,8 @@ export class ThreadLinkButtonHandlers {
 
   @ButtonComponent({ id: /^thread-skip:.+$/ })
   async handleSkipButton(interaction: ButtonInteraction): Promise<void> {
-    const segs = parseCustomIdSegments(interaction.customId, 1);
-    if (!segs) { console.error(`Unexpected customId: ${interaction.customId}`); return; }
+    const segs = assertCustomIdSegments(interaction, 1);
+    if (!segs) return;
     const [threadId] = segs;
     try {
       await setThreadSkipLinking(threadId, true);


### PR DESCRIPTION
## Summary

- Replaced 69 instances of the verbose `parseCustomIdSegments(interaction.customId, N)` + `if (!segs) { console.error(...); return; }` pattern across 18 files
- All callers now use `assertCustomIdSegments(interaction, N)` which handles error logging internally
- `gamedb-admin.command.ts` retains `parseCustomIdSegments` for one non-interaction call (`id` parameter)
- `IgdbSelectService.ts` `return false` variant preserved as `if (!segs) return false;`

## Verification

`grep -rn "Unexpected customId" src/` returns zero hits.

Closes #631

## Test plan
- [ ] Type check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Interaction handlers in affected files still correctly bail on unexpected customIds

🤖 Generated with [Claude Code](https://claude.com/claude-code)