### PR TITLE
refactor: sweep remaining inline truncation patterns to use truncateWithEllipsis() (#627)

### DIFF
--- a/src/RPGClub_GameDB.ts
+++ b/src/RPGClub_GameDB.ts
@@ -34,6 +34,7 @@ import { startIgdbScanService } from "./services/IGDB/IgdbScanService.js";
 import { startUserEmojiService } from "./services/UserEmojiService.js";
 import { tryHandleManagedRawModalInteraction } from "./services/raw-modal/RawModalInteractionRouter.js";
 import { restoreJournalMessageContextsFromDb } from "./commands/now-playing.command.js";
+import { truncateWithEllipsis } from "./utilities/ValidationUtils.js";
 installConsoleLogging();
 
 const PRESENCE_CHECK_INTERVAL_MS: number = 30 * 60 * 1000;
@@ -113,7 +114,7 @@ function getChannelName(channel: Channel | TextBasedChannel | null): string {
 
 function sanitizeSlashValue(value: unknown): string {
   if (typeof value === "string") {
-    return JSON.stringify(value.length > 120 ? `${value.slice(0, 117)}...` : value);
+    return JSON.stringify(truncateWithEllipsis(value, 120));
   }
 
   if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
@@ -127,7 +128,7 @@ function sanitizeSlashValue(value: unknown): string {
   try {
     const serialized = JSON.stringify(value);
     if (!serialized) return "\"\"";
-    return serialized.length > 200 ? `${serialized.slice(0, 197)}...` : serialized;
+    return truncateWithEllipsis(serialized, 200);
   } catch {
     return String(value);
   }

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -29,7 +29,11 @@ import {
   safeReply,
   safeUpdate,
 } from "../../functions/InteractionUtils.js";
-import { isPositiveInt, isValidPlaytimeHours } from "../../utilities/ValidationUtils.js";
+import {
+  isPositiveInt,
+  isValidPlaytimeHours,
+  truncateWithEllipsis,
+} from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const MAX_NOTE_LENGTH = 500;
@@ -337,7 +341,7 @@ async function getCompletionEditValueLabel(
   }
   if (!completion.note) return "No note";
   const compact = completion.note.replace(/\s+/g, " ").trim();
-  return compact.length > 80 ? `${compact.slice(0, 77)}...` : compact;
+  return truncateWithEllipsis(compact, 80);
 }
 
 function extractEditPromptText(interaction: ButtonInteraction): string | null {

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -1592,9 +1592,7 @@ export class GameDbAdmin {
       const result = await GameSearchSynonym.createGroupTerms(terms, interaction.user.id);
       const termList = result.terms.map((term) => `"${term.termText}"`).join(" | ");
       let content = `Saved synonym group #${result.groupId} with ${result.terms.length} terms:\n${termList}`;
-      if (content.length > 1900) {
-        content = `${content.slice(0, 1900)}...`;
-      }
+      content = truncateWithEllipsis(content, 1900);
       await safeReply(interaction, buildTextReply(content, !(isPublic)));
     } catch (err: any) {
       await safeReply(interaction, buildTextReply(`Failed to save synonym group. ${err?.message ?? "Unknown error."}`, !(isPublic)));
@@ -1690,10 +1688,7 @@ export class GameDbAdmin {
       "",
       "Use Add More to continue, or Done to finish.",
     ];
-    let content = summaryLines.join("\n");
-    if (content.length > 1900) {
-      content = `${content.slice(0, 1900)}...`;
-    }
+    const content = truncateWithEllipsis(summaryLines.join("\n"), 1900);
 
     const synonymSummaryReply = buildTextReply(content, true);
     await safeReply(interaction, {
@@ -1868,9 +1863,7 @@ export class GameDbAdmin {
       );
       const termList = result.terms.map((term) => `"${term.termText}"`).join(" | ");
       let content = `Updated synonym group with ${result.terms.length} terms:\n${termList}`;
-      if (content.length > 1900) {
-        content = `${content.slice(0, 1900)}...`;
-      }
+      content = truncateWithEllipsis(content, 1900);
       await safeReply(interaction, buildTextReply(content, true));
     } catch (err: any) {
       await safeReply(interaction, buildTextReply(err?.message ?? "Failed to update synonym group.", true));

--- a/src/commands/gamedb/gamedb-csv-import.service.ts
+++ b/src/commands/gamedb/gamedb-csv-import.service.ts
@@ -23,7 +23,7 @@ import { type IGameDbCsvImportItem } from "../../classes/GameDbCsvImport.js";
 import { GAMEDB_CSV_PLATFORM_MAP } from "../../config/gamedbCsvPlatformMap.js";
 import { buildIgdbSearchLink } from "./gamedb-utils.js";
 import { type IGameDbCsvImport } from "../../classes/GameDbCsvImport.js";
-import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { isPositiveInt, truncateWithEllipsis } from "../../utilities/ValidationUtils.js";
 import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
@@ -104,9 +104,7 @@ export function buildCsvPromptContent(
 
 export function buildCsvPromptContainer(content: string): ContainerBuilder {
   const container = new ContainerBuilder();
-  const safeContent = content.length > 4000
-    ? `${content.slice(0, 3997)}...`
-    : content;
+  const safeContent = truncateWithEllipsis(content, 4000);
   container.addTextDisplayComponents(
     new TextDisplayBuilder().setContent(safeV2TextContent(safeContent, 3500)),
   );

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -19,6 +19,7 @@ import {
 import { SeparatorSpacingSize } from "discord-api-types/v10";
 import { safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
+import { truncateWithEllipsis } from "../../utilities/ValidationUtils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { getHltbCacheByGameId } from "../../classes/HltbCache.js";
@@ -86,10 +87,7 @@ export function buildListFieldValue(lines: string[], maxLength: number): string 
 }
 
 export function trimTextDisplayContent(content: string): string {
-  if (content.length <= 4000) {
-    return content;
-  }
-  return `${content.slice(0, 3997)}...`;
+  return truncateWithEllipsis(content, 4000);
 }
 
 export function isGameReleased(game: IGame, releases: IRelease[]): boolean {

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -100,7 +100,11 @@ import {
 } from "./now-playing-help.js";
 
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
-import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
+import {
+  isPositiveInt,
+  isValidPlaytimeHours,
+  truncateWithEllipsis,
+} from "../utilities/ValidationUtils.js";
 import { formatStructuredLog, logError } from "../utilities/LogUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
@@ -5696,7 +5700,7 @@ export class NowPlayingCommand {
     if (content.length <= 4000) {
       return content;
     }
-    return `${content.slice(0, 3997)}...`;
+    return truncateWithEllipsis(content, 4000);
   }
 
   private buildJournalComponents(

--- a/src/commands/suggestion.command.ts
+++ b/src/commands/suggestion.command.ts
@@ -47,7 +47,7 @@ import { BOT_DEV_PING_USER_ID } from "../config/users.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { buildTextReply, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import { logRawModal } from "../services/raw-modal/RawModalLogging.js";
-import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 
 const SUGGESTION_APPROVE_PREFIX = "suggestion-approve";
@@ -136,9 +136,7 @@ export function buildSuggestionReviewDecisionModal(
   customId: string,
   summaryText: string,
 ): ModalBuilder {
-  const summaryValue = summaryText.length > MAX_MODAL_TEXT_INPUT_VALUE
-    ? `${summaryText.slice(0, MAX_MODAL_TEXT_INPUT_VALUE - 3)}...`
-    : summaryText;
+  const summaryValue = truncateWithEllipsis(summaryText, MAX_MODAL_TEXT_INPUT_VALUE);
 
   return new ModalBuilder()
     .setCustomId(customId)

--- a/src/events/MessageLog.command.ts
+++ b/src/events/MessageLog.command.ts
@@ -4,12 +4,12 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
+import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 const MAX_FIELD_LENGTH = 1000;
 const MAX_DESCRIPTION_LENGTH = 3500;
 
 function truncate(text: string, maxLength = MAX_FIELD_LENGTH): string {
-  if (text.length <= maxLength) return text;
-  return `${text.slice(0, maxLength - 3)}...`;
+  return truncateWithEllipsis(text, maxLength);
 }
 
 function formatMessageContent(message: Message): string {

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -31,7 +31,7 @@ import {
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { notifyUnknownCompletionPlatform } from "../functions/CompletionHelpers.js";
 import { COMPLETION_REACTION_DEV_CHANNEL_ID } from "../config/channels.js";
-import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
@@ -119,9 +119,7 @@ const buildCompletionPromptContent = (
   session: CompletionReactionSession,
   requesterId: string,
 ): string => {
-  const trimmedQuery = session.query.length > 120
-    ? `${session.query.slice(0, 117)}...`
-    : session.query;
+  const trimmedQuery = truncateWithEllipsis(session.query, 120);
   return [
     "Add completion from reaction.",
     `Requested by: <@${requesterId}>`,

--- a/src/functions/ComponentsV2Utils.ts
+++ b/src/functions/ComponentsV2Utils.ts
@@ -1,11 +1,12 @@
 import { MessageFlags } from "discord.js";
 import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
+import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
 export function safeV2TextContent(value: string, maxLength: number): string {
   const normalized = value.split("\0").join("").trim();
   if (normalized.length <= maxLength) return normalized;
-  return `${normalized.slice(0, Math.max(0, maxLength - 3))}...`;
+  return truncateWithEllipsis(normalized, maxLength);
 }
 
 export function buildComponentsV2Flags(isEphemeral: boolean): number {

--- a/src/functions/NominationAdminHelpers.ts
+++ b/src/functions/NominationAdminHelpers.ts
@@ -19,6 +19,7 @@ import {
   type NominationKind,
 } from "../classes/Nomination.js";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
+import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import {
   buildComponentsV2Flags,
   buildNominationListPayload,
@@ -208,8 +209,5 @@ function isSendableTextChannel(channel: TextBasedChannel | null): channel is Tex
 }
 
 function truncateLabel(label: string, maxLength: number): string {
-  if (label.length <= maxLength) {
-    return label;
-  }
-  return `${label.slice(0, maxLength - 3)}...`;
+  return truncateWithEllipsis(label, maxLength);
 }

--- a/src/functions/NominationListComponents.ts
+++ b/src/functions/NominationListComponents.ts
@@ -25,6 +25,7 @@ import {
   getOrReplaceBackblazeImage,
   hasBackblazeB2Config,
 } from "../services/BackblazeB2Service.js";
+import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
 const MAX_SECTIONS_PER_CONTAINER = 10;
 const MAX_REASON_LENGTH = 1500;
@@ -223,17 +224,11 @@ function buildNominationSelectId(kindLabel: string, index: number): string {
 }
 
 function truncateLabel(label: string, maxLength: number): string {
-  if (label.length <= maxLength) {
-    return label;
-  }
-  return `${label.slice(0, maxLength - 3)}...`;
+  return truncateWithEllipsis(label, maxLength);
 }
 
 function trimReason(reason: string): string {
-  if (reason.length <= MAX_REASON_LENGTH) {
-    return reason;
-  }
-  return `${reason.slice(0, MAX_REASON_LENGTH - 3)}...`;
+  return truncateWithEllipsis(reason, MAX_REASON_LENGTH);
 }
 
 function formatDate(date: Date): string {

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -17,11 +17,12 @@ import { formatTableDate, formatPlaytimeHours } from "./DateFormatUtils.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
 import { buildUserHeaderContainer } from "./uiComponents.js";
+import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
 const JOURNAL_PAGE_SIZE = 1;
 
 function trimContent(text: string): string {
-  return text.length <= 4000 ? text : `${text.slice(0, 3997)}...`;
+  return truncateWithEllipsis(text, 4000);
 }
 
 function entryLabel(n: number): string {

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -12,6 +12,7 @@ import {
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
 import { formatTableDate } from "./DateFormatUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
 export interface IJournalSelectEntry {
   gameId: number;
@@ -30,7 +31,7 @@ export function buildJournalSelectRow(
     const rawLabel = `${e.title} Game Journal`;
     const label =
       rawLabel.length > DISCORD_SELECT_LABEL_MAX
-        ? `${rawLabel.slice(0, DISCORD_SELECT_LABEL_MAX - 3)}...`
+        ? truncateWithEllipsis(rawLabel, DISCORD_SELECT_LABEL_MAX)
         : rawLabel;
     const countText = e.journalCount === 1 ? "1 entry" : `${e.journalCount} entries`;
     const lastPart = e.lastJournalAt ? ` · Last entry ${formatTableDate(e.lastJournalAt)}` : "";


### PR DESCRIPTION
## Summary
- Replaces all remaining `slice(0, n - 3) + "..."` and template-literal truncation patterns across 14 files with calls to the shared `truncateWithEllipsis()` helper from `ValidationUtils.ts`
- Adds `truncateWithEllipsis` import to 9 files that didn't have it yet; extends existing imports in 5 files
- Local helper functions in `NominationListComponents.ts`, `NominationAdminHelpers.ts`, `MessageLog.command.ts`, `journalView.ts`, and `gamedb-profile.service.ts` now delegate to the shared utility instead of duplicating the logic

## Verification
Both greps from the issue return zero hits:
- `grep -rn '+ "\.\.\."' src/` -- returns only the definition in ValidationUtils.ts
- `grep -rn "slice.*\.\.\." src/` -- returns only the test assertion and the budget-aware `trimToBudget` helper in todo.command.ts (which handles edge cases like maxLength <= 3 that are outside the scope of truncateWithEllipsis)

Closes #627

## Test plan
- [ ] `npx tsc --noEmit` passes (no type errors)
- [ ] `npm run lint` passes (no lint violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)