### PR TITLE
refactor: adopt Discord.js userMention() / channelMention() over inline template literals (#625)

### DIFF
--- a/src/commands/admin/admin-prompt.utils.ts
+++ b/src/commands/admin/admin-prompt.utils.ts
@@ -5,6 +5,7 @@ import {
   ComponentType,
   type Message,
   type CommandInteraction,
+  userMention,
 } from "discord.js";
 import {
   extractErrorMessage,
@@ -69,7 +70,7 @@ export async function promptUserForChoice(
 
   const promptId = `admin-choice:${userId}`;
   const rows = buildChoiceRows(promptId, options);
-  const content = `<@${userId}> ${question}`;
+  const content = `${userMention(userId)} ${question}`;
 
   let promptMessage: Message | null = null;
   try {
@@ -139,7 +140,7 @@ export async function promptUserForInput(
   }
 
   try {
-    await safeReply(interaction, buildTextReply(`<@${userId}> ${question}`, false));
+    await safeReply(interaction, buildTextReply(`${userMention(userId)} ${question}`, false));
   } catch (err) {
     console.error("Failed to send prompt message:", err);
   }

--- a/src/commands/admin/live-stream-admin.service.ts
+++ b/src/commands/admin/live-stream-admin.service.ts
@@ -8,6 +8,7 @@ import {
   MessageFlags,
   ModalSubmitInteraction,
   type ForumChannel,
+  channelMention,
 } from "discord.js";
 import {
   ActionRowBuilder as ModalActionRowBuilder,
@@ -309,7 +310,7 @@ export async function handleLiveStreamCreateModal(interaction: ModalSubmitIntera
     const eventUrl = `https://discord.com/events/${interaction.guildId}/${event.id}`;
     await safeReply(interaction, buildTextReply(
       `Created live event resources.\n` +
-      `Thread: <#${threadId}>\n` +
+      `Thread: ${channelMention(threadId)}\n` +
       `Event: ${eventUrl}\n` +
       `Scheduled: ${timeZone}`,
       true,
@@ -318,7 +319,7 @@ export async function handleLiveStreamCreateModal(interaction: ModalSubmitIntera
     const msg = error instanceof Error ? error.message : String(error);
     await safeReply(interaction, buildTextReply(
       `Scheduled event creation failed: ${msg}\n` +
-      `Thread was created successfully: <#${threadId}>`,
+      `Thread was created successfully: ${channelMention(threadId)}`,
       true,
     ));
   }

--- a/src/commands/admin/nomination-admin.service.ts
+++ b/src/commands/admin/nomination-admin.service.ts
@@ -3,7 +3,7 @@ import type {
   ModalSubmitInteraction,
   StringSelectMenuInteraction,
 } from "discord.js";
-import { MessageFlags } from "discord.js";
+import { MessageFlags, userMention } from "discord.js";
 import { safeDeferReply, safeReply, sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import {
@@ -162,7 +162,7 @@ export async function handleAdminNominationDeleteReasonModal(
     false,
   );
   const content =
-    `<@${interaction.user.id}> deleted <@${sessionState.userId}>'s nomination ` +
+    `${userMention(interaction.user.id)} deleted ${userMention(sessionState.userId)}'s nomination ` +
     `"${sessionState.gameTitle}" for ${sessionState.kind.toUpperCase()} Round ${sessionState.round}. ` +
     `Reason: ${reason}`;
 

--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -11,6 +11,8 @@ import {
   StringSelectMenuBuilder,
   type Message,
   type MessageCreateOptions,
+  channelMention,
+  userMention,
 } from "discord.js";
 import { safeDeferUpdate, safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
@@ -82,7 +84,7 @@ function buildNominationCountPreview(
   options: WizardNominationOption[],
 ): string {
   const lines = options.map((option, index) => {
-    const nominators = option.userIds.map((userId) => `<@${userId}>`).join(", ");
+    const nominators = option.userIds.map((userId) => userMention(userId)).join(", ");
     return `${index + 1}. ${option.gameTitle} (GameDB ${option.gamedbGameId}) - ${nominators}`;
   });
   return `**${kindLabel} nomination pool (${options.length})**\n${lines.join("\n")}`;
@@ -197,7 +199,7 @@ async function promptSelectNomination(
   );
 
   const promptMessage: Message | null = await channel.send({
-    content: `<@${userId}> ${promptText}`,
+    content: `${userMention(userId)} ${promptText}`,
     components: [selectRow, buttonRow],
     allowedMentions: { users: [userId] },
   }).catch(() => null);
@@ -266,7 +268,7 @@ export async function handleNextRoundSetup(
   if (interaction.channelId !== ADMIN_CHANNEL_ID) {
     await safeReply(
       interaction,
-      buildTextReply(`This command can only be used in <#${ADMIN_CHANNEL_ID}>.`, false),
+      buildTextReply(`This command can only be used in ${channelMention(ADMIN_CHANNEL_ID)}.`, false),
     );
     return;
   }
@@ -344,7 +346,7 @@ export async function handleNextRoundSetup(
     const promptId = `nrs:${interaction.user.id}:${interaction.channelId}`;
     const rows = buildChoiceRows(promptId, options);
     const promptMessage: Message | null = await channel.send({
-      content: `<@${interaction.user.id}> ${question}`,
+      content: `${userMention(interaction.user.id)} ${question}`,
       components: rows,
       allowedMentions: { users: [interaction.user.id] },
     }).catch(() => null);
@@ -779,7 +781,7 @@ export async function handleNextRoundSetup(
             if (plan.existingThreadId) {
               await wizardLog(
                 `[Test] Existing GOTM thread found for "${game.title}": ` +
-                `<#${plan.existingThreadId}>.`,
+                `${channelMention(plan.existingThreadId)}.`,
               );
             } else {
               await wizardLog(
@@ -801,9 +803,9 @@ export async function handleNextRoundSetup(
             kindLabel: "GOTM",
           });
           if (threadResult.threadId && threadResult.created) {
-            await wizardLog(`Linked GOTM thread <#${threadResult.threadId}> for "${game.title}".`);
+            await wizardLog(`Linked GOTM thread ${channelMention(threadResult.threadId)} for "${game.title}".`);
           } else if (threadResult.threadId) {
-            await wizardLog(`Existing GOTM thread found for "${game.title}": <#${threadResult.threadId}>.`);
+            await wizardLog(`Existing GOTM thread found for "${game.title}": ${channelMention(threadResult.threadId)}.`);
           } else {
             await wizardLog(`Checked GOTM thread link for "${game.title}" (none found and none created).`);
           }
@@ -827,7 +829,7 @@ export async function handleNextRoundSetup(
             if (plan.existingThreadId) {
               await wizardLog(
                 `[Test] Existing NR-GOTM thread found for "${game.title}": ` +
-                `<#${plan.existingThreadId}>.`,
+                `${channelMention(plan.existingThreadId)}.`,
               );
             } else {
               await wizardLog(
@@ -853,9 +855,9 @@ export async function handleNextRoundSetup(
             kindLabel: "NR-GOTM",
           });
           if (threadResult.threadId && threadResult.created) {
-            await wizardLog(`Linked NR-GOTM thread <#${threadResult.threadId}> for "${game.title}".`);
+            await wizardLog(`Linked NR-GOTM thread ${channelMention(threadResult.threadId)} for "${game.title}".`);
           } else if (threadResult.threadId) {
-            await wizardLog(`Existing NR-GOTM thread found for "${game.title}": <#${threadResult.threadId}>.`);
+            await wizardLog(`Existing NR-GOTM thread found for "${game.title}": ${channelMention(threadResult.threadId)}.`);
           } else {
             await wizardLog(`Checked NR-GOTM thread link for "${game.title}" (none found and none created).`);
           }
@@ -903,7 +905,7 @@ export async function handleNextRoundSetup(
         });
         if (plan.existingThreadId) {
           threadPlanLines.push(
-            `- GOTM ${game.title}: existing <#${plan.existingThreadId}>`,
+            `- GOTM ${game.title}: existing ${channelMention(plan.existingThreadId)}`,
           );
         } else {
           threadPlanLines.push(
@@ -922,7 +924,7 @@ export async function handleNextRoundSetup(
         });
         if (plan.existingThreadId) {
           threadPlanLines.push(
-            `- NR-GOTM ${game.title}: existing <#${plan.existingThreadId}>`,
+            `- NR-GOTM ${game.title}: existing ${channelMention(plan.existingThreadId)}`,
           );
         } else {
           threadPlanLines.push(

--- a/src/commands/admin/round-setup-wizard.utils.ts
+++ b/src/commands/admin/round-setup-wizard.utils.ts
@@ -3,6 +3,7 @@ import type { IGotmGame } from "../../classes/Gotm.js";
 import type { INrGotmGame } from "../../classes/NrGotm.js";
 import Game from "../../classes/Game.js";
 import type { INextRoundWizardState } from "../../classes/AdminWizardSession.js";
+import { userMention } from "discord.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 
 export type WizardNominationOption = {
@@ -108,7 +109,7 @@ export function toNominationOptionMap(
 }
 
 export function buildNominationPreviewLine(index: number, option: WizardNominationOption): string {
-  const nominators = option.userIds.map((userId) => `<@${userId}>`).join(", ");
+  const nominators = option.userIds.map((userId) => userMention(userId)).join(", ");
   return `${index + 1}. **${option.gameTitle}** (GameDB ${option.gamedbGameId}) by ${nominators}`;
 }
 

--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -9,6 +9,7 @@ import {
   StringSelectMenuInteraction,
   StringSelectMenuOptionBuilder,
   User,
+  userMention,
 } from "discord.js";
 import {
   ContainerBuilder,
@@ -311,7 +312,7 @@ export class AvatarHistoryCommand {
     if (!pageResult) {
       const noResultContainer = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent(
-          safeV2TextContent(`No avatar history found for <@${target.id}>.`, 1000),
+          safeV2TextContent(`No avatar history found for ${userMention(target.id)}.`, 1000),
         ),
       );
       await safeReply(interaction, {
@@ -422,7 +423,7 @@ export class AvatarHistoryCommand {
         components: [
           new ContainerBuilder().addTextDisplayComponents(
             new TextDisplayBuilder().setContent(
-              safeV2TextContent(`No avatar history found for <@${targetId}>.`, 1000),
+              safeV2TextContent(`No avatar history found for ${userMention(targetId)}.`, 1000),
             ),
           ),
         ],

--- a/src/commands/create-thread.command.ts
+++ b/src/commands/create-thread.command.ts
@@ -4,7 +4,13 @@ import type {
   ForumChannel,
   MessageCreateOptions,
 } from "discord.js";
-import { ApplicationCommandOptionType, AttachmentBuilder, MessageFlags } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  AttachmentBuilder,
+  channelMention,
+  MessageFlags,
+  userMention,
+} from "discord.js";
 import { Discord, Slash, SlashOption } from "discordx";
 import Game from "../classes/Game.js";
 import { getThreadsByGameId, setThreadGameLink, upsertThreadRecord } from "../classes/Thread.js";
@@ -18,7 +24,7 @@ import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 const DEFAULT_FIRST_POST_PREFIX = "Thread created by";
 
 function buildDefaultFirstPostText(userId: string): string {
-  return `${DEFAULT_FIRST_POST_PREFIX} <@${userId}>`;
+  return `${DEFAULT_FIRST_POST_PREFIX} ${userMention(userId)}`;
 }
 
 async function autocompleteCreateThreadTitle(
@@ -118,7 +124,7 @@ export class CreateThreadCommand {
     const existingThreadId = existingThreads[0] ?? null;
     if (existingThreadId) {
       await safeReply(interaction, buildTextReply(
-        `A thread is already linked for "${game.title}": <#${existingThreadId}>`,
+        `A thread is already linked for "${game.title}": ${channelMention(existingThreadId)}`,
         true,
       ));
       return;
@@ -181,7 +187,7 @@ export class CreateThreadCommand {
     await setThreadGameLink(thread.id, game.id);
 
     await safeReply(interaction, buildTextReply(
-      `Created thread <#${thread.id}> for "${game.title}" with tag "${selectedTag.name}".`,
+      `Created thread ${channelMention(thread.id)} for "${game.title}" with tag "${selectedTag.name}".`,
       true,
     ));
   }

--- a/src/commands/game-completion/completionator-import-command.service.ts
+++ b/src/commands/game-completion/completionator-import-command.service.ts
@@ -1,4 +1,5 @@
 import type { CommandInteraction, Attachment } from "discord.js";
+import { channelMention } from "discord.js";
 import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import type { CompletionatorAction } from "./completion.types.js";
 import { ephemeralFlag, safeDeferReply, safeReply } from "../../functions/InteractionUtils.js";
@@ -72,7 +73,7 @@ export async function handleCompletionatorImport(
     const threadService = new CompletionatorThreadService();
     const context = await threadService.getOrCreateCompletionatorThread(interaction, session);
     if (!context) return;
-    const threadMention: string = `<#${context.threadId}>`;
+    const threadMention: string = channelMention(context.threadId);
 
     await safeReply(interaction, buildTextReply(
       `Import session #${session.importId} created with ${parsed.length} rows. ` +
@@ -148,7 +149,7 @@ export async function handleCompletionatorImport(
   const context = await threadService.getOrCreateCompletionatorThread(interaction, session);
   if (!context) return;
   await safeReply(interaction, buildTextReply(
-    `Import #${session.importId} resumed. Continue in <#${context.threadId}>.`,
+    `Import #${session.importId} resumed. Continue in ${channelMention(context.threadId)}.`,
     ephemeral,
   ));
 

--- a/src/commands/game-completion/completionator-thread.service.ts
+++ b/src/commands/game-completion/completionator-thread.service.ts
@@ -1,4 +1,5 @@
 import type { CommandInteraction, Message, ThreadChannel } from "discord.js";
+import { userMention } from "discord.js";
 import type { CompletionatorThreadContext, ICompletionatorImport } from "./completion.types.js";
 import { completionatorThreadContexts } from "./completion.types.js";
 import { getCompletionatorThreadKey } from "./completion-helpers.js";
@@ -34,7 +35,7 @@ export class CompletionatorThreadService {
 
     if (channel.id === BOT_DEV_CHANNEL_ID) {
       const introLines = [
-        `<@${session.userId}>`,
+        userMention(session.userId),
         `## Completionator Import #${session.importId}`,
         "Preparing import...",
       ];
@@ -59,7 +60,7 @@ export class CompletionatorThreadService {
     if ("isThread" in channel && typeof channel.isThread === "function" && channel.isThread()) {
       const threadChannel: ThreadChannel = channel as ThreadChannel;
       const introLines = [
-        `<@${session.userId}>`,
+        userMention(session.userId),
         `## Completionator Import #${session.importId}`,
         "Preparing import...",
       ];
@@ -83,7 +84,7 @@ export class CompletionatorThreadService {
     }
 
     const parentMessage: Message = await channel.send({
-      content: `Completionator Import #${session.importId} started by <@${session.userId}>.`,
+      content: `Completionator Import #${session.importId} started by ${userMention(session.userId)}.`,
     });
     if (typeof parentMessage.startThread !== "function") {
       await safeReply(
@@ -100,7 +101,7 @@ export class CompletionatorThreadService {
     });
 
     const introLines = [
-      `<@${session.userId}>`,
+      userMention(session.userId),
       `## Completionator Import #${session.importId}`,
       "Preparing import...",
     ];

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -15,6 +15,7 @@ import {
   StringSelectMenuInteraction,
   TextInputBuilder,
   TextInputStyle,
+  channelMention,
 } from "discord.js";
 import {
   ButtonComponent,
@@ -1236,7 +1237,7 @@ export class GameDbAdmin {
         nowPlaying.find(p => p.threadId)?.threadId;
 
     if (threadId) {
-        embed.addFields({ name: "Thread", value: `✅ <#${threadId}>`, inline: true });
+        embed.addFields({ name: "Thread", value: `✅ ${channelMention(threadId)}`, inline: true });
     } else {
         embed.addFields({ name: "Thread", value: "❌ Missing", inline: true });
     }

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -9,6 +9,8 @@ import {
   TextInputStyle,
   type ForumChannel,
   type MessageCreateOptions,
+  channelMention,
+  userMention,
 } from "discord.js";
 import {
   Discord,
@@ -179,7 +181,7 @@ async function runNowPlayingThreadWizard(
       skipLinking: "Y",
     });
     await setThreadGameLink(thread.id, gameId);
-    await sendStatus(`Created and linked <#${thread.id}>.`);
+    await sendStatus(`Created and linked ${channelMention(thread.id)}.`);
     const nowPlayingMembers = await Game.getNowPlayingMembers(gameId);
     const completions = await Game.getGameCompletions(gameId);
     const mentionIds = new Set<string>([interaction.user.id]);
@@ -187,7 +189,7 @@ async function runNowPlayingThreadWizard(
     completions.forEach((member) => mentionIds.add(member.userId));
 
     if (mentionIds.size) {
-      const mentions = Array.from(mentionIds).map((id) => `<@${id}>`);
+      const mentions = Array.from(mentionIds).map((id) => userMention(id));
       const lines: string[] = [];
       let buffer = "";
       for (const mention of mentions) {

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -12,6 +12,7 @@ import {
   StringSelectMenuInteraction,
   TextInputBuilder,
   TextInputStyle,
+  userMention,
 } from "discord.js";
 import {
   ButtonComponent,
@@ -125,7 +126,7 @@ async function logGiveawayClaim(
   keyId: number,
 ): Promise<void> {
   const message =
-    `<@${userId}> claimed **${keyTitle}** (${platform}) [Key ID: ${keyId}].`;
+    `${userMention(userId)} claimed **${keyTitle}** (${platform}) [Key ID: ${keyId}].`;
   if (channel && typeof channel.send === "function") {
     const embed = new EmbedBuilder()
       .setTitle("Giveaway claim")
@@ -330,10 +331,10 @@ async function claimKey(
   const donorUser = await interaction.client.users
     .fetch(key.donorUserId)
     .catch(() => null);
-  const donorName = donorUser?.username ?? `<@${key.donorUserId}>`;
+  const donorName = donorUser?.username ?? userMention(key.donorUserId);
   const notifyDonor = await Member.getGiveawayDonorNotifySetting(key.donorUserId);
   if (notifyDonor && donorUser && key.donorUserId !== interaction.user.id) {
-    const claimantMention = `<@${interaction.user.id}>`;
+    const claimantMention = userMention(interaction.user.id);
     await donorUser.send({
       content:
         `Your donated key for **${key.gameTitle}** (${key.platform}) was claimed by ` +

--- a/src/commands/help.command.ts
+++ b/src/commands/help.command.ts
@@ -11,6 +11,7 @@ import {
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
   MessageFlags,
+  channelMention,
 } from "discord.js";
 import { ButtonComponent, Discord, SelectMenuComponent, Slash } from "discordx";
 import { isAdmin, isModerator } from "./admin/admin-auth.utils.js";
@@ -264,7 +265,7 @@ const HELP_TOPICS: HelpTopic[] = [
     syntax:
       "Syntax: /gamegiveaway (returns a link to the hub list).",
     notes:
-      `The giveaway list is kept in <#${GIVEAWAY_HUB_CHANNEL_ID}> with claim/donate buttons. ` +
+      `The giveaway list is kept in ${channelMention(GIVEAWAY_HUB_CHANNEL_ID)} with claim/donate buttons. ` +
       "Claims are handled from the list menu; keys are sent by DM.",
   },
   {

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -8,6 +8,7 @@ import {
   ButtonBuilder,
   ButtonStyle,
   ButtonInteraction,
+  userMention,
 } from "discord.js";
 import {
   ContainerBuilder,
@@ -143,7 +144,7 @@ function buildSummaryEmbed(
   const lines = pageMembers.map((member, idx) => {
     const displayIndex = offset + idx + 1;
     const platforms = formatPlatforms(member, filters);
-    return `${displayIndex}. <@${member.userId}> - ${platforms}`;
+    return `${displayIndex}. ${userMention(member.userId)} - ${platforms}`;
   });
 
   const embed = new EmbedBuilder()
@@ -352,7 +353,7 @@ export class MultiplayerInfoCommand {
         const notFoundContainer = new ContainerBuilder().addTextDisplayComponents(
           new TextDisplayBuilder().setContent(
             safeV2TextContent(
-              result.notFoundMessage ?? `No profile data found for <@${userId}>.`,
+              result.notFoundMessage ?? `No profile data found for ${userMention(userId)}.`,
               1000,
             ),
           ),

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -9,6 +9,7 @@ import {
   ContainerBuilder,
   MessageFlags,
   TextDisplayBuilder,
+  userMention,
 } from "discord.js";
 import { Discord, SelectMenuComponent, Slash, SlashChoice, SlashOption } from "discordx";
 import type { NominationKind } from "../classes/Nomination.js";
@@ -125,7 +126,7 @@ async function announceNominationList(
 
     const nominationNotice = new ContainerBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent(
-        safeV2TextContent(`<@${nominatorUserId}> Nominated "${nominatedTitle}"!`, 1000),
+        safeV2TextContent(`${userMention(nominatorUserId)} Nominated "${nominatedTitle}"!`, 1000),
       ),
     );
 

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -20,6 +20,7 @@ import {
   type MessageActionRowComponent,
   type Client,
   type Message,
+  userMention,
 } from "discord.js";
 import {
   Discord,
@@ -921,7 +922,7 @@ export class NowPlayingCommand {
     const usersByGameId = new Map<number, { title: string; users: string[] }>();
     for (const row of nowPlayingRows) {
       const record = usersByGameId.get(row.gameId) ?? { title: row.title, users: [] };
-      record.users.push(`<@${row.userId}>`);
+      record.users.push(userMention(row.userId));
       usersByGameId.set(row.gameId, record);
     }
 
@@ -3335,7 +3336,7 @@ export class NowPlayingCommand {
     if (!entries.length) {
       const emptyMessage = ownerId === interaction.user.id
         ? "Your Now Playing list is empty."
-        : `No Now Playing entries found for <@${ownerId}>.`;
+        : `No Now Playing entries found for ${userMention(ownerId)}.`;
       const container = this.buildNowPlayingMessageContainer(
         title,
         emptyMessage,
@@ -4278,7 +4279,7 @@ export class NowPlayingCommand {
 
       const container = this.buildNowPlayingMessageContainer(
         "Now Playing",
-        `No Now Playing entries found for <@${target.id}>.`,
+        `No Now Playing entries found for ${userMention(target.id)}.`,
       );
       const reply = await safeReply(interaction, {
         components: [container],
@@ -4362,7 +4363,7 @@ export class NowPlayingCommand {
       );
       const container = this.buildNowPlayingMessageContainer(
         "Now Playing - Everyone",
-        `No Now Playing entries found for <@${selectedUserId}>.`,
+        `No Now Playing entries found for ${userMention(selectedUserId)}.`,
       );
       const components = this.withNowPlayingActions(
         true,
@@ -5274,7 +5275,7 @@ export class NowPlayingCommand {
             );
             const emptyMessage = ownerId === interaction.user.id
               ? "Your Now Playing list is empty."
-              : `No Now Playing entries found for <@${ownerId}>.`;
+              : `No Now Playing entries found for ${userMention(ownerId)}.`;
             const container = this.buildNowPlayingMessageContainer(title, emptyMessage);
             const components = [header, container];
             await message.edit({
@@ -5362,7 +5363,7 @@ export class NowPlayingCommand {
             );
             const container = this.buildNowPlayingMessageContainer(
               "Now Playing - Everyone",
-              `No Now Playing entries found for <@${selectedUserId}>.`,
+              `No Now Playing entries found for ${userMention(selectedUserId)}.`,
             );
             const components = this.withNowPlayingActions(
               false,

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -7,6 +7,7 @@ import {
   ActionRowBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
+  userMention,
 } from "discord.js";
 import {
   Discord,
@@ -267,7 +268,7 @@ export async function buildProfileViewPayload(
     }
 
     if (!record) {
-      return { notFoundMessage: `No profile data found for <@${target.id}>.` };
+      return { notFoundMessage: `No profile data found for ${userMention(target.id)}.` };
     }
 
     const nickHistory: string[] = [];
@@ -339,7 +340,7 @@ export class ProfileCommand {
       const notFoundContainer = new ContainerBuilder().addTextDisplayComponents(
         new TextDisplayBuilder().setContent(
           safeV2TextContent(
-            result.notFoundMessage ?? `No profile data found for <@${target.id}>.`,
+            result.notFoundMessage ?? `No profile data found for ${userMention(target.id)}.`,
             1000,
           ),
         ),
@@ -394,7 +395,7 @@ export class ProfileCommand {
         const notFoundContainer = new ContainerBuilder().addTextDisplayComponents(
           new TextDisplayBuilder().setContent(
             safeV2TextContent(
-              result.notFoundMessage ?? `No profile data found for <@${userId}>.`,
+              result.notFoundMessage ?? `No profile data found for ${userMention(userId)}.`,
               1000,
             ),
           ),
@@ -663,7 +664,7 @@ export class ProfileCommand {
       const name = record.globalName ?? record.username;
       const label = name ? `(${name})` : "";
       const botTag = record.isBot ? " [Bot]" : "";
-      return `${idx + 1}. <@${record.userId}> ${label}${botTag}`;
+      return `${idx + 1}. ${userMention(record.userId)} ${label}${botTag}`;
     });
 
     const description = `Filters: ${filterSummary}\n\n${lines.join("\n")}`;
@@ -812,7 +813,7 @@ export class ProfileCommand {
       if (nsw !== undefined) changedFields.push("Switch");
       if (steam !== undefined) changedFields.push("Steam");
 
-      await safeReply(interaction, buildTextReply(`Updated profile for <@${target.id}> (${changedFields.join(", ")}).`, true));
+      await safeReply(interaction, buildTextReply(`Updated profile for ${userMention(target.id)} (${changedFields.join(", ")}).`, true));
     } catch (err: any) {
       const msg = extractErrorMessage(err);
       await safeReply(interaction, buildTextReply(`Error updating profile: ${msg}`, true));

--- a/src/commands/publicreminder.command.ts
+++ b/src/commands/publicreminder.command.ts
@@ -1,5 +1,5 @@
 import type { Channel, CommandInteraction } from "discord.js";
-import { ApplicationCommandOptionType, MessageFlags } from "discord.js";
+import { ApplicationCommandOptionType, channelMention, MessageFlags } from "discord.js";
 import { Discord, Slash, SlashChoice, SlashGroup, SlashOption } from "discordx";
 import {
   extractErrorMessage,
@@ -153,7 +153,7 @@ export class PublicReminderCommand {
 
       const timestamp = Math.floor(parsedDate.getTime() / 1000);
       const createdMsg =
-        `Created reminder #${reminder.reminderId} for <#${channel.id}> at <t:${timestamp}:F>.` +
+        `Created reminder #${reminder.reminderId} for ${channelMention(channel.id)} at <t:${timestamp}:F>.` +
         `${recurEvery && recurUnit ? ` (repeats every ${recurEvery} ${recurUnit})` : ""}`;
       await safeReply(interaction, buildTextReply(createdMsg, true));
     } catch (err: any) {
@@ -183,7 +183,7 @@ export class PublicReminderCommand {
         const recur =
           r.recurEvery && r.recurUnit ? ` (repeats every ${r.recurEvery} ${r.recurUnit})` : "";
         const timestamp = Math.floor(r.dueAt.getTime() / 1000);
-        return `#${r.reminderId}: <#${r.channelId}> at <t:${timestamp}:F>${recur} - ${r.message}`;
+        return `#${r.reminderId}: ${channelMention(r.channelId)} at <t:${timestamp}:F>${recur} - ${r.message}`;
       });
 
       await safeReply(interaction, buildTextReply(lines.join("\n"), true));

--- a/src/commands/rss.command.ts
+++ b/src/commands/rss.command.ts
@@ -1,5 +1,10 @@
 import type { CommandInteraction } from "discord.js";
-import { ApplicationCommandOptionType, MessageFlags, type Channel } from "discord.js";
+import {
+  ApplicationCommandOptionType,
+  channelMention,
+  MessageFlags,
+  type Channel,
+} from "discord.js";
 import { Discord, Slash, SlashGroup, SlashOption } from "discordx";
 import {
   extractErrorMessage,
@@ -99,7 +104,7 @@ export class RssCommand {
         excludeKeywords,
       );
       const addedMsg =
-        `Added feed #${id} (${sanitizedName ?? "unnamed"}) -> <#${channelId}> (url=${url}).`;
+        `Added feed #${id} (${sanitizedName ?? "unnamed"}) -> ${channelMention(channelId)} (url=${url}).`;
       await safeReply(interaction, buildTextReply(addedMsg, true));
     } catch (err: any) {
       const msg = extractErrorMessage(err);
@@ -247,7 +252,7 @@ export class RssCommand {
 
       const lines = feeds.map(
         (f) =>
-          `#${f.feedId}: ${f.feedName ?? "(no name)"} ${f.feedUrl} -> <#${f.channelId}>` +
+          `#${f.feedId}: ${f.feedName ?? "(no name)"} ${f.feedUrl} -> ${channelMention(f.channelId)}` +
           (f.includeKeywords.length ? ` include=[${f.includeKeywords.join(", ")}]` : "") +
           (f.excludeKeywords.length ? ` exclude=[${f.excludeKeywords.join(", ")}]` : ""),
       );

--- a/src/commands/suggestion.command.ts
+++ b/src/commands/suggestion.command.ts
@@ -7,6 +7,7 @@ import {
   MessageFlags,
   ModalSubmitInteraction,
   TextDisplayBuilder,
+  userMention,
 } from "discord.js";
 import {
   ActionRowBuilder as ModalActionRowBuilder,
@@ -409,7 +410,7 @@ async function getCurrentSuggestionForReview(
 function getSuggestionAuthorMention(
   suggestion: Awaited<ReturnType<typeof getSuggestionById>>,
 ): string {
-  return suggestion?.createdBy ? `<@${suggestion.createdBy}>` : "Unknown user";
+  return suggestion?.createdBy ? userMention(suggestion.createdBy) : "Unknown user";
 }
 
 async function sendSuggestionUpdateMessage(
@@ -539,7 +540,7 @@ export class SuggestionCommand {
       if (channel && "send" in channel) {
         await (channel as any).send({
           content:
-            `<@${BOT_DEV_PING_USER_ID}> ${interaction.user.username} has submitted a suggestion!`,
+            `${userMention(BOT_DEV_PING_USER_ID)} ${interaction.user.username} has submitted a suggestion!`,
         });
       }
     } catch {

--- a/src/events/GuildBanLog.command.ts
+++ b/src/events/GuildBanLog.command.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder } from "discord.js";
+import { EmbedBuilder, userMention } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
@@ -29,7 +29,7 @@ function buildBanEmbed(
     .setTitle(title)
     .setColor(color)
     .addFields(
-      { name: "User", value: `<@${userId}>\n${username}` },
+      { name: "User", value: `${userMention(userId)}\n${username}` },
       { name: "Account Created On", value: formatAccountCreated(createdAt) },
     )
     .setFooter({ text: buildIdTimestampFooter(userId, formatTimestampWithDay(Date.now())) });

--- a/src/events/GuildMemberAdd.command.ts
+++ b/src/events/GuildMemberAdd.command.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, Role } from "discord.js";
+import { EmbedBuilder, Role, userMention } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
@@ -34,7 +34,7 @@ export class GuildMemberAdd {
           .setTitle("User Joined")
           .setColor(COLOR_SUCCESS)
           .addFields(
-            { name: "User", value: `<@${member.user.id}>\n${username}` },
+            { name: "User", value: `${userMention(member.user.id)}\n${username}` },
             {
               name: "Account Created On",
               value: formatDiscordDateTime(member.user.createdAt),

--- a/src/events/GuildMemberRemove.command.ts
+++ b/src/events/GuildMemberRemove.command.ts
@@ -1,4 +1,4 @@
-import { AuditLogEvent, EmbedBuilder } from "discord.js";
+import { AuditLogEvent, EmbedBuilder, userMention } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
@@ -72,12 +72,12 @@ export class GuildMemberRemove {
         .setTitle("User Kicked")
         .setColor(COLOR_WARNING)
         .addFields(
-          { name: "User", value: `<@${member.user.id}>\n${username}` },
+          { name: "User", value: `${userMention(member.user.id)}\n${username}` },
           {
             name: "Account Created On",
             value: formatDiscordDateTime(member.user.createdAt),
           },
-          { name: "Moderator", value: `<@${kickAudit.moderatorId}>` },
+          { name: "Moderator", value: userMention(kickAudit.moderatorId) },
           {
             name: "Reason",
             value: kickAudit.reason ?? "No reason provided.",
@@ -96,7 +96,7 @@ export class GuildMemberRemove {
       .setTitle("User Left")
       .setColor(COLOR_NEUTRAL)
       .addFields(
-        { name: "User", value: `<@${member.user.id}>\n${username}` },
+        { name: "User", value: `${userMention(member.user.id)}\n${username}` },
         {
           name: "Account Created On",
           value: formatDiscordDateTime(member.user.createdAt),

--- a/src/events/MessageLog.command.ts
+++ b/src/events/MessageLog.command.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder } from "discord.js";
+import { channelMention, EmbedBuilder } from "discord.js";
 import type { Message } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
@@ -61,10 +61,10 @@ export class MessageLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const channelMention = `<#${resolved.channelId}>`;
+    const deletedChannelMention = channelMention(resolved.channelId);
     const embed = buildAuthorEmbed(
       resolved,
-      `Message deleted in ${channelMention}`,
+      `Message deleted in ${deletedChannelMention}`,
       COLOR_ERROR,
     );
     embed.setDescription(truncate(formatMessageContent(resolved)));

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -7,6 +7,7 @@ import {
   StringSelectMenuBuilder,
   TextInputBuilder,
   TextInputStyle,
+  userMention,
 } from "discord.js";
 import type {
   ButtonInteraction,
@@ -122,9 +123,9 @@ const buildCompletionPromptContent = (
   const trimmedQuery = truncateWithEllipsis(session.query, 120);
   return [
     "Add completion from reaction.",
-    `Requested by: <@${requesterId}>`,
+    `Requested by: ${userMention(requesterId)}`,
     `Message: ${session.messageUrl}`,
-    `Member: <@${session.targetUserId}>`,
+    `Member: ${userMention(session.targetUserId)}`,
     `Game title guess: ${trimmedQuery}`,
     "",
     "Select the completion type to continue.",
@@ -437,7 +438,7 @@ export class MessageReactionAdd {
     safeIgnore(safeUpdate(interaction, {
       content: [
         "Completion added.",
-        `Member: <@${session.targetUserId}>`,
+        `Member: ${userMention(session.targetUserId)}`,
         `Game: ${game.title}`,
         `Type: ${completionType}`,
         `Date: <t:${completedAtUnix}:D>`,

--- a/src/events/PresenceUpdate.command.ts
+++ b/src/events/PresenceUpdate.command.ts
@@ -4,6 +4,7 @@ import {
   ButtonBuilder,
   ButtonInteraction,
   ButtonStyle,
+  userMention,
 } from "discord.js";
 import crypto from "node:crypto";
 import type { Presence } from "discord.js";
@@ -189,7 +190,7 @@ export class PresenceUpdate {
     await PresencePromptHistory.createPrompt(sessionId, user.id, newGame);
 
     const content =
-      `<@${user.id}>, I see that you started playing **${newGame}**. ` +
+      `${userMention(user.id)}, I see that you started playing **${newGame}**. ` +
       "Would you like me to add it to your Now Playing list? Choose an option below.";
     const message = await sendableChannel.send({
       content,
@@ -273,7 +274,7 @@ export class PresenceUpdate {
 
     await PresencePromptHistory.markResolved(sessionId, "DECLINED");
     await safeUpdate(interaction, {
-      content: `<@${session.userId}>, no problem. I won't add it.`,
+      content: `${userMention(session.userId)}, no problem. I won't add it.`,
       components: [],
     });
   }
@@ -294,7 +295,7 @@ export class PresenceUpdate {
     await PresencePromptOptOut.addOptOutGame(session.userId, session.gameTitle);
     await PresencePromptHistory.markResolved(sessionId, "OPT_OUT_GAME");
     await safeUpdate(interaction, {
-      content: `<@${session.userId}>, got it. I won't ask again about **${session.gameTitle}**.`,
+      content: `${userMention(session.userId)}, got it. I won't ask again about **${session.gameTitle}**.`,
       components: [],
     });
     presencePromptSessions.delete(sessionId);
@@ -316,7 +317,7 @@ export class PresenceUpdate {
     await PresencePromptOptOut.addOptOutAll(session.userId);
     await PresencePromptHistory.markResolved(sessionId, "OPT_OUT_ALL");
     await safeUpdate(interaction, {
-      content: `<@${session.userId}>, got it. I won't ask again about any games.`,
+      content: `${userMention(session.userId)}, got it. I won't ask again about any games.`,
       components: [],
     });
     presencePromptSessions.delete(sessionId);

--- a/src/events/ServerChangeLog.command.ts
+++ b/src/events/ServerChangeLog.command.ts
@@ -5,6 +5,7 @@ import {
   type GuildChannel,
   type GuildEmoji,
   type Role,
+  channelMention,
 } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
@@ -26,7 +27,7 @@ function isGuildChannel(channel: any): channel is GuildChannel {
 
 function channelLabel(channel: GuildChannel): string {
   if (channel.type === ChannelType.GuildText || channel.type === ChannelType.GuildAnnouncement) {
-    return `<#${channel.id}>`;
+    return channelMention(channel.id);
   }
   return `${channel.name ?? channel.id}`;
 }

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -9,6 +9,7 @@ import {
   type Message,
   type ModalSubmitInteraction,
   type StringSelectMenuInteraction,
+  userMention,
 } from "discord.js";
 import {
   ContainerBuilder,
@@ -149,7 +150,7 @@ export async function notifyUnknownCompletionPlatform(
     await (channel as any).send({
       content:
         `Unknown completion platform selected.\n` +
-        `User: ${username} (<@${interaction.user.id}>)\n` +
+        `User: ${username} (${userMention(interaction.user.id)})\n` +
         `Game: ${gameTitle} (GameDB #${gameId})`,
       allowedMentions: { parse: [] },
     });
@@ -195,12 +196,12 @@ export async function announceCompletion(
       yearlySummary = `\nGame completion #${yearlyCount} for ${completionYear}`;
     }
     let desc =
-      `<@${user.id}> has added a game completion: **${game.title}** - ` +
+      `${userMention(user.id)} has added a game completion: **${game.title}** - ` +
       `${completionType} - ${dateStr}${hoursStr}` +
       yearlySummary;
     if (isAdminOverride && interaction.user.id !== userId) {
       desc =
-        `<@${interaction.user.id}> added a game completion for <@${user.id}>: ` +
+        `${userMention(interaction.user.id)} added a game completion for ${userMention(user.id)}: ` +
         `**${game.title}** - ${completionType} - ${dateStr}${hoursStr}` +
         yearlySummary;
     }

--- a/src/functions/GotmEntryEmbeds.ts
+++ b/src/functions/GotmEntryEmbeds.ts
@@ -1,4 +1,4 @@
-import { AttachmentBuilder, EmbedBuilder, type Client } from "discord.js";
+import { AttachmentBuilder, channelMention, EmbedBuilder, type Client } from "discord.js";
 import type { IGotmEntry, IGotmGame } from "../classes/Gotm.js";
 import type { INrGotmEntry, INrGotmGame } from "../classes/NrGotm.js";
 import Game from "../classes/Game.js";
@@ -44,7 +44,7 @@ async function formatGames(games: AnyGame[]): Promise<string> {
     const redditUrl = displayAuditValue((g as any).redditUrl);
     const parts: string[] = [];
     const title = g.gamedbGameId ? (await getGameMeta(g.gamedbGameId))?.title ?? g.title : g.title;
-    const titleWithThread = threadId ? `${title} - <#${threadId}>` : title;
+    const titleWithThread = threadId ? `${title} - ${channelMention(threadId)}` : title;
     parts.push(titleWithThread);
     if (redditUrl) {
       parts.push(`[Reddit](${redditUrl})`);

--- a/src/utilities/DiscordConsoleLogger.ts
+++ b/src/utilities/DiscordConsoleLogger.ts
@@ -1,4 +1,4 @@
-import { type MessageCreateOptions, type TextBasedChannel } from "discord.js";
+import { type MessageCreateOptions, type TextBasedChannel, userMention } from "discord.js";
 import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import type { Client } from "discordx";
 
@@ -223,7 +223,7 @@ async function flushLogBuffer(targetLevel?: BufferedLevel): Promise<void> {
         containers.push(buildLogContainer(level, currentDescription));
       }
 
-      const pingContent = level === "error" ? `<@${BOT_DEV_PING_USER_ID}>` : undefined;
+      const pingContent = level === "error" ? userMention(BOT_DEV_PING_USER_ID) : undefined;
       for (let i = 0; i < containers.length; i++) {
         await sendContainerToChannel(channel, containers[i], i === 0 ? pingContent : undefined);
       }


### PR DESCRIPTION
## Summary

- Replaces 50+ instances of `` `<@${userId}>` `` with `userMention(userId)` from `discord.js`
- Replaces 25+ instances of `` `<#${channelId}>` `` with `channelMention(channelId)` from `discord.js`
- Adds `userMention` and/or `channelMention` imports to 30 files
- No behavior change -- output strings are identical

Closes #625. Part of shared-utilities-standardization-pass-5.

## Verification

```
grep -rn '<@\${' src/   # 0 hits
grep -rn '<#\${' src/   # 0 hits
grep -rn '<&\${' src/   # 0 hits
```

## Test plan

- [ ] Type-check passes: `npx tsc --noEmit`
- [ ] Lint passes: `npm run lint`
- [ ] All mention output strings remain identical at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)