### PR TITLE
chore: pipe npm run test output to test-results.txt

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "start:prod": "pm2 start build/RPGClub_GameDB.js",
     "watch": "nodemon --exec npm run dev --watch src --ext ts",
     "compile": "npx tsc --noEmit",
-    "test": "node --no-warnings=ExperimentalWarning --loader ts-node/esm --test src/tests/*.test.ts",
+    "test": "node --no-warnings=ExperimentalWarning --loader ts-node/esm --test src/tests/*.test.ts 2>&1 | tee test-results.txt",
     "lint": "npx eslint",
     "session:start": "node --no-warnings=ExperimentalWarning --loader ts-node/esm scripts/session-start.ts",
     "backup:docker-volumes": "node --no-warnings=ExperimentalWarning --loader ts-node/esm/transpile-only scripts/backup-docker-volumes.ts",


### PR DESCRIPTION
## Summary
- Adds `2>&1 | tee test-results.txt` to the `test` script in `package.json`
- Output continues to display in the terminal and is also written to `test-results.txt` in the project root

## Test plan
- [ ] Run `npm run test` and confirm `test-results.txt` is created in the project root with the full test output

🤖 Generated with [Claude Code](https://claude.com/claude-code)