### PR TITLE
refactor: shared utilities standardization pass 5 (issues 619-623)

### DIFF
--- a/src/RPGClub_GameDB.ts
+++ b/src/RPGClub_GameDB.ts
@@ -35,6 +35,7 @@ import { startUserEmojiService } from "./services/UserEmojiService.js";
 import { tryHandleManagedRawModalInteraction } from "./services/raw-modal/RawModalInteractionRouter.js";
 import { restoreJournalMessageContextsFromDb } from "./commands/now-playing.command.js";
 import { truncateWithEllipsis } from "./utilities/ValidationUtils.js";
+import { logError } from "./utilities/LogUtils.js";
 installConsoleLogging();
 
 const PRESENCE_CHECK_INTERVAL_MS: number = 30 * 60 * 1000;
@@ -50,7 +51,7 @@ async function refreshPresence(): Promise<void> {
   try {
     await updateBotPresence(bot);
   } catch (err) {
-    console.error("Failed to refresh presence:", err);
+    logError("RPGClub_GameDB.refreshPresence", err);
   }
 }
 
@@ -260,7 +261,7 @@ bot.on("error", (err: unknown) => {
     // Ignore ack/unknown-interaction noise
     return;
   }
-  console.error("Discord client error:", err);
+  logError("RPGClub_GameDB.discordClientError", err);
 });
 
 async function run(): Promise<void> {

--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -14,6 +14,8 @@ import {
   type ApiGetRawMeta,
 } from "../services/RpgClubApiClient.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 
 // Interfaces
 export interface IGame {
@@ -551,7 +553,7 @@ export default class Game {
         });
         imageData = Buffer.from(imageResponse.data);
       } catch (err) {
-        console.error("Failed to download cover image:", err);
+        logError("Game.downloadCoverImage", err);
       }
     }
 
@@ -635,11 +637,11 @@ export default class Game {
           "GAMEDB_COMPANIES", "COMPANY_ID", "NAME", "IGDB_COMPANY_ID",
           ic.company.name, ic.company.id,
         );
-        await dbMutate(GameSql.insertGameCompany, {
+        safeIgnore(dbMutate(GameSql.insertGameCompany, {
           gameId,
           companyId,
           role: ic.developer ? "Developer" : ic.publisher ? "Publisher" : null,
-        }).catch(() => {});
+        }));
       }
     }
 
@@ -648,7 +650,7 @@ export default class Game {
         const genreId = await Game.getOrInsertMetadata(
           "GAMEDB_GENRES", "GENRE_ID", "NAME", "IGDB_GENRE_ID", g.name, g.id,
         );
-        await dbMutate(GameSql.insertGameGenre, { gameId, genreId }).catch(() => {});
+        safeIgnore(dbMutate(GameSql.insertGameGenre, { gameId, genreId }));
       }
     }
 
@@ -657,7 +659,7 @@ export default class Game {
         const themeId = await Game.getOrInsertMetadata(
           "GAMEDB_THEMES", "THEME_ID", "NAME", "IGDB_THEME_ID", t.name, t.id,
         );
-        await dbMutate(GameSql.insertGameTheme, { gameId, themeId }).catch(() => {});
+        safeIgnore(dbMutate(GameSql.insertGameTheme, { gameId, themeId }));
       }
     }
 
@@ -666,7 +668,7 @@ export default class Game {
         const modeId = await Game.getOrInsertMetadata(
           "GAMEDB_GAME_MODES_DEF", "MODE_ID", "NAME", "IGDB_GAME_MODE_ID", gm.name, gm.id,
         );
-        await dbMutate(GameSql.insertGameMode, { gameId, modeId }).catch(() => {});
+        safeIgnore(dbMutate(GameSql.insertGameMode, { gameId, modeId }));
       }
     }
 
@@ -676,7 +678,7 @@ export default class Game {
           "GAMEDB_PERSPECTIVES", "PERSPECTIVE_ID", "NAME", "IGDB_PERSPECTIVE_ID",
           pp.name, pp.id,
         );
-        await dbMutate(GameSql.insertGamePerspective, { gameId, persId }).catch(() => {});
+        safeIgnore(dbMutate(GameSql.insertGamePerspective, { gameId, persId }));
       }
     }
 
@@ -685,7 +687,7 @@ export default class Game {
         const engineId = await Game.getOrInsertMetadata(
           "GAMEDB_ENGINES", "ENGINE_ID", "NAME", "IGDB_ENGINE_ID", e.name, e.id,
         );
-        await dbMutate(GameSql.insertGameEngine, { gameId, engineId }).catch(() => {});
+        safeIgnore(dbMutate(GameSql.insertGameEngine, { gameId, engineId }));
       }
     }
 
@@ -694,7 +696,7 @@ export default class Game {
         const franchiseId = await Game.getOrInsertMetadata(
           "GAMEDB_FRANCHISES", "FRANCHISE_ID", "NAME", "IGDB_FRANCHISE_ID", f.name, f.id,
         );
-        await dbMutate(GameSql.insertGameFranchise, { gameId, franchiseId }).catch(() => {});
+        safeIgnore(dbMutate(GameSql.insertGameFranchise, { gameId, franchiseId }));
       }
     }
 
@@ -835,10 +837,7 @@ export default class Game {
       );
       return Game.getPlatformByIgdbId(igdbPlatform.id);
     } catch (err) {
-      console.error(
-        `Failed to insert platform ${igdbPlatform.name} (${igdbPlatform.id})`,
-        err,
-      );
+      logError("Game.insertPlatform", err);
       return null;
     }
   }
@@ -862,10 +861,7 @@ export default class Game {
       }, "id");
       return Game.getRegionById(regionId);
     } catch (err) {
-      console.error(
-        `Failed to insert region for IGDB region ${igdbRegionId}`,
-        err,
-      );
+      logError("Game.insertRegion", err);
       return null;
     }
   }

--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -12,6 +12,7 @@ import {
 import { getDialect } from "../db/dialect.js";
 import { MemberSql } from "../db/sql/index.js";
 import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const dialect = getDialect();
 
@@ -318,7 +319,7 @@ export default class Member {
       );
     } catch (err: any) {
       const msg = err?.message ?? String(err);
-      console.error(`[Member] Failed to update last seen for ${userId}: ${msg}`);
+      logError("Member.updateLastSeen", msg);
     }
   }
 
@@ -1290,7 +1291,7 @@ export default class Member {
       );
     } catch (err: any) {
       const msg = err?.message ?? String(err);
-      console.error(`[Member] Failed to load nick history for ${userId}: ${msg}`);
+      logError("Member.loadNickHistory", msg);
       return [];
     }
   }

--- a/src/classes/UserChannelMessageCount.ts
+++ b/src/classes/UserChannelMessageCount.ts
@@ -1,5 +1,6 @@
 import { dbQuery, dbTransaction, dbMutateConn } from "../db/SqlManager.js";
 import { UserChannelMessageCountSql } from "../db/sql/index.js";
+import { logError } from "../utilities/LogUtils.js";
 
 type ChannelCountBind = {
   userId: string;
@@ -28,10 +29,7 @@ export default class UserChannelMessageCount {
       });
     } catch (err: any) {
       const msg = err?.message ?? String(err);
-      console.error(
-        `[UserChannelMessageCount] Failed to upsert counts for channel` +
-        ` ${channelId}: ${msg}`,
-      );
+      logError("UserChannelMessageCount.upsertCounts", msg);
     }
   }
 
@@ -45,7 +43,7 @@ export default class UserChannelMessageCount {
       return new Set(rows.filter(Boolean));
     } catch (err: any) {
       const msg = err?.message ?? String(err);
-      console.error(`[UserChannelMessageCount] Failed to load scanned channel ids: ${msg}`);
+      logError("UserChannelMessageCount.loadScannedChannelIds", msg);
       return new Set<string>();
     }
   }
@@ -66,9 +64,7 @@ export default class UserChannelMessageCount {
       return map;
     } catch (err: any) {
       const msg = err?.message ?? String(err);
-      console.error(
-        `[UserChannelMessageCount] Failed to load channel scan metadata: ${msg}`,
-      );
+      logError("UserChannelMessageCount.loadChannelScanMetadata", msg);
       return new Map<string, Date>();
     }
   }

--- a/src/commands/admin/admin-prompt.utils.ts
+++ b/src/commands/admin/admin-prompt.utils.ts
@@ -14,6 +14,8 @@ import {
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { type PromptChoiceOption } from "./admin.types.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 export function buildChoiceRows(
   customIdPrefix: string,
@@ -107,14 +109,14 @@ export async function promptUserForChoice(
     });
     await safeDeferUpdate(selection);
     const value = selection.customId.slice(promptId.length + 1);
-    await promptMessage.edit({ components: [] }).catch(() => {});
+    safeIgnore(promptMessage.edit({ components: [] }));
     if (value === "cancel") {
       await safeReply(interaction, buildTextReply(cancelMessage, false));
       return null;
     }
     return value;
   } catch {
-    await promptMessage.edit({ components: [] }).catch(() => {});
+    safeIgnore(promptMessage.edit({ components: [] }));
     await safeReply(interaction, buildTextReply("Timed out waiting for a selection. Cancelled.", false));
     return null;
   }
