### PR TITLE
refactor: replace raw COMPONENTS_V2_FLAG usage and deduplicate local flag helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,3 @@ All interactions should use stable identifiers and include the ability to resume
 You are forbidden from using deprecated commands/functions/etc.
 You are forbidden from committing code to git or reverting changes without being asked to do so directly.
 You are forbidden from reading my .env file.
-After completing a task, restate the prompt before your completion message.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,6 @@ All interactions should use stable identifiers and include the ability to resume
 You are forbidden from using deprecated commands/functions/etc.
 You may commit and push code to feature/fix branches without asking permission or prompting the user. You are forbidden from committing directly to main or reverting changes without being asked to do so directly.
 You are forbidden from reading my .env file.
-After completing a task, restate the prompt before your completion message.
 I develop on a laptop, but run the bot on my desktop.  Do not assume anything based on this machine's environment
 Do all coding tasks in branches. When you're finished, open a PR without prompting and link it to me for approval/merging.
 You are forbidden from using emdashes (—)

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -2435,7 +2435,8 @@ export default {
             if (
               current.type === "CallExpression" &&
               current.callee.type === "Identifier" &&
-              current.callee.name === "buildComponentsV2Flags"
+              (current.callee.name === "buildComponentsV2Flags" ||
+                current.callee.name === "buildComponentsV2EditFlags")
             ) {
               return true;
             }

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -28,11 +28,11 @@ import { resolveNowPlayingRemoval } from "./completion-helpers.js";
 import { promptCompletionPlatformSelection } from "./completion-platform.service.js";
 import { completionAddSessions, type CompletionAddContext } from "./completion.types.js";
 import {
+  buildComponentsV2EditFlags,
   buildComponentsV2Flags,
   buildTextContainer,
   buildTextReply,
 } from "../../functions/ComponentsV2Utils.js";
-import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
 import {
@@ -107,12 +107,12 @@ export async function promptIgdbSelection(
     if (isInteractionSettled(interaction)) {
       await safeReply(interaction, {
         components: loadingComponents,
-        flags: COMPONENTS_V2_FLAG,
+        flags: buildComponentsV2EditFlags(),
       });
     } else {
       await safeUpdate(interaction, {
         components: loadingComponents,
-        flags: COMPONENTS_V2_FLAG,
+        flags: buildComponentsV2EditFlags(),
       });
     }
   }
@@ -123,7 +123,7 @@ export async function promptIgdbSelection(
     if (interaction.isMessageComponent()) {
       await safeReply(interaction, {
         components: [buildTextContainer(content)],
-        flags: COMPONENTS_V2_FLAG,
+        flags: buildComponentsV2EditFlags(),
       });
     } else {
       await safeReply(interaction, buildTextReply(content, true));
@@ -151,7 +151,7 @@ export async function promptIgdbSelection(
       }
       await safeReply(sel, {
         components: [buildTextContainer("Importing game details from IGDB...")],
-        flags: COMPONENTS_V2_FLAG,
+        flags: buildComponentsV2EditFlags(),
       });
 
       const imported = await importGameFromIgdb(gameId);
@@ -214,7 +214,7 @@ export async function promptIgdbSelection(
   if (interaction.isMessageComponent()) {
     await safeReply(interaction, {
       components: [buildTextContainer("Found results on IGDB. Please see the new message below.")],
-      flags: COMPONENTS_V2_FLAG,
+      flags: buildComponentsV2EditFlags(),
     });
     await safeReply(interaction, {
       components: [buildTextContainer(content), ...components],

--- a/src/commands/game-completion/completion-delete.service.ts
+++ b/src/commands/game-completion/completion-delete.service.ts
@@ -1,8 +1,7 @@
 import { type StringSelectMenuInteraction } from "discord.js";
 import Member from "../../classes/Member.js";
 import { replyIfNotOwner, safeReply } from "../../functions/InteractionUtils.js";
-import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
-import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
+import { buildComponentsV2EditFlags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
@@ -37,6 +36,6 @@ export async function handleCompletionDeleteMenu(
 
   safeIgnore(interaction.message.edit({
     components: [],
-    flags: COMPONENTS_V2_FLAG,
+    flags: buildComponentsV2EditFlags(),
   }));
 }

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -21,8 +21,11 @@ import {
   resolveGameCompletionPlatformId,
   resolveGameCompletionPlatformLabel,
 } from "./completion-autocomplete.utils.js";
-import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
-import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
+import {
+  buildComponentsV2EditFlags,
+  buildTextReply,
+  safeV2TextContent,
+} from "../../functions/ComponentsV2Utils.js";
 import {
   isInteractionSettled,
   replyIfNotOwner,
@@ -92,7 +95,7 @@ export async function handleCompletionEditDone(interaction: ButtonInteraction): 
         new TextDisplayBuilder().setContent("Edit complete."),
       ),
     ],
-    flags: COMPONENTS_V2_FLAG,
+    flags: buildComponentsV2EditFlags(),
   });
 }
 
@@ -131,7 +134,7 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
         container,
         new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
       ],
-      flags: COMPONENTS_V2_FLAG,
+      flags: buildComponentsV2EditFlags(),
     });
     return;
   }
@@ -151,7 +154,7 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
         new TextDisplayBuilder().setContent(safeV2TextContent(prompt, 1000)),
       ),
     ],
