### PR TITLE
refactor: remove redundant embeds: [] from v2 component replies

### DIFF
--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -508,7 +508,7 @@ export class GameJournalCommand {
       const allComponents = pageRow
         ? [...searchComponents, pageRow]
         : searchComponents;
-      await safeReply(interaction, { embeds: [], components: allComponents, flags: cvFlags });
+      await safeReply(interaction, { components: allComponents, flags: cvFlags });
       return;
     }
 
@@ -529,7 +529,7 @@ export class GameJournalCommand {
       const components = pageRow
         ? [...allContainers, selectRow, pageRow]
         : [...allContainers, selectRow];
-      await safeReply(interaction, { embeds: [], components, flags: cvFlags });
+      await safeReply(interaction, { components, flags: cvFlags });
       return;
     }
 
@@ -553,7 +553,7 @@ export class GameJournalCommand {
       ? [...listComponents, selectRow, pageRow]
       : [...listComponents, selectRow];
 
-    await safeReply(interaction, { embeds: [], components, flags: cvFlags });
+    await safeReply(interaction, { components, flags: cvFlags });
   }
 
   @SelectMenuComponent({ id: new RegExp(`^${GJ_LIST_SELECT_PREFIX}:\\d+:\\d+:\\d+$`) })
@@ -573,7 +573,6 @@ export class GameJournalCommand {
       callerId, targetUserId, gameId, 1, interaction.guildId, isOwner,
     );
     await safeUpdate(interaction, {
-      embeds: [],
       components: payload.components,
       files: payload.files,
       flags: payload.flags,
@@ -612,7 +611,7 @@ export class GameJournalCommand {
     const components = pageRow
       ? [...listComponents, selectRow, pageRow]
       : [...listComponents, selectRow];
-    await safeUpdate(interaction, { embeds: [], components, flags: buildComponentsV2Flags(false) });
+    await safeUpdate(interaction, { components, flags: buildComponentsV2Flags(false) });
   }
 
   @SelectMenuComponent({ id: new RegExp(`^${GJ_ALL_SELECT_PREFIX}:\\d+:\\d+$`) })
@@ -648,7 +647,7 @@ export class GameJournalCommand {
     const components = pageRow
       ? [...listComponents, selectRow, pageRow]
       : [...listComponents, selectRow];
-    await safeUpdate(interaction, { embeds: [], components, flags: buildComponentsV2Flags(false) });
+    await safeUpdate(interaction, { components, flags: buildComponentsV2Flags(false) });
   }
 
   @ButtonComponent({ id: new RegExp(`^${GJ_ALL_PAGE_PREFIX}:\\d+:\\d+$`) })
@@ -672,7 +671,7 @@ export class GameJournalCommand {
     const components = pageRow
       ? [...allContainers, selectRow, pageRow]
       : [...allContainers, selectRow];
-    await safeUpdate(interaction, { embeds: [], components, flags: buildComponentsV2Flags(false) });
+    await safeUpdate(interaction, { components, flags: buildComponentsV2Flags(false) });
   }
 
   @ButtonComponent({ id: new RegExp(`^${GJ_SEARCH_PAGE_PREFIX}:\\d+:\\d+:\\d+:\\d+:.+$`) })
@@ -732,8 +731,9 @@ export class GameJournalCommand {
     const allComponents = nextPageRow
       ? [...searchComponents, nextPageRow]
       : searchComponents;
-    await safeUpdate(interaction, { 
-      embeds: [], components: allComponents, flags: buildComponentsV2Flags(false) });
+    await safeUpdate(interaction, {
+      components: allComponents, flags: buildComponentsV2Flags(false),
+    });
   }
 
   @ButtonComponent({ id: new RegExp(`^${GJ_VIEW_PAGE_PREFIX}:\\d+:\\d+:\\d+:\\d+$`) })

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -601,7 +601,6 @@ export async function showGameProfile(
   }
 
   await safeReply(interaction, {
-    embeds: [],
     files: profile.files,
     components,
     flags: buildComponentsV2Flags(false),
@@ -627,7 +626,6 @@ export async function showGameProfileFromNomination(
     ),
   ];
   await safeReply(interaction, {
-    embeds: [],
     files: profile.files,
     components,
     flags: buildComponentsV2Flags(true),
@@ -689,7 +687,6 @@ export async function refreshGameProfileMessage(
   const existingComponents = interaction.message?.components ?? [];
   const searchRows = getSearchRowsFromComponents(existingComponents);
   await safeReply(interaction, {
-    embeds: [],
     files: profile.files,
     components: [...profile.components, ...actionRows, ...searchRows],
     flags: buildComponentsV2Flags(false),

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -396,7 +396,6 @@ export class GameDbSearchCommand {
 
     try {
       await safeReply(interaction, {
-        embeds: [],
         files: profile.files,
         components: [...profile.components, ...actionRows, ...response.components],
         flags: response.flags,

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -139,7 +139,6 @@ export class GameDbViewCommand {
         const searchRows = getSearchRowsFromComponents(existingComponents);
         try {
           await safeUpdate(interaction, {
-            embeds: [],
             files: profile.files,
             components: [...profile.components, ...actionRows, ...searchRows],
             flags: buildComponentsV2Flags(false),

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -362,7 +362,6 @@ export class MultiplayerInfoCommand {
         components: [...result.payload.components, backRow],
         flags: buildComponentsV2Flags(false),
         content: null,
-        embeds: [],
       });
     } catch (err: any) {
       const msg = extractErrorMessage(err);


### PR DESCRIPTION
## Summary

- Removes `embeds: []` from all v2 component replies where `IS_COMPONENTS_V2` flag is set, since Discord ignores the embeds array when that flag is present
- Affected files: `game-journal.command.ts` (8 sites), `gamedb-profile.service.ts` (3 sites), `gamedb-view.command.ts`, `gamedb-search.command.ts`, `mp-info.command.ts`
- Non-v2 replies (giveaway, help, GiveawayHubService, `message.edit()` without v2 flags) intentionally left unchanged -- there `embeds: []` still serves to clear embeds

Closes #679

## Test plan

- [ ] Verify game journal view/list/search interactions still render correctly
- [ ] Verify gamedb profile, view, and search interactions still render correctly
- [ ] Verify mp-info back navigation still renders correctly
- [ ] Confirm no visible behavior change (IS_COMPONENTS_V2 already suppressed embed rendering)

🤖 Generated with [Claude Code](https://claude.com/claude-code)