@@ -142,7 +144,7 @@ export async function promptUserForInput(
   try {
     await safeReply(interaction, buildTextReply(`${userMention(userId)} ${question}`, false));
   } catch (err) {
-    console.error("Failed to send prompt message:", err);
+    logError("AdminPromptUtils.sendPromptMessage", err);
   }
 
   try {

--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -50,6 +50,7 @@ import {
 } from "./round-setup-wizard.utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 const NEXT_ROUND_SETUP_COMMAND_KEY = "nextround-setup";
 const MAX_SELECT_OPTIONS = 25;
@@ -216,7 +217,7 @@ async function promptSelectNomination(
     const pickedValue = Number(component.values?.[0] ?? "");
     await safeDeferUpdate(component);
     await promptMessage.delete().catch(async () => {
-      await promptMessage.edit({ components: [] }).catch(() => {});
+      safeIgnore(promptMessage.edit({ components: [] }));
     });
     if (!isPositiveInt(pickedValue)) {
       return null;
@@ -232,7 +233,7 @@ async function promptSelectNomination(
       await safeDeferUpdate(cancel);
     }
     await promptMessage.delete().catch(async () => {
-      await promptMessage.edit({ components: [] }).catch(() => {});
+      safeIgnore(promptMessage.edit({ components: [] }));
     });
     return null;
   }
@@ -365,7 +366,7 @@ export async function handleNextRoundSetup(
       const value = selection.customId.slice(promptId.length + 1);
       const chosenLabel = options.find((opt) => opt.value === value)?.label ?? value;
       await promptMessage.delete().catch(async () => {
-        await promptMessage.edit({ components: [] }).catch(() => {});
+        safeIgnore(promptMessage.edit({ components: [] }));
       });
       await updateEmbed(`> *${chosenLabel}*`);
       if (value === "cancel") {
@@ -376,7 +377,7 @@ export async function handleNextRoundSetup(
       return value;
     } catch {
       await promptMessage.delete().catch(async () => {
-        await promptMessage.edit({ components: [] }).catch(() => {});
+        safeIgnore(promptMessage.edit({ components: [] }));
       });
       await updateEmbed("❌ Timed out waiting for a selection.");
       await closeWizardState("cancelled");
@@ -399,7 +400,7 @@ export async function handleNextRoundSetup(
         return null;
       }
       const content = first.content.trim();
-      await first.delete().catch(() => {});
+      safeIgnore(first.delete());
       await updateEmbed(`> *${content}*`);
       if (/^cancel$/i.test(content)) {
         await updateEmbed("❌ Cancelled by user.");

--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -23,8 +23,11 @@ import {
   PRIVATE_OPTION_DESCRIPTION,
   replyIfNotOwner,
   safeDeferReply,
+  safeDeferUpdate,
+  safeMemberFetch,
   safeReply,
   safeUpdate,
+  safeUserFetch,
 } from "../functions/InteractionUtils.js";
 import {
   buildOptionalPrevNextRow,
@@ -38,7 +41,6 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import { getUserEmojiData, renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { buildTitleHeaderContainer, buildUserHeaderContainer } from "../functions/uiComponents.js";
-import { safeDeferUpdate } from "../functions/InteractionUtils.js";
 import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { isAdmin } from "./admin/admin-auth.utils.js";
@@ -132,7 +134,7 @@ async function buildAvatarHistoryAllPage(
     const checks = await Promise.all(
       allRecords.map(async (record) => {
         if (guild.members.cache.has(record.userId)) return record;
-        const fetched = await guild.members.fetch(record.userId).catch(() => null);
+        const fetched = await safeMemberFetch(guild, record.userId);
         return fetched ? record : null;
       }),
     );
@@ -415,7 +417,7 @@ export class AvatarHistoryCommand {
     const targetId = interaction.values[0];
     if (!targetId) return;
     await safeDeferUpdate(interaction);
-    const target = await interaction.client.users.fetch(targetId).catch(() => null);
+    const target = await safeUserFetch(interaction.client, targetId);
     if (!target) return;
     const pageResult = await buildAvatarHistoryV2Page(target, 0);
     if (!pageResult) {

--- a/src/commands/collection/collection-csv-import.command.ts
+++ b/src/commands/collection/collection-csv-import.command.ts
@@ -98,6 +98,8 @@ import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_EMBED_FIELD_VALUE_MAX } from "../../config/textLimits.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 @Discord()
 @SlashGroup("collection")
@@ -483,16 +485,13 @@ export class CollectionCsvImportCommand {
         itemId: nextItem.itemId,
         rowIndex: nextItem.rowIndex,
       });
-      console.error(
-        "[CsvImport] message render failed",
-        JSON.stringify({
-          importId: session.importId,
-          itemId: nextItem.itemId,
-          rowIndex: nextItem.rowIndex,
-          candidateCount: candidates.length,
-          messages,
-        }),
-      );
+      logError("CsvImport.messageRender", {
+        importId: session.importId,
+        itemId: nextItem.itemId,
+        rowIndex: nextItem.rowIndex,
+        candidateCount: candidates.length,
+        messages,
+      });
       throw error;
     }
   }
@@ -526,10 +525,10 @@ export class CollectionCsvImportCommand {
   ): Promise<void> {
     const guild = interaction.guild;
     if (!guild) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This command can only be used inside a server.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
@@ -721,18 +720,18 @@ export class CollectionCsvImportCommand {
   async onCsvImportAction(interaction: ButtonInteraction): Promise<void> {
     const parsed = parseCollectionCsvImportActionId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This CSV import control is invalid.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This CSV import control is not for you.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
@@ -758,7 +757,7 @@ export class CollectionCsvImportCommand {
 
     const item = await getNextPendingCollectionCsvImportItem(session.importId);
     if (!item || item.itemId !== parsed.itemId) {
-      await safeDeferUpdate(interaction).catch(() => {});
+      safeIgnore(safeDeferUpdate(interaction));
       await this.renderNextCsvImportItem(interaction, session.importId, parsed.ownerId);
       return;
     }
@@ -777,7 +776,7 @@ export class CollectionCsvImportCommand {
     }
 
     if (parsed.action === "skip") {
-      await safeDeferUpdate(interaction).catch(() => {});
+      safeIgnore(safeDeferUpdate(interaction));
       await updateCollectionCsvImportItem(item.itemId, {
         status: "SKIPPED",
         resultReason: "MANUAL_SKIP",
@@ -810,7 +809,7 @@ export class CollectionCsvImportCommand {
         value: item.rawTitle.slice(0, 120),
         placeholder: "Call of Duty Classic",
       }));
-      await interaction.showModal(modal).catch(() => {});
+      safeIgnore(interaction.showModal(modal));
       return;
     }
 
@@ -831,7 +830,7 @@ export class CollectionCsvImportCommand {
         maxLength: 20,
         placeholder: "12345",
       }));
-      await interaction.showModal(modal).catch(() => {});
+      safeIgnore(interaction.showModal(modal));
       return;
     }
   }
@@ -842,18 +841,18 @@ export class CollectionCsvImportCommand {
   async onCsvImportChoose(interaction: ButtonInteraction): Promise<void> {
     const parsed = parseCollectionCsvChooseId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This CSV import choice is invalid.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This CSV import choice is not for you.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
@@ -871,12 +870,12 @@ export class CollectionCsvImportCommand {
 
     const item = await getNextPendingCollectionCsvImportItem(session.importId);
     if (!item || item.itemId !== parsed.itemId) {
-      await safeDeferUpdate(interaction).catch(() => {});
+      safeIgnore(safeDeferUpdate(interaction));
       await this.renderNextCsvImportItem(interaction, session.importId, parsed.ownerId);
       return;
     }
 
-    await safeDeferUpdate(interaction).catch(() => {});
+    safeIgnore(safeDeferUpdate(interaction));
     await this.applyCsvImportSelection({
       ownerId: parsed.ownerId,
       item,
@@ -899,27 +898,27 @@ export class CollectionCsvImportCommand {
   async onCsvImportRemapModal(interaction: ModalSubmitInteraction): Promise<void> {
     const parsed = parseCollectionCsvRemapModalId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This remap form is invalid.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This remap form is not for you.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
     const session = await getCollectionCsvImportById(parsed.importId);
     if (!session || session.userId !== parsed.ownerId || session.status !== "ACTIVE") {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This CSV import session is no longer active.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
@@ -992,27 +991,27 @@ export class CollectionCsvImportCommand {
   async onCsvImportGameIdModal(interaction: ModalSubmitInteraction): Promise<void> {
     const parsed = parseCollectionCsvGameIdModalId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This GameDB ID form is invalid.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This GameDB ID form is not for you.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 
     const session = await getCollectionCsvImportById(parsed.importId);
     if (!session || session.userId !== parsed.ownerId || session.status !== "ACTIVE") {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         "This CSV import session is no longer active.",
         true,
-      )).catch(() => {});
+      )));
       return;
     }
 

--- a/src/commands/collection/collection-import-ui.utils.ts
+++ b/src/commands/collection/collection-import-ui.utils.ts
@@ -11,6 +11,7 @@ import {
 } from "../imports/import-scaffold.service.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
 import type { ImportCandidate } from "../../functions/ImportCandidateUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 export async function buildImportCandidatesContainer(params: {
   ownerId: string;
@@ -89,17 +90,14 @@ export async function buildImportCandidatesContainer(params: {
       container.addSectionComponents(section);
     } catch (error) {
       const messages = flattenErrorMessages(error);
-      console.error(
-        `[${params.logPrefix}] candidate section validation failed`,
-        JSON.stringify({
-          importId: params.importId,
-          itemId: params.itemId,
-          gameDbGameId: entry.gameId,
-          titleLength: entry.title.length,
-          sectionTextLength: sectionText.length,
-          messages,
-        }),
-      );
+      logError(`${params.logPrefix}.sectionValidation`, {
+        importId: params.importId,
+        itemId: params.itemId,
+        gameDbGameId: entry.gameId,
+        titleLength: entry.title.length,
+        sectionTextLength: sectionText.length,
+        messages,
+      });
       container.addTextDisplayComponents(
         new TextDisplayBuilder().setContent(
           safeV2TextContent(`**${entry.title}** | #${entry.gameId}`, 300),

--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -18,6 +18,8 @@ import { buildActionButton, buildUserHeaderContainer } from "../../functions/uiC
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildDisabledPrevNextRowWithIds } from "../../functions/PaginationUtils.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 const COLLECTION_LIST_PAGE_SIZE = 20;
 const COLLECTION_LIST_NAV_PREFIX = "collection-list-nav-v2";
@@ -410,15 +412,12 @@ function validateComponentsForCollectionNavDebug(
         componentType: String((component as any)?.constructor?.name ?? "unknown"),
       });
     } catch (error) {
-      console.error(
-        "[CollectionListNavDebug] component_invalid",
-        JSON.stringify({
-          ...context,
-          componentIndex: index,
-          componentType: String((component as any)?.constructor?.name ?? "unknown"),
-          messages: flattenErrorMessages(error),
-        }),
-      );
+      logError("CollectionListNavDebug.componentInvalid", {
+        ...context,
+        componentIndex: index,
+        componentType: String((component as any)?.constructor?.name ?? "unknown"),
+        messages: flattenErrorMessages(error),
+      });
     }
   }
 }
@@ -638,7 +637,7 @@ export async function applyFiltersToSourceMessage(params: {
 
 export async function closeFilterPanel(interaction: ButtonInteraction): Promise<void> {
   await safeDeferUpdate(interaction);
-  await (interaction.message as any)?.delete?.().catch(() => {});
+  safeIgnore((interaction.message as any)?.delete?.());
 }
 
 function collectTextDisplayContent(

--- a/src/commands/collection/collection-steam-import.command.ts
+++ b/src/commands/collection/collection-steam-import.command.ts
@@ -95,6 +95,8 @@ import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_EMBED_FIELD_VALUE_MAX } from "../../config/textLimits.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 @Discord()
 @SlashGroup("collection")
@@ -458,18 +460,15 @@ export class CollectionSteamImportCommand {
         itemId: nextItem.itemId,
         rowIndex: nextItem.rowIndex,
       });
-      console.error(
-        "[SteamImport] message render failed",
-        JSON.stringify({
-          importId: session.importId,
-          itemId: nextItem.itemId,
-          rowIndex: nextItem.rowIndex,
-          steamAppId: nextItem.steamAppId,
-          steamAppName: nextItem.steamAppName,
-          candidateCount: candidates.length,
-          messages,
-        }),
-      );
+      logError("SteamImport.messageRender", {
+        importId: session.importId,
+        itemId: nextItem.itemId,
+        rowIndex: nextItem.rowIndex,
+        steamAppId: nextItem.steamAppId,
+        steamAppName: nextItem.steamAppName,
+        candidateCount: candidates.length,
+        messages,
+      });
       throw error;
     }
   }
@@ -500,7 +499,7 @@ export class CollectionSteamImportCommand {
   ): Promise<void> {
     const guild = interaction.guild;
     if (!guild) {
-      await safeReply(interaction, buildTextReply("This command can only be used inside a server.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This command can only be used inside a server.", true)));
       return;
     }
 
@@ -676,12 +675,12 @@ export class CollectionSteamImportCommand {
   async onSteamImportAction(interaction: ButtonInteraction): Promise<void> {
     const parsed = parseCollectionSteamImportActionId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply("This Steam import control is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This Steam import control is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await safeReply(interaction, buildTextReply("This Steam import control is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This Steam import control is not for you.", true)));
       return;
     }
 
@@ -707,7 +706,7 @@ export class CollectionSteamImportCommand {
 
     const item = await getNextPendingSteamCollectionImportItem(session.importId);
     if (!item || item.itemId !== parsed.itemId) {
-      await safeDeferUpdate(interaction).catch(() => {});
+      safeIgnore(safeDeferUpdate(interaction));
       await this.renderNextSteamImportItem(interaction, session.importId, parsed.ownerId);
       return;
     }
@@ -726,7 +725,7 @@ export class CollectionSteamImportCommand {
     }
 
     if (parsed.action === "skip") {
-      await safeDeferUpdate(interaction).catch(() => {});
+      safeIgnore(safeDeferUpdate(interaction));
       await updateSteamCollectionImportItem(item.itemId, {
         status: "SKIPPED",
         resultReason: "MANUAL_SKIP",
@@ -766,7 +765,7 @@ export class CollectionSteamImportCommand {
         value: item.steamAppName.slice(0, 120),
         placeholder: "Call of Duty Classic",
       }));
-      await interaction.showModal(modal).catch(() => {});
+      safeIgnore(interaction.showModal(modal));
       return;
     }
 
@@ -787,7 +786,7 @@ export class CollectionSteamImportCommand {
         maxLength: 20,
         placeholder: "12345",
       }));
-      await interaction.showModal(modal).catch(() => {});
+      safeIgnore(interaction.showModal(modal));
       return;
     }
   }
@@ -798,12 +797,12 @@ export class CollectionSteamImportCommand {
   async onSteamImportChoose(interaction: ButtonInteraction): Promise<void> {
     const parsed = parseCollectionSteamChooseId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply("This Steam import choice is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This Steam import choice is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await safeReply(interaction, buildTextReply("This Steam import choice is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This Steam import choice is not for you.", true)));
       return;
     }
 
@@ -821,12 +820,12 @@ export class CollectionSteamImportCommand {
 
     const item = await getNextPendingSteamCollectionImportItem(session.importId);
     if (!item || item.itemId !== parsed.itemId) {
-      await safeDeferUpdate(interaction).catch(() => {});
+      safeIgnore(safeDeferUpdate(interaction));
       await this.renderNextSteamImportItem(interaction, session.importId, parsed.ownerId);
       return;
     }
 
-    await safeDeferUpdate(interaction).catch(() => {});
+    safeIgnore(safeDeferUpdate(interaction));
     await this.applySteamImportSelection({
       ownerId: parsed.ownerId,
       gameId: parsed.gameId,
@@ -851,18 +850,18 @@ export class CollectionSteamImportCommand {
   async onSteamImportRemapModal(interaction: ModalSubmitInteraction): Promise<void> {
     const parsed = parseCollectionSteamRemapModalId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply("This remap form is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This remap form is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await safeReply(interaction, buildTextReply("This remap form is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This remap form is not for you.", true)));
       return;
     }
 
     const session = await getSteamCollectionImportById(parsed.importId);
     if (!session || session.userId !== parsed.ownerId || session.status !== "ACTIVE") {
-      await safeReply(interaction, buildTextReply("This Steam import session is no longer active.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This Steam import session is no longer active.", true)));
       return;
     }
 
@@ -936,18 +935,18 @@ export class CollectionSteamImportCommand {
   async onSteamImportGameIdModal(interaction: ModalSubmitInteraction): Promise<void> {
     const parsed = parseCollectionSteamGameIdModalId(interaction.customId);
     if (!parsed) {
-      await safeReply(interaction, buildTextReply("This GameDB ID form is invalid.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This GameDB ID form is invalid.", true)));
       return;
     }
 
     if (interaction.user.id !== parsed.ownerId) {
-      await safeReply(interaction, buildTextReply("This GameDB ID form is not for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This GameDB ID form is not for you.", true)));
       return;
     }
 
     const session = await getSteamCollectionImportById(parsed.importId);
     if (!session || session.userId !== parsed.ownerId || session.status !== "ACTIVE") {
-      await safeReply(interaction, buildTextReply("This Steam import session is no longer active.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This Steam import session is no longer active.", true)));
       return;
     }
 

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -36,7 +36,7 @@ import {
   buildComponentsV2EditFlags,
 } from "../../functions/ComponentsV2Utils.js";
 import { flattenErrorMessages } from "../imports/import-scaffold.service.js";
-import { formatStructuredLog } from "../../utilities/LogUtils.js";
+import { formatStructuredLog, logError } from "../../utilities/LogUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
 import {
@@ -454,13 +454,10 @@ export class CollectionViewCommand {
       });
       logNavDebug("nav_update_success", debugContext);
     } catch (error) {
-      console.error(
-        "[CollectionListNavDebug] nav_update_failed",
-        JSON.stringify({
-          ...debugContext,
-          messages: flattenErrorMessages(error),
-        }),
-      );
+      logError("CollectionListNavDebug.navUpdateFailed", {
+        ...debugContext,
+        messages: flattenErrorMessages(error),
+      });
       throw error;
     }
   }

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -34,11 +34,10 @@ import {
 } from "../../functions/ComponentsV2Utils.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import {
-  DISCORD_AUTOCOMPLETE_DESC_MAX,
-  DISCORD_SELECT_LABEL_MAX,
-} from "../../config/textLimits.js";
+import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
+import { buildSelectOptions } from "../../functions/uiComponents.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 /**
  * Creates a completion session and returns the session ID
@@ -60,17 +59,17 @@ export async function promptCompletionSelection(
   const localResults = await Game.searchGames(searchTerm);
   if (localResults.length) {
     const sessionId = createCompletionSession(ctx);
-    const options = localResults.slice(0, 24).map((game) => ({
-      label: game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
+    const gameOptions = localResults.map((game) => ({
+      label: game.title,
       value: String(game.id),
       description: `GameDB #${game.id}`,
     }));
-
-    options.push({
+    gameOptions.push({
       label: "Import another game from IGDB",
       value: "import-igdb",
       description: "Search IGDB and import a new GameDB entry",
     });
+    const options = buildSelectOptions(gameOptions);
 
     const select = new StringSelectMenuBuilder()
       // eslint-disable-next-line local/custom-id-has-matching-handler
@@ -508,7 +507,7 @@ export async function importGameFromIgdb(
       const imageResponse = await axios.get(imageUrl, { responseType: "arraybuffer" });
       imageData = Buffer.from(imageResponse.data);
     } catch (err) {
-      console.error("Failed to download cover image:", err);
+      logError("CompletionAddService.downloadCoverImage", err);
     }
   }
 

--- a/src/commands/game-completion/completion-common.service.ts
+++ b/src/commands/game-completion/completion-common.service.ts
@@ -22,6 +22,7 @@ import {
 } from "../profile.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { MAX_CONTAINER_TEXT, MAX_SECTION_TEXT } from "../../config/textLimits.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export type CommonCompletionSort =
   | "title_asc"
@@ -490,7 +491,7 @@ export async function handleCommonCompletionNav(
 
   const targetPage = parsed.direction === "next" ? parsed.page + 1 : Math.max(parsed.page - 1, 0);
 
-  await safeDeferUpdate(interaction).catch(() => {});
+  safeIgnore(safeDeferUpdate(interaction));
 
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
   await renderCommonCompletionPage(interaction, parsed.state, targetPage, ephemeral);
@@ -502,7 +503,7 @@ export async function handleCommonCompletionBack(
   const parsed = parseCommonBackCustomId(interaction.customId);
   if (!parsed) return;
 
-  await safeDeferUpdate(interaction).catch(() => {});
+  safeIgnore(safeDeferUpdate(interaction));
 
   const ephemeral = interaction.message?.flags?.has(MessageFlags.Ephemeral) ?? true;
   await renderCommonCompletionPage(interaction, parsed.state, parsed.page, ephemeral);

--- a/src/commands/game-completion/completion-delete.service.ts
+++ b/src/commands/game-completion/completion-delete.service.ts
@@ -5,6 +5,7 @@ import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 /**
  * Handles completion deletion from the selection menu
@@ -37,12 +38,8 @@ export async function handleCompletionDeleteMenu(
 
   await safeReply(interaction, buildTextReply(`Deleted completion #${completionId}.`, true));
 
-  try {
-    await interaction.message.edit({
-      components: [],
-      flags: COMPONENTS_V2_FLAG,
-    }).catch(() => {});
-  } catch {
-    // ignore
-  }
+  safeIgnore(interaction.message.edit({
+    components: [],
+    flags: COMPONENTS_V2_FLAG,
+  }));
 }

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -36,6 +36,7 @@ import {
 } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildActionButton } from "../../functions/uiComponents.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 const MAX_NOTE_LENGTH = 500;
 type CompletionEditField = "type" | "date" | "platform" | "playtime" | "note";
@@ -157,14 +158,12 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
   if (!channel || !("awaitMessages" in channel)) {
     const updated = await Member.getCompletion(completionId);
     if (updated) {
-      await interaction.message
-        .edit(buildCompletionEditPrompt(
-          ownerId,
-          completionId,
-          updated,
-          "I couldn't listen for your response in this channel.",
-        ))
-        .catch(() => {});
+      safeIgnore(interaction.message.edit(buildCompletionEditPrompt(
+        ownerId,
+        completionId,
+        updated,
+        "I couldn't listen for your response in this channel.",
+      )));
     }
     return;
   }
@@ -181,14 +180,12 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
   if (!message) {
     const updated = await Member.getCompletion(completionId);
     if (updated) {
-      await interaction.message
-        .edit(buildCompletionEditPrompt(
-          ownerId,
-          completionId,
-          updated,
-          "Timed out waiting for your response.",
-        ))
-        .catch(() => {});
+      safeIgnore(interaction.message.edit(buildCompletionEditPrompt(
+        ownerId,
+        completionId,
+        updated,
+        "Timed out waiting for your response.",
+      )));
     }
     return;
   }
@@ -227,27 +224,23 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
     const updated = await Member.getCompletion(completionId);
     if (updated) {
       const notice = await buildCompletionEditSuccessNotice(updated, field as CompletionEditField);
-      await interaction.message
-        .edit(buildCompletionEditPrompt(ownerId, completionId, updated, notice))
-        .catch(() => {});
+      safeIgnore(interaction.message.edit(
+        buildCompletionEditPrompt(ownerId, completionId, updated, notice),
+      ));
     }
   } catch (err: any) {
     const updated = await Member.getCompletion(completionId);
     if (updated) {
-      await interaction.message
-        .edit(
-          buildCompletionEditPrompt(
-            ownerId,
-            completionId,
-            updated,
-            err?.message ?? "Failed to update completion.",
-          ),
-        )
-        .catch(() => {});
+      safeIgnore(interaction.message.edit(buildCompletionEditPrompt(
+        ownerId,
+        completionId,
+        updated,
+        err?.message ?? "Failed to update completion.",
+      )));
     }
   } finally {
     try {
-      await message.delete().catch(() => {});
+      safeIgnore(message.delete());
     } catch {
       // ignore
     }

--- a/src/commands/game-completion/completion-pagination.service.ts
+++ b/src/commands/game-completion/completion-pagination.service.ts
@@ -21,6 +21,7 @@ import {
   safeV2TextContent,
 } from "../../functions/ComponentsV2Utils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 /**
  * Parses a year filter string into a number, "unknown", or null
@@ -182,7 +183,7 @@ export async function handleCompletionListHeader(
   if (!segs) return;
   const [ownerId] = segs;
   if (interaction.user.id !== ownerId) {
-    await safeDeferUpdate(interaction).catch(() => {});
+    safeIgnore(safeDeferUpdate(interaction));
     return;
   }
   await safeReply(interaction, {

--- a/src/commands/game-completion/completion-platform.service.ts
+++ b/src/commands/game-completion/completion-platform.service.ts
@@ -21,6 +21,7 @@ import {
 } from "./completion.types.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export function createCompletionPlatformSession(
   ctx: CompletionPlatformContext,
@@ -85,18 +86,18 @@ export async function handleCompletionPlatformSelect(
   const ctx = completionPlatformSessions.get(sessionId);
 
   if (!ctx) {
-    await safeReply(
+    safeIgnore(safeReply(
       interaction,
       buildTextReply("This completion prompt has expired.", true),
-    ).catch(() => {});
+    ));
     return;
   }
 
   if (interaction.user.id !== ctx.userId) {
-    await safeReply(
+    safeIgnore(safeReply(
       interaction,
       buildTextReply("This completion prompt isn't for you.", true),
-    ).catch(() => {});
+    ));
     return;
   }
 
@@ -114,14 +115,14 @@ export async function handleCompletionPlatformSelect(
     ctx.platforms.some((platform) => platform.id === platformId)
   );
   if (!valid) {
-    await safeReply(
+    safeIgnore(safeReply(
       interaction,
       buildTextReply("Invalid platform selection.", true),
-    ).catch(() => {});
+    ));
     return;
   }
 
-  await safeDeferUpdate(interaction).catch(() => {});
+  safeIgnore(safeDeferUpdate(interaction));
   completionPlatformSessions.delete(sessionId);
 
   if (isOther) {
@@ -143,7 +144,7 @@ export async function handleCompletionPlatformSelect(
     ctx.removeFromNowPlaying,
   );
 
-  await safeReply(interaction, { components: [] }).catch(() => {});
+  safeIgnore(safeReply(interaction, { components: [] }));
 }
 
 export async function resolveDefaultCompletionPlatformId(gameId: number): Promise<number | null> {

--- a/src/commands/game-completion/completionator-handlers.service.ts
+++ b/src/commands/game-completion/completionator-handlers.service.ts
@@ -33,6 +33,7 @@ import { parseCompletionDateInput } from "../profile.command.js";
 import { searchGameDbWithFallback, importGameFromIgdb } from "./completionator-parser.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export class CompletionatorHandlersService {
   private workflowService: CompletionatorWorkflowService;
@@ -137,13 +138,13 @@ export class CompletionatorHandlersService {
 
     const session = await getImportById(parsed.importId);
     if (!session) {
-      await safeReply(interaction, buildTextReply("Import session not found.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("Import session not found.", true)));
       return;
     }
 
     const item = await getImportItemById(parsed.itemId);
     if (!item) {
-      await safeReply(interaction, buildTextReply("Import item not found.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("Import item not found.", true)));
       return;
     }
 
@@ -654,13 +655,11 @@ export class CompletionatorHandlersService {
       ownerId,
     );
     if (context?.message) {
-      await context.message
-        .edit({
-          components: payload.components,
-          files: payload.files,
-          flags: buildComponentsV2Flags(false),
-        })
-        .catch(() => {});
+      safeIgnore(context.message.edit({
+        components: payload.components,
+        files: payload.files,
+        flags: buildComponentsV2Flags(false),
+      }));
     }
 
     await safeReply(interaction, buildTextReply("Completion date saved.", true));
@@ -711,7 +710,7 @@ export class CompletionatorHandlersService {
     }
     const cleanupDeferredReply = async (): Promise<void> => {
       if (shouldDeferForContext) {
-        await interaction.deleteReply().catch(() => {});
+        safeIgnore(interaction.deleteReply());
       }
     };
 
@@ -847,10 +846,10 @@ export class CompletionatorHandlersService {
     if (context) {
       completionatorThreadContexts.delete(key);
       if (context.thread && "delete" in context.thread) {
-        await context.thread.delete().catch(() => {});
+        safeIgnore(context.thread.delete());
       }
       if (context.parentMessage && "delete" in context.parentMessage) {
-        await context.parentMessage.delete().catch(() => {});
+        safeIgnore(context.parentMessage.delete());
       }
     }
 
@@ -858,7 +857,7 @@ export class CompletionatorHandlersService {
       `Import #${session.importId} paused. ` +
       "Resume with `/game-completion import-completionator action:resume`.";
 
-    await safeReply(interaction, buildTextReply(content, true)).catch(() => {});
+    safeIgnore(safeReply(interaction, buildTextReply(content, true)));
   }
 }
 

--- a/src/commands/game-completion/completionator-thread.service.ts
+++ b/src/commands/game-completion/completionator-thread.service.ts
@@ -8,6 +8,7 @@ import { buildComponentsV2Flags, buildTextReply } from "../../functions/Componen
 import { BOT_DEV_CHANNEL_ID } from "../../config/channels.js";
 import { safeReply } from "../../functions/InteractionUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export class CompletionatorThreadService {
   private uiService: CompletionatorUiService;
@@ -132,10 +133,10 @@ export class CompletionatorThreadService {
     completionatorThreadContexts.delete(key);
 
     if (context.thread && "delete" in context.thread) {
-      await context.thread.delete().catch(() => {});
+      safeIgnore(context.thread.delete());
     }
     if (context.parentMessage && "delete" in context.parentMessage) {
-      await context.parentMessage.delete().catch(() => {});
+      safeIgnore(context.parentMessage.delete());
     }
   }
 }

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -49,6 +49,7 @@ import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
 } from "../../config/textLimits.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export class CompletionatorUiService {
   buildCompletionatorBaseLines(
@@ -656,7 +657,7 @@ export class CompletionatorUiService {
     const flags = buildComponentsV2Flags(Boolean(ephemeral));
     const files = payload.files ?? [];
     if (context?.message) {
-      await context.message.edit({ ...payload, files, flags }).catch(() => {});
+      safeIgnore(context.message.edit({ ...payload, files, flags }));
       return;
     }
 

--- a/src/commands/game-completion/completionator-workflow.service.ts
+++ b/src/commands/game-completion/completionator-workflow.service.ts
@@ -38,6 +38,7 @@ import { buildImportTextContainer } from "../imports/import-scaffold.service.js"
 import { canSafeReply, safeDeferReply, safeDeferUpdate } from "../../functions/InteractionUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export class CompletionatorWorkflowService {
   private uiService: CompletionatorUiService;
@@ -727,7 +728,7 @@ export class CompletionatorWorkflowService {
     });
 
     if (removeFromNowPlaying) {
-      await Member.removeNowPlaying(interaction.user.id, item.gameDbGameId!).catch(() => {});
+      safeIgnore(Member.removeNowPlaying(interaction.user.id, item.gameDbGameId!));
     }
 
     completionatorAddFormStates.delete(getCompletionatorFormKey(session.importId, item.itemId));

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -43,6 +43,7 @@ import {
   sanitizeUserInput,
   safeReply,
   safeUpdate,
+  safeUserFetch,
 } from "../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
@@ -52,7 +53,11 @@ import {
   buildTextReply,
   safeV2TextContent,
 } from "../functions/ComponentsV2Utils.js";
-import { buildActionButton, buildUserHeaderContainer } from "../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildSelectOptions,
+  buildUserHeaderContainer,
+} from "../functions/uiComponents.js";
 import {
   GJ_CLOSE_PREFIX,
   GJ_SEARCH_PAGE_PREFIX,
@@ -202,11 +207,11 @@ function buildListSelectRow(
   const start = page * LIST_PAGE_SIZE;
   const pageEntries = entries.slice(start, start + LIST_PAGE_SIZE);
 
-  const options = pageEntries.map((e) => ({
-    label: e.title.slice(0, DISCORD_SELECT_LABEL_MAX),
+  const options = buildSelectOptions(pageEntries.map((e) => ({
+    label: e.title,
     value: String(e.gameId),
     description: `${e.totalEntries} ${entryLabel(e.totalEntries)}`,
-  }));
+  })));
 
   const select = new StringSelectMenuBuilder()
     // eslint-disable-next-line local/custom-id-has-matching-handler
@@ -287,11 +292,11 @@ function buildAllSelectRow(
 ): ActionRowBuilder<StringSelectMenuBuilder> {
   const start = page * ALL_PAGE_SIZE;
   const pageSummaries = summaries.slice(start, start + ALL_PAGE_SIZE);
-  const options = pageSummaries.map((s) => ({
-    label: (s.globalName ?? s.username ?? s.userId).slice(0, DISCORD_SELECT_LABEL_MAX),
+  const options = buildSelectOptions(pageSummaries.map((s) => ({
+    label: s.globalName ?? s.username ?? s.userId,
     value: s.userId,
     description: `${s.gameCount} ${gameLabel(s.gameCount)}`,
-  }));
+  })));
   const select = new StringSelectMenuBuilder()
     // eslint-disable-next-line local/custom-id-has-matching-handler
     .setCustomId(`${GJ_ALL_SELECT_PREFIX}:${callerId}:${page}`)
@@ -600,7 +605,7 @@ export class GameJournalCommand {
 
     await safeDeferUpdate(interaction);
 
-    const target = await interaction.client.users.fetch(targetUserId).catch(() => null);
+    const target = await safeUserFetch(interaction.client, targetUserId);
     if (!target) return;
 
     const entries = await Member.getGameJournalList(targetUserId);
@@ -632,7 +637,7 @@ export class GameJournalCommand {
 
     await safeDeferUpdate(interaction);
 
-    const target = await interaction.client.users.fetch(targetUserId).catch(() => null);
+    const target = await safeUserFetch(interaction.client, targetUserId);
     if (!target) return;
 
     const entries = await Member.getGameJournalList(targetUserId);
@@ -725,7 +730,7 @@ export class GameJournalCommand {
         : rawGameTitle)
       : null;
     const fetchedUser = targetUserId !== "0"
-      ? await interaction.client.users.fetch(targetUserId).catch(() => null)
+      ? await safeUserFetch(interaction.client, targetUserId)
       : null;
     const targetUser = fetchedUser
       ? { id: fetchedUser.id, displayName: fetchedUser.displayName ?? fetchedUser.username }
@@ -878,11 +883,11 @@ export class GameJournalCommand {
       });
       return;
     }
-    const options = entries.map((e) => ({
-      label: (e.title ?? `Entry #${e.entryNumber}`).slice(0, DISCORD_SELECT_LABEL_MAX),
+    const options = buildSelectOptions(entries.map((e) => ({
+      label: e.title ?? `Entry #${e.entryNumber}`,
       value: String(e.entryId),
       description: formatTableDate(e.createdAt),
-    }));
+    })));
     const select = new StringSelectMenuBuilder()
       .setCustomId(`${GJ_HMENU_DELETE_SELECT_PREFIX}:${ownerId}:${gameId}`)
       .setPlaceholder("Choose an entry to delete")

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -68,6 +68,7 @@ import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtil
 import { COLOR_PRIMARY, COLOR_SUCCESS, COLOR_HIGHLIGHT } from "../config/colors.js";
 import { AUDIT_PAGE_SIZE, SYNONYM_LIST_PAGE_SIZE } from "../config/pagination.js";
 import { assertCustomIdSegments, parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
 
 const AUDIT_VIDEO_MODAL_ID = "audit-video-modal";
 const AUDIT_VIDEO_INPUT_ID = "audit-video-url";
@@ -820,7 +821,7 @@ export class GameDbAdmin {
         const buffer = Buffer.from(resp.data);
 
         await Game.updateGameImage(gameId, buffer);
-        await msg.delete().catch(() => {});
+        safeIgnore(msg.delete());
 
         // Update session data locally so UI reflects change if we go back/refresh
         const game = session.games.find(g => g.id === gameId);
@@ -910,7 +911,7 @@ export class GameDbAdmin {
         placeholder: "https://www.youtube.com/watch?v=...",
       }));
 
-    await interaction.showModal(modal).catch(() => {});
+    safeIgnore(interaction.showModal(modal));
   }
 
   @ButtonComponent({ id: /^audit-description:[^:]+:\d+$/ })
@@ -931,7 +932,7 @@ export class GameDbAdmin {
         maxLength: 2000,
       }));
 
-    await interaction.showModal(modal).catch(() => {});
+    safeIgnore(interaction.showModal(modal));
   }
 
   @ModalComponent({ id: /^audit-video-modal:[^:]+:\d+$/ })
@@ -965,10 +966,10 @@ export class GameDbAdmin {
     const refreshed = await Game.getGameById(gameId);
     if (refreshed && interaction.message) {
       const response = await this.buildAuditDetailResponse(sessionId, refreshed);
-      await interaction.message.edit(response).catch(() => {});
+      safeIgnore(interaction.message.edit(response));
     }
 
-    await interaction.deleteReply().catch(() => {});
+    safeIgnore(interaction.deleteReply());
   }
 
   @ModalComponent({ id: /^audit-description-modal:[^:]+:\d+$/ })
@@ -1002,10 +1003,10 @@ export class GameDbAdmin {
     const refreshed = await Game.getGameById(gameId);
     if (refreshed && interaction.message) {
       const response = await this.buildAuditDetailResponse(sessionId, refreshed);
-      await interaction.message.edit(response).catch(() => {});
+      safeIgnore(interaction.message.edit(response));
     }
 
-    await interaction.deleteReply().catch(() => {});
+    safeIgnore(interaction.deleteReply());
   }
 
   @ButtonComponent({ id: /^audit-auto-stop:[^:]+$/ })
@@ -1704,7 +1705,7 @@ export class GameDbAdmin {
       return;
     }
 
-    await interaction.showModal(buildSynonymAddModal(draftId)).catch(() => {});
+    safeIgnore(interaction.showModal(buildSynonymAddModal(draftId)));
   }
 
   @ButtonComponent({ id: /^gamedb-syn-done:\d+$/ })

--- a/src/commands/gamedb/gamedb-add.command.ts
+++ b/src/commands/gamedb/gamedb-add.command.ts
@@ -34,6 +34,7 @@ import {
 import { buildIgdbSelectOptions } from "./gamedb-csv-import.service.js";
 import { showGameProfile, trimTextDisplayContent } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 async function fetchIgdbCoverImage(details: IGDBGameDetails): Promise<Buffer | null> {
   if (!details.cover?.image_id) return null;
@@ -43,7 +44,7 @@ async function fetchIgdbCoverImage(details: IGDBGameDetails): Promise<Buffer | n
     const imageResponse = await axios.get(imageUrl, { responseType: "arraybuffer" });
     return Buffer.from(imageResponse.data);
   } catch (err) {
-    console.error("Failed to download cover image:", err);
+    logError("GamedbAddCommand.downloadCoverImage", err);
     return null;
   }
 }
@@ -99,7 +100,7 @@ export async function processReleaseDates(
         null,
       );
     } catch (err) {
-      console.error(`Failed to add release for game ${gameId}:`, err);
+      logError("GamedbAddCommand.addRelease", err);
     }
   }
 }

--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -52,6 +52,7 @@ import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 const COMPLETION_WIZARD_SESSIONS = new Map<string, CompletionWizardSession>();
 
@@ -244,7 +245,7 @@ async function deleteCompletionWizardMessage(session: CompletionWizardSession): 
     id: session.applicationId,
     token: session.interactionToken,
   });
-  await webhook.deleteMessage(session.ephemeralMessageId).catch(() => {});
+  safeIgnore(webhook.deleteMessage(session.ephemeralMessageId));
 }
 
 export async function startCompletionWizard(
@@ -308,17 +309,17 @@ export class GameDbCompletionCommand {
     const [sessionId, field] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
     if (!session) {
-      await safeReply(interaction, buildTextReply("This completion request has expired.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion request has expired.", true)));
       return;
     }
     if (interaction.user.id !== session.userId) {
-      await safeReply(interaction, buildTextReply("This menu isn't for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This menu isn't for you.", true)));
       return;
     }
 
     const value = interaction.values?.[0];
     if (!value) {
-      await safeReply(interaction, buildTextReply("No selection made.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("No selection made.", true)));
       return;
     }
 
@@ -352,11 +353,11 @@ export class GameDbCompletionCommand {
     const [sessionId] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
     if (!session) {
-      await safeReply(interaction, buildTextReply("This completion request has expired.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion request has expired.", true)));
       return;
     }
     if (interaction.user.id !== session.userId) {
-      await safeReply(interaction, buildTextReply("This action isn't for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This action isn't for you.", true)));
       return;
     }
 
@@ -395,7 +396,7 @@ export class GameDbCompletionCommand {
       maxLength: MAX_COMPLETION_NOTE_LEN,
     }));
 
-    await interaction.showModal(modal).catch(() => {});
+    safeIgnore(interaction.showModal(modal));
   }
    
   @ModalComponent({ id: /^gamedb-completion-modal:\d+$/ })
@@ -404,13 +405,13 @@ export class GameDbCompletionCommand {
     if (!segs) return;
     const [sessionId] = segs;
     const session = COMPLETION_WIZARD_SESSIONS.get(sessionId);
-    await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral }).catch(() => {});
+    safeIgnore(safeDeferReply(interaction, { flags: MessageFlags.Ephemeral }));
     if (!session) {
-      await safeReply(interaction, buildTextReply("This completion request has expired.", false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion request has expired.", false)));
       return;
     }
     if (interaction.user.id !== session.userId) {
-      await safeReply(interaction, buildTextReply("This action isn't for you.", false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This action isn't for you.", false)));
       return;
     }
 
@@ -424,7 +425,7 @@ export class GameDbCompletionCommand {
       try {
         completedAt = parseCompletionDateInput(dateInput);
       } catch (err: any) {
-        await safeReply(interaction, buildTextReply(err?.message ?? "Invalid completion date.", false)).catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply(err?.message ?? "Invalid completion date.", false)));
         return;
       }
     }
@@ -432,7 +433,7 @@ export class GameDbCompletionCommand {
     const playtimeInput = getModalField(interaction, "completion-playtime");
     const playtimeCheck = validateCompletionPlaytimeInput(playtimeInput);
     if (playtimeCheck.error) {
-      await safeReply(interaction, buildTextReply(playtimeCheck.error, false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply(playtimeCheck.error, false)));
       return;
     }
     const playtime = playtimeCheck.value;
@@ -440,12 +441,12 @@ export class GameDbCompletionCommand {
     const noteInput = getModalField(interaction, "completion-note");
     const note = noteInput ? noteInput : null;
     if (note && note.length > MAX_COMPLETION_NOTE_LEN) {
-      await safeReply(interaction, buildTextReply(`Note must be ${MAX_COMPLETION_NOTE_LEN} characters or fewer.`, false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply(`Note must be ${MAX_COMPLETION_NOTE_LEN} characters or fewer.`, false)));
       return;
     }
 
     if (!session.platformChoice) {
-      await safeReply(interaction, buildTextReply("Platform selection missing.", false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("Platform selection missing.", false)));
       return;
     }
     const isOtherPlatform = session.platformChoice === "other";
@@ -453,7 +454,7 @@ export class GameDbCompletionCommand {
     if (!isOtherPlatform) {
       const parsedId = Number(session.platformChoice);
       if (!isPositiveInt(parsedId)) {
-        await safeReply(interaction, buildTextReply("Invalid platform selection.", false)).catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply("Invalid platform selection.", false)));
         return;
       }
       platformId = parsedId;
@@ -474,7 +475,7 @@ export class GameDbCompletionCommand {
         note,
       });
       if (removeFromNowPlaying) {
-        await Member.removeNowPlaying(interaction.user.id, session.gameId).catch(() => {});
+        safeIgnore(Member.removeNowPlaying(interaction.user.id, session.gameId));
       }
 
       await updateGameProfileMessageById(
@@ -486,9 +487,9 @@ export class GameDbCompletionCommand {
 
       await deleteCompletionWizardMessage(session);
       COMPLETION_WIZARD_SESSIONS.delete(sessionId);
-      await interaction.deleteReply().catch(() => {});
+      safeIgnore(interaction.deleteReply());
     } catch (err: any) {
-      await safeReply(interaction, buildTextReply(`Failed to add completion: ${err?.message ?? String(err)}`, false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply(`Failed to add completion: ${err?.message ?? String(err)}`, false)));
     }
   }
    
@@ -500,19 +501,19 @@ export class GameDbCompletionCommand {
     const gameId = Number(gameIdRaw);
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
     if (!isPositiveInt(gameId)) {
-      await safeReply(interaction, buildTextReply("Invalid GameDB id.", false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("Invalid GameDB id.", false)));
       return;
     }
 
     const game = await Game.getGameById(gameId);
     if (!game) {
-      await safeReply(interaction, buildTextReply("That game was not found in GameDB.", false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("That game was not found in GameDB.", false)));
       return;
     }
 
     const noteRaw = getModalField(interaction, "gamedb-nowplaying-note");
     if (noteRaw.length > MAX_NOW_PLAYING_NOTE_LEN) {
-      await safeReply(interaction, buildTextReply(`Note must be ${MAX_NOW_PLAYING_NOTE_LEN} characters or fewer.`, false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply(`Note must be ${MAX_NOW_PLAYING_NOTE_LEN} characters or fewer.`, false)));
       return;
     }
 
@@ -520,8 +521,8 @@ export class GameDbCompletionCommand {
     try {
       const platforms = await Game.getPlatformsForGame(gameId);
       if (!platforms.length) {
-        await safeReply(interaction, buildTextReply("This game has no platform data yet. Add to Now Playing from `/now-playing list` " +
-            "after platform data is available.", false)).catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply("This game has no platform data yet. Add to Now Playing from `/now-playing list` " +
+            "after platform data is available.", false)));
         return;
       }
       const defaultPlatform = platforms[0];
@@ -530,11 +531,11 @@ export class GameDbCompletionCommand {
       await nowPlaying.showSingle(interaction, interaction.user, true);
     } catch (err: any) {
       if (isUniqueConstraintError(err)) {
-        await safeReply(interaction, buildTextReply(`**${game.title}** is already in your Now Playing list.`, false)).catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply(`**${game.title}** is already in your Now Playing list.`, false)));
         return;
       }
       const msg = err?.message ?? "Failed to add to Now Playing.";
-      await safeReply(interaction, buildTextReply(`Failed to add: ${msg}`, false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply(`Failed to add: ${msg}`, false)));
     }
   }
 }

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -32,6 +32,8 @@ import {
   getSearchRowsFromComponents,
   isHltbImportEligible,
 } from "./gamedb-utils.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 export type GameProfileRenderContext = {
   guildId?: string;
@@ -561,7 +563,7 @@ export async function buildGameProfile(
       isReleased,
     };
   } catch (error: any) {
-    console.error("Failed to build game profile:", error);
+    logError("GamedbProfileService.buildGameProfile", error);
     return null;
   }
 }
@@ -711,9 +713,9 @@ export async function updateGameProfileMessageById(
     profile.isReleased,
   );
   const searchRows = getSearchRowsFromComponents(message.components ?? []);
-  await message.edit({
+  safeIgnore(message.edit({
     embeds: [],
     files: profile.files,
     components: [...profile.components, ...actionRows, ...searchRows],
-  }).catch(() => {});
+  }));
 }

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -30,6 +30,7 @@ import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 const GAMEDB_THREAD_MODAL_PREFIX = "gamedb-thread-modal";
 const GAMEDB_THREAD_TITLE_INPUT_ID = "gamedb-thread-title";
@@ -61,9 +62,9 @@ export async function showNowPlayingThreadModal(
   const sourceChannelId = interaction.channelId;
   const sourceMessageId = interaction.message?.id;
   if (!sourceChannelId || !sourceMessageId) {
-    await safeReply(interaction, buildTextReply(
+    safeIgnore(safeReply(interaction, buildTextReply(
       "Unable to open thread modal from this message.", true,
-    )).catch(() => {});
+    )));
     return;
   }
 
@@ -95,9 +96,9 @@ export async function showNowPlayingThreadModal(
     );
 
   await interaction.showModal(modal).catch(async () => {
-    await safeReply(interaction, buildTextReply(
+    safeIgnore(safeReply(interaction, buildTextReply(
       "Failed to open thread customization modal.", true,
-    )).catch(() => {});
+    )));
   });
 }
 
@@ -118,7 +119,7 @@ async function runNowPlayingThreadWizard(
     interaction.isModalSubmit();
   const sendStatus = async (content: string): Promise<void> => {
     if (isModalInteraction && isInteractionSettled(interaction)) {
-      await safeReply(interaction, buildTextReply(content, false)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply(content, false)));
       return;
     }
     await safeReply(interaction, { ...buildTextReply(content, false), __forceFollowUp: true });
@@ -229,15 +230,13 @@ export class GameDbThreadCommand {
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
 
     if (!isPositiveInt(gameId) || !sourceChannelId || !sourceMessageId) {
-      await safeReply(interaction, buildTextReply("Invalid thread request payload.", false))
-        .catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("Invalid thread request payload.", false)));
       return;
     }
 
     const game = await Game.getGameById(gameId);
     if (!game) {
-      await safeReply(interaction, buildTextReply("That game was not found in GameDB.", false))
-        .catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("That game was not found in GameDB.", false)));
       return;
     }
 
@@ -252,15 +251,15 @@ export class GameDbThreadCommand {
     const threadBody = bodyInput || defaultBody;
 
     if (!threadTitle || threadTitle.length > MAX_THREAD_TITLE_LEN) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         `Thread title must be between 1 and ${MAX_THREAD_TITLE_LEN} characters.`, false,
-      )).catch(() => {});
+      )));
       return;
     }
     if (!threadBody || threadBody.length > MAX_THREAD_BODY_LEN) {
-      await safeReply(interaction, buildTextReply(
+      safeIgnore(safeReply(interaction, buildTextReply(
         `Initial post must be between 1 and ${MAX_THREAD_BODY_LEN} characters.`, false,
-      )).catch(() => {});
+      )));
       return;
     }
 

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -42,6 +42,7 @@ import { showNowPlayingThreadModal } from "./gamedb-thread.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 @Discord()
 @SlashGroup("gamedb")
@@ -175,7 +176,7 @@ export class GameDbViewCommand {
             maxLength: 500,
           }),
         );
-      await interaction.showModal(modal).catch(() => {});
+      safeIgnore(interaction.showModal(modal));
       return;
     }
 

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -55,13 +55,13 @@ import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { COLOR_SUCCESS } from "../config/colors.js";
 import { CLAIM_MENU_CHUNK_SIZE } from "../config/pagination.js";
 import {
-  DISCORD_SELECT_LABEL_MAX,
   GIVEAWAY_MAX_TITLE_LENGTH,
   GIVEAWAY_MAX_PLATFORM_LENGTH,
   GIVEAWAY_MAX_KEY_LENGTH,
 } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
-import { buildTextInputRow } from "../functions/uiComponents.js";
+import { buildSelectOptions, buildTextInputRow } from "../functions/uiComponents.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
 const GIVEAWAY_DONATE_MODAL_ID = "giveaway-donate-modal";
 const GIVEAWAY_REVOKE_MODAL_ID = "giveaway-revoke-modal";
 const GIVEAWAY_DONATE_TITLE_ID = "giveaway-donate-title";
@@ -95,10 +95,10 @@ function buildKeySelectMenus(
     if (!chunk.length) {
       continue;
     }
-    const options = chunk.map((key) => ({
-      label: key.gameTitle.slice(0, DISCORD_SELECT_LABEL_MAX),
+    const options = buildSelectOptions(chunk.map((key) => ({
+      label: key.gameTitle,
       value: String(key.keyId),
-    }));
+    })));
     const range = getKeyRangeLabel(chunk);
     const select = new StringSelectMenuBuilder()
        
@@ -132,7 +132,7 @@ async function logGiveawayClaim(
       .setDescription(message)
       .setColor(COLOR_SUCCESS)
       .setTimestamp(new Date());
-    await channel.send({ embeds: [embed] }).catch(() => {});
+    safeIgnore(channel.send({ embeds: [embed] }));
   }
 }
 
@@ -334,11 +334,11 @@ async function claimKey(
   const notifyDonor = await Member.getGiveawayDonorNotifySetting(key.donorUserId);
   if (notifyDonor && donorUser && key.donorUserId !== interaction.user.id) {
     const claimantMention = userMention(interaction.user.id);
-    await donorUser.send({
+    safeIgnore(donorUser.send({
       content:
         `Your donated key for **${key.gameTitle}** (${key.platform}) was claimed by ` +
         `${claimantMention}. Thanks for contributing!`,
-    }).catch(() => {});
+    }));
   }
 
   return {
@@ -483,18 +483,18 @@ async function updatePublicListMessage(
   }
 
   if (payload.content) {
-    await message.edit({
+    safeIgnore(message.edit({
       content: payload.content,
       embeds: [],
       components: [],
-    }).catch(() => {});
+    }));
     return;
   }
 
-  await message.edit({
+  safeIgnore(message.edit({
     embeds: payload.embeds,
     components: payload.components,
-  }).catch(() => {});
+  }));
 }
 
 @Discord()
@@ -559,7 +559,7 @@ export class GiveawayCommand {
     keyValue = sanitizeUserInput(keyValue, { preserveNewlines: false });
     const created = await handleDonation(interaction, title, platform, keyValue);
     if (created) {
-      await refreshGiveawayHubMessage(interaction.client).catch(() => {});
+      safeIgnore(refreshGiveawayHubMessage(interaction.client));
     }
   }
 
@@ -577,7 +577,7 @@ export class GiveawayCommand {
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
     const removed = await handleRevoke(interaction, keyId);
     if (removed) {
-      await refreshGiveawayHubMessage(interaction.client).catch(() => {});
+      safeIgnore(refreshGiveawayHubMessage(interaction.client));
     }
   }
   */
@@ -639,7 +639,7 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: "giveaway-hub-donate" })
   async handleHubDonate(interaction: ButtonInteraction): Promise<void> {
-    await interaction.showModal(buildDonateModal()).catch(() => {});
+    safeIgnore(interaction.showModal(buildDonateModal()));
   }
    
   @ButtonComponent({ id: GIVEAWAY_DONOR_SETTINGS_ID })
@@ -663,7 +663,7 @@ export class GiveawayCommand {
    
   @ButtonComponent({ id: "giveaway-hub-revoke" })
   async handleHubRevoke(interaction: ButtonInteraction): Promise<void> {
-    await interaction.showModal(buildRevokeModal()).catch(() => {});
+    safeIgnore(interaction.showModal(buildRevokeModal()));
   }
    
   @ButtonComponent({ id: /^giveaway-donor-notify:\d+:(yes|no)$/ })
@@ -938,8 +938,7 @@ export class GiveawayCommand {
       );
     }
 
-    await refreshGiveawayHubMessage(interaction.client)
-      .catch(() => {});
+    safeIgnore(refreshGiveawayHubMessage(interaction.client));
   }
    
   @ButtonComponent({ id: /^giveaway-claim-cancel:\d+$/ })
@@ -968,7 +967,7 @@ export class GiveawayCommand {
 
     const created = await handleDonation(interaction, title, platform, keyValue);
     if (created) {
-      await refreshGiveawayHubMessage(interaction.client).catch(() => {});
+      safeIgnore(refreshGiveawayHubMessage(interaction.client));
     }
   }
    
@@ -984,7 +983,7 @@ export class GiveawayCommand {
 
     const removed = await handleRevoke(interaction, keyId);
     if (removed) {
-      await refreshGiveawayHubMessage(interaction.client).catch(() => {});
+      safeIgnore(refreshGiveawayHubMessage(interaction.client));
     }
   }
 }

--- a/src/commands/imports/import-scaffold.service.ts
+++ b/src/commands/imports/import-scaffold.service.ts
@@ -7,6 +7,7 @@ import {
   ThumbnailBuilder,
 } from "@discordjs/builders";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 type ImportLogEvent = (message: string, meta: Record<string, string | number>) => void;
 
@@ -125,15 +126,12 @@ export function buildImportMessageContainer(
     container.addSectionComponents(section);
   } catch (error) {
     const messages = flattenErrorMessages(error);
-    console.error(
-      `[${params.logPrefix}] header section validation failed`,
-      JSON.stringify({
-        ...params.logMeta,
-        contentLength: safeContent.length,
-        hasThumbnail: Boolean(params.thumbnailUrl),
-        messages,
-      }),
-    );
+    logError(`${params.logPrefix}.headerSectionValidation`, {
+      ...params.logMeta,
+      contentLength: safeContent.length,
+      hasThumbnail: Boolean(params.thumbnailUrl),
+      messages,
+    });
     container.addTextDisplayComponents(
       new TextDisplayBuilder().setContent(safeV2TextContent(params.content, 1000)),
     );
@@ -173,17 +171,14 @@ export function logImportComponentDiagnostics(
         rowIndex: params.rowIndex,
         componentIndex: index,
       });
-      console.error(
-        `[${params.logPrefix}] component validation failed`,
-        JSON.stringify({
-          importId: params.importId,
-          itemId: params.itemId,
-          rowIndex: params.rowIndex,
-          componentIndex: index,
-          componentType: describeComponentForDebug(component),
-          messages,
-        }),
-      );
+      logError(`${params.logPrefix}.componentValidation`, {
+        importId: params.importId,
+        itemId: params.itemId,
+        rowIndex: params.rowIndex,
+        componentIndex: index,
+        componentType: describeComponentForDebug(component),
+        messages,
+      });
     }
   });
 }

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -43,6 +43,7 @@ import {
 } from "../config/pagination.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { chunk } from "../utilities/ArrayUtils.js";
 
 const MAX_OPTIONS = 25;
 
@@ -91,14 +92,6 @@ function decodeFilters(key: string): PlatformFilters {
   };
 }
 
-function chunkIds(ids: string[], size: number): string[][] {
-  const chunks: string[][] = [];
-  for (let i = 0; i < ids.length; i += size) {
-    chunks.push(ids.slice(i, i + size));
-  }
-  return chunks;
-}
-
 async function filterActiveGuildMembers(
   members: IMemberPlatformRecord[],
   guild: CommandInteraction["guild"],
@@ -106,7 +99,7 @@ async function filterActiveGuildMembers(
   if (!guild || members.length === 0) return members;
 
   const ids = members.map((member) => member.userId);
-  const chunks = chunkIds(ids, GUILD_FETCH_CHUNK_SIZE);
+  const chunks = chunk(ids, GUILD_FETCH_CHUNK_SIZE);
   const present = new Set<string>();
 
   for (const chunk of chunks) {

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -46,6 +46,7 @@ import {
 import { showGameProfileFromNomination } from "./gamedb.command.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const NOMINATE_REASON_MAX_LENGTH = 1500;
 
@@ -137,7 +138,7 @@ async function announceNominationList(
       allowedMentions: { parse: [] },
     });
   } catch (error) {
-    console.error(`Failed to announce nomination list in channel ${channelId}:`, error);
+    logError("NominateCommand.announceNominationList", error);
   }
 }
 

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -53,6 +53,7 @@ import {
   safeDeferUpdate,
   safeReply,
   safeUpdate,
+  safeUserFetch,
   sanitizeUserInput,
   type AnyRepliable,
 } from "../functions/InteractionUtils.js";
@@ -3314,7 +3315,7 @@ export class NowPlayingCommand {
     const ownerUser =
       interaction.user.id === ownerId
         ? interaction.user
-        : await interaction.client.users.fetch(ownerId).catch(() => null);
+        : await safeUserFetch(interaction.client, ownerId);
     const target = ownerUser ?? interaction.user;
     const title = ownerId === interaction.user.id && isEphemeral
       ? "Your Now Playing List"
@@ -4338,7 +4339,7 @@ export class NowPlayingCommand {
 
     const entries = await Member.getNowPlaying(selectedUserId);
     const target =
-      (await interaction.client.users.fetch(selectedUserId).catch(() => null)) ??
+      (await safeUserFetch(interaction.client, selectedUserId)) ??
       interaction.user;
 
     if (!entries.length) {
@@ -5242,7 +5243,7 @@ export class NowPlayingCommand {
           const ownerId = context.ownerUserId;
           const target = ownerId === interaction.user.id
             ? interaction.user
-            : await interaction.client.users.fetch(ownerId).catch(() => null);
+            : await safeUserFetch(interaction.client, ownerId);
           if (!target) {
             continue;
           }
@@ -5336,7 +5337,7 @@ export class NowPlayingCommand {
         if (context.view === "everyone-selected" && context.selectedUserId) {
           const selectedUserId = context.selectedUserId;
           const target =
-            (await interaction.client.users.fetch(selectedUserId).catch(() => null)) ??
+            (await safeUserFetch(interaction.client, selectedUserId)) ??
             interaction.user;
           const entries = getDisplayNowPlayingEntries(
             await Member.getNowPlaying(selectedUserId),

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -42,6 +42,7 @@ import {
   formatTableDate,
 } from "../functions/DateFormatUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { chunk } from "../utilities/ArrayUtils.js";
 
 export { formatDiscordTimestamp, formatPlaytimeHours, formatTableDate };
 
@@ -133,14 +134,6 @@ function summarizeFilters(filters: IMemberSearchFilters): string {
   if (filters.lastSeenBefore) parts.push(`seen<=${filters.lastSeenBefore.toISOString()}`);
   parts.push(`includeDeparted=${filters.includeDeparted ? "yes" : "no"}`);
   return parts.join(" | ") || "none";
-}
-
-function chunkOptions<T>(items: T[], size: number): T[][] {
-  const chunks: T[][] = [];
-  for (let i = 0; i < items.length; i += size) {
-    chunks.push(items.slice(i, i + size));
-  }
-  return chunks;
 }
 
 function buildProfileContentContainer(
@@ -679,13 +672,13 @@ export class ProfileCommand {
       };
     });
 
-    const selectChunks = chunkOptions(selectOptions, 25);
-    const components = selectChunks.slice(0, 5).map((chunk, idx) =>
+    const selectChunks = chunk(selectOptions, 25);
+    const components = selectChunks.slice(0, 5).map((chunkPart, idx) =>
       new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
         new StringSelectMenuBuilder()
           .setCustomId(`profile-search-select-${idx}`)
           .setPlaceholder("Select a member to view their profile")
-          .addOptions(chunk)
+          .addOptions(chunkPart)
           .setMinValues(1)
           .setMaxValues(1),
       ),

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -52,6 +52,8 @@ import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtil
 import { sleep } from "../utilities/DelayUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 
 type CompletionAddContext = {
   targetUserId: string;
@@ -270,8 +272,7 @@ export class SuperAdmin {
     const ctx = superadminCompletionAddSessions.get(sessionId);
 
     if (!ctx) {
-      await safeReply(interaction, buildTextReply("This completion prompt has expired.", true))
-        .catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion prompt has expired.", true)));
       return;
     }
 
@@ -281,7 +282,7 @@ export class SuperAdmin {
 
     const value = interaction.values?.[0];
     if (!value) {
-      await safeReply(interaction, buildTextReply("No selection received.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("No selection received.", true)));
       return;
     }
 
@@ -292,7 +293,7 @@ export class SuperAdmin {
     } finally {
       superadminCompletionAddSessions.delete(sessionId);
       try {
-        await safeReply(interaction, { components: [] }).catch(() => {});
+        safeIgnore(safeReply(interaction, { components: [] }));
       } catch {
         // ignore
       }
@@ -309,7 +310,7 @@ export class SuperAdmin {
     const ctx = superadminCompletionPlatformSessions.get(sessionId);
 
     if (!ctx) {
-      await safeReply(interaction, buildTextReply("This completion prompt has expired.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion prompt has expired.", true)));
       return;
     }
 
@@ -317,7 +318,7 @@ export class SuperAdmin {
     if (!okToUseCommand) return;
 
     if (interaction.user.id !== ctx.userId) {
-      await safeReply(interaction, buildTextReply("This completion prompt isn't for you.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("This completion prompt isn't for you.", true)));
       return;
     }
 
@@ -335,7 +336,7 @@ export class SuperAdmin {
       ctx.platforms.some((platform) => platform.id === platformId)
     );
     if (!valid) {
-      await safeReply(interaction, buildTextReply("Invalid platform selection.", true)).catch(() => {});
+      safeIgnore(safeReply(interaction, buildTextReply("Invalid platform selection.", true)));
       return;
     }
 
@@ -472,9 +473,9 @@ export class SuperAdmin {
     if ("isMessageComponent" in interaction && interaction.isMessageComponent()) {
       const loading = { content: `Searching IGDB for "${searchTerm}"...`, components: [] };
       if (isInteractionSettled(interaction)) {
-        await safeReply(interaction, loading).catch(() => {});
+        safeIgnore(safeReply(interaction, loading));
       } else {
-        await safeUpdate(interaction, loading).catch(() => {});
+        safeIgnore(safeUpdate(interaction, loading));
       }
     } else {
       await safeReply(interaction, buildTextReply(`Searching IGDB for "${searchTerm}"...`, true));
@@ -484,7 +485,7 @@ export class SuperAdmin {
     if (!igdbSearch.results.length) {
       const content = `No GameDB or IGDB matches found for "${searchTerm}".`;
       if ("isMessageComponent" in interaction && interaction.isMessageComponent()) {
-        await safeReply(interaction, buildTextReply(content, false)).catch(() => {});
+        safeIgnore(safeReply(interaction, buildTextReply(content, false)));
       } else {
         await safeReply(interaction, buildTextReply(content, true));
       }
@@ -509,10 +510,10 @@ export class SuperAdmin {
         if (!sel.deferred && !sel.replied) {
           await safeDeferUpdate(sel);
         }
-        await safeReply(sel, {
+        safeIgnore(safeReply(sel, {
           content: "Importing game details from IGDB...",
           components: [],
-        }).catch(() => {});
+        }));
 
         const imported = await this.importGameFromIgdbForCompletion(gameId);
         const game = await Game.getGameById(imported.gameId);
@@ -624,7 +625,7 @@ export class SuperAdmin {
       return;
     }
 
-    await (targetChannel as any).send({ content: sanitizedMessage }).catch(() => {});
+    safeIgnore((targetChannel as any).send({ content: sanitizedMessage }));
     await safeReply(interaction, buildTextReply("Message sent.", true));
   }
 
@@ -683,7 +684,7 @@ export class SuperAdmin {
         const imageResponse = await axios.get(imageUrl, { responseType: "arraybuffer" });
         imageData = Buffer.from(imageResponse.data);
       } catch (err) {
-        console.error("Failed to download cover image:", err);
+        logError("SuperadminCommand.downloadCoverImage", err);
       }
     }
 
@@ -841,13 +842,13 @@ export class SuperAdmin {
             continue;
           } catch (retryErr) {
             failCount++;
-            console.error(`Failed to upsert user ${user.id} after stripping avatar`, retryErr);
+            logError("SuperadminCommand.upsertUserAfterStrippingAvatar", retryErr);
             await sleep(1000);
             continue;
           }
         }
         failCount++;
-        console.error(`Failed to upsert user ${user.id}`, err);
+        logError("SuperadminCommand.upsertUser", err);
       }
 
       await sleep(1000);

--- a/src/db/postgresClient.ts
+++ b/src/db/postgresClient.ts
@@ -1,4 +1,5 @@
 import pg from "pg";
+import { logError } from "../utilities/LogUtils.js";
 
 const { Pool } = pg;
 
@@ -43,7 +44,7 @@ export async function initPostgresPool(): Promise<void> {
   });
 
   pool.on("error", (err: Error) => {
-    console.error("[PostgreSQL] Unexpected client error:", err);
+    logError("postgresClient.clientError", err);
   });
 
   // Verify connectivity immediately so startup fails fast on bad credentials.

--- a/src/events/GuildMemberAdd.command.ts
+++ b/src/events/GuildMemberAdd.command.ts
@@ -5,6 +5,7 @@ import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
 import { COLOR_SUCCESS } from "../config/colors.js";
+import { logError } from "../utilities/LogUtils.js";
 
 function formatDiscordDateTime(date: Date): string {
   return `<t:${Math.floor(date.getTime() / 1000)}:F>`;
@@ -51,9 +52,7 @@ export class GuildMemberAdd {
 
     if (!member.user.bot) {
       recordCurrentAvatarIfNew(member).catch((err: any) => {
-        console.error(
-          `[GuildMemberAdd] Failed to record avatar for ${member.user.id}: ${err?.message ?? err}`,
-        );
+        logError("GuildMemberAdd.recordAvatar", err?.message ?? err);
       });
     }
 

--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -3,6 +3,7 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import Member, { type IMemberRecord } from "../classes/Member.js";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 import { logAvatarChange, updateAvatarRecordFromUrl } from "../utilities/AvatarLogUtils.js";
 import {
   ensureUserEmojiForMember,
@@ -183,7 +184,7 @@ export class GuildMemberUpdate {
       await Member.upsert(record);
     } catch (err: any) {
       const msg = err?.message ?? String(err);
-      console.error(`[GuildMemberUpdate] Failed to upsert nickname change for ${user.id}: ${msg}`);
+      logError("GuildMemberUpdate.upsertNicknameChange", msg);
     }
   }
 }

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -35,6 +35,7 @@ import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../conf
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { buildTextInputRow } from "../functions/uiComponents.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const PUSH_PIN_EMOJI = "📌";
 const PLUS_EMOJI = "➕";
@@ -650,7 +651,7 @@ export class MessageReactionAdd {
         const imageResponse = await axios.get(imageUrl, { responseType: "arraybuffer" });
         imageData = Buffer.from(imageResponse.data);
       } catch (err) {
-        console.error("Failed to download cover image:", err);
+        logError("MessageReactionAdd.downloadCoverImage", err);
       }
     }
 

--- a/src/events/PresenceUpdate.command.ts
+++ b/src/events/PresenceUpdate.command.ts
@@ -19,6 +19,7 @@ import { igdbService } from "../services/IGDB/IgdbService.js";
 import { safeReply, safeUpdate } from "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { PRESENCE_PROMPT_CHANNEL_ID } from "../config/channels.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const YES_PREFIX = "presence-np-yes";
 const NO_PREFIX = "presence-np-no";
@@ -123,7 +124,7 @@ export class PresenceUpdate {
         user.username ?? user.globalName ?? "",
         newPresence.activities,
       ).catch((err) => {
-        console.error("Failed to record user activity icons:", err);
+        logError("PresenceUpdate.recordActivityIcons", err);
       });
     }
 

--- a/src/events/Starboard.command.ts
+++ b/src/events/Starboard.command.ts
@@ -6,6 +6,7 @@ import { Discord, On } from "discordx";
 import Starboard from "../classes/Starboard.js";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { QUOTABLES_CHANNEL_ID } from "../config/channels.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
 
 const STAR_EMOJI = "⭐";
 const STAR_EMOJI_NAME = "star";
@@ -52,7 +53,7 @@ export class StarboardHandler {
     if (user.bot) return;
 
     if (reaction.partial) {
-      await reaction.fetch().catch(() => {});
+      safeIgnore(reaction.fetch());
     }
     const message = reaction.message?.partial
       ? await reaction.message.fetch().catch(() => null)

--- a/src/events/ThreadCreated.command.ts
+++ b/src/events/ThreadCreated.command.ts
@@ -6,6 +6,7 @@ import { NOW_PLAYING_FORUM_ID, WHATCHA_PLAYING_CHANNEL_ID } from "../config/chan
 import { COLOR_PRIMARY } from "../config/colors.js";
 import { sleep } from "../utilities/DelayUtils.js";
 import { DISCORD_EMBED_FIELD_VALUE_MAX } from "../config/textLimits.js";
+import { logError } from "../utilities/LogUtils.js";
 
 @Discord()
 export class ThreadCreated {
@@ -161,7 +162,7 @@ export class ThreadCreated {
           }
         }
       } catch (err) {
-        console.error('Failed to resolve forum tag names:', err);
+        logError("ThreadCreated.resolveForumTagNames", err);
       }
 
       const channel = await client.channels.fetch(WHATCHA_PLAYING_CHANNEL_ID);
@@ -169,7 +170,7 @@ export class ThreadCreated {
         try {
           await (channel as TextChannel).send({ embeds: [nowPlayingEmbed] });
         } catch (err) {
-          console.error('Failed to send Now Playing embed:', err);
+          logError("ThreadCreated.sendNowPlayingEmbed", err);
         }
       }
     }

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -25,7 +25,9 @@ import Member from "../classes/Member.js";
 import { ANNOUNCEMENT_CHANNEL_ID, BOT_DEV_CHANNEL_ID } from "../config/channels.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { buildComponentsV2Flags, buildTextContainer } from "./ComponentsV2Utils.js";
-import { isInteractionSettled, safeReply, safeUpdate } from "./InteractionUtils.js";
+import { isInteractionSettled, safeReply, safeUpdate, safeUserFetch } from "./InteractionUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const MAX_PLAYTIME_HOURS = 999999.99;
 const COMPLETION_COVER_ATTACHMENT_PREFIX = "completion-cover";
@@ -178,7 +180,7 @@ export async function announceCompletion(
       return;
     }
 
-    const user = await interaction.client.users.fetch(userId).catch(() => null);
+    const user = await safeUserFetch(interaction.client, userId);
     if (!user) {
       return;
     }
@@ -234,7 +236,7 @@ export async function announceCompletion(
       flags: COMPONENTS_V2_FLAG,
     });
   } catch (err) {
-    console.error("Failed to announce completion:", err);
+    logError("CompletionHelpers.announceCompletion", err);
   }
 }
 
@@ -297,20 +299,20 @@ export async function promptRemoveFromNowPlaying(
       time: 120_000,
     });
     const remove = selection.customId.endsWith(":yes");
-    await safeUpdate(selection, {
+    safeIgnore(safeUpdate(selection, {
       components: [buildTextContainer(
         remove
           ? "Okay, I'll remove it from Now Playing."
           : "Okay, I'll leave it in your Now Playing list.",
       )],
       flags: buildComponentsV2Flags(false),
-    }).catch(() => {});
+    }));
     return remove;
   } catch {
-    await message.edit({
+    safeIgnore(message.edit({
       components: [buildTextContainer("No response received. Leaving it in your Now Playing list.")],
       flags: buildComponentsV2Flags(false),
-    }).catch(() => {});
+    }));
     return false;
   }
 }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -1,10 +1,15 @@
 import { MessageFlags, MessageFlagsBitField } from "discord.js";
+import { logError } from "../utilities/LogUtils.js";
 import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import type {
+  Client,
   CommandInteraction,
+  Guild,
+  GuildMember,
   InteractionDeferReplyOptions,
   ModalSubmitInteraction,
   RepliableInteraction,
+  User,
 } from "discord.js";
 import { BOT_DEV_CHANNEL_ID } from "../config/channels.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
@@ -407,7 +412,7 @@ export async function safeReply(interaction: AnyRepliable, options: any): Promis
     } catch (err: any) {
       if (!isAckError(err)) throw err;
       const ackCode = err?.code ?? err?.rawError?.code;
-      console.error("[safeReply] editReply ack error", {
+      logError("InteractionUtils.safeReply", {
         code: err?.code,
         status: err?.status,
         message: err?.message,
@@ -565,4 +570,12 @@ export function resolveMemberLabel(
     return (member as import("discord.js").User).username;
   }
   return fallback.username;
+}
+
+export async function safeUserFetch(client: Client, userId: string): Promise<User | null> {
+  return client.users.fetch(userId).catch(() => null);
+}
+
+export async function safeMemberFetch(guild: Guild, userId: string): Promise<GuildMember | null> {
+  return guild.members.fetch(userId).catch(() => null);
 }

--- a/src/functions/NominationAdminHelpers.ts
+++ b/src/functions/NominationAdminHelpers.ts
@@ -28,6 +28,7 @@ import {
 import {
   getUpcomingNominationWindow,
 } from "./NominationWindow.js";
+import { logError } from "../utilities/LogUtils.js";
 
 export const ADMIN_NOMINATION_DELETE_SELECT_PREFIX = "admin-nom-del-select";
 export const ADMIN_NOMINATION_DELETE_REASON_MODAL_PREFIX = "admin-nom-del-reason";
@@ -148,7 +149,7 @@ export async function announceNominationChange(
       allowedMentions: { parse: [] },
     });
   } catch (err) {
-    console.error(`Failed to announce nomination change in channel ${channelId}:`, err);
+    logError("NominationAdminHelpers.announceChange", err);
   }
 }
 

--- a/src/functions/NominationListComponents.ts
+++ b/src/functions/NominationListComponents.ts
@@ -26,6 +26,7 @@ import {
   hasBackblazeB2Config,
 } from "../services/BackblazeB2Service.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const MAX_SECTIONS_PER_CONTAINER = 10;
 const MAX_REASON_LENGTH = 1500;
@@ -307,7 +308,7 @@ async function appendVoteImageAttachment(
       );
       return stored.url;
     } catch (error) {
-      console.error("Backblaze upload failed for nomination vote image:", error);
+      logError("NominationListComponents.backblazeUpload", error);
     }
   }
 

--- a/src/functions/SetPresence.ts
+++ b/src/functions/SetPresence.ts
@@ -1,6 +1,7 @@
 import { ActivityType, Client } from "discord.js";
 import type { AnyRepliable } from "./InteractionUtils.js";
 import BotPresenceHistory, { type IPresenceHistoryEntry } from "../classes/BotPresenceHistory.js";
+import { logError } from "../utilities/LogUtils.js";
 
 export type { IPresenceHistoryEntry };
 
@@ -26,7 +27,7 @@ async function internalSetPresence(
       await BotPresenceHistory.savePresence(activityName, userId, username);
       console.log("Presence saved to database.");
     } catch (error) {
-      console.error("Error saving presence to database:", error);
+      logError("SetPresence.save", error);
     }
   }
 }
@@ -35,7 +36,7 @@ export async function getPresenceHistory(limit: number): Promise<IPresenceHistor
   try {
     return BotPresenceHistory.getPresenceHistory(limit);
   } catch (error) {
-    console.error("Error loading presence history from database:", error);
+    logError("SetPresence.loadHistory", error);
     return [];
   }
 }
@@ -62,6 +63,6 @@ export async function updateBotPresence(bot: Client): Promise<void> {
       console.log("No presence data found in database.");
     }
   } catch (error) {
-    console.error("Error reading presence from database:", error);
+    logError("SetPresence.read", error);
   }
 }

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -2,6 +2,7 @@ import {
   ActionRowBuilder,
   ButtonStyle,
   StringSelectMenuBuilder,
+  StringSelectMenuOptionBuilder,
   TextInputBuilder,
   TextInputStyle,
 } from "discord.js";
@@ -66,8 +67,30 @@ import {
 } from "../services/UserEmojiService.js";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
 import { formatTableDate } from "./DateFormatUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import {
+  DISCORD_AUTOCOMPLETE_DESC_MAX,
+  DISCORD_SELECT_LABEL_MAX,
+  DISCORD_SELECT_OPTIONS_MAX,
+} from "../config/textLimits.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
+
+export interface ISelectOptionInput {
+  label: string;
+  value: string;
+  description?: string;
+}
+
+export function buildSelectOptions(
+  inputs: ISelectOptionInput[],
+  maxOptions = DISCORD_SELECT_OPTIONS_MAX,
+): StringSelectMenuOptionBuilder[] {
+  return inputs.slice(0, maxOptions).map((item) =>
+    new StringSelectMenuOptionBuilder()
+      .setLabel(item.label.slice(0, DISCORD_SELECT_LABEL_MAX))
+      .setValue(item.value)
+      .setDescription((item.description ?? "").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX)),
+  );
+}
 
 export interface IJournalSelectEntry {
   gameId: number;

--- a/src/services/ForumThreadJoinService.ts
+++ b/src/services/ForumThreadJoinService.ts
@@ -2,6 +2,7 @@ import type { ForumChannel, ThreadChannel } from "discord.js";
 import { ChannelType } from "discord.js";
 import type { Client } from "discordx";
 import { LIVE_EVENT_FORUM_ID, NOW_PLAYING_FORUM_ID } from "../config/channels.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const TARGET_FORUM_IDS: string[] = [
   NOW_PLAYING_FORUM_ID,
@@ -18,8 +19,7 @@ async function joinThread(thread: ThreadChannel): Promise<void> {
       await thread.join();
     }
   } catch (err) {
-    const name = thread?.name ?? thread?.id ?? "unknown";
-    console.error(`[ForumJoin] Failed to join thread ${name}:`, err);
+    logError("ForumThreadJoinService.joinThread", err);
   }
 }
 
@@ -41,7 +41,7 @@ export async function joinAllTargetForumThreads(client: Client): Promise<void> {
         await joinThread(thread);
       }
     } catch (err) {
-      console.error(`[ForumJoin] Failed to join threads for forum ${forumId}:`, err);
+      logError("ForumThreadJoinService.joinThreadsForForum", err);
     }
   }
 }

--- a/src/services/GameReleaseAnnouncementService.ts
+++ b/src/services/GameReleaseAnnouncementService.ts
@@ -9,6 +9,7 @@ import { NEW_GAME_ANNOUNCEMENT_CHANNEL_ID } from "../config/channels.js";
 import { buildGameProfileMessagePayload } from "../commands/gamedb.command.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { resolveAssetPath } from "../functions/AssetPath.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const CHECK_INTERVAL_MS = 60_000;
 const BATCH_SIZE = 25;
@@ -89,10 +90,7 @@ async function checkAndSendReleaseAnnouncements(client: Client): Promise<void> {
       });
       await GameReleaseAnnouncement.markAnnouncementSent(candidate.releaseId, new Date());
     } catch (err) {
-      console.error(
-        `[GameReleaseAnnouncementService] Failed release announcement ${candidate.releaseId}:`,
-        err,
-      );
+      logError("GameReleaseAnnouncementService.releaseAnnouncement", err);
     }
   }
 }
@@ -110,7 +108,7 @@ export function startGameReleaseAnnouncementService(client: Client): void {
     try {
       await checkAndSendReleaseAnnouncements(client);
     } catch (err) {
-      console.error("[GameReleaseAnnouncementService] Announcement cycle failed:", err);
+      logError("GameReleaseAnnouncementService.announcementCycle", err);
     } finally {
       currentlyChecking = false;
     }

--- a/src/services/GamedbAuditService.ts
+++ b/src/services/GamedbAuditService.ts
@@ -5,6 +5,8 @@ import Game from "../classes/Game.js";
 import { igdbService } from "./IGDB/IgdbService.js";
 import { COLOR_PRIMARY, COLOR_SUCCESS } from "../config/colors.js";
 import { sleep, AUDIT_STEP_DELAY_MS } from "../utilities/DelayUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 
 export type AutoAcceptResult = {
   updated: number;
@@ -538,7 +540,7 @@ export async function runAutoAcceptImagesAudit(
     const trimmed = trimLogLines(logLines);
     const content = trimmed.length ? trimmed.join("\n") : "Processing...";
     currentEmbed.setDescription(content);
-    await message.edit({ embeds: [currentEmbed] }).catch(() => {});
+    safeIgnore(message.edit({ embeds: [currentEmbed] }));
   };
 
   const { updated, skipped, failed, logs } = await performAutoAcceptImages(
@@ -548,7 +550,7 @@ export async function runAutoAcceptImagesAudit(
     currentEmbed
       .setDescription("No games found with missing images and valid IGDB IDs.")
       .setColor(COLOR_SUCCESS);
-    await message.edit({ embeds: [currentEmbed] }).catch(() => {});
+    safeIgnore(message.edit({ embeds: [currentEmbed] }));
     return;
   }
 
@@ -557,7 +559,7 @@ export async function runAutoAcceptImagesAudit(
     `⏭️ Skipped: ${skipped}\n❌ Failed: ${failed}`;
   await updateEmbed(summary);
   currentEmbed.setColor(COLOR_SUCCESS);
-  await message.edit({ embeds: [currentEmbed] }).catch(() => {});
+  safeIgnore(message.edit({ embeds: [currentEmbed] }));
 }
 
 export function startGamedbAutoImageAuditService(
@@ -574,7 +576,7 @@ export function startGamedbAutoImageAuditService(
     try {
       await runAutoAcceptImagesAudit(client, channelId, titleWords);
     } catch (err) {
-      console.error("GameDB auto accept image audit failed:", err);
+      logError("GamedbAuditService.autoAcceptImageAudit", err);
     } finally {
       running = false;
     }

--- a/src/services/GiveawayHubService.ts
+++ b/src/services/GiveawayHubService.ts
@@ -9,6 +9,8 @@ import {
 import { countAvailableGameKeys, listAvailableGameKeys } from "../classes/GameKey.js";
 import { GIVEAWAY_HUB_CHANNEL_ID } from "../config/channels.js";
 import { buildPageFooterText } from "../functions/PaginationUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 const GIVEAWAY_HUB_SCAN_LIMIT = 50;
 
 export const KEYS_PAGE_SIZE = 20;
@@ -216,7 +218,7 @@ async function deleteAllGiveawayHubMessages(
   let fetched = await channel.messages.fetch({ limit: GIVEAWAY_HUB_SCAN_LIMIT }).catch(() => null);
   while (fetched && fetched.size) {
     for (const message of fetched.values()) {
-      await message.delete().catch(() => {});
+      safeIgnore(message.delete());
     }
     fetched = await channel.messages.fetch({ limit: GIVEAWAY_HUB_SCAN_LIMIT }).catch(() => null);
   }
@@ -256,7 +258,7 @@ async function updateGiveawayHubMessages(
   const messages = await channel.messages
     .fetch({ limit: GIVEAWAY_HUB_SCAN_LIMIT })
     .catch((err) => {
-      console.error("Giveaway hub fetch failed:", err);
+      logError("GiveawayHubService.fetch", err);
       return null;
     });
   const hubMessages = messages
@@ -279,7 +281,7 @@ async function updateGiveawayHubMessages(
     const existing = hubMessages[i];
     if (existing) {
       await existing.edit({ content, embeds: batch, components }).catch((err) => {
-        console.error("Giveaway hub edit failed:", err);
+        logError("GiveawayHubService.edit", err);
       });
     } else {
       await channel.send({
@@ -288,7 +290,7 @@ async function updateGiveawayHubMessages(
         components,
         flags: options?.suppressNotifications ? MessageFlags.SuppressNotifications : undefined,
       }).catch((err) => {
-        console.error("Giveaway hub send failed:", err);
+        logError("GiveawayHubService.send", err);
       });
     }
   }
@@ -297,7 +299,7 @@ async function updateGiveawayHubMessages(
     const extras = hubMessages.slice(totalMessages);
     for (const extra of extras) {
       await extra.delete().catch((err) => {
-        console.error("Giveaway hub delete failed:", err);
+        logError("GiveawayHubService.delete", err);
       });
     }
   }
@@ -315,7 +317,7 @@ export async function refreshGiveawayHubMessage(
   const channel = await client.channels
     .fetch(GIVEAWAY_HUB_CHANNEL_ID)
     .catch((err) => {
-      console.error("Giveaway hub channel fetch failed:", err);
+      logError("GiveawayHubService.channelFetch", err);
       return null;
     });
   const textChannel = channel?.isTextBased() ? channel : null;

--- a/src/services/IGDB/IgdbScanService.ts
+++ b/src/services/IGDB/IgdbScanService.ts
@@ -3,6 +3,7 @@ import { oraWithConnection } from "../../db/SqlManager.js";
 import Game from "../../classes/Game.js";
 import { igdbService } from "./IgdbService.js";
 import { sleep } from "../../utilities/DelayUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 type IgdbScanConfig = {
   enabled: boolean;
@@ -157,10 +158,7 @@ export async function igdbScanTick(): Promise<void> {
           }
         } catch (err: any) {
           failCount++;
-          console.error(
-            `[IGDB Scan] Failed to refresh ${candidate.title} (ID: ${candidate.gameId}):`,
-            err?.message ?? err,
-          );
+          logError("IgdbScanService.refreshCandidate", err?.message ?? err);
         }
       }
 
@@ -179,7 +177,7 @@ export async function igdbScanTick(): Promise<void> {
       );
     });
   } catch (err) {
-    console.error("[IGDB Scan] Batch failed:", err);
+    logError("IgdbScanService.batch", err);
   }
 }
 

--- a/src/services/IGDB/IgdbService.ts
+++ b/src/services/IGDB/IgdbService.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { logError } from "../../utilities/LogUtils.js";
 
 interface ITwitchAuthResponse {
   access_token: string;
@@ -78,7 +79,7 @@ class IgdbService {
   constructor() {
     // Config is read lazily via getters to allow dotenv to populate env before use
     if (!process.env.IGDB_CLIENT_ID || !process.env.IGDB_CLIENT_SECRET) {
-      console.error("IGDB_CLIENT_ID or IGDB_CLIENT_SECRET not set in environment variables.");
+      logError("IgdbService", "IGDB_CLIENT_ID or IGDB_CLIENT_SECRET not configured");
     }
   }
 
@@ -107,7 +108,7 @@ class IgdbService {
       this.tokenExpiry = Date.now() + (response.data.expires_in * 1000) - 60000;
       return this.accessToken;
     } catch (error) {
-      console.error("IGDB: Failed to fetch Twitch access token:", error);
+      logError("IgdbService.fetchToken", error);
       throw new Error("IGDB service unavailable: Could not authenticate with Twitch.");
     }
   }
@@ -150,7 +151,7 @@ class IgdbService {
         total: parseInt(response.headers?.["x-count"] as string, 10) || response.data.length,
       };
     } catch (error: any) {
-      console.error("IGDB: Failed to search games:", error);
+      logError("IgdbService.searchGames", error);
       throw new Error(`IGDB service unavailable: Could not search for games. Error: ${error.message}`);
     }
   }
@@ -272,7 +273,7 @@ class IgdbService {
 
       return details;
     } catch (error: any) {
-      console.error("IGDB: Failed to get game details:", error);
+      logError("IgdbService.getGameDetails", error);
       throw new Error(`IGDB service unavailable: Could not retrieve game details. Error: ${error.message}`);
     }
   }
@@ -308,7 +309,7 @@ class IgdbService {
 
       return response.data ?? [];
     } catch (error: any) {
-      console.error("IGDB: Failed to fetch platforms:", error);
+      logError("IgdbService.fetchPlatforms", error);
       throw new Error(
         `IGDB service unavailable: Could not fetch platforms. Error: ${error.message}`,
       );

--- a/src/services/NominationReminderService.ts
+++ b/src/services/NominationReminderService.ts
@@ -3,6 +3,7 @@ import type { Client } from "discordx";
 import { DateTime } from "luxon";
 import BotVotingInfo, { type IBotVotingInfoEntry } from "../classes/BotVotingInfo.js";
 import { NOMINATION_DISCUSSION_CHANNEL_IDS } from "../config/nominationChannels.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const CHECK_INTERVAL_MS = 60_000;
 const REMINDER_ZONE = "America/New_York";
@@ -50,7 +51,7 @@ export function startNominationReminderService(client: Client): void {
     try {
       await checkAndSendReminders(client);
     } catch (err) {
-      console.error("Nomination reminder check failed:", err);
+      logError("NominationReminderService.check", err);
     } finally {
       currentlyChecking = false;
     }
@@ -133,7 +134,7 @@ async function sendReminderToAllChannels(client: Client, content: string): Promi
       await textChannel.send(content);
       successCount += 1;
     } catch (err) {
-      console.error(`Failed to send nomination reminder to channel ${channelId}:`, err);
+      logError("NominationReminderService.sendReminder", err);
     }
   }
 

--- a/src/services/PublicReminderService.ts
+++ b/src/services/PublicReminderService.ts
@@ -5,6 +5,7 @@ import {
   disableReminder,
   type IPublicReminder,
 } from "../classes/PublicReminder.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const PUBLIC_REMINDER_INTERVAL_MS: number = 60_000;
 const MAX_PER_CYCLE = 50;
@@ -21,7 +22,7 @@ export function startPublicReminderService(client: Client): void {
     try {
       await checkPublicReminders(client);
     } catch (err) {
-      console.error("[PublicReminderService] Error checking reminders:", err);
+      logError("PublicReminderService.check", err);
     } finally {
       checkingPublic = false;
     }
@@ -46,7 +47,7 @@ async function checkPublicReminders(client: Client): Promise<void> {
       if (!channel || !(channel as any).isTextBased?.()) continue;
       await (channel as any).send(reminder.message);
     } catch (err) {
-      console.error(`[PublicReminderService] Failed to send reminder #${reminder.reminderId}:`, err);
+      logError("PublicReminderService.sendReminder", err);
     }
 
     await handleRecurrence(reminder);

--- a/src/services/ReminderService.ts
+++ b/src/services/ReminderService.ts
@@ -5,6 +5,7 @@ import {
   buildReminderButtons,
   buildReminderMessage,
 } from "../functions/ReminderUi.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const CHECK_INTERVAL_MS = 60_000;
 const MAX_REMINDERS_PER_CYCLE = 25;
@@ -26,7 +27,7 @@ export function startReminderService(client: Client): void {
     try {
       await processDueReminders(client);
     } catch (err) {
-      console.error("Reminder delivery failed:", err);
+      logError("ReminderService.delivery", err);
     } finally {
       currentlyChecking = false;
     }
@@ -70,7 +71,7 @@ async function deliverReminder(
       await Reminder.markSent(reminder.reminderId);
     }
   } catch (err: any) {
-    console.error(`Failed to deliver reminder ${reminder.reminderId} (attempt ${reminder.failureCount + 1}):`, err);
+    logError("ReminderService.deliverReminder", err);
     
     await Reminder.recordFailure(reminder.reminderId);
     

--- a/src/services/RssFeedService.ts
+++ b/src/services/RssFeedService.ts
@@ -11,6 +11,7 @@ import {
   type IRssFeedItem,
   type IRssFeed,
 } from "../classes/RssFeed.js";
+import { logError } from "../utilities/LogUtils.js";
 
 const POLL_INTERVAL_MS: number = 5 * 60 * 1000;
 const ERROR_LOG_COOLDOWN = 60 * 60 * 1000; // 1 hour
@@ -53,12 +54,12 @@ async function processFeed(
     if (msg.includes("Status code 500")) {
       const last = lastErrorLog.get(feed.feedUrl) || 0;
       if (Date.now() - last > ERROR_LOG_COOLDOWN) {
-        console.error(`[RSS] 500 Error for ${feed.feedUrl} (logged once/hr).`);
+        logError("RssFeedService.500Error", feed.feedUrl);
         lastErrorLog.set(feed.feedUrl, Date.now());
       }
       return;
     }
-    console.error(`[RSS] Failed to parse feed ${feed.feedUrl}:`, err);
+    logError("RssFeedService.parseFeed", err);
     return;
   }
 
@@ -127,10 +128,10 @@ async function processFeed(
         await textChannel.send(`${item.title}\n${item.link}`);
       }
     } catch (err) {
-      console.error(`[RSS] Failed to send items for feed ${feed.feedUrl}:`, err);
+      logError("RssFeedService.sendItems", err);
     }
   } catch (err) {
-    console.error(`[RSS] Failed to fetch channel ${feed.channelId}:`, err);
+    logError("RssFeedService.fetchChannel", err);
   }
 }
 
@@ -152,7 +153,7 @@ export function startRssFeedService(client: Client): void {
         }
       });
     } catch (err) {
-      console.error("[RSS] Polling error:", err);
+      logError("RssFeedService.polling", err);
     } finally {
       isPolling = false;
     }

--- a/src/services/ThreadLinkPromptService.ts
+++ b/src/services/ThreadLinkPromptService.ts
@@ -32,6 +32,8 @@ import { shouldPrompt, markPrompted, getGameReleaseYear } from "./ThreadLinkProm
 import { COLOR_BLUE_INFO } from "../config/colors.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../utilities/AsyncUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 
 function hasIgdbConfig(): boolean {
   return Boolean(process.env.IGDB_CLIENT_ID && process.env.IGDB_CLIENT_SECRET);
@@ -84,7 +86,7 @@ async function promptThread(thread: ThreadChannel): Promise<void> {
       components: [buildButtons(thread.id)],
     });
   } catch (err) {
-    console.error("[ThreadLinkPrompt] Failed to post prompt:", err);
+    logError("ThreadLinkPromptService.postPrompt", err);
   }
 }
 