-    flags: COMPONENTS_V2_FLAG,
+    flags: buildComponentsV2EditFlags(),
   });
 
   const channel = interaction.channel;
@@ -288,7 +291,7 @@ export async function handleCompletionTypeSelect(
           new TextDisplayBuilder().setContent("Completion not found."),
         ),
       ],
-      flags: COMPONENTS_V2_FLAG,
+      flags: buildComponentsV2EditFlags(),
     });
     return;
   }
@@ -360,7 +363,7 @@ function buildCompletionEditPrompt(
           new TextDisplayBuilder().setContent("Completion not found."),
         ),
       ],
-      flags: COMPONENTS_V2_FLAG,
+      flags: buildComponentsV2EditFlags(),
     };
   }
 
@@ -426,6 +429,6 @@ function buildCompletionEditPrompt(
       buildButtonRow(...fieldButtons),
       buildButtonRow(...secondaryButtons),
     ],
-    flags: COMPONENTS_V2_FLAG,
+    flags: buildComponentsV2EditFlags(),
   };
 }

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -3,7 +3,6 @@ import {
   StringSelectMenuBuilder,
   ButtonBuilder,
   ButtonStyle,
-  MessageFlags,
   type CommandInteraction,
   type ButtonInteraction,
   type StringSelectMenuInteraction,
@@ -17,9 +16,13 @@ import { COMPLETION_PAGE_SIZE } from "../profile.command.js";
 import { formatDiscordTimestamp, formatTableDate } from "../../functions/DateFormatUtils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { safeReply, safeUpdate } from "../../functions/InteractionUtils.js";
-import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
+import {
+  buildComponentsV2EditFlags,
+  buildComponentsV2Flags,
+  buildTextReply,
+  safeV2TextContent,
+} from "../../functions/ComponentsV2Utils.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
-import { COMPONENTS_V2_FLAG } from "../../config/flags.js";
 import {
   DISCORD_SELECT_LABEL_MAX,
   DISCORD_SELECT_OPTIONS_MAX,
@@ -32,10 +35,6 @@ import {
   buildUserHeaderContainer,
   type IJournalSelectEntry,
 } from "../../functions/uiComponents.js";
-
-function buildCompletionV2Flags(ephemeral: boolean): number {
-  return (ephemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
-}
 
 /**
  * Renders a leaderboard showing all members with completions, optionally filtered by game title
@@ -56,7 +55,7 @@ export async function renderCompletionLeaderboard(
           new TextDisplayBuilder().setContent(safeV2TextContent(text, 1000)),
         ),
       ],
-      flags: buildCompletionV2Flags(ephemeral),
+      flags: buildComponentsV2Flags(ephemeral),
     });
     return;
   }
@@ -96,7 +95,7 @@ export async function renderCompletionLeaderboard(
       container,
       new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
     ],
-    flags: buildCompletionV2Flags(ephemeral),
+    flags: buildComponentsV2Flags(ephemeral),
   });
 }
 
@@ -132,7 +131,7 @@ export async function renderCompletionPage(
           ),
         ),
         ],
-        flags: buildCompletionV2Flags(ephemeral),
+        flags: buildComponentsV2Flags(ephemeral),
       });
       return;
     }
@@ -145,7 +144,7 @@ export async function renderCompletionPage(
           new TextDisplayBuilder().setContent(safeV2TextContent(text, 1000)),
         ),
       ],
-      flags: buildCompletionV2Flags(ephemeral),
+      flags: buildComponentsV2Flags(ephemeral),
     });
     return;
   }
@@ -180,7 +179,7 @@ export async function renderCompletionPage(
       ...(journalSelectRow ? [journalSelectRow] : []),
       ...paginationRows,
     ],
-    flags: buildCompletionV2Flags(ephemeral),
+    flags: buildComponentsV2Flags(ephemeral),
   });
 }
 
@@ -243,11 +242,11 @@ export async function renderSelectionPage(
   const allComponents = [header, ...containers, selectRow, ...paginationRows];
 
   if (interaction.isMessageComponent()) {
-    await safeUpdate(interaction, { components: allComponents, flags: COMPONENTS_V2_FLAG });
+    await safeUpdate(interaction, { components: allComponents, flags: buildComponentsV2EditFlags() });
   } else {
     await safeReply(interaction, {
       components: allComponents,
-      flags: MessageFlags.Ephemeral | COMPONENTS_V2_FLAG,
+      flags: buildComponentsV2Flags(true),
     });
   }
 }

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -242,7 +242,10 @@ export async function renderSelectionPage(
   const allComponents = [header, ...containers, selectRow, ...paginationRows];
 
   if (interaction.isMessageComponent()) {
-    await safeUpdate(interaction, { components: allComponents, flags: buildComponentsV2EditFlags() });
+    await safeUpdate(interaction, {
+      components: allComponents,
+      flags: buildComponentsV2EditFlags(),
+    });
   } else {
     await safeReply(interaction, {
       components: allComponents,

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -77,7 +77,11 @@ import {
   announceCompletion,
   notifyUnknownCompletionPlatform,
 } from "../functions/CompletionHelpers.js";
-import { buildTextReply, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
+import {
+  buildComponentsV2Flags,
+  buildTextReply,
+  safeV2TextContent,
+} from "../functions/ComponentsV2Utils.js";
 import { formatPlatformDisplayName } from "../functions/PlatformDisplay.js";
 import {
   autocompleteGameCompletionPlatform,
@@ -95,7 +99,6 @@ import {
   formatTableDate,
 } from "../functions/DateFormatUtils.js";
 import { parseTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
-import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { STANDARD_PLATFORM_IDS } from "../config/standardPlatforms.js";
 import { composeVoteImage } from "../services/collageGenerator.js";
 import {
@@ -263,10 +266,6 @@ type NowPlayingListComponents = ContainerBuilder[];
 type NowPlayingPayloadComponents = Array<
   ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder>
 >;
-
-function buildComponentsV2Flags(isEphemeral: boolean): number {
-  return (isEphemeral ? MessageFlags.Ephemeral : 0) | COMPONENTS_V2_FLAG;
-}
 
 function buildNowPlayingSortStateToken(entryCount: number): string {
   return Array.from({ length: entryCount }, (_, index) => index.toString(36)).join("");

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -22,8 +22,11 @@ import { formatPlaytimeHours, formatTableDate } from "./DateFormatUtils.js";
 import Game, { type IGame } from "../classes/Game.js";
 import Member from "../classes/Member.js";
 import { ANNOUNCEMENT_CHANNEL_ID, BOT_DEV_CHANNEL_ID } from "../config/channels.js";
-import { COMPONENTS_V2_FLAG } from "../config/flags.js";
-import { buildComponentsV2Flags, buildTextContainer } from "./ComponentsV2Utils.js";
+import {
+  buildComponentsV2EditFlags,
+  buildComponentsV2Flags,
+  buildTextContainer,
+} from "./ComponentsV2Utils.js";
 import { isInteractionSettled, safeReply, safeUpdate, safeUserFetch } from "./InteractionUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError } from "../utilities/LogUtils.js";
@@ -233,7 +236,7 @@ export async function announceCompletion(
     await (channel as any).send({
       files,
       components: [container],
-      flags: COMPONENTS_V2_FLAG,
+      flags: buildComponentsV2EditFlags(),
     });
   } catch (err) {
     logError("CompletionHelpers.announceCompletion", err);

--- a/src/functions/ComponentsV2Utils.ts
+++ b/src/functions/ComponentsV2Utils.ts
@@ -40,7 +40,7 @@ export function buildTextSend(
 ): { components: ContainerBuilder[]; flags: number } {
   return {
     components: [buildTextContainer(content)],
-    flags: COMPONENTS_V2_FLAG,
+    flags: buildComponentsV2EditFlags(),
   };
 }
 
@@ -49,7 +49,7 @@ export function buildContainerSend(
 ): { components: ContainerBuilder[]; flags: number } {
   return {
     components: [container],
-    flags: COMPONENTS_V2_FLAG,
+    flags: buildComponentsV2EditFlags(),
   };
 }
 

--- a/src/functions/ComponentsV2Utils.ts
+++ b/src/functions/ComponentsV2Utils.ts
@@ -1,4 +1,4 @@
-import { MessageFlags } from "discord.js";
+import { MessageFlags, MessageFlagsBitField } from "discord.js";
 import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
@@ -87,4 +87,14 @@ export function buildTitledContainer(
 
 export function buildFieldsText(fields: EmbedField[]): string {
   return fields.map((f) => `**${f.name}**\n${f.value}`).join("\n\n");
+}
+
+export function hasComponentsV2Flag(flags: unknown): boolean {
+  try {
+    const bitfield = new MessageFlagsBitField(flags as any).bitfield;
+    const asBigInt = typeof bitfield === "bigint" ? bitfield : BigInt(bitfield);
+    return (asBigInt & BigInt(COMPONENTS_V2_FLAG)) === BigInt(COMPONENTS_V2_FLAG);
+  } catch {
+    return false;
+  }
 }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -168,7 +168,6 @@ function normalizeOptions(options: any): any {
   return normalizeComponentsV2Payload(restOptions);
 }
 
-
 function normalizeComponentsV2Payload(options: any): any {
   if (!options || typeof options !== "object") {
     return options;

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -12,8 +12,12 @@ import type {
   User,
 } from "discord.js";
 import { BOT_DEV_CHANNEL_ID } from "../config/channels.js";
-import { COMPONENTS_V2_FLAG } from "../config/flags.js";
-import { buildComponentsV2Flags, buildTextReply, safeV2TextContent } from "./ComponentsV2Utils.js";
+import {
+  buildComponentsV2Flags,
+  buildTextReply,
+  hasComponentsV2Flag,
+  safeV2TextContent,
+} from "./ComponentsV2Utils.js";
 
 export type AnyRepliable = RepliableInteraction | CommandInteraction;
 
@@ -164,15 +168,6 @@ function normalizeOptions(options: any): any {
   return normalizeComponentsV2Payload(restOptions);
 }
 
-function hasComponentsV2Flag(flags: unknown): boolean {
-  try {
-    const bitfield = new MessageFlagsBitField(flags as any).bitfield;
-    const asBigInt = typeof bitfield === "bigint" ? bitfield : BigInt(bitfield);
-    return (asBigInt & BigInt(COMPONENTS_V2_FLAG)) === BigInt(COMPONENTS_V2_FLAG);
-  } catch {
-    return false;
-  }
-}
 
 function normalizeComponentsV2Payload(options: any): any {
   if (!options || typeof options !== "object") {

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -14,8 +14,7 @@ import Member, { type ICompletionRecord } from "../classes/Member.js";
 import Game from "../classes/Game.js";
 import Thread from "../classes/Thread.js";
 import { formatTableDate, formatPlaytimeHours } from "./DateFormatUtils.js";
-import { COMPONENTS_V2_FLAG } from "../config/flags.js";
-import { safeV2TextContent } from "./ComponentsV2Utils.js";
+import { buildComponentsV2EditFlags, safeV2TextContent } from "./ComponentsV2Utils.js";
 import { buildActionButton, buildButtonRow, buildUserHeaderContainer } from "./uiComponents.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
@@ -218,6 +217,6 @@ export async function buildJournalView(options: IJournalViewOptions): Promise<{
     components,
     files,
     allowedMentions: { users: [] },
-    flags: COMPONENTS_V2_FLAG,
+    flags: buildComponentsV2EditFlags(),
   };
 }

--- a/src/services/GameReleaseAnnouncementService.ts
+++ b/src/services/GameReleaseAnnouncementService.ts
@@ -7,7 +7,7 @@ import GameReleaseAnnouncement, {
 } from "../classes/GameReleaseAnnouncement.js";
 import { NEW_GAME_ANNOUNCEMENT_CHANNEL_ID } from "../config/channels.js";
 import { buildGameProfileMessagePayload } from "../commands/gamedb.command.js";
-import { COMPONENTS_V2_FLAG } from "../config/flags.js";
+import { buildComponentsV2EditFlags } from "../functions/ComponentsV2Utils.js";
 import { resolveAssetPath } from "../functions/AssetPath.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
 
@@ -82,7 +82,7 @@ async function checkAndSendReleaseAnnouncements(client: Client): Promise<void> {
           new AttachmentBuilder(RELEASE_SPACER_IMAGE_PATH, { name: "force-message-width.png" }),
         ],
         components: payload.components,
-        flags: COMPONENTS_V2_FLAG,
+        flags: buildComponentsV2EditFlags(),
       });
       await GameReleaseAnnouncement.markAnnouncementSent(candidate.releaseId, new Date());
     } catch (err) {

--- a/src/utilities/DiscordConsoleLogger.ts
+++ b/src/utilities/DiscordConsoleLogger.ts
@@ -4,8 +4,7 @@ import type { Client } from "discordx";
 
 import { DISCORD_CONSOLE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { BOT_DEV_PING_USER_ID } from "../config/users.js";
-import { COMPONENTS_V2_FLAG } from "../config/flags.js";
-import { safeV2TextContent } from "../functions/ComponentsV2Utils.js";
+import { buildComponentsV2EditFlags, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import {
   COLOR_INFO,
   COLOR_WARNING,
@@ -149,7 +148,7 @@ async function sendContainerToChannel(
 ): Promise<void> {
   await channel.send({
     components: [container],
-    flags: COMPONENTS_V2_FLAG,
+    flags: buildComponentsV2EditFlags(),
     ...(content ? { content } : {}),
   });
 }


### PR DESCRIPTION
## Summary

* Moved `hasComponentsV2Flag` from `InteractionUtils.ts` into `ComponentsV2Utils.ts` (exported) so `COMPONENTS_V2_FLAG` is only referenced in the allowed files.
* Deleted local `buildComponentsV2Flags` reimplementation in `now-playing.command.ts` and `buildCompletionV2Flags` in `completion-list.service.ts`; both now import the shared helper.
* Replaced all raw `COMPONENTS_V2_FLAG` usages in `completion-add`, `completion-edit`, `completion-delete`, `CompletionHelpers`, `journalView`, `GameReleaseAnnouncementService`, and `DiscordConsoleLogger` with `buildComponentsV2EditFlags()`.
* Updated the custom ESLint rule `require-components-v2-flag-with-v2-components` to accept `buildComponentsV2EditFlags` as a valid Components V2 flag generator.
* Fixed the pre-existing lint issues (line length in `completion-list.service.ts`, extra blank line in `InteractionUtils.ts`).
* Removed the prompt restatement rule from AGENTS.md and CLAUDE.md.

## Test plan

* Type-check passes (`tsc --noEmit` clean).
* Linter passes (`npm run lint` clean).
* Flag behavior unchanged: all edits use `buildComponentsV2EditFlags()`, ephemeral replies use `buildComponentsV2Flags(true/false)`.

Closes #680