### PR TITLE
refactor: migrate raw ButtonBuilder chains to buildActionButton helper

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -4203,10 +4203,11 @@ export class NowPlayingCommand {
       const notesAction = showNotes ? "hide" : "show";
       const notesLabel = showNotes ? "Hide Notes" : "Show Notes";
       buttons.push(
-        new ButtonBuilder()
-          .setCustomId(`${NOW_PLAYING_LIST_NOTES_PREFIX}:${ownerId}:${notesAction}`)
-          .setLabel(notesLabel)
-          .setStyle(ButtonStyle.Secondary),
+        buildActionButton({
+          customId: `${NOW_PLAYING_LIST_NOTES_PREFIX}:${ownerId}:${notesAction}`,
+          label: notesLabel,
+          style: ButtonStyle.Secondary,
+        }),
       );
     }
     return buttons.length > 0 ? buildButtonRow(...buttons) : null;

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -1,6 +1,5 @@
 import {
   AttachmentBuilder,
-  ButtonBuilder,
   ButtonStyle,
   ComponentType,
   type ButtonInteraction,
@@ -30,7 +29,7 @@ import {
 import { isInteractionSettled, safeReply, safeUpdate, safeUserFetch } from "./InteractionUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError } from "../utilities/LogUtils.js";
-import { buildButtonRow } from "./uiComponents.js";
+import { buildActionButton, buildButtonRow } from "./uiComponents.js";
 
 const MAX_PLAYTIME_HOURS = 999999.99;
 const COMPLETION_COVER_ATTACHMENT_PREFIX = "completion-cover";
@@ -255,14 +254,8 @@ export async function promptRemoveFromNowPlaying(
   const yesId = `${promptId}:yes`;
   const noId = `${promptId}:no`;
   const row = buildButtonRow(
-    new ButtonBuilder()
-      .setCustomId(yesId)
-      .setLabel("Yes")
-      .setStyle(ButtonStyle.Danger),
-    new ButtonBuilder()
-      .setCustomId(noId)
-      .setLabel("No")
-      .setStyle(ButtonStyle.Secondary),
+    buildActionButton({ customId: yesId, label: "Yes", style: ButtonStyle.Danger }),
+    buildActionButton({ customId: noId, label: "No", style: ButtonStyle.Secondary }),
   );
 
   const payload = {


### PR DESCRIPTION
## Summary
- Replaced 3 raw `new ButtonBuilder()` chains in `now-playing.command.ts` and `CompletionHelpers.ts` with the shared `buildActionButton` helper from `uiComponents.ts`
- Removed the now-unused `ButtonBuilder` import from `CompletionHelpers.ts`

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] No functional behavior changed -- refactor only

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)