### PR TITLE
refactor: add buildTextInputRow() helper and migrate all modal text input sites (#624)

### DIFF
--- a/src/commands/admin/gotm-audit-handlers.ts
+++ b/src/commands/admin/gotm-audit-handlers.ts
@@ -7,9 +7,6 @@ import type {
 } from "discord.js";
 import {
   ModalBuilder,
-  ActionRowBuilder,
-  TextInputBuilder,
-  TextInputStyle,
 } from "discord.js";
 import {
   safeDeferUpdate,
@@ -42,6 +39,7 @@ import {
 } from "./gotm-audit-ui.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 
 export async function handleGotmAuditSelect(
   interaction: StringSelectMenuInteraction): Promise<void> {
@@ -140,14 +138,7 @@ export async function handleGotmAuditAction(interaction: ButtonInteraction): Pro
        
       .setCustomId(`${GOTM_AUDIT_MANUAL_PREFIX}:${ownerId}:${importId}:${itemId}`)
       .setTitle("Manual GameDB Entry");
-    const input = new TextInputBuilder()
-       
-      .setCustomId(GOTM_AUDIT_MANUAL_INPUT_ID)
-      .setLabel("GameDB ID")
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true);
-    const row = new ActionRowBuilder<TextInputBuilder>().addComponents(input);
-    modal.addComponents(row);
+    modal.addComponents(buildTextInputRow({ customId: GOTM_AUDIT_MANUAL_INPUT_ID, label: "GameDB ID" }));
     await interaction.showModal(modal);
     return;
   }
@@ -157,14 +148,7 @@ export async function handleGotmAuditAction(interaction: ButtonInteraction): Pro
        
       .setCustomId(`${GOTM_AUDIT_QUERY_PREFIX}:${ownerId}:${importId}:${itemId}`)
       .setTitle("Manual GameDB Search");
-    const input = new TextInputBuilder()
-       
-      .setCustomId(GOTM_AUDIT_QUERY_INPUT_ID)
-      .setLabel("Search query")
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true);
-    const row = new ActionRowBuilder<TextInputBuilder>().addComponents(input);
-    modal.addComponents(row);
+    modal.addComponents(buildTextInputRow({ customId: GOTM_AUDIT_QUERY_INPUT_ID, label: "Search query" }));
     await interaction.showModal(modal);
     return;
   }

--- a/src/commands/collection/collection-csv-import.command.ts
+++ b/src/commands/collection/collection-csv-import.command.ts
@@ -7,8 +7,6 @@ import {
   ModalBuilder,
   ModalSubmitInteraction,
   StringSelectMenuInteraction,
-  TextInputBuilder,
-  TextInputStyle,
   ActionRowBuilder,
   type Attachment,
 } from "discord.js";
@@ -99,6 +97,7 @@ import {
 import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_EMBED_FIELD_VALUE_MAX } from "../../config/textLimits.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 
 @Discord()
 @SlashGroup("collection")
@@ -804,18 +803,13 @@ export class CollectionCsvImportCommand {
         )
         .setTitle("CSV import remap");
 
-      const remapInput = new TextInputBuilder()
-        .setCustomId(CSV_REMAP_INPUT_ID)
-        .setLabel("Search title")
-        .setStyle(TextInputStyle.Short)
-        .setRequired(true)
-        .setMaxLength(120)
-        .setValue(item.rawTitle.slice(0, 120))
-        .setPlaceholder("Call of Duty Classic");
-
-      modal.addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(remapInput),
-      );
+      modal.addComponents(buildTextInputRow({
+        customId: CSV_REMAP_INPUT_ID,
+        label: "Search title",
+        maxLength: 120,
+        value: item.rawTitle.slice(0, 120),
+        placeholder: "Call of Duty Classic",
+      }));
       await interaction.showModal(modal).catch(() => {});
       return;
     }
@@ -831,17 +825,12 @@ export class CollectionCsvImportCommand {
         )
         .setTitle("CSV import: Enter GameDB ID");
 
-      const gameIdInput = new TextInputBuilder()
-        .setCustomId(CSV_GAME_ID_INPUT_ID)
-        .setLabel("GameDB ID (or IGDB numeric ID)")
-        .setStyle(TextInputStyle.Short)
-        .setRequired(true)
-        .setMaxLength(20)
-        .setPlaceholder("12345");
-
-      modal.addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(gameIdInput),
-      );
+      modal.addComponents(buildTextInputRow({
+        customId: CSV_GAME_ID_INPUT_ID,
+        label: "GameDB ID (or IGDB numeric ID)",
+        maxLength: 20,
+        placeholder: "12345",
+      }));
       await interaction.showModal(modal).catch(() => {});
       return;
     }

--- a/src/commands/collection/collection-steam-import.command.ts
+++ b/src/commands/collection/collection-steam-import.command.ts
@@ -7,8 +7,6 @@ import {
   ModalBuilder,
   ModalSubmitInteraction,
   StringSelectMenuInteraction,
-  TextInputBuilder,
-  TextInputStyle,
   ActionRowBuilder,
 } from "discord.js";
 import {
@@ -96,6 +94,7 @@ import { SteamApiError, steamApiService } from "../../services/SteamApiService.j
 import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_EMBED_FIELD_VALUE_MAX } from "../../config/textLimits.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 
 @Discord()
 @SlashGroup("collection")
@@ -760,18 +759,13 @@ export class CollectionSteamImportCommand {
         )
         .setTitle("Steam import remap");
 