@@ -110,7 +112,7 @@ export class ThreadLinkButtonHandlers {
     const title = threadName.split("(")[0].trim() || threadName;
 
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
-    await interaction.message.edit({ components: [] }).catch(() => {});
+    safeIgnore(interaction.message.edit({ components: [] }));
 
     try {
       const localMatches = (await Game.searchGames(title)).filter((g) =>
@@ -162,7 +164,7 @@ export class ThreadLinkButtonHandlers {
 
         try {
           await interaction.message.delete().catch(async () => {
-            await interaction.message.edit({ components: [] }).catch(() => {});
+            safeIgnore(interaction.message.edit({ components: [] }));
           });
         } catch {
           // ignore
@@ -237,7 +239,7 @@ export class ThreadLinkButtonHandlers {
         "Okay, I'll skip linking a game for this thread going forward.",
         true,
       ));
-      await interaction.message.edit({ components: [] }).catch(() => {});
+      safeIgnore(interaction.message.edit({ components: [] }));
     } catch (err: any) {
       const msg = err?.message ?? String(err);
       await safeReply(interaction, buildTextReply(`Failed to update skip flag: ${msg}`, true));

--- a/src/services/ThreadSyncService.ts
+++ b/src/services/ThreadSyncService.ts
@@ -6,6 +6,7 @@ import type {
 } from "discord.js";
 import { upsertThreadRecord } from "../classes/Thread.js";
 import { NOW_PLAYING_FORUM_ID } from "../config/channels.js";
+import { logError } from "../utilities/LogUtils.js";
 const DEFAULT_SYNC_INTERVAL_MS = 10 * 60 * 1000;
 
 function isTargetForum(thread: AnyThreadChannel | ThreadChannel | null): boolean {
@@ -49,7 +50,7 @@ async function syncForumThreads(client: Client): Promise<void> {
       await captureThread(thread);
     }
   } catch (err) {
-    console.error("[ThreadSync] Sync failed:", err);
+    logError("ThreadSyncService.sync", err);
   }
 }
 
@@ -60,7 +61,7 @@ export function startThreadSyncService(client: Client): void {
       if (!isTargetForum(thread)) return;
       await captureThread(thread);
     } catch (err) {
-      console.error("[ThreadSync] threadCreate handler failed:", err);
+      logError("ThreadSyncService.threadCreate", err);
     }
   });
 
@@ -79,7 +80,7 @@ export function startThreadSyncService(client: Client): void {
         lastSeenAt: message.createdAt ?? new Date(),
       });
     } catch (err) {
-      console.error("[ThreadSync] messageCreate handler failed:", err);
+      logError("ThreadSyncService.messageCreate", err);
     }
   });
 

