### PR TITLE
refactor: flip command visibility default to public with private boolean param (#629)

### DIFF
--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -18,12 +18,12 @@ import {
 } from "@discordjs/builders";
 import { ButtonComponent, Discord, SelectMenuComponent, Slash, SlashOption } from "discordx";
 import {
-  deferWithShowInChat,
+  deferWithPrivateFlag,
+  PRIVATE_OPTION_DESCRIPTION,
   replyIfNotOwner,
   safeDeferReply,
   safeReply,
   safeUpdate,
-  SHOW_IN_CHAT_DESCRIPTION,
 } from "../functions/InteractionUtils.js";
 import {
   buildOptionalPrevNextRow,
@@ -199,12 +199,12 @@ export class AvatarHistoryCommand {
     })
     member: User | undefined,
     @SlashOption({
-      description: SHOW_IN_CHAT_DESCRIPTION,
-      name: "showinchat",
+      description: PRIVATE_OPTION_DESCRIPTION,
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     @SlashOption({
       description: "List all members with avatar history and their stored count.",
       name: "all",
@@ -221,7 +221,7 @@ export class AvatarHistoryCommand {
     scan: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const ephemeral = !showInChat;
+    const ephemeral = privateFlag ?? false;
 
     if (scan === true) {
       await safeDeferReply(interaction, { flags: buildComponentsV2Flags(true) });
@@ -271,7 +271,7 @@ export class AvatarHistoryCommand {
     }
 
     if (showAll === true) {
-      await deferWithShowInChat(interaction, showInChat);
+      await deferWithPrivateFlag(interaction, privateFlag);
       const pageResult = await buildAvatarHistoryAllPage(
         interaction.guild,
         0,
@@ -304,7 +304,7 @@ export class AvatarHistoryCommand {
       return;
     }
 
-    await deferWithShowInChat(interaction, showInChat);
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     const target = member ?? interaction.user;
     const pageResult = await buildAvatarHistoryV2Page(target, 0);

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -125,15 +125,15 @@ export class CollectionViewCommand {
     })
     ownershipType: CollectionOwnershipType | undefined,
     @SlashOption({
-      name: "showinchat",
-      description: "If true, show results in channel instead of private response.",
+      name: "private",
+      description: "Send reply privately (only visible to you).",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const isEphemeral = !showInChat;
+    const isEphemeral = privateFlag ?? false;
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(isEphemeral) });
 
     const targetUserId = member?.id ?? interaction.user.id;
@@ -230,15 +230,15 @@ export class CollectionViewCommand {
     })
     showAll: boolean | undefined,
     @SlashOption({
-      name: "showinchat",
-      description: "If true, show results in channel instead of private response.",
+      name: "private",
+      description: "Send reply privately (only visible to you).",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const isEphemeral = !showInChat;
+    const isEphemeral = privateFlag ?? false;
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(isEphemeral) });
 
     if (showAll) {

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -22,7 +22,7 @@ import {
   ModalComponent,
 } from "discordx";
 import {
-  deferWithShowInChat,
+  deferWithPrivateFlag,
   safeDeferReply,
   safeReply,
   safeUpdate,
@@ -307,16 +307,16 @@ export class GameCompletionCommands {
     })
     member: User | undefined,
     @SlashOption({
-      description: "If true, show in channel instead of ephemerally.",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const ephemeral = !showInChat;
-    await deferWithShowInChat(interaction, showInChat);
+    const ephemeral = privateFlag ?? false;
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     const sanitizedQuery = query
       ? sanitizeUserInput(query, { preserveNewlines: false })
@@ -410,16 +410,16 @@ export class GameCompletionCommands {
     })
     query: string | undefined,
     @SlashOption({
-      description: "If true, show in channel instead of ephemerally.",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const ephemeral = !showInChat;
-    await deferWithShowInChat(interaction, showInChat);
+    const ephemeral = privateFlag ?? false;
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     let leftUserId = interaction.user.id;
     let rightUserId: string | null = null;

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -27,12 +27,12 @@ import {
 } from "discordx";
 import {
   safeDeferReply,
+  PRIVATE_OPTION_DESCRIPTION,
   replyIfNotOwner,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
   sanitizeUserInput,
-  SHOW_IN_CHAT_DESCRIPTION,
 } from "../functions/InteractionUtils.js";
 import { decodeBase64Url, encodeWithMaxLength } from "../functions/CustomIdUtils.js";
 import {
@@ -445,15 +445,15 @@ export class GameDbAdmin {
     })
     showCompleteGames: boolean | undefined,
     @SlashOption({
-      description: SHOW_IN_CHAT_DESCRIPTION,
-      name: "showinchat",
+      description: PRIVATE_OPTION_DESCRIPTION,
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const isPublic = !!showInChat;
+    const isPublic = !(privateFlag ?? false);
     await safeDeferReply(interaction, { flags: isPublic ? undefined : MessageFlags.Ephemeral });
 
     if (!(await isAdmin(interaction))) return;
@@ -588,15 +588,15 @@ export class GameDbAdmin {
     })
     gameIdsRaw: string,
     @SlashOption({
-      description: SHOW_IN_CHAT_DESCRIPTION,
-      name: "showinchat",
+      description: PRIVATE_OPTION_DESCRIPTION,
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const isPublic = !!showInChat;
+    const isPublic = !(privateFlag ?? false);
     await safeDeferReply(interaction, { flags: isPublic ? undefined : MessageFlags.Ephemeral });
 
     if (!(await isAdmin(interaction))) return;
@@ -1559,15 +1559,15 @@ export class GameDbAdmin {
     })
     additionalSynonyms: string | undefined,
     @SlashOption({
-      description: SHOW_IN_CHAT_DESCRIPTION,
-      name: "showinchat",
+      description: PRIVATE_OPTION_DESCRIPTION,
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const isPublic = !!showInChat;
+    const isPublic = !(privateFlag ?? false);
     await safeDeferReply(interaction, { flags: isPublic ? undefined : MessageFlags.Ephemeral });
     if (!(await isAdmin(interaction))) return;
 
@@ -1614,15 +1614,15 @@ export class GameDbAdmin {
     })
     query: string | undefined,
     @SlashOption({
-      description: SHOW_IN_CHAT_DESCRIPTION,
-      name: "showinchat",
+      description: PRIVATE_OPTION_DESCRIPTION,
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const isPublic = !!showInChat;
+    const isPublic = !(privateFlag ?? false);
     await safeDeferReply(interaction, { flags: isPublic ? undefined : MessageFlags.Ephemeral });
     if (!(await isAdmin(interaction))) return;
 

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -532,23 +532,23 @@ export class GiveawayCommand {
   @Slash({ description: "List available donated game keys", name: "list" })
   async listKeys(
     @SlashOption({
-      description: "Show in chat (public) instead of ephemeral",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const ephemeral = !showInChat;
-    await deferWithShowInChat(interaction, showInChat);
+    const ephemeral = privateFlag ?? false;
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     const sessionId = `giveaway-${Date.now()}-${Math.floor(Math.random() * 100000)}`;
     const payload = await buildKeyListPayload(
       0,
       sessionId,
       interaction.user.id,
-      Boolean(showInChat),
+      !(privateFlag ?? false),
     );
 
     await safeReply(interaction, {

--- a/src/commands/hltb.command.ts
+++ b/src/commands/hltb.command.ts
@@ -7,7 +7,7 @@ import { COLOR_PRIMARY } from "../config/colors.js";
 import Game from "../classes/Game.js";
 import { getHltbCacheByGameId, upsertHltbCache } from "../classes/HltbCache.js";
 import {
-  deferWithShowInChat,
+  deferWithPrivateFlag,
   ephemeralFlag,
   safeReply,
   sanitizeUserInput,
@@ -63,17 +63,17 @@ export class hltb {
     })
     title: string,
     @SlashOption({
-      description: "If set to true, show the results in the channel instead of ephemerally.",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
     title = sanitizeUserInput(title, { preserveNewlines: false });
-    const ephemeral = !showInChat;
-    await deferWithShowInChat(interaction, showInChat);
+    const ephemeral = privateFlag ?? false;
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     try {
       const result = await resolveHltbResult(title);

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -22,7 +22,7 @@ import {
 } from "discordx";
 import Member, { type IMemberPlatformRecord } from "../classes/Member.js";
 import {
-  deferWithShowInChat,
+  deferWithPrivateFlag,
   ephemeralFlag,
   extractErrorMessage,
   safeDeferUpdate,
@@ -254,12 +254,12 @@ export class MultiplayerInfoCommand {
   @Slash({ description: "Show members with multiplayer handles", name: "mp-info" })
   async mpInfo(
     @SlashOption({
-      description: "If true, post in channel instead of ephemerally.",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     @SlashOption({
       description: "Include Steam users.",
       name: "steam",
@@ -304,8 +304,8 @@ export class MultiplayerInfoCommand {
           psn: psn ?? true,
           nsw: nsw ?? true,
         };
-    const ephemeral = !showInChat;
-    await deferWithShowInChat(interaction, showInChat);
+    const ephemeral = privateFlag ?? false;
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     const anyIncluded = filters.steam || filters.xbl || filters.psn || filters.nsw;
     if (!anyIncluded) {

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -31,11 +31,11 @@ import {
   getUpcomingNominationWindow,
 } from "../functions/NominationWindow.js";
 import {
-  deferWithShowInChat,
+  deferWithPrivateFlag,
+  PRIVATE_OPTION_DESCRIPTION,
   safeDeferReply,
   safeReply,
   sanitizeUserInput,
-  SHOW_IN_CHAT_DESCRIPTION,
 } from "../functions/InteractionUtils.js";
 import { buildTextReply, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import {
@@ -291,23 +291,23 @@ export class NominateCommand {
     })
     rawKind: string,
     @SlashOption({
-      description: SHOW_IN_CHAT_DESCRIPTION,
-      name: "showinchat",
+      description: PRIVATE_OPTION_DESCRIPTION,
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean = false,
+    privateFlag: boolean = false,
     interaction: CommandInteraction,
   ): Promise<void> {
     const selectedKind = parseNominationKind(rawKind);
-    const ephemeral = !showInChat;
+    const ephemeral = privateFlag;
 
     if (!selectedKind) {
       await safeReply(interaction, buildTextReply("Please choose either GOTM or NR-GOTM.", true));
       return;
     }
 
-    await deferWithShowInChat(interaction, showInChat);
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     try {
       const window = await getUpcomingNominationWindow();

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -25,7 +25,7 @@ import Member, {
   type IMemberSearchFilters,
 } from "../classes/Member.js";
 import {
-  deferWithShowInChat,
+  deferWithPrivateFlag,
   ephemeralFlag,
   extractErrorMessage,
   safeDeferReply,
@@ -310,17 +310,17 @@ export class ProfileCommand {
     })
     member: User | undefined,
     @SlashOption({
-      description: "If true, post in channel instead of ephemerally.",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
     const target = member ?? interaction.user;
-    const ephemeral = !showInChat;
-    await deferWithShowInChat(interaction, showInChat);
+    const ephemeral = privateFlag ?? false;
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     const result = await buildProfileViewPayload(target);
 
@@ -428,12 +428,12 @@ export class ProfileCommand {
   @SlashGroup("profile")
   async profileSearch(
     @SlashOption({
-      description: "If true, post in channel instead of ephemerally.",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     @SlashOption({
       description: "Filter by user id.",
       name: "userid",
@@ -576,8 +576,8 @@ export class ProfileCommand {
     includeDeparted: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const ephemeral = !showInChat;
-    await deferWithShowInChat(interaction, showInChat);
+    const ephemeral = privateFlag ?? false;
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     userId = userId ? sanitizeUserInput(userId, { preserveNewlines: false }) : undefined;
     username = username ? sanitizeUserInput(username, { preserveNewlines: false }) : undefined;

--- a/src/commands/round-history.command.ts
+++ b/src/commands/round-history.command.ts
@@ -71,12 +71,12 @@ type IRoundHistoryFilterState = {
   page: number;
 };
 
-function buildRoundHistorySessionId(userId: string, showInChat: boolean): string {
-  const visibility = showInChat ? "1" : "0";
+function buildRoundHistorySessionId(userId: string, isPrivate: boolean): string {
+  const visibility = isPrivate ? "1" : "0";
   return `u${userId}_c${visibility}`;
 }
 
-function parseShowInChatFromSessionId(sessionId: string): boolean | null {
+function parsePrivateFlagFromSessionId(sessionId: string): boolean | null {
   const match = /^u\d+_c([01])$/.exec(sessionId);
   if (!match || !match[1]) {
     return null;
@@ -498,15 +498,15 @@ export class RoundHistoryCommand {
   @Slash({ description: "Query historical GOTM/NR-GOTM rounds", name: "round-history" })
   async roundHistory(
     @SlashOption({
-      description: "If true, show results in the channel instead of ephemerally.",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const sessionId = buildRoundHistorySessionId(interaction.user.id, Boolean(showInChat));
+    const sessionId = buildRoundHistorySessionId(interaction.user.id, Boolean(privateFlag));
     let modal: ModalBuilder | null = null;
     let modalJson: unknown = null;
 
@@ -515,7 +515,7 @@ export class RoundHistoryCommand {
       modalJson = modal.toJSON();
       logRoundHistoryModalDebug("open.before_show", {
         sessionId,
-        showInChat: Boolean(showInChat),
+        privateFlag: Boolean(privateFlag),
         modalConstructor: modal.constructor.name,
         hasToJson: typeof modal.toJSON === "function",
         customId: (modalJson as { custom_id?: unknown }).custom_id,
@@ -539,7 +539,7 @@ export class RoundHistoryCommand {
       }
       logRoundHistoryModalDebug("open.show_failed", {
         sessionId,
-        showInChat: Boolean(showInChat),
+        privateFlag: Boolean(privateFlag),
         error: error instanceof Error ? error : String(error),
         modalConstructor: modal?.constructor.name ?? "none",
         hasModalToJson: modal ? typeof modal.toJSON === "function" : false,
@@ -574,8 +574,8 @@ export class RoundHistoryCommand {
     }
 
     const year = Number.isInteger(selectedYear) ? selectedYear : getCurrentYear();
-    const showInChat = parseShowInChatFromSessionId(parsedCustomId.sessionId);
-    const ephemeral = showInChat === null ? true : !showInChat;
+    const privateFlag = parsePrivateFlagFromSessionId(parsedCustomId.sessionId);
+    const ephemeral = privateFlag === null ? true : (privateFlag ?? false);
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(ephemeral) });
 
     const response = await buildRoundHistoryResponse(interaction, {

--- a/src/commands/round.command.ts
+++ b/src/commands/round.command.ts
@@ -1,7 +1,7 @@
 import { type CommandInteraction, ApplicationCommandOptionType } from "discord.js";
 import { Discord, Slash, SlashOption } from "discordx";
 import {
-  deferWithShowInChat,
+  deferWithPrivateFlag,
   extractErrorMessage,
   safeReply,
 } from "../functions/InteractionUtils.js";
@@ -23,16 +23,16 @@ export class CurrentRoundCommand {
   })
   async round(
     @SlashOption({
-      description: "If true, show results in the channel instead of ephemerally.",
-      name: "showinchat",
+      description: "Send reply privately (only visible to you).",
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const ephemeral = !showInChat;
-    await deferWithShowInChat(interaction, showInChat);
+    const ephemeral = privateFlag ?? false;
+    await deferWithPrivateFlag(interaction, privateFlag);
 
     try {
       const current = await BotVotingInfo.getCurrentRound();

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -35,11 +35,11 @@ import {
   ACCESS_DENIED_SERVER_OWNER,
   AnyRepliable,
   safeDeferReply,
+  PRIVATE_OPTION_DESCRIPTION,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
   sanitizeUserInput,
-  SHOW_IN_CHAT_DESCRIPTION,
 } from "../functions/InteractionUtils.js";
 import { countSuggestions } from "../classes/Suggestion.js";
 import {
@@ -1246,15 +1246,15 @@ export class TodoCommand {
     })
     perPage: number | undefined,
     @SlashOption({
-      description: SHOW_IN_CHAT_DESCRIPTION,
-      name: "showinchat",
+      description: PRIVATE_OPTION_DESCRIPTION,
+      name: "private",
       required: false,
       type: ApplicationCommandOptionType.Boolean,
     })
-    showInChat: boolean | undefined,
+    privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const isPublic = showInChat !== false;
+    const isPublic = !(privateFlag ?? false);
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(!isPublic) });
 
     const resolvedPerPage = clampNumber(perPage ?? TODO_DEFAULT_PAGE_SIZE, 1, TODO_MAX_PAGE_SIZE);

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -510,6 +510,14 @@ export async function deferWithShowInChat(
   await safeDeferReply(interaction, { flags: buildComponentsV2Flags(!showInChat) });
 }
 
+/** Defers reply; defaults to public. Pass privateFlag=true to send ephemerally. */
+export async function deferWithPrivateFlag(
+  interaction: AnyRepliable,
+  privateFlag?: boolean,
+): Promise<void> {
+  await safeDeferReply(interaction, { flags: buildComponentsV2Flags(privateFlag ?? false) });
+}
+
 export function extractErrorMessage(err: unknown): string {
   const e = err as any;
   return e?.message ?? String(e);
@@ -524,6 +532,7 @@ export const ACCESS_DENIED_OWNER = "Access denied. Command is restricted to the 
 export const ACCESS_DENIED_SERVER_OWNER = "Access denied. Command requires server owner.";
 export const ACCESS_DENIED_REGULARS = "Access denied. Command requires the Regulars role.";
 export const SHOW_IN_CHAT_DESCRIPTION = "Show in chat (public) instead of ephemeral";
+export const PRIVATE_OPTION_DESCRIPTION = "Send reply privately (only visible to you).";
 
 /** Returns true and replies ephemerally if user is not the owner. */
 export async function replyIfNotOwner(


### PR DESCRIPTION
Closes #629

## Summary

- Added `PRIVATE_OPTION_DESCRIPTION` and `deferWithPrivateFlag()` to `InteractionUtils.ts`
- Renamed `show_in_chat` slash option to `private` in all 12 affected commands
- Replaced `showInChat: boolean` params with `privateFlag: boolean` at all call sites
- Updated inversion logic: `!showInChat` becomes `privateFlag ?? false`
- `round-history.command.ts`: renamed `buildRoundHistorySessionId`/`parseShowInChatFromSessionId` helpers; session encoding updated so `"1"` = private (ephemeral)
- `SHOW_IN_CHAT_DESCRIPTION` and `deferWithShowInChat` retained in `InteractionUtils.ts` for future removal
- `grep -rn "show_in_chat|showInChat" src/` returns zero call-site hits

## Test plan

- [ ] Type-check passes: `npx tsc --noEmit`
- [ ] Lint passes: `npm run lint`
- [ ] `/round` with no `private` option returns public reply
- [ ] `/round private:true` returns ephemeral reply
- [ ] Spot-check same behavior on `/hltb`, `/nominate`, `/profile`, `/game-completion`

🤖 Generated with [Claude Code](https://claude.com/claude-code)