-      const remapInput = new TextInputBuilder()
-        .setCustomId(STEAM_REMAP_INPUT_ID)
-        .setLabel("Search title")
-        .setStyle(TextInputStyle.Short)
-        .setRequired(true)
-        .setMaxLength(120)
-        .setValue(item.steamAppName.slice(0, 120))
-        .setPlaceholder("Call of Duty Classic");
-
-      modal.addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(remapInput),
-      );
+      modal.addComponents(buildTextInputRow({
+        customId: STEAM_REMAP_INPUT_ID,
+        label: "Search title",
+        maxLength: 120,
+        value: item.steamAppName.slice(0, 120),
+        placeholder: "Call of Duty Classic",
+      }));
       await interaction.showModal(modal).catch(() => {});
       return;
     }
@@ -787,17 +781,12 @@ export class CollectionSteamImportCommand {
         )
         .setTitle("Steam import: Enter GameDB ID");
 
-      const gameIdInput = new TextInputBuilder()
-        .setCustomId(STEAM_GAME_ID_INPUT_ID)
-        .setLabel("GameDB ID (or IGDB numeric ID)")
-        .setStyle(TextInputStyle.Short)
-        .setRequired(true)
-        .setMaxLength(20)
-        .setPlaceholder("12345");
-
-      modal.addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(gameIdInput),
-      );
+      modal.addComponents(buildTextInputRow({
+        customId: STEAM_GAME_ID_INPUT_ID,
+        label: "GameDB ID (or IGDB numeric ID)",
+        maxLength: 20,
+        placeholder: "12345",
+      }));
       await interaction.showModal(modal).catch(() => {});
       return;
     }

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -5,9 +5,6 @@ import {
   ModalBuilder,
   ModalSubmitInteraction,
   StringSelectMenuInteraction,
-  TextInputBuilder,
-  TextInputStyle,
-  ActionRowBuilder,
   type GuildMember,
   type User,
 } from "discord.js";
@@ -41,6 +38,7 @@ import {
 import { flattenErrorMessages } from "../imports/import-scaffold.service.js";
 import { formatStructuredLog } from "../../utilities/LogUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 import {
   buildAllCollectionsOverviewMessages,
   buildCollectionOverviewResponse,
@@ -542,24 +540,21 @@ export class CollectionViewCommand {
         )
         .setTitle("Collection filters");
 
-      const titleInput = new TextInputBuilder()
-        .setCustomId(COLLECTION_FILTER_TITLE_INPUT_ID)
-        .setLabel("Title contains")
-        .setStyle(TextInputStyle.Short)
-        .setRequired(false)
-        .setMaxLength(100)
-        .setValue(currentState.title ?? "");
-      const platformInput = new TextInputBuilder()
-        .setCustomId(COLLECTION_FILTER_PLATFORM_INPUT_ID)
-        .setLabel("Platform contains")
-        .setStyle(TextInputStyle.Short)
-        .setRequired(false)
-        .setMaxLength(100)
-        .setValue(currentState.platform ?? "");
-
       modal.addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(titleInput),
-        new ActionRowBuilder<TextInputBuilder>().addComponents(platformInput),
+        buildTextInputRow({
+          customId: COLLECTION_FILTER_TITLE_INPUT_ID,
+          label: "Title contains",
+          required: false,
+          maxLength: 100,
+          value: currentState.title ?? "",
+        }),
+        buildTextInputRow({
+          customId: COLLECTION_FILTER_PLATFORM_INPUT_ID,
+          label: "Platform contains",
+          required: false,
+          maxLength: 100,
+          value: currentState.platform ?? "",
+        }),
       );
       safeIgnore(interaction.showModal(modal));
       return;

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -11,8 +11,6 @@ import {
   ButtonStyle,
   StringSelectMenuBuilder,
   ModalBuilder,
-  TextInputBuilder,
-  TextInputStyle,
   MessageFlags,
 } from "discord.js";
 import {
@@ -46,6 +44,7 @@ import {
 } from "../imports/import-scaffold.service.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import { buildCompletionatorChooseId } from "./completion-helpers.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
@@ -694,14 +693,11 @@ export class CompletionatorUiService {
       // eslint-disable-next-line local/custom-id-has-matching-handler
       .setCustomId(`comp-import-date:${userId}:${importId}:${itemId}`)
       .setTitle("Completion Date");
-    const dateInput = new TextInputBuilder()
-       
-      .setCustomId("completion-date")
-      .setLabel("Completion date (YYYY-MM-DD)")
-      .setPlaceholder("2025-12-31")
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true);
-    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(dateInput));
+    modal.addComponents(buildTextInputRow({
+      customId: "completion-date",
+      label: "Completion date (YYYY-MM-DD)",
+      placeholder: "2025-12-31",
+    }));
     return modal;
   }
 
@@ -719,14 +715,11 @@ export class CompletionatorUiService {
       // eslint-disable-next-line local/custom-id-has-matching-handler
       .setCustomId(`comp-import-modal:${kind}:${userId}:${importId}:${itemId}`)
       .setTitle(title);
-    const input = new TextInputBuilder()
-       
-      .setCustomId("completionator-input")
-      .setLabel(label.slice(0, 45))
-      .setPlaceholder((itemTitle ?? placeholder).slice(0, DISCORD_SELECT_LABEL_MAX))
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true);
-    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+    modal.addComponents(buildTextInputRow({
+      customId: "completionator-input",
+      label: label.slice(0, 45),
+      placeholder: (itemTitle ?? placeholder).slice(0, DISCORD_SELECT_LABEL_MAX),
+    }));
     return modal;
   }
 }

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -13,7 +13,6 @@ import {
   ModalBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
-  TextInputBuilder,
   TextInputStyle,
   channelMention,
 } from "discord.js";