--- a/src/services/UserEmojiService.ts
+++ b/src/services/UserEmojiService.ts
@@ -2,6 +2,7 @@ import sharp from "sharp";
 import type { Client, GuildMember } from "discord.js";
 import Member from "../classes/Member.js";
 import { sleep } from "../utilities/DelayUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 import {
   ADMIN_ROLE_ID,
   MEMBER_ROLE_ID,
@@ -123,14 +124,14 @@ export async function startUserEmojiService(client: Client): Promise<void> {
     console.log("[UserEmojiService] FORCE_EMOJI_REFRESH detected -- all emojis will be re-uploaded.");
   }
   syncAllUserEmoji(client, forceRefresh).catch((err) => {
-    console.error("[UserEmojiService] Initial sync failed:", err);
+    logError("UserEmojiService.initialSync", err);
   });
 }
 
 async function syncAllUserEmoji(client: Client, forceRefresh = false): Promise<void> {
   const app = client.application;
   if (!app) {
-    console.error("[UserEmojiService] client.application not available.");
+    logError("UserEmojiService", "client.application not available");
     return;
   }
 
@@ -149,7 +150,7 @@ async function syncAllUserEmoji(client: Client, forceRefresh = false): Promise<v
 
   const guild = client.guilds.cache.first();
   if (!guild) {
-    console.error("[UserEmojiService] No guild found.");
+    logError("UserEmojiService", "no guild found");
     return;
   }
 
@@ -174,7 +175,7 @@ async function syncAllUserEmoji(client: Client, forceRefresh = false): Promise<v
         try {
           await app.emojis.delete(emojiId);
         } catch (err) {
-          console.error(`[UserEmojiService] Failed to delete emoji for refresh (${member.displayName}):`, err);
+          logError("UserEmojiService.deleteEmojiForRefresh", err);
         }
       }
       const avatarUrl = member.displayAvatarURL({ extension: "png", size: 128, forceStatic: true });
