### PR TITLE
feat: add buildTextSend, buildContainerSend, buildAccentContainer, buildTitledContainer, buildFieldsText helpers

### DIFF
--- a/src/functions/ComponentsV2Utils.ts
+++ b/src/functions/ComponentsV2Utils.ts
@@ -3,6 +3,8 @@ import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
+export type EmbedField = { name: string; value: string };
+
 export function safeV2TextContent(value: string, maxLength: number): string {
   const normalized = value.split("\0").join("").trim();
   if (normalized.length <= maxLength) return normalized;
@@ -31,4 +33,58 @@ export function buildTextReply(
     components: [buildTextContainer(content)],
     flags: buildComponentsV2Flags(isEphemeral),
   };
+}
+
+export function buildTextSend(
+  content: string,
+): { components: ContainerBuilder[]; flags: number } {
+  return {
+    components: [buildTextContainer(content)],
+    flags: COMPONENTS_V2_FLAG,
+  };
+}
+
+export function buildContainerSend(
+  container: ContainerBuilder,
+): { components: ContainerBuilder[]; flags: number } {
+  return {
+    components: [container],
+    flags: COMPONENTS_V2_FLAG,
+  };
+}
+
+export function buildAccentContainer(
+  content: string,
+  color?: number,
+): ContainerBuilder {
+  const container = new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(safeV2TextContent(content, 3500)),
+  );
+  if (color !== undefined) container.setAccentColor(color);
+  return container;
+}
+
+export function buildTitledContainer(
+  title: string,
+  body: string,
+  options?: { color?: number; footer?: string },
+): ContainerBuilder {
+  const container = new ContainerBuilder().addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(
+      safeV2TextContent(`# ${title}\n${body}`, 3500),
+    ),
+  );
+  if (options?.footer) {
+    container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(
+        safeV2TextContent(`-# ${options.footer}`, 1000),
+      ),
+    );
+  }
+  if (options?.color !== undefined) container.setAccentColor(options.color);
+  return container;
+}
+
+export function buildFieldsText(fields: EmbedField[]): string {
+  return fields.map((f) => `**${f.name}**\n${f.value}`).join("\n\n");
 }


### PR DESCRIPTION
## Summary

- Adds `buildTextSend` -- channel.send equivalent of `buildTextReply` (no ephemeral flag)
- Adds `buildContainerSend` -- wraps an arbitrary `ContainerBuilder` for channel sends
- Adds `buildAccentContainer` -- `ContainerBuilder` with optional `setAccentColor` + `TextDisplay`, replacing `setColor`/`setDescription` EmbedBuilder pairs
- Adds `buildTitledContainer` -- `# title\nbody` with optional color and footer, replacing `setTitle`/`setDescription`/`setColor`/`setFooter` chains
- Adds `buildFieldsText` -- converts `addFields` arrays to `**name**\nvalue` markdown
- Exports `EmbedField` type for use with `buildFieldsText`

All additions are pure with no call-site changes. Downstream migration items in pass 1 depend on these helpers.

## Test plan

- [x] `tsc --noEmit` passes with no errors
- [x] `npm run lint` passes with no warnings

Closes #678

🤖 Generated with [Claude Code](https://claude.com/claude-code)