@@ -63,6 +62,7 @@ import GameSearchSynonymDraft, {
 import axios from "axios";
 import { igdbService } from "../services/IGDB/IgdbService.js";
 import { buildPageFooterText, shouldRenderPrevNextButtons } from "../functions/PaginationUtils.js";
+import { buildTextInputRow } from "../functions/uiComponents.js";
 import { parseSynonymQuickAddTerms } from "./gamedb-synonym.utils.js";
 import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { COLOR_PRIMARY, COLOR_SUCCESS, COLOR_HIGHLIGHT } from "../config/colors.js";
@@ -99,18 +99,16 @@ function clampSynonymOptionText(value: string, maxLength = 100): string {
 }
 
 function buildSynonymGroupEditModal(ownerId: string, groupId: number, terms: string): ModalBuilder {
-  const input = new TextInputBuilder()
-    .setCustomId(SYNONYM_EDIT_GROUP_INPUT_ID)
-    .setLabel("Synonym terms, one per line")
-    .setStyle(TextInputStyle.Paragraph)
-    .setRequired(true)
-    .setMaxLength(2000)
-    .setValue(terms);
-
   return new ModalBuilder()
     .setCustomId(`${SYNONYM_EDIT_GROUP_MODAL_PREFIX}:${ownerId}:${groupId}`)
     .setTitle("Edit Search Synonym Group")
-    .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+    .addComponents(buildTextInputRow({
+      customId: SYNONYM_EDIT_GROUP_INPUT_ID,
+      label: "Synonym terms, one per line",
+      style: TextInputStyle.Paragraph,
+      maxLength: 2000,
+      value: terms,
+    }));
 }
 
 function buildSynonymListCustomId(
@@ -176,18 +174,16 @@ function parseSynonymPairs(
 }
 
 function buildSynonymAddModal(draftId: number): ModalBuilder {
-  const input = new TextInputBuilder()
-    .setCustomId(SYNONYM_ADD_BULK_INPUT_ID)
-    .setLabel("Synonym pairs, one per line")
-    .setStyle(TextInputStyle.Paragraph)
-    .setPlaceholder("GTA <-> Grand Theft Auto\nKH <-> Kingdom Hearts\n1 <-> one")
-    .setRequired(true)
-    .setMaxLength(2000);
-
   return new ModalBuilder()
     .setCustomId(`${SYNONYM_ADD_MODAL_PREFIX}:${draftId}`)
     .setTitle("Add GameDB Search Synonyms")
-    .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+    .addComponents(buildTextInputRow({
+      customId: SYNONYM_ADD_BULK_INPUT_ID,
+      label: "Synonym pairs, one per line",
+      style: TextInputStyle.Paragraph,
+      placeholder: "GTA <-> Grand Theft Auto\nKH <-> Kingdom Hearts\n1 <-> one",
+      maxLength: 2000,
+    }));
 }
 
 function buildSynonymContinueComponents(draftId: number): Array<ActionRowBuilder<ButtonBuilder>> {
@@ -908,16 +904,11 @@ export class GameDbAdmin {
     const modal = new ModalBuilder()
       .setCustomId(`${AUDIT_VIDEO_MODAL_ID}:${sessionId}:${gameIdStr}`)
       .setTitle("Add YouTube Video")
-      .addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(
-          new TextInputBuilder()
-            .setCustomId(AUDIT_VIDEO_INPUT_ID)
-            .setLabel("YouTube URL")
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true)
-            .setPlaceholder("https://www.youtube.com/watch?v=..."),
-        ),
-      );
+      .addComponents(buildTextInputRow({
+        customId: AUDIT_VIDEO_INPUT_ID,
+        label: "YouTube URL",
+        placeholder: "https://www.youtube.com/watch?v=...",
+      }));
 
     await interaction.showModal(modal).catch(() => {});
   }
@@ -933,16 +924,12 @@ export class GameDbAdmin {
     const modal = new ModalBuilder()
       .setCustomId(`${AUDIT_DESCRIPTION_MODAL_ID}:${sessionId}:${gameIdStr}`)
       .setTitle("Add Description")
-      .addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(
-          new TextInputBuilder()
-            .setCustomId(AUDIT_DESCRIPTION_INPUT_ID)
-            .setLabel("Description")
-            .setStyle(TextInputStyle.Paragraph)
-            .setRequired(true)
-            .setMaxLength(2000),
-        ),
-      );
+      .addComponents(buildTextInputRow({
+        customId: AUDIT_DESCRIPTION_INPUT_ID,
+        label: "Description",
+        style: TextInputStyle.Paragraph,
+        maxLength: 2000,
+      }));
 
     await interaction.showModal(modal).catch(() => {});
   }

--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -4,7 +4,6 @@ import {
   ButtonStyle,
   MessageFlags,
   StringSelectMenuBuilder,
-  TextInputBuilder,
   TextInputStyle,
   WebhookClient,
   type ButtonInteraction,
@@ -52,6 +51,7 @@ import { trimTextDisplayContent } from "./gamedb-profile.service.js";
 import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 
 const COMPLETION_WIZARD_SESSIONS = new Map<string, CompletionWizardSession>();
 
@@ -382,40 +382,18 @@ export class GameDbCompletionCommand {
       .setTitle("Add Completion Details");
 
     if (session.dateChoice === "date") {
-      modal.addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(
-          new TextInputBuilder()
-             
-            .setCustomId("completion-date")
-            .setLabel("Completion date (YYYY-MM-DD)")
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true),
-        ),
-      );
+      modal.addComponents(buildTextInputRow({ customId: "completion-date", label: "Completion date (YYYY-MM-DD)" }));
     }
 
-    modal.addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-           
-          .setCustomId("completion-playtime")
-          .setLabel("Playtime hours (optional)")
-          .setStyle(TextInputStyle.Short)
-          .setRequired(false),
-      ),
-    );
+    modal.addComponents(buildTextInputRow({ customId: "completion-playtime", label: "Playtime hours (optional)", required: false }));
 