@@ -190,7 +191,7 @@ async function syncAllUserEmoji(client: Client, forceRefresh = false): Promise<v
           await sleep(CREATION_THROTTLE_MS);
         }
       } catch (err) {
-        console.error(`[UserEmojiService] Failed to recreate emoji for ${member.displayName}:`, err);
+        logError("UserEmojiService.recreateEmoji", err);
       }
     }
   }
@@ -212,12 +213,12 @@ async function syncAllUserEmoji(client: Client, forceRefresh = false): Promise<v
       await app.emojis.delete(emojiId);
       console.log(`[UserEmojiService] Deleted orphaned emoji: ${emojiName}`);
     } catch (err) {
-      console.error(`[UserEmojiService] Failed to delete orphan ${emojiName}:`, err);
+      logError("UserEmojiService.deleteOrphanEmoji", err);
     }
     const orphanUserId = dbNameToUser.get(emojiName);
     if (orphanUserId) {
       await Member.updateEmojiName(orphanUserId, null).catch((err) => {
-        console.error(`[UserEmojiService] Failed to clear emoji name for ${orphanUserId}:`, err);
+        logError("UserEmojiService.clearEmojiName", err);
       });
     }
   }
@@ -241,12 +242,12 @@ async function createEmojiForMember(
     if (emoji.id) {
       emojiCache.set(member.id, { emojiId: emoji.id, emojiName });
       await Member.updateEmojiName(member.id, emojiName).catch((err) => {
-        console.error(`[UserEmojiService] Failed to save emoji name for ${member.id}:`, err);
+        logError("UserEmojiService.saveEmojiName", err);
       });
       return true;
     }
   } catch (err) {
-    console.error(`[UserEmojiService] Failed to create emoji for ${member.displayName}:`, err);
+    logError("UserEmojiService.createEmoji", err);
   }
   return false;
 }
