### PR TITLE
refactor: extract page footer and ID/timestamp builders to shared utils (#630)

### DIFF
--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -61,7 +61,7 @@ import GameSearchSynonymDraft, {
 } from "../classes/GameSearchSynonymDraft.js";
 import axios from "axios";
 import { igdbService } from "../services/IGDB/IgdbService.js";
-import { shouldRenderPrevNextButtons } from "../functions/PaginationUtils.js";
+import { buildPageFooterText, shouldRenderPrevNextButtons } from "../functions/PaginationUtils.js";
 import { parseSynonymQuickAddTerms } from "./gamedb-synonym.utils.js";
 import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { COLOR_PRIMARY, COLOR_SUCCESS, COLOR_HIGHLIGHT } from "../config/colors.js";
@@ -1114,7 +1114,7 @@ export class GameDbAdmin {
             `${imageStatus} ${videoStatus} ${descStatus} ${releaseStatus}`;
         }).join("\n"),
       )
-      .setFooter({ text: `Page ${page + 1}/${totalPages}` });
+      .setFooter({ text: buildPageFooterText(page, totalPages) });
 
     const select = new StringSelectMenuBuilder()
       .setCustomId(`audit-select:${sessionId}`)

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -35,7 +35,7 @@ import {
   buildTextReply,
   safeV2TextContent,
 } from "../functions/ComponentsV2Utils.js";