-    modal.addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-           
-          .setCustomId("completion-note")
-          .setLabel(`Note (optional, ${MAX_COMPLETION_NOTE_LEN} chars max)`)
-          .setStyle(TextInputStyle.Paragraph)
-          .setRequired(false)
-          .setMaxLength(MAX_COMPLETION_NOTE_LEN),
-      ),
-    );
+    modal.addComponents(buildTextInputRow({
+      customId: "completion-note",
+      label: `Note (optional, ${MAX_COMPLETION_NOTE_LEN} chars max)`,
+      style: TextInputStyle.Paragraph,
+      required: false,
+      maxLength: MAX_COMPLETION_NOTE_LEN,
+    }));
 
     await interaction.showModal(modal).catch(() => {});
   }

--- a/src/commands/gamedb/gamedb-csv-import.command.ts
+++ b/src/commands/gamedb/gamedb-csv-import.command.ts
@@ -8,9 +8,6 @@ import {
   ModalBuilder,
   ModalSubmitInteraction,
   StringSelectMenuInteraction,
-  TextInputBuilder,
-  TextInputStyle,
-  ActionRowBuilder,
 } from "discord.js";
 import {
   ButtonComponent,
@@ -75,6 +72,7 @@ import { processReleaseDates } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 
 const GAMEDB_CSV_ACTIONS = ["start", "resume", "status", "pause", "cancel"] as const;
 type GameDbCsvAction = (typeof GAMEDB_CSV_ACTIONS)[number];
@@ -581,13 +579,7 @@ export class GameDbCsvImportCommand {
       const modal = new ModalBuilder()
         .setCustomId(`${GAMEDB_CSV_MANUAL_PREFIX}:${ownerId}:${importId}:${itemId}`)
         .setTitle("Manual IGDB Import");
-      const input = new TextInputBuilder()
-        .setCustomId(GAMEDB_CSV_MANUAL_INPUT_ID)
-        .setLabel("IGDB game ID")
-        .setStyle(TextInputStyle.Short)
-        .setRequired(true);
-      const row = new ActionRowBuilder<TextInputBuilder>().addComponents(input);
-      modal.addComponents(row);
+      modal.addComponents(buildTextInputRow({ customId: GAMEDB_CSV_MANUAL_INPUT_ID, label: "IGDB game ID" }));
       await interaction.showModal(modal);
       return;
     }
@@ -596,13 +588,7 @@ export class GameDbCsvImportCommand {
       const modal = new ModalBuilder()
         .setCustomId(`${GAMEDB_CSV_QUERY_PREFIX}:${ownerId}:${importId}:${itemId}`)
         .setTitle("Manual IGDB Search");
-      const input = new TextInputBuilder()
-        .setCustomId(GAMEDB_CSV_QUERY_INPUT_ID)
-        .setLabel("Search query")
-        .setStyle(TextInputStyle.Short)
-        .setRequired(true);
-      const row = new ActionRowBuilder<TextInputBuilder>().addComponents(input);
-      modal.addComponents(row);
+      modal.addComponents(buildTextInputRow({ customId: GAMEDB_CSV_QUERY_INPUT_ID, label: "Search query" }));
       await interaction.showModal(modal);
       return;
     }

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -1,11 +1,9 @@
 import {
-  ActionRowBuilder,
   AttachmentBuilder,
   ButtonInteraction,
   MessageFlags,
   ModalBuilder,
   ModalSubmitInteraction,
-  TextInputBuilder,
   TextInputStyle,
   type ForumChannel,
   type MessageCreateOptions,
@@ -31,6 +29,7 @@ import Game from "../../classes/Game.js";
 import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 
 const GAMEDB_THREAD_MODAL_PREFIX = "gamedb-thread-modal";
 const GAMEDB_THREAD_TITLE_INPUT_ID = "gamedb-thread-title";
@@ -80,26 +79,19 @@ export async function showNowPlayingThreadModal(
     )
     .setTitle("Create Now Playing Thread")
     .addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-           
-          .setCustomId(GAMEDB_THREAD_TITLE_INPUT_ID)
-          .setLabel("Thread Title")
-          .setStyle(TextInputStyle.Short)
-          .setRequired(true)
-          .setMaxLength(MAX_THREAD_TITLE_LEN)
-          .setValue(defaultTitle),
-      ),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-           
-          .setCustomId(GAMEDB_THREAD_BODY_INPUT_ID)
-          .setLabel("Initial Post")
-          .setStyle(TextInputStyle.Paragraph)
-          .setRequired(true)
-          .setMaxLength(MAX_THREAD_BODY_LEN)
-          .setValue(defaultBody),
-      ),
+      buildTextInputRow({
+        customId: GAMEDB_THREAD_TITLE_INPUT_ID,
+        label: "Thread Title",
+        maxLength: MAX_THREAD_TITLE_LEN,
+        value: defaultTitle,
+      }),
+      buildTextInputRow({
+        customId: GAMEDB_THREAD_BODY_INPUT_ID,
+        label: "Initial Post",
+        style: TextInputStyle.Paragraph,
+        maxLength: MAX_THREAD_BODY_LEN,
+        value: defaultBody,
+      }),
     );
 
   await interaction.showModal(modal).catch(async () => {

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -1,10 +1,8 @@
 import {
-  ActionRowBuilder,
   ApplicationCommandOptionType,
   ButtonInteraction,
   CommandInteraction,
   ModalBuilder,
-  TextInputBuilder,
   TextInputStyle,
 } from "discord.js";
 import {
@@ -43,6 +41,7 @@ import { startCompletionWizard } from "./gamedb-completion.command.js";
 import { showNowPlayingThreadModal } from "./gamedb-thread.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
 
 @Discord()
 @SlashGroup("gamedb")
@@ -168,14 +167,13 @@ export class GameDbViewCommand {
         .setCustomId(`gamedb-nowplaying-modal:${gameId}`)
         .setTitle("Add to Now Playing")
         .addComponents(
-          new ActionRowBuilder<TextInputBuilder>().addComponents(
-            new TextInputBuilder()
-              .setCustomId("gamedb-nowplaying-note")
-              .setLabel("Note (optional)")
-              .setStyle(TextInputStyle.Paragraph)
-              .setRequired(false)
-              .setMaxLength(500),
-          ),
+          buildTextInputRow({
+            customId: "gamedb-nowplaying-note",
+            label: "Note (optional)",
+            style: TextInputStyle.Paragraph,
+            required: false,
+            maxLength: 500,
+          }),
         );
       await interaction.showModal(modal).catch(() => {});
       return;

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -10,8 +10,6 @@ import {
   ModalSubmitInteraction,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
-  TextInputBuilder,
-  TextInputStyle,
   userMention,
 } from "discord.js";
 import {
@@ -63,6 +61,7 @@ import {
   GIVEAWAY_MAX_KEY_LENGTH,
 } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { buildTextInputRow } from "../functions/uiComponents.js";
 const GIVEAWAY_DONATE_MODAL_ID = "giveaway-donate-modal";
 const GIVEAWAY_REVOKE_MODAL_ID = "giveaway-revoke-modal";
 const GIVEAWAY_DONATE_TITLE_ID = "giveaway-donate-title";
@@ -355,52 +354,23 @@ async function claimKey(
 }
 
 function buildDonateModal(): ModalBuilder {
-  const titleInput = new TextInputBuilder()
-     
-    .setCustomId(GIVEAWAY_DONATE_TITLE_ID)
-    .setLabel("Game title")
-    .setStyle(TextInputStyle.Short)
-    .setRequired(true)
-    .setMaxLength(GIVEAWAY_MAX_TITLE_LENGTH);
-  const platformInput = new TextInputBuilder()
-     
-    .setCustomId(GIVEAWAY_DONATE_PLATFORM_ID)
-    .setLabel("Platform (Steam, Epic, GOG, etc.)")
-    .setStyle(TextInputStyle.Short)
-    .setRequired(true)
-    .setMaxLength(GIVEAWAY_MAX_PLATFORM_LENGTH);
-  const keyInput = new TextInputBuilder()
-     
-    .setCustomId(GIVEAWAY_DONATE_KEY_ID)
-    .setLabel("Game key")
-    .setStyle(TextInputStyle.Short)
-    .setRequired(true)
-    .setMaxLength(GIVEAWAY_MAX_KEY_LENGTH);
-
   return new ModalBuilder()
-     
+
     .setCustomId(GIVEAWAY_DONATE_MODAL_ID)
     .setTitle("Donate a Game Key")
     .addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(titleInput),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(platformInput),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(keyInput),
+      buildTextInputRow({ customId: GIVEAWAY_DONATE_TITLE_ID, label: "Game title", maxLength: GIVEAWAY_MAX_TITLE_LENGTH }),
+      buildTextInputRow({ customId: GIVEAWAY_DONATE_PLATFORM_ID, label: "Platform (Steam, Epic, GOG, etc.)", maxLength: GIVEAWAY_MAX_PLATFORM_LENGTH }),
+      buildTextInputRow({ customId: GIVEAWAY_DONATE_KEY_ID, label: "Game key", maxLength: GIVEAWAY_MAX_KEY_LENGTH }),
     );
 }
 
 function buildRevokeModal(): ModalBuilder {
-  const keyIdInput = new TextInputBuilder()
-     
-    .setCustomId(GIVEAWAY_REVOKE_KEY_ID)
-    .setLabel("Key ID")
-    .setStyle(TextInputStyle.Short)
-    .setRequired(true);
-
   return new ModalBuilder()
-     
+
     .setCustomId(GIVEAWAY_REVOKE_MODAL_ID)
     .setTitle("Revoke a Game Key")
-    .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(keyIdInput));
+    .addComponents(buildTextInputRow({ customId: GIVEAWAY_REVOKE_KEY_ID, label: "Key ID" }));
 }
 
 function buildKeyListComponents(

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -11,7 +11,6 @@ import {
   ActionRowBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
-  TextInputBuilder,
   TextInputStyle,
   ButtonBuilder,
   ButtonStyle,
@@ -59,7 +58,11 @@ import {
 } from "../functions/InteractionUtils.js";
 import Game, { type IGame } from "../classes/Game.js";
 import { buildJournalView } from "../functions/journalView.js";
-import { buildJournalSelectRow, buildUserHeaderContainer } from "../functions/uiComponents.js";
+import {
+  buildJournalSelectRow,
+  buildTextInputRow,
+  buildUserHeaderContainer,
+} from "../functions/uiComponents.js";
 import { EphemeralOwnerMenu } from "../functions/EphemeralOwnerMenu.js";
 import { igdbService } from "../services/IGDB/IgdbService.js";
 import {
@@ -652,18 +655,17 @@ function buildEditNoteModal(
   title: string,
   currentNote: string | null,
 ): ModalBuilder {
-  const input = new TextInputBuilder()
-    .setCustomId(NOW_PLAYING_NOTE_INPUT_ID)
-    .setLabel(title.slice(0, 45))
-    .setStyle(TextInputStyle.Paragraph)
-    .setRequired(false)
-    .setMaxLength(MAX_NOW_PLAYING_NOTE_LEN)
-    .setValue(currentNote ?? "");
-
   return new ModalBuilder()
     .setCustomId(`${NOW_PLAYING_NOTE_MODAL_ID}:${ownerId}:${gameId}`)
     .setTitle("Edit Now Playing Note")
-    .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+    .addComponents(buildTextInputRow({
+      customId: NOW_PLAYING_NOTE_INPUT_ID,
+      label: title.slice(0, 45),
+      style: TextInputStyle.Paragraph,
+      required: false,
+      maxLength: MAX_NOW_PLAYING_NOTE_LEN,
+      value: currentNote ?? "",
+    }));
 }
 
 function buildEditNotesModal(
@@ -681,14 +683,14 @@ function buildEditNotesModal(
     .setTitle("Edit Now Playing Notes");
 
   entries.forEach((entry) => {
-    const input = new TextInputBuilder()
-      .setCustomId(`${NOW_PLAYING_NOTE_INPUT_ID}:${entry.gameId}`)
-      .setLabel(formatEntryTitleWithPlatform(entry).slice(0, 45))
-      .setStyle(TextInputStyle.Paragraph)
-      .setRequired(false)
-      .setMaxLength(MAX_NOW_PLAYING_NOTE_LEN)
-      .setValue(entry.note ?? "");
-    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(input));
+    modal.addComponents(buildTextInputRow({
+      customId: `${NOW_PLAYING_NOTE_INPUT_ID}:${entry.gameId}`,
+      label: formatEntryTitleWithPlatform(entry).slice(0, 45),
+      style: TextInputStyle.Paragraph,
+      required: false,
+      maxLength: MAX_NOW_PLAYING_NOTE_LEN,
+      value: entry.note ?? "",
+    }));
   });
 
   return modal;
@@ -1105,22 +1107,14 @@ export class NowPlayingCommand {
       .setCustomId(NOW_PLAYING_ADD_MODAL_ID)
       .setTitle("Add Now Playing Game")
       .addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(
-          new TextInputBuilder()
-            .setCustomId(NOW_PLAYING_ADD_TITLE_INPUT_ID)
-            .setLabel("Game title")
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true)
-            .setMaxLength(100),
-        ),
-        new ActionRowBuilder<TextInputBuilder>().addComponents(
-          new TextInputBuilder()
-            .setCustomId(NOW_PLAYING_ADD_NOTE_INPUT_ID)
-            .setLabel("Note (optional)")
-            .setStyle(TextInputStyle.Paragraph)
-            .setRequired(false)
-            .setMaxLength(MAX_NOW_PLAYING_NOTE_LEN),
-        ),
+        buildTextInputRow({ customId: NOW_PLAYING_ADD_TITLE_INPUT_ID, label: "Game title", maxLength: 100 }),
+        buildTextInputRow({
+          customId: NOW_PLAYING_ADD_NOTE_INPUT_ID,
+          label: "Note (optional)",
+          style: TextInputStyle.Paragraph,
+          required: false,
+          maxLength: MAX_NOW_PLAYING_NOTE_LEN,
+        }),
       );
   }
 
@@ -2057,34 +2051,28 @@ export class NowPlayingCommand {
     const modal = new ModalBuilder()
       .setCustomId(`${NOW_PLAYING_COMPLETE_MODAL_ID}:${sessionId}`)
       .setTitle("Add Completion Details");
-    const modalRows: ActionRowBuilder<TextInputBuilder>[] = [
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-          .setCustomId(NOW_PLAYING_COMPLETE_DATE_INPUT_ID)
-          .setLabel("Completion date (blank unknown)")
-          .setStyle(TextInputStyle.Short)
-          .setRequired(false)
-          .setPlaceholder("today or 03/10/2025"),
-      ),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(
-        new TextInputBuilder()
-          .setCustomId(NOW_PLAYING_COMPLETE_HOURS_INPUT_ID)
-          .setLabel("Final playtime hours (optional)")
-          .setStyle(TextInputStyle.Short)
-          .setRequired(false),
-      ),
+    const modalRows = [
+      buildTextInputRow({
+        customId: NOW_PLAYING_COMPLETE_DATE_INPUT_ID,
+        label: "Completion date (blank unknown)",
+        required: false,
+        placeholder: "today or 03/10/2025",
+      }),
+      buildTextInputRow({
+        customId: NOW_PLAYING_COMPLETE_HOURS_INPUT_ID,
+        label: "Final playtime hours (optional)",
+        required: false,
+      }),
     ];
     if (session.addCompletionNote) {
-      const noteInput = new TextInputBuilder()
-        .setCustomId(NOW_PLAYING_COMPLETE_NOTE_INPUT_ID)
-        .setLabel("Note (optional)")
-        .setStyle(TextInputStyle.Paragraph)
-        .setRequired(false)
-        .setMaxLength(MAX_NOW_PLAYING_NOTE_LEN);
-      if (noteValue) {
-        noteInput.setValue(noteValue.slice(0, MAX_NOW_PLAYING_NOTE_LEN));
-      }
-      modalRows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(noteInput));
+      modalRows.push(buildTextInputRow({
+        customId: NOW_PLAYING_COMPLETE_NOTE_INPUT_ID,
+        label: "Note (optional)",
+        style: TextInputStyle.Paragraph,
+        required: false,
+        maxLength: MAX_NOW_PLAYING_NOTE_LEN,
+        value: noteValue ? noteValue.slice(0, MAX_NOW_PLAYING_NOTE_LEN) : undefined,
+      }));
     }
     modal.addComponents(...modalRows);
     safeIgnore(interaction.showModal(modal));

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -10,7 +10,6 @@ import {
   PermissionsBitField,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
-  TextInputBuilder,
   TextInputStyle,
 } from "discord.js";
 import {
@@ -63,6 +62,7 @@ import { decodeBase64Url, encodeWithMaxLength } from "../functions/CustomIdUtils
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import { formatDiscordTimestamp } from "../functions/DateFormatUtils.js";
+import { buildTextInputRow } from "../functions/uiComponents.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { DISCORD_TEXT_INPUT_MAX } from "../config/textLimits.js";
 import { TODO_DEFAULT_PAGE_SIZE, TODO_MAX_PAGE_SIZE } from "../config/pagination.js";
@@ -1478,23 +1478,9 @@ export class TodoCommand {
       )
       .setTitle("Create GitHub Issue");
 
-    const titleInput = new TextInputBuilder()
-      .setCustomId(TODO_CREATE_TITLE_ID)
-      .setLabel("Title")
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true)
-      .setMaxLength(256);
-
-    const bodyInput = new TextInputBuilder()
-      .setCustomId(TODO_CREATE_BODY_ID)
-      .setLabel("Description")
-      .setStyle(TextInputStyle.Paragraph)
-      .setRequired(true)
-      .setMaxLength(DISCORD_TEXT_INPUT_MAX);
-
     modal.addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(titleInput),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(bodyInput),
+      buildTextInputRow({ customId: TODO_CREATE_TITLE_ID, label: "Title", maxLength: 256 }),
+      buildTextInputRow({ customId: TODO_CREATE_BODY_ID, label: "Description", style: TextInputStyle.Paragraph, maxLength: DISCORD_TEXT_INPUT_MAX }),
     );
     modal.addLabelComponents((label) =>
       label
@@ -2527,18 +2513,13 @@ export class TodoCommand {
       )
       .setTitle(basePayload.query ? "Edit Query" : "Filter by Query");
 
-    const queryInput = new TextInputBuilder()
-      .setCustomId(TODO_QUERY_INPUT_ID)
-      .setLabel("Query")
-      .setStyle(TextInputStyle.Short)
-      .setRequired(false)
-      .setMaxLength(200);
-
-    if (basePayload.query) {
-      queryInput.setValue(basePayload.query);
-    }
-
-    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(queryInput));
+    modal.addComponents(buildTextInputRow({
+      customId: TODO_QUERY_INPUT_ID,
+      label: "Query",
+      required: false,
+      maxLength: 200,
+      value: basePayload.query || undefined,
+    }));
     await interaction.showModal(modal);
   }
 
@@ -2581,28 +2562,15 @@ export class TodoCommand {
       )
       .setTitle("Edit GitHub Issue");
 
-    const titleInput = new TextInputBuilder()
-      .setCustomId(TODO_CREATE_TITLE_ID)
-      .setLabel("Title")
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true)
-      .setMaxLength(256)
-      .setValue(issue.title);
-
-    const bodyInput = new TextInputBuilder()
-      .setCustomId(TODO_CREATE_BODY_ID)
-      .setLabel("Description")
-      .setStyle(TextInputStyle.Paragraph)
-      .setRequired(true)
-      .setMaxLength(DISCORD_TEXT_INPUT_MAX);
-
-    if (issue.body) {
-      bodyInput.setValue(issue.body.slice(0, DISCORD_TEXT_INPUT_MAX));
-    }
-
     modal.addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(titleInput),
-      new ActionRowBuilder<TextInputBuilder>().addComponents(bodyInput),
+      buildTextInputRow({ customId: TODO_CREATE_TITLE_ID, label: "Title", maxLength: 256, value: issue.title }),
+      buildTextInputRow({
+        customId: TODO_CREATE_BODY_ID,
+        label: "Description",
+        style: TextInputStyle.Paragraph,
+        maxLength: DISCORD_TEXT_INPUT_MAX,
+        value: issue.body?.slice(0, DISCORD_TEXT_INPUT_MAX) || undefined,
+      }),
     );
     modal.addLabelComponents((label) =>
       label
@@ -2646,14 +2614,12 @@ export class TodoCommand {
       )
       .setTitle("Add Comment");
 
-    const commentInput = new TextInputBuilder()
-      .setCustomId(TODO_COMMENT_INPUT_ID)
-      .setLabel("Comment")
-      .setStyle(TextInputStyle.Paragraph)
-      .setRequired(true)
-      .setMaxLength(DISCORD_TEXT_INPUT_MAX);
-
-    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(commentInput));
+    modal.addComponents(buildTextInputRow({
+      customId: TODO_COMMENT_INPUT_ID,
+      label: "Comment",
+      style: TextInputStyle.Paragraph,
+      maxLength: DISCORD_TEXT_INPUT_MAX,
+    }));
 
     await interaction.showModal(modal);
   }
