### PR TITLE
refactor: standardization pass 8 (issues 651-655)

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -15,7 +15,7 @@ import {
 } from "../services/RpgClubApiClient.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 
 // Interfaces
 export interface IGame {
@@ -1156,9 +1156,7 @@ export default class Game {
     });
 
     if (missingPlatformIds.size) {
-      console.warn(
-        `Missing platform IDs in GAMEDB_PLATFORMS: ${Array.from(missingPlatformIds).join(", ")}`,
-      );
+      logWarn("Game.getPlatformsByIgdbIds", `Missing platform IDs in GAMEDB_PLATFORMS: ${Array.from(missingPlatformIds).join(", ")}`);
     }
 
     return games.map((game) => ({
@@ -1531,9 +1529,7 @@ export default class Game {
     const platformMap = await Game.getPlatformsByIgdbIds(uniqueIds);
     const missingIds = uniqueIds.filter((id) => !platformMap.has(id));
     if (missingIds.length) {
-      console.warn(
-        `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingIds.join(", ")}`,
-      );
+      logWarn("Game.syncIgdbPlatforms", `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingIds.join(", ")}`);
     }
 
     await dbTransaction(async (conn) => {

--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -12,7 +12,7 @@ import {
 import { getDialect } from "../db/dialect.js";
 import { MemberSql } from "../db/sql/index.js";
 import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 
 const dialect = getDialect();
 
@@ -224,9 +224,7 @@ async function getNowPlayingThreadIdSql(connection: AnyConn): Promise<string> {
     } catch (err) {
       nowPlayingLinkedThreadColumnAvailable = false;
       const msg = err instanceof Error ? err.message : String(err);
-      console.warn(
-        `[Member] Failed to detect LINKED_THREAD_ID column; using legacy links: ${msg}`,
-      );
+      logWarn("Member.detectLinkedThreadColumn", `Failed to detect LINKED_THREAD_ID column; using legacy links: ${msg}`);
     }
   }
 

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -36,7 +36,7 @@ import {
   buildComponentsV2EditFlags,
 } from "../../functions/ComponentsV2Utils.js";
 import { flattenErrorMessages } from "../imports/import-scaffold.service.js";
-import { formatStructuredLog, logError } from "../../utilities/LogUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
 import {
@@ -164,11 +164,7 @@ export class CollectionViewCommand {
         ),
       ]);
     } catch (err) {
-      console.error(formatStructuredLog({
-        context: "collection list",
-        event: "build_response_failed",
-        error: err instanceof Error ? err.message : String(err),
-      }));
+      logError("collection list.build_response_failed", err);
       await safeReply(
         interaction,
         buildTextReply("Failed to load your collection. Please try again.", isEphemeral),
@@ -190,22 +186,14 @@ export class CollectionViewCommand {
         flags: buildComponentsV2Flags(isEphemeral),
       });
     } catch (err) {
-      console.error(formatStructuredLog({
-        context: "collection list",
-        event: "safe_reply_failed",
-        error: err instanceof Error ? err.message : String(err),
-      }));
+      logError("collection list.safe_reply_failed", err);
       try {
         await safeReply(
           interaction,
           buildTextReply("Failed to display collection. Please try again.", isEphemeral),
         );
       } catch (fallbackErr) {
-        console.error(formatStructuredLog({
-          context: "collection list",
-          event: "fallback_safe_reply_failed",
-          error: fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr),
-        }));
+        logError("collection list.fallback_safe_reply_failed", fallbackErr);
       }
     }
     console.log("[collection list] step: reply sent");

--- a/src/commands/game-completion/completion-delete.service.ts
+++ b/src/commands/game-completion/completion-delete.service.ts
@@ -1,6 +1,6 @@
 import { type StringSelectMenuInteraction } from "discord.js";
 import Member from "../../classes/Member.js";
-import { safeReply } from "../../functions/InteractionUtils.js";
+import { replyIfNotOwner, safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
@@ -16,10 +16,7 @@ export async function handleCompletionDeleteMenu(
   const segs = assertCustomIdSegments(interaction, 1);
   if (!segs) return;
   const [ownerId] = segs;
-  if (interaction.user.id !== ownerId) {
-    await safeReply(interaction, buildTextReply("This delete prompt isn't for you.", true));
-    return;
-  }
+  if (await replyIfNotOwner(interaction, ownerId)) return;
 
   const completionId = Number(interaction.values[0]);
   if (!isPositiveInt(completionId)) {

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -38,6 +38,7 @@ import Game from "../classes/Game.js";
 import { getThreadsByGameId } from "../classes/Thread.js";
 import {
   ephemeralFlag,
+  replyIfNotOwner,
   safeDeferReply,
   safeDeferUpdate,
   sanitizeUserInput,
@@ -787,10 +788,7 @@ export class GameJournalCommand {
     const segments = parseCustomIdSegments(interaction.customId, 3);
     if (!segments) return;
     const [ownerId, gameIdRaw, pageRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeDeferUpdate(interaction);
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
     const gameId = Number(gameIdRaw);
     const page = Number(pageRaw);
     const container = new ContainerBuilder().addTextDisplayComponents(
@@ -805,10 +803,7 @@ export class GameJournalCommand {
     const segments = parseCustomIdSegments(interaction.customId, 2);
     if (!segments) return;
     const [ownerId, gameIdRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeDeferUpdate(interaction);
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
     const modal = buildHmenuModal(
       `${GJ_HMENU_ADD_MODAL_ID}:${ownerId}:${gameIdRaw}`,
       "Add Journal Entry",
@@ -821,10 +816,7 @@ export class GameJournalCommand {
     const segments = parseCustomIdSegments(interaction.customId, 3);
     if (!segments) return;
     const [ownerId, gameIdRaw, pageRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeDeferUpdate(interaction);
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
     const gameId = Number(gameIdRaw);
     const page = Number(pageRaw);
     const offset = Math.max(0, page - 1);
@@ -859,10 +851,7 @@ export class GameJournalCommand {
     const segments = parseCustomIdSegments(interaction.customId, 2);
     if (!segments) return;
     const [ownerId, gameIdRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeDeferUpdate(interaction);
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
     const gameId = Number(gameIdRaw);
     const entries = await Member.getGameJournalEntries(ownerId, gameId, {
       limit: 5,
@@ -916,10 +905,7 @@ export class GameJournalCommand {
     const segments = parseCustomIdSegments(interaction.customId, 2);
     if (!segments) return;
     const [ownerId, gameIdRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeDeferUpdate(interaction);
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
     const entryId = Number(interaction.values[0]);
     const entry = await Member.getGameJournalEntryForUser(ownerId, entryId);
     if (!entry || entry.gameId !== Number(gameIdRaw)) {
@@ -960,10 +946,7 @@ export class GameJournalCommand {
     const segments = parseCustomIdSegments(interaction.customId, 4);
     if (!segments) return;
     const [action, ownerId, gameIdRaw, entryIdRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeDeferUpdate(interaction);
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
     if (action === "yes") {
       const removed = await Member.deleteGameJournalEntry(ownerId, Number(entryIdRaw));
       if (!removed) {
@@ -990,10 +973,7 @@ export class GameJournalCommand {
     const segments = parseCustomIdSegments(interaction.customId, 2);
     if (!segments) return;
     const [ownerId, gameIdRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeReply(interaction, buildTextReply("Only the owner can submit journal entries.", false));
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
     const title = sanitizeUserInput(
       interaction.fields.getTextInputValue(JOURNAL_TITLE_INPUT_ID) ?? "",
       { preserveNewlines: true, maxLength: 120 },
@@ -1021,10 +1001,7 @@ export class GameJournalCommand {
     const segments = parseCustomIdSegments(interaction.customId, 3);
     if (!segments) return;
     const [ownerId, gameIdRaw, entryIdRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeReply(interaction, buildTextReply("Only the owner can edit journal entries.", false));
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
     const gameId = Number(gameIdRaw);
     const entryId = Number(entryIdRaw);
     const existing = await Member.getGameJournalEntryForUser(ownerId, entryId);

--- a/src/commands/gamedb/gamedb-add.command.ts
+++ b/src/commands/gamedb/gamedb-add.command.ts
@@ -34,7 +34,7 @@ import {
 import { buildIgdbSelectOptions } from "./gamedb-csv-import.service.js";
 import { showGameProfile, trimTextDisplayContent } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { logError } from "../../utilities/LogUtils.js";
+import { logError, logWarn } from "../../utilities/LogUtils.js";
 
 async function fetchIgdbCoverImage(details: IGDBGameDetails): Promise<Buffer | null> {
   if (!details.cover?.image_id) return null;
@@ -70,9 +70,7 @@ export async function processReleaseDates(
   const platformMap = await Game.getPlatformsByIgdbIds(uniquePlatformIds);
   const missingPlatformIds = uniquePlatformIds.filter((id) => !platformMap.has(id));
   if (missingPlatformIds.length) {
-    console.warn(
-      `[GameDB] Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingPlatformIds.join(", ")}`,
-    );
+    logWarn("GamedbAdd.addGame", `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingPlatformIds.join(", ")}`);
   }
 
   for (const release of releaseDates) {

--- a/src/commands/gamedb/gamedb-csv-import.service.ts
+++ b/src/commands/gamedb/gamedb-csv-import.service.ts
@@ -28,6 +28,7 @@ import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
 } from "../../config/textLimits.js";
+import { logWarn } from "../../utilities/LogUtils.js";
 
 export const GAMEDB_CSV_RESULT_LIMIT = 15;
 
@@ -257,9 +258,7 @@ export async function buildIgdbSelectOptions(
   const platformMap = await Game.getPlatformsByIgdbIds(uniquePlatformIds);
   const missingPlatformIds = uniquePlatformIds.filter((id) => !platformMap.has(id));
   if (missingPlatformIds.length) {
-    console.warn(
-      `[GameDB] Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingPlatformIds.join(", ")}`,
-    );
+    logWarn("GamedbCsvImport", `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingPlatformIds.join(", ")}`);
   }
 
   return results.map((game) => {

--- a/src/commands/generate-vote-image.command.ts
+++ b/src/commands/generate-vote-image.command.ts
@@ -12,7 +12,7 @@ import { getUpcomingNominationWindow } from "../functions/NominationWindow.js";
 import { isAdmin } from "./admin/admin-auth.utils.js";
 import { composeVoteImage, type VoteImageType } from "../services/collageGenerator.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
-import { formatStructuredLog } from "../utilities/LogUtils.js";
+import { formatStructuredLog, logError } from "../utilities/LogUtils.js";
 
 const GENERATION_LOCK_TTL_MS = 2 * 60 * 1000;
 
@@ -226,8 +226,7 @@ export class GenerateVoteImageCommand {
         ));
       }
 
-      console.error(formatStructuredLog({
-        event: "vote_image_generation_failed",
+      logError("vote_image_generation_failed", {
         guildId: interaction.guildId,
         round: roundNumber,
         voteType: voteKind.label,
@@ -235,7 +234,7 @@ export class GenerateVoteImageCommand {
         durationMs: Date.now() - startedAt,
         errorCode: "GENERATION_FAILED",
         error: errorMessage,
-      }));
+      });
     } finally {
       releaseLock(interaction.guildId, roundNumber, voteKind.label);
       console.info(formatStructuredLog({

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -60,7 +60,11 @@ import {
   GIVEAWAY_MAX_KEY_LENGTH,
 } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
-import { buildSelectOptions, buildTextInputRow } from "../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildSelectOptions,
+  buildTextInputRow,
+} from "../functions/uiComponents.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 const GIVEAWAY_DONATE_MODAL_ID = "giveaway-donate-modal";
 const GIVEAWAY_REVOKE_MODAL_ID = "giveaway-revoke-modal";
@@ -251,16 +255,8 @@ function buildClaimConfirmComponents(
   confirmId: string,
   cancelId: string,
 ): ActionRowBuilder<ButtonBuilder>[] {
-  const yesButton = new ButtonBuilder()
-     
-    .setCustomId(confirmId)
-    .setLabel("Yes")
-    .setStyle(ButtonStyle.Success);
-  const noButton = new ButtonBuilder()
-     
-    .setCustomId(cancelId)
-    .setLabel("No")
-    .setStyle(ButtonStyle.Secondary);
+  const yesButton = buildActionButton({ customId: confirmId, label: "Yes", style: ButtonStyle.Success });
+  const noButton = buildActionButton({ customId: cancelId, label: "No", style: ButtonStyle.Secondary });
   return [new ActionRowBuilder<ButtonBuilder>().addComponents(yesButton, noButton)];
 }
 
@@ -286,18 +282,16 @@ function buildDonorSettingsRow(
   userId: string,
   enabled: boolean,
 ): ActionRowBuilder<ButtonBuilder> {
-  const yesButton = new ButtonBuilder()
-     
-    .setCustomId(`${GIVEAWAY_DONOR_NOTIFY_ID}:${userId}:yes`)
-    .setLabel("Yes")
-    .setStyle(ButtonStyle.Success)
-    .setDisabled(enabled);
-  const noButton = new ButtonBuilder()
-     
-    .setCustomId(`${GIVEAWAY_DONOR_NOTIFY_ID}:${userId}:no`)
-    .setLabel("No")
-    .setStyle(ButtonStyle.Secondary)
-    .setDisabled(!enabled);
+  const yesButton = buildActionButton({
+    customId: `${GIVEAWAY_DONOR_NOTIFY_ID}:${userId}:yes`,
+    label: "Yes",
+    style: ButtonStyle.Success,
+  }).setDisabled(enabled);
+  const noButton = buildActionButton({
+    customId: `${GIVEAWAY_DONOR_NOTIFY_ID}:${userId}:no`,
+    label: "No",
+    style: ButtonStyle.Secondary,
+  }).setDisabled(!enabled);
   return new ActionRowBuilder<ButtonBuilder>().addComponents(yesButton, noButton);
 }
 
@@ -384,11 +378,11 @@ function buildKeyListComponents(
   const rows: ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] = [];
   if (keys.length) {
     if (isPublic) {
-      const claimButton = new ButtonBuilder()
-         
-        .setCustomId(`giveaway-claim-button:${sessionId}:${page}`)
-        .setLabel("Claim a key")
-        .setStyle(ButtonStyle.Primary);
+      const claimButton = buildActionButton({
+        customId: `giveaway-claim-button:${sessionId}:${page}`,
+        label: "Claim a key",
+        style: ButtonStyle.Primary,
+      });
       rows.push(new ActionRowBuilder<ButtonBuilder>().addComponents(claimButton));
     } else {
       const selectRows = buildKeySelectMenus(

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -24,8 +24,8 @@ import {
 import Member, { type IMemberPlatformRecord } from "../classes/Member.js";
 import {
   deferWithPrivateFlag,
-  ephemeralFlag,
   extractErrorMessage,
+  replyIfNotOwner,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
@@ -238,7 +238,7 @@ async function renderMpInfoPage(
     await safeReply(interaction as any, {
       embeds: [embed],
       components,
-      flags: ephemeralFlag(ephemeral),
+      flags: buildComponentsV2Flags(ephemeral),
     });
   }
 }
@@ -315,10 +315,7 @@ export class MultiplayerInfoCommand {
     const segments = parseCustomIdSegments(interaction.customId, 3);
     if (!segments) return;
     const [ownerId, filterKey, pageRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeReply(interaction, buildTextReply("This menu isn't for you.", true));
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const userId = interaction.values?.[0];
     if (!userId) {
@@ -388,10 +385,7 @@ export class MultiplayerInfoCommand {
     const segments = parseCustomIdSegments(interaction.customId, 3);
     if (!segments) return;
     const [ownerId, filterKey, pageRaw] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeReply(interaction, buildTextReply("This menu isn't for you.", true));
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const page = Number(pageRaw);
     if (Number.isNaN(page)) return;
@@ -405,10 +399,7 @@ export class MultiplayerInfoCommand {
     const segments = parseCustomIdSegments(interaction.customId, 4);
     if (!segments) return;
     const [ownerId, filterKey, pageRaw, dir] = segments;
-    if (interaction.user.id !== ownerId) {
-      await safeReply(interaction, buildTextReply("This menu isn't for you.", true));
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ownerId)) return;
 
     const page = Number(pageRaw);
     if (Number.isNaN(page)) return;

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -110,7 +110,7 @@ import {
   isValidPlaytimeHours,
   truncateWithEllipsis,
 } from "../utilities/ValidationUtils.js";
-import { formatStructuredLog, logError } from "../utilities/LogUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
@@ -245,11 +245,7 @@ export async function restoreJournalMessageContextsFromDb(): Promise<void> {
     }
     console.log(`[Journal] Restored ${rows.length} message context(s) from DB.`);
   } catch (err) {
-    console.error(formatStructuredLog({
-      context: "Journal",
-      event: "restore_contexts_failed",
-      error: err instanceof Error ? err.message : String(err),
-    }));
+    logError("Journal.restore_contexts_failed", err);
   }
 }
 
@@ -510,11 +506,7 @@ export async function trackNowPlayingJournalContext(
     createdAt,
     ownerUserId,
     gameId,
-  ).catch((err) => console.error(formatStructuredLog({
-    context: "Journal",
-    event: "persist_context_failed",
-    error: err instanceof Error ? err.message : String(err),
-  })));
+  ).catch((err) => logError("Journal.persist_context_failed", err));
 }
 
 export async function refreshJournalMessages(
@@ -533,11 +525,7 @@ export async function refreshJournalMessages(
     if (now - ctx.createdAt > NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS) {
       nowPlayingJournalContexts.delete(key);
       await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
-        .catch((err) => console.error(formatStructuredLog({
-          context: "Journal",
-          event: "delete_expired_context_failed",
-          error: err instanceof Error ? err.message : String(err),
-        })));
+        .catch((err) => logError("Journal.delete_expired_context_failed", err));
       continue;
     }
     const existing = latestByChannel.get(ctx.channelId);
@@ -553,11 +541,7 @@ export async function refreshJournalMessages(
       const key = `${ctx.channelId}:${ctx.messageId}`;
       nowPlayingJournalContexts.delete(key);
       await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
-        .catch((err) => console.error(formatStructuredLog({
-          context: "Journal",
-          event: "delete_unreachable_context_failed",
-          error: err instanceof Error ? err.message : String(err),
-        })));
+        .catch((err) => logError("Journal.delete_unreachable_context_failed", err));
       continue;
     }
     const message = await channel.messages.fetch(ctx.messageId).catch(() => null);
@@ -565,11 +549,7 @@ export async function refreshJournalMessages(
       const key = `${ctx.channelId}:${ctx.messageId}`;
       nowPlayingJournalContexts.delete(key);
       await Member.deleteJournalMessageContext(ctx.channelId, ctx.messageId)
-        .catch((err) => console.error(formatStructuredLog({
-          context: "Journal",
-          event: "delete_missing_context_failed",
-          error: err instanceof Error ? err.message : String(err),
-        })));
+        .catch((err) => logError("Journal.delete_missing_context_failed", err));
       continue;
     }
     const guildId = channel.isDMBased() ? null : (channel as any).guildId as string;
@@ -590,11 +570,7 @@ export async function refreshJournalMessages(
     await message.edit({
       components: payload.components as any[],
       files: payload.files,
-    }).catch((err) => console.error(formatStructuredLog({
-      context: "Journal",
-      event: "refresh_public_message_failed",
-      error: err instanceof Error ? err.message : String(err),
-    })));
+    }).catch((err) => logError("Journal.refresh_public_message_failed", err));
   }
 }
 
@@ -5465,11 +5441,7 @@ export class NowPlayingCommand {
       if (now - context.createdAt > NOW_PLAYING_JOURNAL_CONTEXT_TTL_MS) {
         nowPlayingJournalContexts.delete(key);
         await Member.deleteJournalMessageContext(context.channelId, context.messageId)
-          .catch((err) => console.error(formatStructuredLog({
-            context: "Journal",
-            event: "delete_expired_context_from_db_failed",
-            error: err instanceof Error ? err.message : String(err),
-          })));
+          .catch((err) => logError("Journal.delete_expired_context_from_db_failed", err));
         continue;
       }
       if (context.channelId !== channelId) continue;
@@ -5488,11 +5460,7 @@ export class NowPlayingCommand {
     if (!channel?.isTextBased()) {
       nowPlayingJournalContexts.delete(latestKey);
       await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
-        .catch((err) => console.error(formatStructuredLog({
-          context: "Journal",
-          event: "delete_unreachable_context_from_db_failed",
-          error: err instanceof Error ? err.message : String(err),
-        })));
+        .catch((err) => logError("Journal.delete_unreachable_context_from_db_failed", err));
       return;
     }
 
@@ -5500,22 +5468,14 @@ export class NowPlayingCommand {
     if (!message) {
       nowPlayingJournalContexts.delete(latestKey);
       await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
-        .catch((err) => console.error(formatStructuredLog({
-          context: "Journal",
-          event: "delete_missing_context_from_db_failed",
-          error: err instanceof Error ? err.message : String(err),
-        })));
+        .catch((err) => logError("Journal.delete_missing_context_from_db_failed", err));
       return;
     }
 
     await message.delete().catch(() => null);
     nowPlayingJournalContexts.delete(latestKey);
     await Member.deleteJournalMessageContext(latestContext.channelId, latestContext.messageId)
-      .catch((err) => console.error(formatStructuredLog({
-        context: "Journal",
-        event: "delete_context_from_db_after_message_delete_failed",
-        error: err instanceof Error ? err.message : String(err),
-      })));
+      .catch((err) => logError("Journal.delete_context_from_db_after_message_delete_failed", err));
   }
 
   private async trackJournalReply(

--- a/src/commands/suggestion.command.ts
+++ b/src/commands/suggestion.command.ts
@@ -45,8 +45,11 @@ import {
 import { createIssue } from "../services/GithubIssuesService.js";
 import { BOT_DEV_CHANNEL_ID, GAMEDB_UPDATES_CHANNEL_ID } from "../config/channels.js";
 import { BOT_DEV_PING_USER_ID } from "../config/users.js";
-import { COMPONENTS_V2_FLAG } from "../config/flags.js";
-import { buildTextReply, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
+import {
+  buildComponentsV2Flags,
+  buildTextReply,
+  safeV2TextContent,
+} from "../functions/ComponentsV2Utils.js";
 import { logRawModal } from "../services/raw-modal/RawModalLogging.js";
 import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
@@ -98,10 +101,6 @@ async function loadSuggestionReviewSession(
     return null;
   }
   return session;
-}
-
-function buildComponentsV2Flags(isEphemeral: boolean): number {
-  return (isEphemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
 }
 
 function parseSuggestionReviewActionId(

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -25,6 +25,7 @@ import {
   extractErrorMessage,
   isInteractionSettled,
   safeDeferReply,
+  replyIfNotOwner,
   safeDeferUpdate,
   safeReply,
   safeUpdate,
@@ -317,10 +318,7 @@ export class SuperAdmin {
     const okToUseCommand: boolean = await isSuperAdmin(interaction as any);
     if (!okToUseCommand) return;
 
-    if (interaction.user.id !== ctx.userId) {
-      safeIgnore(safeReply(interaction, buildTextReply("This completion prompt isn't for you.", true)));
-      return;
-    }
+    if (await replyIfNotOwner(interaction, ctx.userId)) return;
 
     const selected = interaction.values?.[0];
     const isOther = selected === "other";

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -62,7 +62,7 @@ import { decodeBase64Url, encodeWithMaxLength } from "../functions/CustomIdUtils
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import { formatDiscordTimestamp } from "../functions/DateFormatUtils.js";
-import { buildTextInputRow } from "../functions/uiComponents.js";
+import { buildActionButton, buildTextInputRow } from "../functions/uiComponents.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { DISCORD_TEXT_INPUT_MAX } from "../config/textLimits.js";
 import { TODO_DEFAULT_PAGE_SIZE, TODO_MAX_PAGE_SIZE } from "../config/pagination.js";
@@ -1059,20 +1059,23 @@ function buildIssueListComponents(
     );
   const labelRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(labelSelect);
 
-  const queryButton = new ButtonBuilder()
-    .setCustomId(buildTodoQueryButtonId(payloadToken, payload.page))
-    .setLabel(payload.query ? "Edit Query" : "Filter by Query")
-    .setStyle(ButtonStyle.Secondary);
+  const queryButton = buildActionButton({
+    customId: buildTodoQueryButtonId(payloadToken, payload.page),
+    label: payload.query ? "Edit Query" : "Filter by Query",
+    style: ButtonStyle.Secondary,
+  });
 
-  const createButton = new ButtonBuilder()
-    .setCustomId(buildTodoCreateButtonId(payloadToken, payload.page))
-    .setLabel("Create Issue")
-    .setStyle(ButtonStyle.Success);
+  const createButton = buildActionButton({
+    customId: buildTodoCreateButtonId(payloadToken, payload.page),
+    label: "Create Issue",
+    style: ButtonStyle.Success,
+  });
 
-  const closeButton = new ButtonBuilder()
-    .setCustomId(buildTodoCloseButtonId(payloadToken, payload.page))
-    .setLabel("Close Issue")
-    .setStyle(ButtonStyle.Danger);
+  const closeButton = buildActionButton({
+    customId: buildTodoCloseButtonId(payloadToken, payload.page),
+    label: "Close Issue",
+    style: ButtonStyle.Danger,
+  });
 
   const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
     createButton,
@@ -1081,11 +1084,11 @@ function buildIssueListComponents(
   );
   if (suggestionCount > 0) {
     actionRow.addComponents(
-      new ButtonBuilder()
-        // eslint-disable-next-line local/custom-id-has-matching-handler
-        .setCustomId(TODO_REVIEW_SUGGESTIONS_BUTTON_ID)
-        .setLabel("Review Suggestions")
-        .setStyle(ButtonStyle.Primary),
+      buildActionButton({
+        customId: TODO_REVIEW_SUGGESTIONS_BUTTON_ID,
+        label: "Review Suggestions",
+        style: ButtonStyle.Primary,
+      }),
     );
   }
 
@@ -1098,16 +1101,16 @@ function buildIssueListComponents(
     const prevDisabled = payload.page <= 1;
     const nextDisabled = payload.page >= totalPages;
     const pagingRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(buildTodoListCustomId(payloadToken, payload.page - 1))
-        .setLabel("Prev Page")
-        .setStyle(ButtonStyle.Secondary)
-        .setDisabled(prevDisabled),
-      new ButtonBuilder()
-        .setCustomId(buildTodoListCustomId(payloadToken, payload.page + 1))
-        .setLabel("Next Page")
-        .setStyle(ButtonStyle.Secondary)
-        .setDisabled(nextDisabled),
+      buildActionButton({
+        customId: buildTodoListCustomId(payloadToken, payload.page - 1),
+        label: "Prev Page",
+        style: ButtonStyle.Secondary,
+      }).setDisabled(prevDisabled),
+      buildActionButton({
+        customId: buildTodoListCustomId(payloadToken, payload.page + 1),
+        label: "Next Page",
+        style: ButtonStyle.Secondary,
+      }).setDisabled(nextDisabled),
     );
     components.push(pagingRow);
   }
@@ -1158,32 +1161,37 @@ function buildIssueViewComponents(
 
   const isOpen = issue.state === "open";
   const stateButton = isOpen
-    ? new ButtonBuilder()
-        .setCustomId(buildTodoCloseViewId(payloadToken, payload.page, issue.number))
-        .setLabel("Close Issue")
-        .setStyle(ButtonStyle.Danger)
-    : new ButtonBuilder()
-        .setCustomId(buildTodoReopenViewId(payloadToken, payload.page, issue.number))
-        .setLabel("Reopen Issue")
-        .setStyle(ButtonStyle.Success);
+    ? buildActionButton({
+        customId: buildTodoCloseViewId(payloadToken, payload.page, issue.number),
+        label: "Close Issue",
+        style: ButtonStyle.Danger,
+      })
+    : buildActionButton({
+        customId: buildTodoReopenViewId(payloadToken, payload.page, issue.number),
+        label: "Reopen Issue",
+        style: ButtonStyle.Success,
+      });
 
   const actionRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(buildTodoCommentButtonId(payloadToken, payload.page, issue.number))
-      .setLabel("Add Comment")
-      .setStyle(ButtonStyle.Primary),
-    new ButtonBuilder()
-      .setCustomId(buildTodoEditViewButtonId(payloadToken, payload.page, issue.number))
-      .setLabel("Edit")
-      .setStyle(ButtonStyle.Secondary),
+    buildActionButton({
+      customId: buildTodoCommentButtonId(payloadToken, payload.page, issue.number),
+      label: "Add Comment",
+      style: ButtonStyle.Primary,
+    }),
+    buildActionButton({
+      customId: buildTodoEditViewButtonId(payloadToken, payload.page, issue.number),
+      label: "Edit",
+      style: ButtonStyle.Secondary,
+    }),
     stateButton,
   );
 
   const backRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(buildTodoListBackId(payloadToken, payload.page))
-      .setLabel("Back")
-      .setStyle(ButtonStyle.Secondary),
+    buildActionButton({
+      customId: buildTodoListBackId(payloadToken, payload.page),
+      label: "Back",
+      style: ButtonStyle.Secondary,
+    }),
   );
 
   return { components: [container, actionRow, backRow] };
@@ -1543,10 +1551,11 @@ export class TodoCommand {
     const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
 
     const cancelRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setCustomId(buildTodoCloseCancelId(parsed.payloadToken, parsed.page))
-        .setLabel("Cancel")
-        .setStyle(ButtonStyle.Secondary),
+      buildActionButton({
+        customId: buildTodoCloseCancelId(parsed.payloadToken, parsed.page),
+        label: "Cancel",
+        style: ButtonStyle.Secondary,
+      }),
     );
 
     await safeReply(

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -51,15 +51,25 @@ const ACTION_DEFAULTS: Record<ButtonAction, { label: string; style: ButtonStyle 
 };
 
 export function buildActionButton(
-  action: ButtonAction,
-  customId: string,
+  action: ButtonAction, customId: string, label?: string): ButtonBuilder;
+export function buildActionButton(
+  opts: { customId: string; label: string; style: ButtonStyle }): ButtonBuilder;
+export function buildActionButton(
+  actionOrOpts: ButtonAction | { customId: string; label: string; style: ButtonStyle },
+  customId?: string,
   label?: string,
 ): ButtonBuilder {
-  const d = ACTION_DEFAULTS[action];
+  if (typeof actionOrOpts === "string") {
+    const d = ACTION_DEFAULTS[actionOrOpts];
+    return new ButtonBuilder()
+      .setCustomId(customId!)
+      .setLabel(label ?? d.label)
+      .setStyle(d.style);
+  }
   return new ButtonBuilder()
-    .setCustomId(customId)
-    .setLabel(label ?? d.label)
-    .setStyle(d.style);
+    .setCustomId(actionOrOpts.customId)
+    .setLabel(actionOrOpts.label)
+    .setStyle(actionOrOpts.style);
 }
 import {
   getUserEmojiString,

--- a/src/services/BackblazeB2Service.ts
+++ b/src/services/BackblazeB2Service.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import crypto from "node:crypto";
 import { sleep } from "../utilities/DelayUtils.js";
+import { logWarn } from "../utilities/LogUtils.js";
 
 const BACKBLAZE_AUTH_URL = "https://api.backblazeb2.com/b2api/v2/b2_authorize_account";
 
@@ -97,10 +98,7 @@ async function withRetry<T>(fn: () => Promise<T>, label: string): Promise<T> {
       lastError = error;
       if (!isTransientError(error) || attempt === RETRY_MAX_ATTEMPTS) throw error;
       const delay = RETRY_BASE_DELAY_MS * Math.pow(2, attempt - 1);
-      console.warn(
-        `[Backblaze] ${label} failed (attempt ${attempt}/${RETRY_MAX_ATTEMPTS}), ` +
-        `retrying in ${delay}ms...`,
-      );
+      logWarn("BackblazeB2Service.retry", `${label} failed (attempt ${attempt}/${RETRY_MAX_ATTEMPTS}), retrying in ${delay}ms...`);
       await sleep(delay);
     }
   }

--- a/src/services/GameReleaseAnnouncementService.ts
+++ b/src/services/GameReleaseAnnouncementService.ts
@@ -9,7 +9,7 @@ import { NEW_GAME_ANNOUNCEMENT_CHANNEL_ID } from "../config/channels.js";
 import { buildGameProfileMessagePayload } from "../commands/gamedb.command.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { resolveAssetPath } from "../functions/AssetPath.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 
 const CHECK_INTERVAL_MS = 60_000;
 const BATCH_SIZE = 25;
@@ -61,9 +61,7 @@ async function checkAndSendReleaseAnnouncements(client: Client): Promise<void> {
 
   const channel = await fetchGameNewsChannel(client);
   if (!channel) {
-    console.warn(
-      `[GameReleaseAnnouncementService] Game news channel ${NEW_GAME_ANNOUNCEMENT_CHANNEL_ID} is unavailable.`,
-    );
+    logWarn("GameReleaseAnnouncementService.announceRelease", `Game news channel ${NEW_GAME_ANNOUNCEMENT_CHANNEL_ID} is unavailable.`);
     return;
   }
 
@@ -75,9 +73,7 @@ async function checkAndSendReleaseAnnouncements(client: Client): Promise<void> {
         prefaceText: buildAnnouncementPreface(candidate),
       });
       if (!payload) {
-        console.warn(
-          `[GameReleaseAnnouncementService] Missing GameDB profile for release ${candidate.releaseId}.`,
-        );
+        logWarn("GameReleaseAnnouncementService.announceRelease", `Missing GameDB profile for release ${candidate.releaseId}.`);
         continue;
       }
       await channel.send({

--- a/src/services/GiveawayHubService.ts
+++ b/src/services/GiveawayHubService.ts
@@ -10,7 +10,7 @@ import { countAvailableGameKeys, listAvailableGameKeys } from "../classes/GameKe
 import { GIVEAWAY_HUB_CHANNEL_ID } from "../config/channels.js";
 import { buildPageFooterText } from "../functions/PaginationUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 const GIVEAWAY_HUB_SCAN_LIMIT = 50;
 
 export const KEYS_PAGE_SIZE = 20;
@@ -322,9 +322,7 @@ export async function refreshGiveawayHubMessage(
     });
   const textChannel = channel?.isTextBased() ? channel : null;
   if (!textChannel) {
-    console.warn(
-      `Giveaway hub channel ${GIVEAWAY_HUB_CHANNEL_ID} not found or not text-based.`,
-    );
+    logWarn("GiveawayHubService.updateHub", `Giveaway hub channel ${GIVEAWAY_HUB_CHANNEL_ID} not found or not text-based.`);
     return;
   }
 
@@ -332,7 +330,7 @@ export async function refreshGiveawayHubMessage(
   const shouldRecreate = options?.forceRecreate ?? false;
   if (shouldRecreate) {
     if (!("send" in textChannel)) {
-      console.warn("Giveaway hub channel does not support send.");
+      logWarn("GiveawayHubService.updateHub", "Giveaway hub channel does not support send.");
       return;
     }
     await deleteAllGiveawayHubMessages(textChannel);

--- a/src/services/IGDB/IgdbScanService.ts
+++ b/src/services/IGDB/IgdbScanService.ts
@@ -3,7 +3,7 @@ import { oraWithConnection } from "../../db/SqlManager.js";
 import Game from "../../classes/Game.js";
 import { igdbService } from "./IgdbService.js";
 import { sleep } from "../../utilities/DelayUtils.js";
-import { logError } from "../../utilities/LogUtils.js";
+import { logError, logWarn } from "../../utilities/LogUtils.js";
 
 type IgdbScanConfig = {
   enabled: boolean;
@@ -99,7 +99,7 @@ export async function igdbScanTick(): Promise<void> {
   const config = getScanConfig();
   if (!config.enabled) return;
   if (!hasIgdbConfig()) {
-    console.warn("[IGDB Scan] IGDB credentials not configured; skipping scan.");
+    logWarn("IgdbScanService.tick", "IGDB credentials not configured; skipping scan.");
     return;
   }
 
@@ -130,10 +130,7 @@ export async function igdbScanTick(): Promise<void> {
         try {
           const details = await igdbService.getGameDetails(candidate.igdbId);
           if (!details) {
-            console.warn(
-              `[IGDB Scan] No IGDB details returned for ${candidate.title}` +
-              ` (ID: ${candidate.gameId}).`,
-            );
+            logWarn("IgdbScanService.refreshCandidate", `No IGDB details returned for ${candidate.title} (ID: ${candidate.gameId}).`);
             await Game.touchGameUpdatedAt(candidate.gameId);
             continue;
           }
@@ -191,7 +188,7 @@ export function startIgdbScanService(): void {
   let isRunning = false;
   const tick = async () => {
     if (isRunning) {
-      console.warn("[IGDB Scan] Previous scan still running; skipping.");
+      logWarn("IgdbScanService.tick", "Previous scan still running; skipping.");
       return;
     }
     isRunning = true;

--- a/src/services/IGDB/IgdbService.ts
+++ b/src/services/IGDB/IgdbService.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { logError } from "../../utilities/LogUtils.js";
+import { logError, logWarn } from "../../utilities/LogUtils.js";
 
 interface ITwitchAuthResponse {
   access_token: string;
@@ -267,7 +267,7 @@ class IgdbService {
           const releases = await this.fetchReleaseDates(igdbId, token);
           details.release_dates = releases;
         } catch (err) {
-          console.warn("IGDB: Failed to fetch release_dates via fallback endpoint:", err);
+          logWarn("IgdbService.getGameDetails", `Failed to fetch release_dates via fallback endpoint: ${err}`);
         }
       }
 

--- a/src/services/NominationReminderService.ts
+++ b/src/services/NominationReminderService.ts
@@ -3,7 +3,7 @@ import type { Client } from "discordx";
 import { DateTime } from "luxon";
 import BotVotingInfo, { type IBotVotingInfoEntry } from "../classes/BotVotingInfo.js";
 import { NOMINATION_DISCUSSION_CHANNEL_IDS } from "../config/nominationChannels.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 
 const CHECK_INTERVAL_MS = 60_000;
 const REMINDER_ZONE = "America/New_York";
@@ -118,7 +118,7 @@ async function sendReminderToAllChannels(client: Client, content: string): Promi
     try {
       const channel = await client.channels.fetch(channelId);
       if (!channel) {
-        console.warn(`Nomination reminder skipped channel ${channelId}: not found.`);
+        logWarn("NominationReminderService.sendReminder", `Skipped channel ${channelId}: not found.`);
         continue;
       }
 
@@ -127,7 +127,7 @@ async function sendReminderToAllChannels(client: Client, content: string): Promi
         : null;
 
       if (!textChannel || !isSendableTextChannel(textChannel)) {
-        console.warn(`Nomination reminder skipped channel ${channelId}: not text-based or cannot send.`);
+        logWarn("NominationReminderService.sendReminder", `Skipped channel ${channelId}: not text-based or cannot send.`);
         continue;
       }
 

--- a/src/services/ReminderService.ts
+++ b/src/services/ReminderService.ts
@@ -5,7 +5,7 @@ import {
   buildReminderButtons,
   buildReminderMessage,
 } from "../functions/ReminderUi.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 
 const CHECK_INTERVAL_MS = 60_000;
 const MAX_REMINDERS_PER_CYCLE = 25;
@@ -77,7 +77,7 @@ async function deliverReminder(
     
     // If we've failed 5 times, mark it as sent so it stops retrying forever.
     if (reminder.failureCount + 1 >= 5) {
-      console.warn(`Reminder ${reminder.reminderId} reached max failures. Disabling.`);
+      logWarn("ReminderService.deliverReminder", `Reminder ${reminder.reminderId} reached max failures. Disabling.`);
       await Reminder.markFailedPermanently(reminder.reminderId);
     }
   }

--- a/src/services/RssFeedService.ts
+++ b/src/services/RssFeedService.ts
@@ -11,7 +11,7 @@ import {
   type IRssFeedItem,
   type IRssFeed,
 } from "../classes/RssFeed.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 
 const POLL_INTERVAL_MS: number = 5 * 60 * 1000;
 const ERROR_LOG_COOLDOWN = 60 * 60 * 1000; // 1 hour
@@ -110,11 +110,11 @@ async function processFeed(
   try {
     const channel = await client.channels.fetch(feed.channelId).catch(() => null);
     if (!channel) {
-      console.warn(`[RSS] Channel ${feed.channelId} not found for feed #${feed.feedId}`);
+      logWarn("RssFeedService.processChannel", `Channel ${feed.channelId} not found for feed #${feed.feedId}`);
       return;
     }
     if (!(typeof (channel as any).isTextBased === "function" && (channel as any).isTextBased())) {
-      console.warn(`[RSS] Channel ${feed.channelId} is not text-based for feed #${feed.feedId}`);
+      logWarn("RssFeedService.processChannel", `Channel ${feed.channelId} is not text-based for feed #${feed.feedId}`);
       return;
     }
 
@@ -140,7 +140,7 @@ export function startRssFeedService(client: Client): void {
 
   const tick = async () => {
     if (isPolling) {
-      console.warn("[RSS] Previous poll still running, skipping this cycle.");
+      logWarn("RssFeedService.tick", "Previous poll still running, skipping this cycle.");
       return;
     }
     isPolling = true;

--- a/src/services/ThreadLinkPromptService.ts
+++ b/src/services/ThreadLinkPromptService.ts
@@ -33,7 +33,7 @@ import { COLOR_BLUE_INFO } from "../config/colors.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 
 function hasIgdbConfig(): boolean {
   return Boolean(process.env.IGDB_CLIENT_ID && process.env.IGDB_CLIENT_SECRET);
@@ -249,9 +249,7 @@ export class ThreadLinkButtonHandlers {
 
 export function startThreadLinkPromptService(client: Client): void {
   if (!hasIgdbConfig()) {
-    console.warn(
-      "[ThreadLinkPrompt] IGDB_CLIENT_ID/SECRET not set; skipping thread link prompts.",
-    );
+    logWarn("ThreadLinkPromptService.start", "IGDB_CLIENT_ID/SECRET not set; skipping thread link prompts.");
   }
 
   client.on("threadCreate", async (thread) => {

--- a/src/services/ThreadSyncService.ts
+++ b/src/services/ThreadSyncService.ts
@@ -6,7 +6,7 @@ import type {
 } from "discord.js";
 import { upsertThreadRecord } from "../classes/Thread.js";
 import { NOW_PLAYING_FORUM_ID } from "../config/channels.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 const DEFAULT_SYNC_INTERVAL_MS = 10 * 60 * 1000;
 
 function isTargetForum(thread: AnyThreadChannel | ThreadChannel | null): boolean {
@@ -36,7 +36,7 @@ async function syncForumThreads(client: Client): Promise<void> {
   try {
     const forum = await client.channels.fetch(NOW_PLAYING_FORUM_ID);
     if (!forum || !("threads" in forum)) {
-      console.warn("[ThreadSync] Forum channel not found or invalid");
+      logWarn("ThreadSyncService.syncForumThreads", "Forum channel not found or invalid.");
       return;
     }
 

--- a/src/utilities/CustomIdUtils.ts
+++ b/src/utilities/CustomIdUtils.ts
@@ -1,4 +1,4 @@
-import { formatStructuredLog } from "./LogUtils.js";
+import { logError } from "./LogUtils.js";
 
 /**
  * Splits a colon-delimited custom ID and returns the segments after the prefix.
@@ -15,7 +15,7 @@ export function parseCustomIdSegments(
 }
 
 export function logUnexpectedCustomId(customId: string): void {
-  console.error(formatStructuredLog({ context: "UnexpectedCustomId", customId }));
+  logError("UnexpectedCustomId", customId);
 }
 
 export function assertCustomIdSegments(

--- a/src/utilities/LogUtils.ts
+++ b/src/utilities/LogUtils.ts
@@ -5,3 +5,7 @@ export function formatStructuredLog(fields: Record<string, unknown>): string {
 export function logError(context: string, error: unknown): void {
   console.error(formatStructuredLog({ context, error }));
 }
+
+export function logWarn(context: string, message: unknown): void {
+  console.warn(formatStructuredLog({ context, message }));
+}


### PR DESCRIPTION
## Summary

- **#651** Replace inline `interaction.user.id !== ownerId` checks with `replyIfNotOwner` in `game-journal.command.ts`, `mp-info.command.ts`, `completion-delete.service.ts`, and `superadmin.command.ts`
- **#652** Delete local `buildComponentsV2Flags` duplicate in `suggestion.command.ts` and import the canonical one from `ComponentsV2Utils.js`; replace `ephemeralFlag` with `buildComponentsV2Flags` in `mp-info.command.ts`
- **#653** Add `logWarn` to `LogUtils.ts` mirroring `logError`; migrate all `console.warn` calls across ~15 files to `logWarn(context, message)`
- **#654** Replace `console.error(formatStructuredLog({...}))` inline patterns with `logError` in `now-playing.command.ts` (10 sites), `collection-view.command.ts` (3 sites), `generate-vote-image.command.ts`, and `CustomIdUtils.ts`; remove now-unused `formatStructuredLog` imports where all uses were covered
- **#655** Add object-form overload `buildActionButton({ customId, label, style })` to `uiComponents.ts`; migrate all raw `ButtonBuilder` chains in `todo.command.ts` (12 chains) and `giveaway.command.ts` (5 chains)

## Test plan

- [ ] TypeScript compiles clean (`npx tsc --noEmit`)
- [ ] ESLint passes with no errors (`npm run lint`)
- [ ] Owner-only interactions in game-journal/mp-info now show "This list isn't for you." instead of silently deferring
- [ ] Warn logs appear as structured JSON via `logWarn`
- [ ] Buttons in `/todo` and `/giveaway` render and function as before

Closes #651, #652, #653, #654, #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)