### PR TITLE
refactor: add buildActionButton() factory and migrate highest-density callers (#626)

### DIFF
--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -14,7 +14,7 @@ import UserGameCollection, {
 import { flattenErrorMessages } from "../imports/import-scaffold.service.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { safeDeferUpdate } from "../../functions/InteractionUtils.js";
-import { buildUserHeaderContainer } from "../../functions/uiComponents.js";
+import { buildActionButton, buildUserHeaderContainer } from "../../functions/uiComponents.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildDisabledPrevNextRowWithIds } from "../../functions/PaginationUtils.js";
@@ -254,18 +254,17 @@ export function buildCollectionFilterPanelComponents(params: {
 }): ActionRowBuilder<ButtonBuilder>[] {
   return [
     new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(
-          buildCollectionFilterPanelActionId({
-            viewerUserId: params.viewerUserId,
-            targetUserId: params.targetUserId,
-            sourceMessageId: params.sourceMessageId,
-            isEphemeral: params.isEphemeral,
-            action: "text",
-          }),
-        )
-        .setLabel("Edit Text")
-        .setStyle(ButtonStyle.Primary),
+      buildActionButton(
+        "edit",
+        buildCollectionFilterPanelActionId({
+          viewerUserId: params.viewerUserId,
+          targetUserId: params.targetUserId,
+          sourceMessageId: params.sourceMessageId,
+          isEphemeral: params.isEphemeral,
+          action: "text",
+        }),
+        "Edit Text",
+      ),
       new ButtonBuilder()
         .setCustomId(
           buildCollectionFilterPanelActionId({

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -35,6 +35,7 @@ import {
   truncateWithEllipsis,
 } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { buildActionButton } from "../../functions/uiComponents.js";
 
 const MAX_NOTE_LENGTH = 500;
 type CompletionEditField = "type" | "date" | "platform" | "playtime" | "note";
@@ -399,11 +400,7 @@ function buildCompletionEditPrompt(
       .setCustomId(`comp-edit-field:${ownerId}:${completionId}:note`)
       .setLabel("Note")
       .setStyle(ButtonStyle.Secondary),
-    new ButtonBuilder()
-      // eslint-disable-next-line local/custom-id-has-matching-handler
-      .setCustomId(`comp-edit-done:${ownerId}:${completionId}`)
-      .setLabel("Done")
-      .setStyle(ButtonStyle.Success),
+    buildActionButton("confirm", `comp-edit-done:${ownerId}:${completionId}`, "Done"),
   ];
 
   const currentParts = [

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -52,7 +52,7 @@ import {
   buildTextReply,
   safeV2TextContent,
 } from "../functions/ComponentsV2Utils.js";
-import { buildUserHeaderContainer } from "../functions/uiComponents.js";
+import { buildActionButton, buildUserHeaderContainer } from "../functions/uiComponents.js";
 import {
   GJ_CLOSE_PREFIX,
   GJ_SEARCH_PAGE_PREFIX,
@@ -117,18 +117,9 @@ function buildHmenuActionRow(
   page = 1,
 ): ActionRowBuilder<ButtonBuilder> {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(`${GJ_HMENU_ADD_PREFIX}:${ownerId}:${gameId}`)
-      .setLabel("Add Entry")
-      .setStyle(ButtonStyle.Success),
-    new ButtonBuilder()
-      .setCustomId(`${GJ_HMENU_EDIT_PREFIX}:${ownerId}:${gameId}:${page}`)
-      .setLabel("Edit Entry")
-      .setStyle(ButtonStyle.Primary),
-    new ButtonBuilder()
-      .setCustomId(`${GJ_HMENU_DELETE_PREFIX}:${ownerId}:${gameId}`)
-      .setLabel("Delete Entry")
-      .setStyle(ButtonStyle.Danger),
+    buildActionButton("add", `${GJ_HMENU_ADD_PREFIX}:${ownerId}:${gameId}`, "Add Entry"),
+    buildActionButton("edit", `${GJ_HMENU_EDIT_PREFIX}:${ownerId}:${gameId}:${page}`, "Edit Entry"),
+    buildActionButton("delete", `${GJ_HMENU_DELETE_PREFIX}:${ownerId}:${gameId}`, "Delete Entry"),
     new ButtonBuilder()
       .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-add:${ownerId}`)
       .setLabel("?")
@@ -841,10 +832,7 @@ export class GameJournalCommand {
             new TextDisplayBuilder().setContent("No journal entries to edit."),
           ),
           new ActionRowBuilder<ButtonBuilder>().addComponents(
-            new ButtonBuilder()
-              .setCustomId(`${GJ_HMENU_ADD_PREFIX}:${ownerId}:${gameId}`)
-              .setLabel("Add Entry")
-              .setStyle(ButtonStyle.Success),
+            buildActionButton("add", `${GJ_HMENU_ADD_PREFIX}:${ownerId}:${gameId}`, "Add Entry"),
           ),
         ],
         flags: buildComponentsV2Flags(true),
@@ -883,10 +871,7 @@ export class GameJournalCommand {
             new TextDisplayBuilder().setContent("No journal entries to delete."),
           ),
           new ActionRowBuilder<ButtonBuilder>().addComponents(
-            new ButtonBuilder()
-              .setCustomId(`${GJ_HMENU_ADD_PREFIX}:${ownerId}:${gameId}`)
-              .setLabel("Add Entry")
-              .setStyle(ButtonStyle.Success),
+            buildActionButton("add", `${GJ_HMENU_ADD_PREFIX}:${ownerId}:${gameId}`, "Add Entry"),
           ),
         ],
         flags: buildComponentsV2Flags(true),
@@ -947,18 +932,14 @@ export class GameJournalCommand {
       ),
     );
     const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(
-          `${GJ_HMENU_DELETE_CONFIRM_PREFIX}:yes:${ownerId}:${gameIdRaw}:${entryId}`,
-        )
-        .setLabel("Delete")
-        .setStyle(ButtonStyle.Danger),
-      new ButtonBuilder()
-        .setCustomId(
-          `${GJ_HMENU_DELETE_CONFIRM_PREFIX}:no:${ownerId}:${gameIdRaw}:${entryId}`,
-        )
-        .setLabel("Cancel")
-        .setStyle(ButtonStyle.Secondary),
+      buildActionButton(
+        "delete",
+        `${GJ_HMENU_DELETE_CONFIRM_PREFIX}:yes:${ownerId}:${gameIdRaw}:${entryId}`,
+      ),
+      buildActionButton(
+        "cancel",
+        `${GJ_HMENU_DELETE_CONFIRM_PREFIX}:no:${ownerId}:${gameIdRaw}:${entryId}`,
+      ),
       new ButtonBuilder()
         .setCustomId(`${NOW_PLAYING_HELP_PREFIX}:journal-delete-confirm:${ownerId}`)
         .setLabel("?")

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -5,6 +5,29 @@ import {
   SectionBuilder,
   TextDisplayBuilder,
 } from "@discordjs/builders";
+
+type ButtonAction = "add" | "edit" | "delete" | "confirm" | "cancel" | "close";
+
+const ACTION_DEFAULTS: Record<ButtonAction, { label: string; style: ButtonStyle }> = {
+  add:     { label: "Add",     style: ButtonStyle.Success   },
+  edit:    { label: "Edit",    style: ButtonStyle.Primary   },
+  delete:  { label: "Delete",  style: ButtonStyle.Danger    },
+  confirm: { label: "Confirm", style: ButtonStyle.Success   },
+  cancel:  { label: "Cancel",  style: ButtonStyle.Secondary },
+  close:   { label: "Close",   style: ButtonStyle.Secondary },
+};
+
+export function buildActionButton(
+  action: ButtonAction,
+  customId: string,
+  label?: string,
+): ButtonBuilder {
+  const d = ACTION_DEFAULTS[action];
+  return new ButtonBuilder()
+    .setCustomId(customId)
+    .setLabel(label ?? d.label)
+    .setStyle(d.style);
+}
 import {
   getUserEmojiString,
   renderUsernameWithEmoji,


### PR DESCRIPTION
## Summary

- Adds `buildActionButton(action, customId, label?)` to `src/functions/uiComponents.ts` with defaults for `add/edit/delete/confirm/cancel/close` actions
- Migrates `game-journal.command.ts` (6 button replacements: Add Entry, Edit Entry, Delete Entry x3, Cancel)
- Migrates `collection-list.service.ts` (Edit Text button)
- Migrates `completion-edit.service.ts` (Done/confirm button)
- Skipped: `GiveawayHubService.ts` buttons have custom semantics (disabled state, non-CRUD labels) that don't match factory conventions; `collection-list.service.ts` Cancel button is intentionally Danger (not Secondary)

Closes #626

## Test plan

- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] Journal hmenu buttons (Add Entry, Edit Entry, Delete Entry) render correctly
- [ ] Journal delete confirm row shows Delete (Danger) and Cancel (Secondary) buttons
- [ ] Collection filter panel Edit Text button renders as Primary style
- [ ] Completion edit Done button renders as Success style

🤖 Generated with [Claude Code](https://claude.com/claude-code)