@@ -2696,15 +2662,12 @@ export class TodoCommand {
       )
       .setTitle("Edit Title");
 
-    const titleInput = new TextInputBuilder()
-      .setCustomId(TODO_EDIT_TITLE_INPUT_ID)
-      .setLabel("Title")
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true)
-      .setMaxLength(256)
-      .setValue(issue.title);
-
-    modal.addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(titleInput));
+    modal.addComponents(buildTextInputRow({
+      customId: TODO_EDIT_TITLE_INPUT_ID,
+      label: "Title",
+      maxLength: 256,
+      value: issue.title,
+    }));
 
     await interaction.showModal(modal);
   }
@@ -2747,20 +2710,13 @@ export class TodoCommand {
       )
       .setTitle("Edit Description");
 
-    const descriptionInput = new TextInputBuilder()
-      .setCustomId(TODO_EDIT_DESC_INPUT_ID)
-      .setLabel("Description")
-      .setStyle(TextInputStyle.Paragraph)
-      .setRequired(true)
-      .setMaxLength(DISCORD_TEXT_INPUT_MAX);
-
-    if (issue.body) {
-      descriptionInput.setValue(issue.body.slice(0, DISCORD_TEXT_INPUT_MAX));
-    }
-
-    modal.addComponents(
-      new ActionRowBuilder<TextInputBuilder>().addComponents(descriptionInput),
-    );
+    modal.addComponents(buildTextInputRow({
+      customId: TODO_EDIT_DESC_INPUT_ID,
+      label: "Description",
+      style: TextInputStyle.Paragraph,
+      maxLength: DISCORD_TEXT_INPUT_MAX,
+      value: issue.body?.slice(0, DISCORD_TEXT_INPUT_MAX) || undefined,
+    }));
 
     await interaction.showModal(modal);
   }

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -5,8 +5,6 @@ import {
   MessageFlags,
   ModalBuilder,
   StringSelectMenuBuilder,
-  TextInputBuilder,
-  TextInputStyle,
   userMention,
 } from "discord.js";
 import type {
@@ -36,6 +34,7 @@ import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtil
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
+import { buildTextInputRow } from "../functions/uiComponents.js";
 
 const PUSH_PIN_EMOJI = "📌";
 const PLUS_EMOJI = "➕";
@@ -476,18 +475,12 @@ export class MessageReactionAdd {
        
       .setCustomId(`completion-react-title-modal:${sessionId}`)
       .setTitle("Change completion title")
-      .addComponents(
-        new ActionRowBuilder<TextInputBuilder>().addComponents(
-          new TextInputBuilder()
-             
-            .setCustomId("completion-react-title-input")
-            .setLabel("Game title")
-            .setStyle(TextInputStyle.Short)
-            .setRequired(true)
-            .setMaxLength(100)
-            .setValue(session.query.slice(0, DISCORD_SELECT_LABEL_MAX)),
-        ),
-      );
+      .addComponents(buildTextInputRow({
+        customId: "completion-react-title-input",
+        label: "Game title",
+        maxLength: 100,
+        value: session.query.slice(0, DISCORD_SELECT_LABEL_MAX),
+      }));
 
     safeIgnore(interaction.showModal(modal));
   }

--- a/src/functions/NominationAdminHelpers.ts
+++ b/src/functions/NominationAdminHelpers.ts
@@ -4,7 +4,6 @@ import {
   ModalBuilder,
   StringSelectMenuBuilder,
   TextDisplayBuilder,
-  TextInputBuilder,
   TextInputStyle,
   type RepliableInteraction,
   type TextBasedChannel,
@@ -20,6 +19,7 @@ import {
 } from "../classes/Nomination.js";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
+import { buildTextInputRow } from "./uiComponents.js";
 import {
   buildComponentsV2Flags,
   buildNominationListPayload,
@@ -100,18 +100,16 @@ export function buildDeletionReasonModal(
   userId: string,
   gameTitle: string,
 ): ModalBuilder {
-  const reasonInput = new TextInputBuilder()
-    .setCustomId(ADMIN_NOMINATION_DELETE_REASON_INPUT_ID)
-    .setLabel("Deletion reason")
-    .setStyle(TextInputStyle.Paragraph)
-    .setRequired(true)
-    .setMaxLength(250)
-    .setPlaceholder(`Why should "${truncateLabel(gameTitle, 80)}" be removed?`);
-
   return new ModalBuilder()
     .setCustomId(buildDeletionReasonModalCustomId(kind, round, userId))
     .setTitle("Delete nomination")
-    .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(reasonInput));
+    .addComponents(buildTextInputRow({
+      customId: ADMIN_NOMINATION_DELETE_REASON_INPUT_ID,
+      label: "Deletion reason",
+      style: TextInputStyle.Paragraph,
+      maxLength: 250,
+      placeholder: `Why should "${truncateLabel(gameTitle, 80)}" be removed?`,
+    }));
 }
 
 export function buildDeletionReasonState(

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -1,10 +1,42 @@
-import { ActionRowBuilder, ButtonStyle, StringSelectMenuBuilder } from "discord.js";
+import {
+  ActionRowBuilder,
+  ButtonStyle,
+  StringSelectMenuBuilder,
+  TextInputBuilder,
+  TextInputStyle,
+} from "discord.js";
 import {
   ButtonBuilder,
   ContainerBuilder,
   SectionBuilder,
   TextDisplayBuilder,
 } from "@discordjs/builders";
+
+export interface IModalTextInputOptions {
+  customId: string;
+  label: string;
+  style?: TextInputStyle;
+  required?: boolean;
+  placeholder?: string;
+  minLength?: number;
+  maxLength?: number;
+  value?: string;
+}
+
+export function buildTextInputRow(
+  options: IModalTextInputOptions,
+): ActionRowBuilder<TextInputBuilder> {
+  const input = new TextInputBuilder()
+    .setCustomId(options.customId)
+    .setLabel(options.label)
+    .setStyle(options.style ?? TextInputStyle.Short)
+    .setRequired(options.required ?? true);
+  if (options.placeholder != null) input.setPlaceholder(options.placeholder);
+  if (options.minLength != null) input.setMinLength(options.minLength);
+  if (options.maxLength != null) input.setMaxLength(options.maxLength);
+  if (options.value != null) input.setValue(options.value);
+  return new ActionRowBuilder<TextInputBuilder>().addComponents(input);
+}
 
 type ButtonAction = "add" | "edit" | "delete" | "confirm" | "cancel" | "close";
 


### PR DESCRIPTION
## Summary

- Adds `buildTextInputRow(options: IModalTextInputOptions)` to `src/functions/uiComponents.ts` per issue spec
- Migrates all 43 `new ActionRowBuilder<TextInputBuilder>()` constructions across 15 files to use the new helper
- Removes now-unused `TextInputBuilder` (and `TextInputStyle` where only Short style was used) from discord.js imports in each migrated file

## Test plan

- [ ] Type-check passes: `npx tsc --noEmit`
- [ ] Lint passes: `npm run lint`
- [ ] All modal interactions (giveaway donate/revoke, todo create/edit/comment, now-playing note/add/complete, collection filters, gamedb completion, synonyms, etc.) continue to function correctly

Closes #624

🤖 Generated with [Claude Code](https://claude.com/claude-code)