@@ -265,7 +266,7 @@ export async function syncUserEmojiFromAvatarChange(
   try {
     await app.emojis.delete(existing.emojiId);
   } catch (err) {
-    console.error(`[UserEmojiService] Failed to delete old emoji for ${userId}:`, err);
+    logError("UserEmojiService.deleteOldEmoji", err);
   }
   emojiCache.delete(userId);
 
@@ -278,7 +279,7 @@ export async function syncUserEmojiFromAvatarChange(
       emojiCache.set(userId, { emojiId: emoji.id, emojiName: existing.emojiName });
     }
   } catch (err) {
-    console.error(`[UserEmojiService] Failed to recreate emoji for ${userId}:`, err);
+    logError("UserEmojiService.recreateEmoji", err);
   }
 }
 
@@ -298,7 +299,7 @@ export async function syncUserEmojiFromDisplayNameChange(
     try {
       await app.emojis.delete(existing.emojiId);
     } catch (err) {
-      console.error(`[UserEmojiService] Failed to delete old emoji for ${member.id}:`, err);
+      logError("UserEmojiService.deleteOldEmoji", err);
     }
     emojiCache.delete(member.id);
   }
@@ -312,11 +313,11 @@ export async function syncUserEmojiFromDisplayNameChange(
     if (emoji.id) {
       emojiCache.set(member.id, { emojiId: emoji.id, emojiName: newEmojiName });
       await Member.updateEmojiName(member.id, newEmojiName).catch((err) => {
-        console.error(`[UserEmojiService] Failed to save emoji name for ${member.id}:`, err);
+        logError("UserEmojiService.saveEmojiName", err);
       });
     }
   } catch (err) {
-    console.error(`[UserEmojiService] Failed to recreate emoji for ${member.id}:`, err);
+    logError("UserEmojiService.recreateEmoji", err);
   }
 }
 

