### PR TITLE
refactor: migrate log-channel EmbedBuilder to v2 containers

### DIFF
--- a/src/events/GuildBanLog.command.ts
+++ b/src/events/GuildBanLog.command.ts
@@ -1,10 +1,15 @@
-import { EmbedBuilder, userMention } from "discord.js";
+import { userMention } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { BAN_LOG_CHANNEL_ID, UNBAN_LOG_CHANNEL_ID } from "../config/channels.js";
 import { buildIdTimestampFooter } from "../functions/InteractionUtils.js";
 import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+  buildFieldsText,
+} from "../functions/ComponentsV2Utils.js";
 
 async function resolveLogChannel(client: Client, channelId: string): Promise<any | null> {
   const channel = await client.channels.fetch(channelId).catch(() => null);
@@ -17,28 +22,21 @@ function formatAccountCreated(date: Date): string {
   return `<t:${Math.floor(date.getTime() / 1000)}:F>`;
 }
 
-function buildBanEmbed(
+function buildBanContainer(
   title: string,
   userId: string,
   username: string,
-  avatarUrl: string | null,
   createdAt: Date,
   color: number,
-): EmbedBuilder {
-  const embed = new EmbedBuilder()
-    .setTitle(title)
-    .setColor(color)
-    .addFields(
-      { name: "User", value: `${userMention(userId)}\n${username}` },
-      { name: "Account Created On", value: formatAccountCreated(createdAt) },
-    )
-    .setFooter({ text: buildIdTimestampFooter(userId, formatTimestampWithDay(Date.now())) });
-
-  if (avatarUrl) {
-    embed.setThumbnail(avatarUrl);
-  }
-
-  return embed;
+) {
+  const body = buildFieldsText([
+    { name: "User", value: `${userMention(userId)}\n${username}` },
+    { name: "Account Created On", value: formatAccountCreated(createdAt) },
+  ]);
+  return buildTitledContainer(title, body, {
+    color,
+    footer: buildIdTimestampFooter(userId, formatTimestampWithDay(Date.now())),
+  });
 }
 
 @Discord()
@@ -52,16 +50,15 @@ export class GuildBanLog {
     if (!logChannel) return;
 
     const username = user.tag ?? user.username ?? user.id;
-    const embed = buildBanEmbed(
+    const container = buildBanContainer(
       "User Banned",
       user.id,
       username,
-      user.displayAvatarURL?.() ?? null,
       user.createdAt ?? new Date(),
       COLOR_ERROR,
     );
 
-    await (logChannel as any).send({ embeds: [embed] });
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -73,15 +70,14 @@ export class GuildBanLog {
     if (!logChannel) return;
 
     const username = user.tag ?? user.username ?? user.id;
-    const embed = buildBanEmbed(
+    const container = buildBanContainer(
       "User Unbanned",
       user.id,
       username,
-      user.displayAvatarURL?.() ?? null,
       user.createdAt ?? new Date(),
       COLOR_INFO,
     );
 
-    await (logChannel as any).send({ embeds: [embed] });
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 }

--- a/src/events/GuildMemberAdd.command.ts
+++ b/src/events/GuildMemberAdd.command.ts
@@ -1,4 +1,4 @@
-import { EmbedBuilder, Role, userMention } from "discord.js";
+import { Role, userMention } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
@@ -6,6 +6,11 @@ import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
 import { COLOR_SUCCESS } from "../config/colors.js";
 import { logError } from "../utilities/LogUtils.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+  buildFieldsText,
+} from "../functions/ComponentsV2Utils.js";
 
 function formatDiscordDateTime(date: Date): string {
   return `<t:${Math.floor(date.getTime() / 1000)}:F>`;
@@ -31,22 +36,16 @@ export class GuildMemberAdd {
       const logChannel = await resolveLogChannel(_client);
       if (logChannel) {
         const username = member.user.tag ?? member.user.username ?? member.user.id;
-        const embed = new EmbedBuilder()
-          .setTitle("User Joined")
-          .setColor(COLOR_SUCCESS)
-          .addFields(
-            { name: "User", value: `${userMention(member.user.id)}\n${username}` },
-            {
-              name: "Account Created On",
-              value: formatDiscordDateTime(member.user.createdAt),
-            },
-          )
-          .setFooter({
-            text: `ID: ${member.user.id} • ${formatTimestampWithDay(Date.now())}`,
-          })
-          .setThumbnail(member.user.displayAvatarURL());
+        const body = buildFieldsText([
+          { name: "User", value: `${userMention(member.user.id)}\n${username}` },
+          { name: "Account Created On", value: formatDiscordDateTime(member.user.createdAt) },
+        ]);
+        const container = buildTitledContainer("User Joined", body, {
+          color: COLOR_SUCCESS,
+          footer: `ID: ${member.user.id} • ${formatTimestampWithDay(Date.now())}`,
+        });
 
-        await (logChannel as any).send({ embeds: [embed] });
+        await (logChannel as any).send({ ...buildContainerSend(container) });
       }
     }
 

--- a/src/events/GuildMemberRemove.command.ts
+++ b/src/events/GuildMemberRemove.command.ts
@@ -1,10 +1,16 @@
-import { AuditLogEvent, EmbedBuilder, userMention } from "discord.js";
+import { AuditLogEvent, userMention } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { COLOR_WARNING, COLOR_NEUTRAL } from "../config/colors.js";
 import { sleep } from "../utilities/DelayUtils.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+  buildFieldsText,
+} from "../functions/ComponentsV2Utils.js";
+
 const KICK_LOG_WINDOW_MS = 30_000;
 const KICK_LOG_RETRY_COUNT = 3;
 const KICK_LOG_RETRY_DELAY_MS = 750;
@@ -66,47 +72,31 @@ export class GuildMemberRemove {
     if (!logChannel) return;
 
     const username = member.user.tag ?? member.user.username ?? member.user.id;
+    const footer = `ID: ${member.user.id} • ${formatTimestampWithDay(Date.now())}`;
     const kickAudit = await getKickAudit(_client, member.guild.id, member.user.id);
     if (kickAudit) {
-      const embed = new EmbedBuilder()
-        .setTitle("User Kicked")
-        .setColor(COLOR_WARNING)
-        .addFields(
-          { name: "User", value: `${userMention(member.user.id)}\n${username}` },
-          {
-            name: "Account Created On",
-            value: formatDiscordDateTime(member.user.createdAt),
-          },
-          { name: "Moderator", value: userMention(kickAudit.moderatorId) },
-          {
-            name: "Reason",
-            value: kickAudit.reason ?? "No reason provided.",
-          },
-        )
-        .setFooter({
-          text: `ID: ${member.user.id} • ${formatTimestampWithDay(Date.now())}`,
-        })
-        .setThumbnail(member.user.displayAvatarURL());
-
-      await (logChannel as any).send({ embeds: [embed] });
+      const body = buildFieldsText([
+        { name: "User", value: `${userMention(member.user.id)}\n${username}` },
+        { name: "Account Created On", value: formatDiscordDateTime(member.user.createdAt) },
+        { name: "Moderator", value: userMention(kickAudit.moderatorId) },
+        { name: "Reason", value: kickAudit.reason ?? "No reason provided." },
+      ]);
+      const container = buildTitledContainer("User Kicked", body, {
+        color: COLOR_WARNING,
+        footer,
+      });
+      await (logChannel as any).send({ ...buildContainerSend(container) });
       return;
     }
 
-    const embed = new EmbedBuilder()
-      .setTitle("User Left")
-      .setColor(COLOR_NEUTRAL)
-      .addFields(
-        { name: "User", value: `${userMention(member.user.id)}\n${username}` },
-        {
-          name: "Account Created On",
-          value: formatDiscordDateTime(member.user.createdAt),
-        },
-      )
-      .setFooter({
-        text: `ID: ${member.user.id} • ${formatTimestampWithDay(Date.now())}`,
-      })
-      .setThumbnail(member.user.displayAvatarURL());
-
-    await (logChannel as any).send({ embeds: [embed] });
+    const body = buildFieldsText([
+      { name: "User", value: `${userMention(member.user.id)}\n${username}` },
+      { name: "Account Created On", value: formatDiscordDateTime(member.user.createdAt) },
+    ]);
+    const container = buildTitledContainer("User Left", body, {
+      color: COLOR_NEUTRAL,
+      footer,
+    });
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 }

--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -1,4 +1,3 @@
-import { EmbedBuilder } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import Member, { type IMemberRecord } from "../classes/Member.js";
@@ -18,6 +17,10 @@ import {
 } from "../config/roles.js";
 import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
 import { buildIdTimestampFooter } from "../functions/InteractionUtils.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+} from "../functions/ComponentsV2Utils.js";
 
 const QUALIFYING_ROLE_IDS_SET = new Set(
   [REGULARS_ROLE_ID, ADMIN_ROLE_ID, MODERATOR_ROLE_ID, MEMBER_ROLE_ID].filter(
@@ -50,7 +53,6 @@ export class GuildMemberUpdate {
     if (!user.bot && (addedRoles.size > 0 || removedRoles.size > 0)) {
       const logChannel = await resolveLogChannel(_client);
       if (logChannel) {
-        const authorName = user.globalName ?? user.username;
         const timestamp = formatTimestampWithDay(Date.now());
         const sendRoleLog = async (
           label: string,
@@ -58,16 +60,11 @@ export class GuildMemberUpdate {
           color: number,
         ): Promise<void> => {
           if (roleId === newMember.guild.id) return;
-          const embed = new EmbedBuilder()
-            .setAuthor({
-              name: authorName,
-              iconURL: user.displayAvatarURL(),
-            })
-            .setTitle(label)
-            .setDescription(`<@&${roleId}>`)
-            .setColor(color)
-            .setFooter({ text: buildIdTimestampFooter(user.id, timestamp) });
-          await (logChannel as any).send({ embeds: [embed] });
+          const container = buildTitledContainer(label, `<@&${roleId}>`, {
+            color,
+            footer: buildIdTimestampFooter(user.id, timestamp),
+          });
+          await (logChannel as any).send({ ...buildContainerSend(container) });
         };
 
         for (const role of addedRoles.values()) {
@@ -108,7 +105,6 @@ export class GuildMemberUpdate {
     if (!user.bot && nicknameChanged) {
       const logChannel = await resolveLogChannel(_client);
       if (logChannel) {
-        const authorName = user.globalName ?? user.username;
         const timestamp = formatTimestampWithDay(Date.now());
         const sendNameLog = async (
           title: string,
@@ -116,16 +112,12 @@ export class GuildMemberUpdate {
           afterValue: string,
           color: number,
         ): Promise<void> => {
-          const embed = new EmbedBuilder()
-            .setAuthor({
-              name: authorName,
-              iconURL: user.displayAvatarURL(),
-            })
-            .setTitle(title)
-            .setDescription(`**Before:** ${beforeValue}\n**+After:** ${afterValue}`)
-            .setColor(color)
-            .setFooter({ text: buildIdTimestampFooter(user.id, timestamp) });
-          await (logChannel as any).send({ embeds: [embed] });
+          const container = buildTitledContainer(
+            title,
+            `**Before:** ${beforeValue}\n**+After:** ${afterValue}`,
+            { color, footer: buildIdTimestampFooter(user.id, timestamp) },
+          );
+          await (logChannel as any).send({ ...buildContainerSend(container) });
         };
 
         const oldNicknameValue =

--- a/src/events/MessageLog.command.ts
+++ b/src/events/MessageLog.command.ts
@@ -1,10 +1,15 @@
-import { channelMention, EmbedBuilder } from "discord.js";
+import { channelMention } from "discord.js";
 import type { Message } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+} from "../functions/ComponentsV2Utils.js";
+
 const MAX_FIELD_LENGTH = 1000;
 const MAX_DESCRIPTION_LENGTH = 3500;
 
@@ -27,30 +32,6 @@ function formatTimestamp(timestamp: number | null | undefined): string {
   return `<t:${unixSeconds}:F>`;
 }
 
-function buildAuthorEmbed(
-  message: Message,
-  title: string,
-  color: number,
-): EmbedBuilder {
-  const embed = new EmbedBuilder()
-    .setTitle(title)
-    .setColor(color);
-
-  if (message.author) {
-    const name = message.author.globalName ?? message.author.username;
-    embed.setAuthor({
-      name,
-      iconURL: message.author.displayAvatarURL(),
-    });
-    embed.setFooter({
-      text: `ID: ${message.author.id} • ${formatTimestamp(message.createdTimestamp)}`,
-    });
-  }
-
-  embed.addFields({ name: "Message ID", value: message.id });
-  return embed;
-}
-
 @Discord()
 export class MessageLog {
   @On()
@@ -62,14 +43,17 @@ export class MessageLog {
     if (!logChannel) return;
 
     const deletedChannelMention = channelMention(resolved.channelId);
-    const embed = buildAuthorEmbed(
-      resolved,
+    const body = truncate(formatMessageContent(resolved));
+    const footer = resolved.author
+      ? `ID: ${resolved.author.id} • ${formatTimestamp(resolved.createdTimestamp)}`
+      : undefined;
+    const container = buildTitledContainer(
       `Message deleted in ${deletedChannelMention}`,
-      COLOR_ERROR,
+      body,
+      { color: COLOR_ERROR, footer },
     );
-    embed.setDescription(truncate(formatMessageContent(resolved)));
 
-    await logChannel.send({ embeds: [embed] });
+    await logChannel.send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -100,24 +84,19 @@ export class MessageLog {
       : null;
     const channelName = (resolvedNew.channel as { name?: string } | null)?.name ?? "channel";
     const channelLabel = `#${channelName}`;
-    const title = "Message edited";
-    const embed = buildAuthorEmbed(
-      resolvedNew,
-      title,
-      COLOR_INFO,
-    );
-    embed.setFields([]);
     const beforeValue = truncate(beforeText || "No text content.");
     const afterValue = truncate(afterText || "No text content.");
     const linkLine = jumpUrl ? `[${channelLabel}](${jumpUrl})` : "";
     const description =
       `**Before:** ${beforeValue}\n**+After:** ${afterValue}` +
       (linkLine ? `\n${linkLine}` : "");
-    embed.setDescription(truncate(description, MAX_DESCRIPTION_LENGTH));
-    embed.setFooter({
-      text: `ID: ${resolvedNew.id} • ${formatTimestampWithDay(resolvedNew.editedTimestamp)}`,
-    });
+    const footer = `ID: ${resolvedNew.id} • ${formatTimestampWithDay(resolvedNew.editedTimestamp)}`;
+    const container = buildTitledContainer(
+      "Message edited",
+      truncate(description, MAX_DESCRIPTION_LENGTH),
+      { color: COLOR_INFO, footer },
+    );
 
-    await logChannel.send({ embeds: [embed] });
+    await logChannel.send({ ...buildContainerSend(container) });
   }
 }

--- a/src/events/ServerChangeLog.command.ts
+++ b/src/events/ServerChangeLog.command.ts
@@ -1,6 +1,5 @@
 import {
   ChannelType,
-  EmbedBuilder,
   PermissionsBitField,
   type GuildChannel,
   type GuildEmoji,
@@ -11,12 +10,13 @@ import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+} from "../functions/ComponentsV2Utils.js";
 
-function buildBaseEmbed(title: string, color = COLOR_INFO): EmbedBuilder {
-  return new EmbedBuilder()
-    .setTitle(title)
-    .setColor(color)
-    .setFooter({ text: formatTimestampWithDay(Date.now()) });
+function buildBaseContainer(title: string, body: string, color = COLOR_INFO) {
+  return buildTitledContainer(title, body, { color, footer: formatTimestampWithDay(Date.now()) });
 }
 
 function isGuildChannel(channel: any): channel is GuildChannel {
@@ -60,10 +60,11 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Channel created");
-    embed.setDescription(`${channelLabel(channel)} (${channel.id})`);
-
-    await (logChannel as any).send({ embeds: [embed] });
+    const container = buildBaseContainer(
+      "Channel created",
+      `${channelLabel(channel)} (${channel.id})`,
+    );
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -72,10 +73,12 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Channel deleted", COLOR_ERROR);
-    embed.setDescription(`${channel.name ?? channel.id} (${channel.id})`);
-
-    await (logChannel as any).send({ embeds: [embed] });
+    const container = buildBaseContainer(
+      "Channel deleted",
+      `${channel.name ?? channel.id} (${channel.id})`,
+      COLOR_ERROR,
+    );
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -113,9 +116,9 @@ export class ServerChangeLog {
     const filtered = changes.filter((line) => line);
     if (!filtered.length) return;
 
-    const embed = buildBaseEmbed("Channel updated");
-    embed.setDescription(`${channelLabel(newChannel)} (${newChannel.id})\n${filtered.join("\n")}`);
-    await (logChannel as any).send({ embeds: [embed] });
+    const body = `${channelLabel(newChannel)} (${newChannel.id})\n${filtered.join("\n")}`;
+    const container = buildBaseContainer("Channel updated", body);
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -124,9 +127,8 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Role created");
-    embed.setDescription(`${roleLabel(role)} (${role.id})`);
-    await (logChannel as any).send({ embeds: [embed] });
+    const container = buildBaseContainer("Role created", `${roleLabel(role)} (${role.id})`);
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -135,9 +137,12 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Role deleted", COLOR_ERROR);
-    embed.setDescription(`${role.name ?? role.id} (${role.id})`);
-    await (logChannel as any).send({ embeds: [embed] });
+    const container = buildBaseContainer(
+      "Role deleted",
+      `${role.name ?? role.id} (${role.id})`,
+      COLOR_ERROR,
+    );
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -150,14 +155,18 @@ export class ServerChangeLog {
     changes.push(diffLines("Name", oldRole.name ?? null, newRole.name ?? null) ?? "");
     changes.push(diffLines("Color", String(oldRole.color), String(newRole.color)) ?? "");
     changes.push(diffLines("Hoist", String(oldRole.hoist), String(newRole.hoist)) ?? "");
-    changes.push(diffLines("Mentionable", String(oldRole.mentionable), String(newRole.mentionable)) ?? "");
-    changes.push(diffLines("Permissions", formatPermissions(oldRole), formatPermissions(newRole)) ?? "");
+    changes.push(
+      diffLines("Mentionable", String(oldRole.mentionable), String(newRole.mentionable)) ?? "",
+    );
+    changes.push(
+      diffLines("Permissions", formatPermissions(oldRole), formatPermissions(newRole)) ?? "",
+    );
     const filtered = changes.filter((line) => line);
     if (!filtered.length) return;
 
-    const embed = buildBaseEmbed("Role updated");
-    embed.setDescription(`${roleLabel(newRole)} (${newRole.id})\n${filtered.join("\n")}`);
-    await (logChannel as any).send({ embeds: [embed] });
+    const body = `${roleLabel(newRole)} (${newRole.id})\n${filtered.join("\n")}`;
+    const container = buildBaseContainer("Role updated", body);
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -165,9 +174,8 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Emoji created");
-    embed.setDescription(`${emojiLabel(emoji)} (${emoji.id})`);
-    await (logChannel as any).send({ embeds: [embed] });
+    const container = buildBaseContainer("Emoji created", `${emojiLabel(emoji)} (${emoji.id})`);
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -175,9 +183,12 @@ export class ServerChangeLog {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const embed = buildBaseEmbed("Emoji deleted", COLOR_ERROR);
-    embed.setDescription(`${emoji.name ?? "emoji"} (${emoji.id})`);
-    await (logChannel as any).send({ embeds: [embed] });
+    const container = buildBaseContainer(
+      "Emoji deleted",
+      `${emoji.name ?? "emoji"} (${emoji.id})`,
+      COLOR_ERROR,
+    );
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -190,14 +201,18 @@ export class ServerChangeLog {
 
     const changes: string[] = [];
     changes.push(diffLines("Name", oldEmoji.name ?? null, newEmoji.name ?? null) ?? "");
-    changes.push(diffLines("Animated", String(oldEmoji.animated), String(newEmoji.animated)) ?? "");
-    changes.push(diffLines("Available", String(oldEmoji.available), String(newEmoji.available)) ?? "");
+    changes.push(
+      diffLines("Animated", String(oldEmoji.animated), String(newEmoji.animated)) ?? "",
+    );
+    changes.push(
+      diffLines("Available", String(oldEmoji.available), String(newEmoji.available)) ?? "",
+    );
     const filtered = changes.filter((line) => line);
     if (!filtered.length) return;
 
-    const embed = buildBaseEmbed("Emoji updated");
-    embed.setDescription(`${emojiLabel(newEmoji)} (${newEmoji.id})\n${filtered.join("\n")}`);
-    await (logChannel as any).send({ embeds: [embed] });
+    const body = `${emojiLabel(newEmoji)} (${newEmoji.id})\n${filtered.join("\n")}`;
+    const container = buildBaseContainer("Emoji updated", body);
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 
   @On()
@@ -207,8 +222,12 @@ export class ServerChangeLog {
 
     const changes: string[] = [];
     changes.push(diffLines("Name", oldGuild.name ?? null, newGuild.name ?? null) ?? "");
-    changes.push(diffLines("Description", oldGuild.description ?? null, newGuild.description ?? null) ?? "");
-    changes.push(diffLines("Locale", oldGuild.preferredLocale ?? null, newGuild.preferredLocale ?? null) ?? "");
+    changes.push(
+      diffLines("Description", oldGuild.description ?? null, newGuild.description ?? null) ?? "",
+    );
+    changes.push(
+      diffLines("Locale", oldGuild.preferredLocale ?? null, newGuild.preferredLocale ?? null) ?? "",
+    );
     const oldIcon = oldGuild.iconURL({ size: 128, extension: "png" }) ?? null;
     const newIcon = newGuild.iconURL({ size: 128, extension: "png" }) ?? null;
     changes.push(diffLines("Icon", oldIcon, newIcon) ?? "");
@@ -219,8 +238,8 @@ export class ServerChangeLog {
     const filtered = changes.filter((line) => line);
     if (!filtered.length) return;
 
-    const embed = buildBaseEmbed("Server updated");
-    embed.setDescription(`${newGuild.name ?? newGuild.id}\n${filtered.join("\n")}`);
-    await (logChannel as any).send({ embeds: [embed] });
+    const body = `${newGuild.name ?? newGuild.id}\n${filtered.join("\n")}`;
+    const container = buildBaseContainer("Server updated", body);
+    await (logChannel as any).send({ ...buildContainerSend(container) });
   }
 }

--- a/src/events/Starboard.command.ts
+++ b/src/events/Starboard.command.ts
@@ -1,12 +1,16 @@
-import { EmbedBuilder } from "discord.js";
 import { COLOR_DARK } from "../config/colors.js";
 import type { Message, MessageReaction, PartialMessageReaction } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
+import { MediaGalleryBuilder, MediaGalleryItemBuilder } from "@discordjs/builders";
 import Starboard from "../classes/Starboard.js";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { QUOTABLES_CHANNEL_ID } from "../config/channels.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+} from "../functions/ComponentsV2Utils.js";
 
 const STAR_EMOJI = "⭐";
 const STAR_EMOJI_NAME = "star";
@@ -76,23 +80,20 @@ export class StarboardHandler {
     const imageUrl = getImageUrl(message);
     const channelName = (message.channel as { name?: string } | null)?.name ?? "channel";
     const channelLabel = `#${channelName}`;
-    const embed = new EmbedBuilder()
-      .setAuthor({
-        name: message.author.globalName ?? message.author.username,
-        iconURL: message.author.displayAvatarURL(),
-      })
-      .setDescription(content)
-      .addFields({ name: "Source", value: `[${channelLabel}](${message.url})` })
-      .setFooter({
-        text: `${message.id} • ${formatTimestampWithDay(message.createdTimestamp)}`,
-      })
-      .setColor(COLOR_DARK);
+    const authorName = message.author.globalName ?? message.author.username;
+    const body = `${content}\n\n**Source:** [${channelLabel}](${message.url})`;
+    const container = buildTitledContainer(authorName, body, {
+      color: COLOR_DARK,
+      footer: `${message.id} • ${formatTimestampWithDay(message.createdTimestamp)}`,
+    });
 
     if (imageUrl) {
-      embed.setImage(imageUrl);
+      container.addMediaGalleryComponents(
+        new MediaGalleryBuilder().addItems(new MediaGalleryItemBuilder().setURL(imageUrl)),
+      );
     }
 
-    const posted = await quotablesChannel.send({ embeds: [embed] });
+    const posted = await quotablesChannel.send({ ...buildContainerSend(container) });
     await Starboard.insert({
       messageId: message.id,
       channelId: message.channelId,

--- a/src/events/ThreadCreated.command.ts
+++ b/src/events/ThreadCreated.command.ts
@@ -1,12 +1,17 @@
-import { EmbedBuilder, ChannelType, type ForumChannel, type TextChannel } from "discord.js";
+import { ChannelType, type ForumChannel, type TextChannel } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
+import { MediaGalleryBuilder, MediaGalleryItemBuilder } from "@discordjs/builders";
 import { joinThreadIfTarget } from "../services/ForumThreadJoinService.js";
 import { NOW_PLAYING_FORUM_ID, WHATCHA_PLAYING_CHANNEL_ID } from "../config/channels.js";
 import { COLOR_PRIMARY } from "../config/colors.js";
 import { sleep } from "../utilities/DelayUtils.js";
 import { DISCORD_EMBED_FIELD_VALUE_MAX } from "../config/textLimits.js";
 import { logError } from "../utilities/LogUtils.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+} from "../functions/ComponentsV2Utils.js";
 
 @Discord()
 export class ThreadCreated {
@@ -23,7 +28,6 @@ export class ThreadCreated {
       await sleep(10_000);
       // Resolve thread author (prefer starter message author; fallback to thread.ownerId)
       let authorName: string = 'Unknown';
-      let authorIconUrl: string | undefined;
       let authorProfileUrl: string | undefined;
       let imageUrl: string | undefined;
 
@@ -31,7 +35,6 @@ export class ThreadCreated {
         const starter = await thread.fetchStarterMessage();
         if (starter) {
           authorName = starter.member?.displayName ?? starter.author.username;
-          authorIconUrl = starter.author.displayAvatarURL();
           authorProfileUrl = `https://discord.com/users/${starter.author.id}`;
 
           // try attachments first
@@ -121,7 +124,6 @@ export class ThreadCreated {
           const ownerUser = await client.users.fetch(thread.ownerId);
           if (ownerUser) {
             authorName = ownerUser.username;
-            authorIconUrl = ownerUser.displayAvatarURL();
             authorProfileUrl = `https://discord.com/users/${ownerUser.id}`;
           }
         } catch {
@@ -129,21 +131,14 @@ export class ThreadCreated {
         }
       }
 
-      const nowPlayingEmbed = new EmbedBuilder()
-        .setColor(COLOR_PRIMARY)
-        .setTitle(`${thread.name}`)
-        .setURL(`https://discord.com/channels/${thread.guildId}/${thread.id}`)
-        .setDescription(`New "Now Playing" Forum Post`)
-        .setAuthor({
-          name: authorName,
-          iconURL: authorIconUrl,
-          url: authorProfileUrl,
-        });
-      if (imageUrl) {
-        nowPlayingEmbed.setImage(imageUrl);
-      }
+      const threadUrl = `https://discord.com/channels/${thread.guildId}/${thread.id}`;
+      const authorLink = authorProfileUrl ? `[${authorName}](${authorProfileUrl})` : authorName;
+      const bodyParts: string[] = [
+        `New "Now Playing" Forum Post ([link](${threadUrl}))`,
+        `Posted by ${authorLink}`,
+      ];
 
-      // Add forum thread tag names as fields (if any)
+      // Add forum thread tag names (if any)
       try {
         if (thread.appliedTags && thread.appliedTags.length && thread.parentId) {
           const parent = await client.channels.fetch(thread.parentId);
@@ -153,11 +148,10 @@ export class ThreadCreated {
               .map((id) => forum.availableTags.find((t) => t.id === id)?.name)
               .filter((n): n is string => Boolean(n));
             if (tagNames.length) {
-              nowPlayingEmbed.addFields({
-                name: tagNames.length > 1 ? 'Tags' : 'Tag',
-                value: tagNames.join(', ').slice(0, DISCORD_EMBED_FIELD_VALUE_MAX),
-                inline: false,
-              });
+              const label = tagNames.length > 1 ? 'Tags' : 'Tag';
+              bodyParts.push(
+                `**${label}:** ${tagNames.join(', ').slice(0, DISCORD_EMBED_FIELD_VALUE_MAX)}`,
+              );
             }
           }
         }
@@ -165,10 +159,22 @@ export class ThreadCreated {
         logError("ThreadCreated.resolveForumTagNames", err);
       }
 
+      const container = buildTitledContainer(
+        thread.name,
+        bodyParts.join("\n"),
+        { color: COLOR_PRIMARY },
+      );
+
+      if (imageUrl) {
+        container.addMediaGalleryComponents(
+          new MediaGalleryBuilder().addItems(new MediaGalleryItemBuilder().setURL(imageUrl)),
+        );
+      }
+
       const channel = await client.channels.fetch(WHATCHA_PLAYING_CHANNEL_ID);
       if (channel && channel.isTextBased()) {
         try {
-          await (channel as TextChannel).send({ embeds: [nowPlayingEmbed] });
+          await (channel as TextChannel).send({ ...buildContainerSend(container) });
         } catch (err) {
           logError("ThreadCreated.sendNowPlayingEmbed", err);
         }

--- a/src/events/UserUpdate.command.ts
+++ b/src/events/UserUpdate.command.ts
@@ -1,10 +1,13 @@
-import { EmbedBuilder } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
 import { formatTimestampWithDay, resolveLogChannel } from "../utilities/DiscordLogUtils.js";
 import { logAvatarChange, updateAvatarRecordFromUrl } from "../utilities/AvatarLogUtils.js";
 import { syncUserEmojiFromAvatarChange } from "../services/UserEmojiService.js";
 import { COLOR_INFO } from "../config/colors.js";
+import {
+  buildTitledContainer,
+  buildContainerSend,
+} from "../functions/ComponentsV2Utils.js";
 
 @Discord()
 export class UserUpdate {
@@ -50,7 +53,6 @@ export class UserUpdate {
     const logChannel = await resolveLogChannel(client);
     if (!logChannel) return;
 
-    const authorName = newUser.globalName ?? newUser.username;
     const timestamp = formatTimestampWithDay(Date.now());
 
     const sendNameLog = async (
@@ -58,16 +60,12 @@ export class UserUpdate {
       beforeValue: string,
       afterValue: string,
     ): Promise<void> => {
-      const embed = new EmbedBuilder()
-        .setAuthor({
-          name: authorName,
-          iconURL: newUser.displayAvatarURL(),
-        })
-        .setTitle(title)
-        .setDescription(`**Before:** ${beforeValue}\n**+After:** ${afterValue}`)
-        .setColor(COLOR_INFO)
-        .setFooter({ text: `ID: ${newUser.id} • ${timestamp}` });
-      await (logChannel as any).send({ embeds: [embed] });
+      const container = buildTitledContainer(
+        title,
+        `**Before:** ${beforeValue}\n**+After:** ${afterValue}`,
+        { color: COLOR_INFO, footer: `ID: ${newUser.id} • ${timestamp}` },
+      );
+      await (logChannel as any).send({ ...buildContainerSend(container) });
     };
 
     if (usernameChanged) {


### PR DESCRIPTION
## Summary
- Replaces all 11 `new EmbedBuilder()` calls across 7 event files with `buildTitledContainer` / `buildContainerSend` from `ComponentsV2Utils`
- Starboard and ThreadCreated images are preserved via `MediaGallery` (functional content, not decoration)
- ThreadCreated thread link and author profile link are preserved as markdown links in the body

**Behavior note:** Avatar thumbnails and author icon URLs are dropped (decoration not supported by v2 container helpers); images-as-content are preserved via media gallery.

## Files changed
- `src/events/GuildBanLog.command.ts`
- `src/events/MessageLog.command.ts`
- `src/events/UserUpdate.command.ts`
- `src/events/ServerChangeLog.command.ts`
- `src/events/GuildMemberAdd.command.ts`
- `src/events/GuildMemberRemove.command.ts`
- `src/events/Starboard.command.ts`
- `src/events/GuildMemberUpdate.command.ts`
- `src/events/ThreadCreated.command.ts`

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] No functional behavior changed -- refactor only (avatar thumbnails/author icons dropped per v2 limitations)

Closes #701

🤖 Generated with [Claude Code](https://claude.com/claude-code)