### PR TITLE
refactor: add common response string constants to InteractionUtils.ts

### DIFF
--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -533,6 +533,10 @@ export const ACCESS_DENIED_SERVER_OWNER = "Access denied. Command requires serve
 export const ACCESS_DENIED_REGULARS = "Access denied. Command requires the Regulars role.";
 export const SHOW_IN_CHAT_DESCRIPTION = "Show in chat (public) instead of ephemeral";
 export const PRIVATE_OPTION_DESCRIPTION = "Send reply privately (only visible to you).";
+export const NO_RESULTS_MESSAGE = "No results found.";
+export const NOTHING_TO_DISPLAY = "Nothing to display.";
+export const GAME_NOT_FOUND_MESSAGE = "Could not find that game.";
+export const USER_NOT_FOUND_MESSAGE = "Could not find that user.";
 
 /** Returns true and replies ephemerally if user is not the owner. */
 export async function replyIfNotOwner(


### PR DESCRIPTION
Closes #628

## Summary
- Adds `NO_RESULTS_MESSAGE`, `NOTHING_TO_DISPLAY`, `GAME_NOT_FOUND_MESSAGE`, and `USER_NOT_FOUND_MESSAGE` constants to `src/functions/InteractionUtils.ts`
- Placed near existing `ACCESS_DENIED_*` block, following the same pattern established in pass 3
- No existing inline occurrences of these exact strings were found to replace; constants are canonical forms for all future usage

## Verification
`grep -rn '"No results found\.\|Nothing to display\.' src/` returns zero hits outside `InteractionUtils.ts` -- passes.

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes

Part of shared-utilities-standardization-pass-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)