### PR TITLE
refactor: adopt DISCORD_SELECT_OPTIONS_MAX for all .slice(0, 25) sites

### DIFF
--- a/src/commands/collection/collection-autocomplete.utils.ts
+++ b/src/commands/collection/collection-autocomplete.utils.ts
@@ -6,7 +6,7 @@ import UserGameCollection, {
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../../config/textLimits.js";
 
 export const COLLECTION_ENTRY_VALUE_PREFIX = "collection";
 
@@ -45,7 +45,7 @@ export async function autocompleteCollectionGameTitle(
 
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
-    results.slice(0, 25).map((game) => ({
+    results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
     })),

--- a/src/commands/create-thread.command.ts
+++ b/src/commands/create-thread.command.ts
@@ -19,7 +19,7 @@ import { safeDeferReply, safeReply, sanitizeOptionalInput, sanitizeUserInput } f
   "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { formatGameTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../config/textLimits.js";
 
 const DEFAULT_FIRST_POST_PREFIX = "Thread created by";
 
@@ -40,7 +40,7 @@ async function autocompleteCreateThreadTitle(
 
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
-    results.slice(0, 25).map((game) => ({
+    results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
     })),
@@ -63,7 +63,7 @@ async function autocompleteCreateThreadTag(
 
   const filtered = forum.availableTags
     .filter((tag) => !query || tag.name.toLowerCase().includes(query))
-    .slice(0, 25)
+    .slice(0, DISCORD_SELECT_OPTIONS_MAX)
     .map((tag) => ({
       name: tag.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: tag.name.slice(0, DISCORD_SELECT_LABEL_MAX),

--- a/src/commands/game-completion/completion-autocomplete.utils.ts
+++ b/src/commands/game-completion/completion-autocomplete.utils.ts
@@ -8,7 +8,7 @@ import Member from "../../classes/Member.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../../config/textLimits.js";
 
 const PLATFORM_CACHE_TTL_MS = 5 * 60 * 1000;
 const COMPLETION_TITLE_VALUE_PREFIX = "completion";
@@ -121,7 +121,7 @@ export async function autocompleteUserCompletionTitle(
     value: buildCompletionTitleAutocompleteValue(completion.completionId),
   }));
 
-  await interaction.respond(options.slice(0, 25));
+  await interaction.respond(options.slice(0, DISCORD_SELECT_OPTIONS_MAX));
 }
 
 export async function autocompleteGameCompletionPlatform(
@@ -157,7 +157,7 @@ async function autocompleteGameCompletionPlatformWithOptions(
     : platforms;
 
   const options = sortPlatformsForAutocomplete(filtered, standardFirstIds)
-    .slice(0, 25)
+    .slice(0, DISCORD_SELECT_OPTIONS_MAX)
     .map((platform) => ({
       name: buildPlatformAutocompleteLabel(platform),
       value: String(platform.id),

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -79,7 +79,7 @@ import {
   JOURNAL_ALL_PAGE_SIZE as ALL_PAGE_SIZE,
   JOURNAL_SEARCH_PAGE_SIZE as SEARCH_PAGE_SIZE,
 } from "../config/pagination.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../config/textLimits.js";
 
 const gjHmenu = new EphemeralOwnerMenu();
 
@@ -330,7 +330,7 @@ async function autocompleteJournalSearchGame(
   }
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
-    results.slice(0, 25).map((game) => ({
+    results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(game.id),
     })),

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -17,7 +17,7 @@ import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUt
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { decodeBase64Url, encodeBase64Url } from "../../functions/CustomIdUtils.js";
 import Game from "../../classes/Game.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../../config/textLimits.js";
 
 export interface ISearchFilters {
   upcomingRelease?: boolean;
@@ -250,7 +250,7 @@ export async function autocompleteSearchPlatform(
         || p.code.toLowerCase().includes(query),
     )
     : platforms;
-  const options = filtered.slice(0, 25).map((p) => ({
+  const options = filtered.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((p) => ({
     name: (p.abbreviation ? `${p.name} (${p.abbreviation})` : p.name).slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(p.id),
   }));
@@ -267,7 +267,7 @@ export async function autocompleteSearchCompany(
   const filtered = query
     ? companies.filter((c) => c.name.toLowerCase().includes(query))
     : companies;
-  const options = filtered.slice(0, 25).map((c) => ({
+  const options = filtered.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((c) => ({
     name: c.name.slice(0, DISCORD_SELECT_LABEL_MAX),
     value: String(c.id),
   }));

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -45,7 +45,7 @@ import {
 } from "../config/nominationChannels.js";
 import { showGameProfileFromNomination } from "./gamedb.command.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../config/textLimits.js";
 import { logError } from "../utilities/LogUtils.js";
 
 const NOMINATE_REASON_MAX_LENGTH = 1500;
@@ -63,7 +63,7 @@ async function autocompleteNominationTitle(
 
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
-    results.slice(0, 25).map((game) => ({
+    results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
       value: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
     })),

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -111,7 +111,11 @@ import {
   truncateWithEllipsis,
 } from "../utilities/ValidationUtils.js";
 import { formatStructuredLog, logError } from "../utilities/LogUtils.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import {
+  DISCORD_AUTOCOMPLETE_DESC_MAX,
+  DISCORD_SELECT_LABEL_MAX,
+  DISCORD_SELECT_OPTIONS_MAX,
+} from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 
@@ -2265,7 +2269,7 @@ export class NowPlayingCommand {
       note,
       sourceSessionId,
     });
-    const options = platforms.slice(0, 25).map((platform) => ({
+    const options = platforms.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((platform) => ({
       label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(platform.id),
     }));
@@ -2615,7 +2619,7 @@ export class NowPlayingCommand {
             uniqueById.set(platform.id, platform);
           }
         });
-        const deduped = Array.from(uniqueById.values()).slice(0, 25);
+        const deduped = Array.from(uniqueById.values()).slice(0, DISCORD_SELECT_OPTIONS_MAX);
         if (!deduped.length && entry.platformId) {
           deduped.push({
             id: entry.platformId,
@@ -2672,7 +2676,7 @@ export class NowPlayingCommand {
       return;
     }
 
-    const options = platforms.slice(0, 25).map((platform) => ({
+    const options = platforms.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((platform) => ({
       label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
       value: String(platform.id),
     }));
@@ -4907,7 +4911,7 @@ export class NowPlayingCommand {
 
     const selectOptions = entries
       .filter((entry) => isPositiveInt(entry.gameId))
-      .slice(0, 25)
+      .slice(0, DISCORD_SELECT_OPTIONS_MAX)
       .map((entry) => ({
         label: formatEntryTitleWithPlatform(entry).slice(0, DISCORD_SELECT_LABEL_MAX),
         value: String(entry.gameId),
@@ -5763,7 +5767,7 @@ export class NowPlayingCommand {
       return nameA.localeCompare(nameB);
     });
 
-    const options = sorted.slice(0, 25).map((record) => {
+    const options = sorted.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((record) => {
       const displayName = record.globalName ?? record.username ?? record.userId;
       return {
         label: displayName.slice(0, DISCORD_SELECT_LABEL_MAX),

--- a/src/commands/round-history.command.ts
+++ b/src/commands/round-history.command.ts
@@ -44,6 +44,7 @@ import {
   parseRawModalCustomId,
 } from "../services/raw-modal/RawModalCustomId.js";
 import { ROUND_HISTORY_PAGE_SIZE } from "../config/pagination.js";
+import { DISCORD_SELECT_OPTIONS_MAX } from "../config/textLimits.js";
 import { buildDisabledPrevNextRowWithIds } from "../functions/PaginationUtils.js";
 
 const ROUND_HISTORY_MODAL_TITLE = "Round History";
@@ -108,7 +109,7 @@ function getModalYearOptions(): APISelectMenuOption[] {
 
   return Array.from(years)
     .sort((a, b) => b - a)
-    .slice(0, 25)
+    .slice(0, DISCORD_SELECT_OPTIONS_MAX)
     .map((year) => ({
       label: String(year),
       value: String(year),


### PR DESCRIPTION
## Summary

- Replaces 15 instances of the magic number `25` with `DISCORD_SELECT_OPTIONS_MAX` from `src/config/textLimits.ts`
- Adds the constant to imports in 8 files; `round-history.command.ts` gets a new textLimits import
- No behavior change

Closes #649

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] `npm run lint` passes (verified)
- [ ] No `.slice(0, 25)` literals remain in `src/` (verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)