--- a/src/utilities/ArrayUtils.ts
+++ b/src/utilities/ArrayUtils.ts
@@ -1,0 +1,7 @@
+export function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}


### PR DESCRIPTION
## Summary

Closes #619, #620, #621, #622, #623

- **#621** - Extract shared `chunk<T>()` to `src/utilities/ArrayUtils.ts`; remove local `chunkIds`/`chunkOptions` from `mp-info.command.ts` and `profile.command.ts`
- **#622** - Add `buildSelectOptions()` + `ISelectOptionInput` to `uiComponents.ts`; migrate `game-journal.command.ts` (3 sites), `completion-add.service.ts`, and `giveaway.command.ts`
- **#623** - Add `safeUserFetch()`/`safeMemberFetch()` to `InteractionUtils.ts`; migrate all 8+ raw `.users.fetch().catch(() => null)` and `.members.fetch().catch(() => null)` call sites across 5 files
- **#620** - Complete `safeIgnore()` sweep: zero `.catch(() => {})` remain in app source (28 files updated, 148 instances converted)
- **#619** - Route all ad-hoc `console.error()` calls through `logError(context, error)` from `LogUtils.ts`; zero raw `console.error` remain in non-script app code (30+ files updated)

## Test plan

- [ ] `npx tsc --noEmit` passes (verified: clean)
- [ ] `npm run lint` passes (verified: clean)
- [ ] Verify `grep -rn "\.catch(() => {})" src/` returns no results (excluding AsyncUtils.ts)
- [ ] Verify `grep -rn "function chunkIds\|function chunkOptions" src/` returns no results
- [ ] Verify `grep -rn "\.users\.fetch.*\.catch(() => null)" src/` returns no results (except InteractionUtils.ts implementation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)