-import { buildDisabledPrevNextRow } from "../functions/PaginationUtils.js";
+import { buildDisabledPrevNextRow, buildPageFooterText } from "../functions/PaginationUtils.js";
 import {
   GUILD_FETCH_CHUNK_SIZE,
   MP_INFO_PAGE_SIZE as PAGE_SIZE,
@@ -154,7 +154,7 @@ function buildSummaryEmbed(
   if (totalPages > 1) {
     const footerText = [
       "Want to list your multiplayer info? Use /profile edit",
-      `Page ${safePage + 1} of ${totalPages}.`,
+      buildPageFooterText(safePage, totalPages),
     ].join("\n");
     embed.setFooter({ text: footerText });
   }

--- a/src/events/GuildBanLog.command.ts
+++ b/src/events/GuildBanLog.command.ts
@@ -3,6 +3,7 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { BAN_LOG_CHANNEL_ID, UNBAN_LOG_CHANNEL_ID } from "../config/channels.js";
+import { buildIdTimestampFooter } from "../functions/InteractionUtils.js";
 import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
 
 async function resolveLogChannel(client: Client, channelId: string): Promise<any | null> {
@@ -31,7 +32,7 @@ function buildBanEmbed(
       { name: "User", value: `<@${userId}>\n${username}` },
       { name: "Account Created On", value: formatAccountCreated(createdAt) },
     )
-    .setFooter({ text: `ID: ${userId} • ${formatTimestampWithDay(Date.now())}` });
+    .setFooter({ text: buildIdTimestampFooter(userId, formatTimestampWithDay(Date.now())) });
 
   if (avatarUrl) {
     embed.setThumbnail(avatarUrl);

--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -16,6 +16,7 @@ import {
   REGULARS_ROLE_ID,
 } from "../config/roles.js";
 import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
+import { buildIdTimestampFooter } from "../functions/InteractionUtils.js";
 
 const QUALIFYING_ROLE_IDS_SET = new Set(
   [REGULARS_ROLE_ID, ADMIN_ROLE_ID, MODERATOR_ROLE_ID, MEMBER_ROLE_ID].filter(
@@ -64,7 +65,7 @@ export class GuildMemberUpdate {
             .setTitle(label)
             .setDescription(`<@&${roleId}>`)
             .setColor(color)
-            .setFooter({ text: `ID: ${user.id} • ${timestamp}` });
+            .setFooter({ text: buildIdTimestampFooter(user.id, timestamp) });
           await (logChannel as any).send({ embeds: [embed] });
         };
 
@@ -122,7 +123,7 @@ export class GuildMemberUpdate {
             .setTitle(title)
             .setDescription(`**Before:** ${beforeValue}\n**+After:** ${afterValue}`)
             .setColor(color)
-            .setFooter({ text: `ID: ${user.id} • ${timestamp}` });
+            .setFooter({ text: buildIdTimestampFooter(user.id, timestamp) });
           await (logChannel as any).send({ embeds: [embed] });
         };
 

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -12,6 +12,10 @@ import { buildComponentsV2Flags, buildTextReply, safeV2TextContent } from "./Com
 
 export type AnyRepliable = RepliableInteraction | CommandInteraction;
 
+export function buildIdTimestampFooter(id: string, timestamp: string): string {
+  return `ID: ${id} • ${timestamp}`;
+}
+
 /** True if the interaction has already been deferred or replied to. */
 export function isInteractionSettled(interaction: AnyRepliable): boolean {
   return interaction.deferred || interaction.replied;

--- a/src/functions/PaginationUtils.ts
+++ b/src/functions/PaginationUtils.ts
@@ -1,5 +1,10 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from "discord.js";
 
+export function buildPageFooterText(page: number, totalPages: number, suffix?: string): string {
+  const base = `Page ${page + 1}/${totalPages}`;
+  return suffix ? `${base} • ${suffix}` : base;
+}
+
 export function shouldRenderPrevNextButtons(
   prevDisabled: boolean,
   nextDisabled: boolean,

--- a/src/services/GiveawayHubService.ts
+++ b/src/services/GiveawayHubService.ts
@@ -8,6 +8,7 @@ import {
 } from "discord.js";
 import { countAvailableGameKeys, listAvailableGameKeys } from "../classes/GameKey.js";
 import { GIVEAWAY_HUB_CHANNEL_ID } from "../config/channels.js";
+import { buildPageFooterText } from "../functions/PaginationUtils.js";
 const GIVEAWAY_HUB_SCAN_LIMIT = 50;
 
 export const KEYS_PAGE_SIZE = 20;
@@ -43,7 +44,7 @@ export function buildKeyListEmbed(
   const embed = new EmbedBuilder()
     .setTitle("Game Key Giveaway")
     .setDescription("Available keys:")
-    .setFooter({ text: `Page ${page + 1}/${totalPages} • ${totalCount} total` });
+    .setFooter({ text: buildPageFooterText(page, totalPages, `${totalCount} total`) });
 
   const lines = keys.map((key, idx) => {
     const number = page * KEYS_PAGE_SIZE + idx + 1;


### PR DESCRIPTION
## Summary

- Adds `buildPageFooterText(page, totalPages, suffix?)` to `src/functions/PaginationUtils.ts` -- generates `Page X/Y` or `Page X/Y • <suffix>` strings
- Adds `buildIdTimestampFooter(id, timestamp)` to `src/functions/InteractionUtils.ts` -- generates `ID: X • <timestamp>` strings
- Migrates all inline occurrences in:
  - `GiveawayHubService.ts` -- `Page ${page + 1}/${totalPages} • ${totalCount} total`
  - `gamedb-admin.command.ts` -- `Page ${page + 1}/${totalPages}`
  - `mp-info.command.ts` -- `Page ${safePage + 1} of ${totalPages}.` (also standardizes separator from "of" to "/")
  - `GuildBanLog.command.ts` -- `ID: ${userId} • <timestamp>`
  - `GuildMemberUpdate.command.ts` (x2) -- `ID: ${user.id} • ${timestamp}`

## Verification

`grep -rn "Page \${page" src/` returns zero hits.
`grep -rn "ID: \${" src/` returns zero hits.
`npx tsc --noEmit` and `npm run lint` pass clean.

## Test plan

- [ ] Giveaway hub embed footer shows correct page/total format
- [ ] GameDB audit embed footer shows correct page format
- [ ] MP info embed footer shows correct page format when paginated
- [ ] Ban/unban log embeds show correct `ID: X • timestamp` footer
- [ ] Role add/remove and nickname log embeds show correct `ID: X • timestamp` footer

Closes #630

🤖 Generated with [Claude Code](https://claude.com/claude-code)