### PR TITLE
feat: add open-pr skill to enforce CLAUDE.md PR ceremony

### DIFF
--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: open-pr
+description: Open a pull request following the full CLAUDE.md PR ceremony: lint, build body with one Closes #X per line, create PR, then verify closing-issue linkage. Use when asked to "open a PR", "create PR", or "submit PR for issue #N".
+---
+
+This skill encodes the mandatory PR ceremony from CLAUDE.md. Run it every time a PR needs to be opened — do not skip steps.
+
+## Steps (always run in order)
+
+### 1. Lint
+
+```bash
+npm run lint
+```
+
+If violations are reported, fix them before proceeding. The fixes must be committed to the branch as part of the PR.
+
+### 2. Confirm branch
+
+The PR must be opened from a feature or fix branch, never from `main`. Verify the current branch:
+
+```bash
+git branch --show-current
+```
+
+If on `main`, stop and tell the user.
+
+### 3. Build the PR body
+
+Each issue being closed must get its own `Closes #X` line. Comma-separated closes on a single line are **not** reliably picked up by GitHub.
+
+Format:
+```
+## Summary
+<1-3 bullet points describing what changed and why>
+
+## Test plan
+<bulleted checklist of how to verify the change>
+
+Closes #N
+Closes #M
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+```
+
+Pass the body via HEREDOC to preserve formatting:
+
+```bash
+gh pr create --title "<title>" --body "$(cat <<'EOF'
+## Summary
+- <point 1>
+
+## Test plan
+- [ ] <step>
+
+Closes #N
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+### 4. Verify closing-issue linkage
+
+After the PR is created, capture the PR number from the `gh pr create` output and verify:
+
+```bash
+gh pr view <N> --json closingIssuesReferences
+```
+
+Expected output contains each linked issue number. If an issue is missing, GitHub did not pick up the `Closes` line — check formatting and update the PR body.
+
+Report the linkage result to the user, then give the PR URL.
+
+## Common mistakes to avoid
+
+- Do NOT put multiple issue numbers on one `Closes` line (`Closes #1, #2` is unreliable).
+- Do NOT skip the linkage verification step.
+- Do NOT open the PR before lint passes.
+- Do NOT open a PR from `main`.


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/open-pr/SKILL.md` — a new Claude Code skill that encodes the full PR ceremony required by CLAUDE.md
- Skill enforces: lint must pass first, one `Closes #X` line per issue (not comma-separated), `gh pr create` with HEREDOC body, and post-create linkage verification via `gh pr view <N> --json closingIssuesReferences`

## Test plan
- [ ] Trigger the skill with `/open-pr` and confirm it runs lint before proceeding
- [ ] Open a PR closing two issues and verify each gets its own `Closes #X` line in the body
- [ ] Confirm `gh pr view --json closingIssuesReferences` is run and result is reported

Closes #692

🤖 Generated with [Claude Code](https://claude.com/claude-code)