### PR TITLE
refactor: Standardize ActionRowBuilder<StringSelectMenuBuilder> with a shared buildSelectRow helper

### DIFF
--- a/src/commands/admin/admin-help.service.ts
+++ b/src/commands/admin/admin-help.service.ts
@@ -10,6 +10,7 @@ import {
   buildComponentsV2EditFlags,
   buildFieldsText,
 } from "../../functions/ComponentsV2Utils.js";
+import { buildSelectRow } from "../../functions/uiComponents.js";
 
 export const ADMIN_HELP_TOPICS: AdminHelpTopic[] = [
   {
@@ -117,7 +118,7 @@ export function buildAdminHelpButtons(
     )
     .addOptions({ label: "Back to Help Main Menu", value: "help-main" });
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 export function buildAdminHelpEmbed(topic: AdminHelpTopic): ContainerBuilder {

--- a/src/commands/admin/gotm-audit-ui.service.ts
+++ b/src/commands/admin/gotm-audit-ui.service.ts
@@ -3,7 +3,11 @@ import {
   ButtonStyle,
   StringSelectMenuBuilder,
 } from "discord.js";
-import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildSelectRow,
+} from "../../functions/uiComponents.js";
 import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
 import { type IGotmAuditImport, type IGotmAuditItem } from "../../classes/GotmAuditImport.js";
 import {
@@ -74,7 +78,7 @@ export function buildGotmAuditPromptComponents(
           default: idx === 0,
         })),
       );
-    rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
+    rows.push(buildSelectRow(select));
   }
 
   const manualBtn = buildActionButton({

--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -1,7 +1,6 @@
 import type { CommandInteraction, StringSelectMenuInteraction } from "discord.js";
 import { COLOR_PRIMARY } from "../../config/colors.js";
 import {
-  ActionRowBuilder,
   AttachmentBuilder,
   ButtonStyle,
   ComponentType,
@@ -13,7 +12,11 @@ import {
   userMention,
 } from "discord.js";
 import { safeDeferUpdate, safeReply } from "../../functions/InteractionUtils.js";
-import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildSelectRow,
+} from "../../functions/uiComponents.js";
 import {
   buildTextReply,
   buildTitledContainer,
@@ -197,7 +200,7 @@ async function promptSelectNomination(
     .setMinValues(1)
     .setMaxValues(1)
     .addOptions(options);
-  const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  const selectRow = buildSelectRow(select);
   const buttonRow = buildButtonRow(
 
     buildActionButton({ customId: cancelId, label: "Cancel", style: ButtonStyle.Danger }),

--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -44,6 +44,7 @@ import {
   buildSelectOptions,
   buildTitleHeaderContainer,
   buildUserHeaderContainer,
+  buildSelectRow,
 } from "../functions/uiComponents.js";
 import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
@@ -189,7 +190,7 @@ async function buildAvatarHistoryAllPage(
         ...(emojiData ? { emoji: emojiData } : {}),
       };
     })));
-  const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu);
+  const selectRow = buildSelectRow(selectMenu);
 
   return { headerContainer, contentContainer, selectRow, totalPages, safePage };
 }

--- a/src/commands/collection/collection-overview.service.ts
+++ b/src/commands/collection/collection-overview.service.ts
@@ -15,6 +15,7 @@ import { formatLocalNumber } from "../../functions/DateFormatUtils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { buildSelectRow } from "../../functions/uiComponents.js";
 
 export const COLLECTION_OVERVIEW_SELECT_PREFIX = "collection-overview-select-v1";
 const COLLECTION_OVERVIEW_SELECT_OVERVIEW = "overview";
@@ -272,7 +273,7 @@ export async function buildCollectionOverviewResponse(params: {
     .setPlaceholder("View collection by platform")
     .addOptions(options);
 
-  const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  const row = buildSelectRow(select);
   return [container, row];
 }
 

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -1,5 +1,4 @@
 import {
-  ActionRowBuilder,
   StringSelectMenuBuilder,
   ButtonStyle,
   ComponentType,
@@ -39,6 +38,7 @@ import {
   buildActionButton,
   buildButtonRow,
   buildSelectOptions,
+  buildSelectRow,
 } from "../../functions/uiComponents.js";
 import { assertCustomIdSegments, parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
@@ -84,7 +84,7 @@ export async function promptCompletionSelection(
     await safeReply(interaction, {
       components: [
         ...buildTextReply(`Select the game for "${searchTerm}".`, true).components,
-        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+        buildSelectRow(select),
       ],
       flags: buildComponentsV2Flags(true),
     });

--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -39,7 +39,11 @@ import {
   truncateWithEllipsis,
 } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
-import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildSelectRow,
+} from "../../functions/uiComponents.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 const MAX_NOTE_LENGTH = 500;
@@ -131,7 +135,7 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
     await safeUpdate(interaction, {
       components: [
         container,
-        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+        buildSelectRow(select),
       ],
       flags: buildComponentsV2EditFlags(),
     });

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -35,6 +35,7 @@ import {
   buildJournalSelectRow,
   buildUserHeaderContainer,
   type IJournalSelectEntry,
+  buildSelectRow,
 } from "../../functions/uiComponents.js";
 
 /**
@@ -90,7 +91,7 @@ export async function renderCompletionLeaderboard(
   await safeReply(interaction, {
     components: [
       container,
-      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+      buildSelectRow(select),
     ],
     flags: buildComponentsV2Flags(ephemeral),
   });
@@ -219,7 +220,7 @@ export async function renderSelectionPage(
     .setPlaceholder(`Select a completion to ${mode}`)
     .addOptions(selectOptions);
 
-  const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  const selectRow = buildSelectRow(select);
 
   const yearPart = year == null ? "" : String(year);
   const queryPart = query ? `:${query.slice(0, MAX_QUERY_LENGTH)}` : "";
@@ -270,7 +271,7 @@ function buildYearJumpRow(
     .setPlaceholder("Jump to year")
     .addOptions(options);
 
-  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  return buildSelectRow(select);
 }
 
 function buildPaginationRows(

--- a/src/commands/game-completion/completion-platform.service.ts
+++ b/src/commands/game-completion/completion-platform.service.ts
@@ -5,7 +5,7 @@ import type {
   StringSelectMenuInteraction,
   ButtonInteraction,
 } from "discord.js";
-import { ActionRowBuilder, StringSelectMenuBuilder } from "discord.js";
+import { StringSelectMenuBuilder } from "discord.js";
 import { replyIfNotOwner, safeDeferUpdate, safeReply } from "../../functions/InteractionUtils.js";
 import {
   notifyUnknownCompletionPlatform,
@@ -22,6 +22,7 @@ import {
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { buildSelectRow } from "../../functions/uiComponents.js";
 
 export function createCompletionPlatformSession(
   ctx: CompletionPlatformContext,
@@ -72,7 +73,7 @@ export async function promptCompletionPlatformSelection(
     .setPlaceholder("Select the platform")
     .addOptions(options);
   await safeReply(interaction, {
-    components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
+    components: [buildSelectRow(select)],
     flags: buildComponentsV2Flags(true),
   });
 }

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -51,6 +51,7 @@ import {
   buildActionButton,
   buildButtonRow,
   buildTextInputRow,
+  buildSelectRow,
 } from "../../functions/uiComponents.js";
 import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
@@ -460,9 +461,9 @@ export class CompletionatorUiService {
     });
 
     return [
-      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(typeSelect),
-      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(dateSelect),
-      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(platformSelect),
+      buildSelectRow(typeSelect),
+      buildSelectRow(dateSelect),
+      buildSelectRow(platformSelect),
       buildButtonRow(addButton, skipButton, pauseButton),
     ];
   }
@@ -519,7 +520,7 @@ export class CompletionatorUiService {
     const buttons = buildButtonRow(skipBtn, pauseBtn);
 
     return {
-      updateRow: new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(updateSelect),
+      updateRow: buildSelectRow(updateSelect),
       buttonsRow: buttons,
     };
   }

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -59,6 +59,7 @@ import {
   buildSelectOptions,
   buildUserHeaderContainer,
   buildButtonRow,
+  buildSelectRow,
 } from "../functions/uiComponents.js";
 import {
   GJ_CLOSE_PREFIX,
@@ -216,7 +217,7 @@ function buildListSelectRow(
     .setPlaceholder("Select a game to read its journal")
     .addOptions(options);
 
-  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  return buildSelectRow(select);
 }
 
 function buildListPageRow(
@@ -297,7 +298,7 @@ function buildAllSelectRow(
     .setCustomId(`${GJ_ALL_SELECT_PREFIX}:${callerId}:${page}`)
     .setPlaceholder("Select a member to view their journals")
     .addOptions(options);
-  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  return buildSelectRow(select);
 }
 
 function buildAllPageRow(
@@ -851,7 +852,7 @@ export class GameJournalCommand {
     const container = buildTextContainer(
     "## Delete Journal Entry\nSelect an entry to delete.",
       );
-    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+    const row = buildSelectRow(select);
     const helpRow = buildButtonRow(
       buildActionButton({ customId: `${NOW_PLAYING_HELP_PREFIX}:journal-delete:${ownerId}`, label: "?", style: ButtonStyle.Secondary }),
     );

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -65,7 +65,12 @@ import GameSearchSynonymDraft, {
 import axios from "axios";
 import { igdbService } from "../services/IGDB/IgdbService.js";
 import { buildPageFooterText, shouldRenderPrevNextButtons } from "../functions/PaginationUtils.js";
-import { buildActionButton, buildButtonRow, buildTextInputRow } from "../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildTextInputRow,
+  buildSelectRow,
+} from "../functions/uiComponents.js";
 import { parseSynonymQuickAddTerms } from "./gamedb-synonym.utils.js";
 import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { COLOR_PRIMARY, COLOR_SUCCESS, COLOR_HIGHLIGHT } from "../config/colors.js";
@@ -332,7 +337,7 @@ export class GameDbAdmin {
         };
       });
       select.addOptions(selectOptions);
-      components.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
+      components.push(buildSelectRow(select));
 
       const deleteSelect = new StringSelectMenuBuilder()
         .setCustomId(buildSynonymGroupSelectCustomId(
@@ -343,7 +348,7 @@ export class GameDbAdmin {
         ))
         .setPlaceholder("Select a group to delete");
       deleteSelect.addOptions(selectOptions);
-      components.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(deleteSelect));
+      components.push(buildSelectRow(deleteSelect));
     }
     components.push(buttonRow);
 
@@ -1114,7 +1119,7 @@ export class GameDbAdmin {
       buildActionButton({ customId: `audit-page:${sessionId}:next`, label: "Next", style: ButtonStyle.Secondary }).setDisabled(nextDisabled),
     );
 
-    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+    const row = buildSelectRow(select);
 
     const actionRows: ActionRowBuilder<any>[] = [row];
     if (shouldRenderPrevNextButtons(prevDisabled, nextDisabled)) {

--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -60,6 +60,7 @@ import {
   buildActionButton,
   buildButtonRow,
   buildTextInputRow,
+  buildSelectRow,
 } from "../../functions/uiComponents.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
@@ -200,9 +201,9 @@ function buildCompletionWizardComponents(
   const rows: Array<
     ActionRowBuilder<StringSelectMenuBuilder> | ActionRowBuilder<ButtonBuilder>
   > = [
-    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(typeSelect),
-    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(dateSelect),
-    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(platformSelect),
+    buildSelectRow(typeSelect),
+    buildSelectRow(dateSelect),
+    buildSelectRow(platformSelect),
   ];
 
   if (session.requiresRemoveChoice) {
@@ -222,7 +223,7 @@ function buildCompletionWizardComponents(
           default: session.removeChoice === "no",
         },
       );
-    rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(removeSelect));
+    rows.push(buildSelectRow(removeSelect));
   }
 
   const nextButton = buildActionButton({ customId: `gamedb-completion-next:${session.id}`, label: "Next", style: ButtonStyle.Primary });

--- a/src/commands/gamedb/gamedb-csv-import.service.ts
+++ b/src/commands/gamedb/gamedb-csv-import.service.ts
@@ -3,7 +3,11 @@ import {
   ButtonStyle,
   StringSelectMenuBuilder,
 } from "discord.js";
-import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildSelectRow,
+} from "../../functions/uiComponents.js";
 import {
   ContainerBuilder,
   TextDisplayBuilder,
@@ -133,7 +137,7 @@ export function buildCsvPromptComponents(
           default: idx === 0,
         })),
       );
-    rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
+    rows.push(buildSelectRow(select));
   }
    
   const manualBtn = buildActionButton({

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -53,7 +53,11 @@ import { handleNoResults } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { MAX_CONTAINER_TEXT } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
-import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildSelectRow,
+} from "../../functions/uiComponents.js";
 
 function formatUpcomingDate(date: Date | null | undefined): string {
   if (!date) return "";
@@ -196,7 +200,7 @@ function buildSearchResponse(
     .setPlaceholder("Select a game to view details")
     .addOptions(options);
 
-  const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(selectMenu);
+  const selectRow = buildSelectRow(selectMenu);
 
   const prevDisabled = safePage === 0;
   const nextDisabled = safePage >= totalPages - 1;

--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -71,6 +71,7 @@ import {
   buildSelectOptions,
   buildTextInputRow,
   buildButtonRow,
+  buildSelectRow,
 } from "../functions/uiComponents.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 const GIVEAWAY_DONATE_MODAL_ID = "giveaway-donate-modal";
@@ -117,7 +118,7 @@ function buildKeySelectMenus(
       .setMinValues(1)
       .setMaxValues(1)
       .addOptions(options);
-    rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
+    rows.push(buildSelectRow(select));
   }
   return rows;
 }

--- a/src/commands/help.command.ts
+++ b/src/commands/help.command.ts
@@ -30,7 +30,7 @@ import { decodeBase64Url, encodeBase64Url } from "../functions/CustomIdUtils.js"
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { GIVEAWAY_HUB_CHANNEL_ID } from "../config/channels.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
-import { buildActionButton, buildButtonRow } from "../functions/uiComponents.js";
+import { buildActionButton, buildButtonRow , buildSelectRow } from "../functions/uiComponents.js";
 
 type HelpTopicId =
   | "noms"
@@ -466,7 +466,7 @@ function buildProfileHelpButtons(
     )
     .addOptions({ label: "Back to Help Main Menu", value: "help-main" });
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 function buildProfileHelpContainer(topic: ProfileHelpTopic): ContainerBuilder {
@@ -491,7 +491,7 @@ function buildNowPlayingHelpButtons(
     )
     .addOptions({ label: "Back to Help Main Menu", value: "help-main" });
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 function buildNowPlayingHelpContainer(topic: NowPlayingHelpTopic): ContainerBuilder {
@@ -528,7 +528,7 @@ function buildGamedbHelpButtons(
     )
     .addOptions({ label: "Back to Help Main Menu", value: "help-main" });
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 function buildGamedbHelpContainer(topic: GameDbHelpTopic): ContainerBuilder {
@@ -717,7 +717,7 @@ function buildGameCompletionHelpButtons(
     )
     .addOptions({ label: "Back to Help Main Menu", value: "help-main" });
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 function buildGameCompletionHelpContainer(topic: GameCompletionHelpTopic): ContainerBuilder {
@@ -848,7 +848,7 @@ function buildRssHelpButtons(
     )
     .addOptions({ label: "Back to Help Main Menu", value: "help-main" });
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 function buildRssHelpContainer(topic: RssHelpTopic): ContainerBuilder {
@@ -1282,7 +1282,7 @@ function buildCategoryComponents(
     select.addOptions({ label: "Back to Help Main Menu", value: "help-main" });
   }
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 function buildCategoryHelpResponse(

--- a/src/commands/mod.command.ts
+++ b/src/commands/mod.command.ts
@@ -24,6 +24,7 @@ import {
   type EmbedField,
 } from "../functions/ComponentsV2Utils.js";
 import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
+import { buildSelectRow } from "../functions/uiComponents.js";
 
 type ModHelpTopicId = "presence" | "presence-history";
 
@@ -68,7 +69,7 @@ function buildModHelpButtons(
     )
     .addOptions({ label: "Back to Help Main Menu", value: "help-main" });
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 export function buildModHelpContainer(topic: ModHelpTopic): ContainerBuilder {

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -42,7 +42,7 @@ import {
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 import { chunk } from "../utilities/ArrayUtils.js";
-import { buildActionButton, buildButtonRow } from "../functions/uiComponents.js";
+import { buildActionButton, buildButtonRow , buildSelectRow } from "../functions/uiComponents.js";
 
 const MAX_OPTIONS = 25;
 
@@ -179,7 +179,7 @@ function buildPageComponents(
     .addOptions(options)
     .setMinValues(1)
     .setMaxValues(1);
-  components.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
+  components.push(buildSelectRow(select));
 
   const navRow = buildDisabledPrevNextRow(
     `mpinfo-page:${ownerId}:${filterKey}`,

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -65,6 +65,7 @@ import {
   buildJournalSelectRow,
   buildTextInputRow,
   buildUserHeaderContainer,
+  buildSelectRow,
 } from "../functions/uiComponents.js";
 import { EphemeralOwnerMenu } from "../functions/EphemeralOwnerMenu.js";
 import { igdbService } from "../services/IGDB/IgdbService.js";
@@ -964,7 +965,7 @@ export class NowPlayingCommand {
       });
 
       const selectId = `nowplaying-add-select:${sessionId}`;
-      const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+      const selectRow = buildSelectRow(
         new StringSelectMenuBuilder()
           .setCustomId(selectId)
           .setPlaceholder("Select the game to add")
@@ -1161,11 +1162,10 @@ export class NowPlayingCommand {
     });
     const cancelButton = buildActionButton("cancel", `nowplaying-list-cancel:${session.userId}`);
 
-    const typeRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(typeSelect);
-    const removeRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(removeSelect);
-    const announceRow = new ActionRowBuilder<StringSelectMenuBuilder>()
-      .addComponents(announceSelect);
-    const noteRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(noteSelect);
+    const typeRow = buildSelectRow(typeSelect);
+    const removeRow = buildSelectRow(removeSelect);
+    const announceRow = buildSelectRow(announceSelect);
+    const noteRow = buildSelectRow(noteSelect);
     const helpButton = buildActionButton({
       customId: `${NOW_PLAYING_HELP_PREFIX}:completion-config:${session.userId}`,
       label: "?",
@@ -1536,7 +1536,7 @@ export class NowPlayingCommand {
         interaction.guildId,
         [
           container,
-          new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+          buildSelectRow(select),
         ],
       ),
       flags: buildComponentsV2Flags(true),
@@ -2041,7 +2041,7 @@ export class NowPlayingCommand {
     const payload = {
       components: [
         container,
-        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+        buildSelectRow(select),
       ],
       flags: buildComponentsV2Flags(true),
     };
@@ -2426,7 +2426,7 @@ export class NowPlayingCommand {
     const payload = {
       components: [
         container,
-        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+        buildSelectRow(select),
       ],
       flags: buildComponentsV2Flags(true),
     };
@@ -3269,7 +3269,7 @@ export class NowPlayingCommand {
       .setCustomId(`${NOW_PLAYING_JOURNAL_DELETE_SELECT_PREFIX}:${ownerId}:${gameId}:${page}`)
       .setPlaceholder("Choose an entry to delete")
       .addOptions(options);
-    const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+    const row = buildSelectRow(select);
     const container = buildTextContainer("## Delete Journal Entry\nSelect an entry to delete.");
     const helpRow = buildButtonRow(
       buildActionButton({ customId: `${NOW_PLAYING_HELP_PREFIX}:journal-delete:${ownerId}`, label: "?", style: ButtonStyle.Secondary }),
@@ -3536,7 +3536,7 @@ export class NowPlayingCommand {
       .setCustomId(`${NOW_PLAYING_EDIT_MENU_START_JOURNAL_SELECT_PREFIX}:${ownerId}`)
       .setPlaceholder("Select a game to start a journal")
       .addOptions(options);
-    const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+    const selectRow = buildSelectRow(select);
     const container = buildTextContainer("## Start a Game Journal\nSelect a game to write your first entry.");
     await safeUpdate(interaction, {
       components: [container, selectRow],
@@ -4416,7 +4416,7 @@ export class NowPlayingCommand {
       .setCustomId(`${NOW_PLAYING_REMOVE_SELECT_PREFIX}:${ownerId}`)
       .setPlaceholder("Select a game to remove")
       .addOptions(selectOptions);
-    const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(removeSelect);
+    const selectRow = buildSelectRow(removeSelect);
 
     const doneRow = buildButtonRow(
       buildActionButton("confirm", `nowplaying-remove-done:${ownerId}`, "Done"),
@@ -4555,7 +4555,7 @@ export class NowPlayingCommand {
           value: option.value,
           default: selectedIndex === optionIndex,
         })));
-      rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
+      rows.push(buildSelectRow(select));
     }
     const components: Array<
       ContainerBuilder | ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>
@@ -4613,7 +4613,7 @@ export class NowPlayingCommand {
           value: String(entryIndex),
           default: selectedIndex === entryIndex,
         })));
-      rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu));
+      rows.push(buildSelectRow(menu));
     }
 
     const actionRow = buildButtonRow(
@@ -5213,7 +5213,7 @@ export class NowPlayingCommand {
       .setPlaceholder("View a member's Now Playing list")
       .addOptions(options);
 
-    return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+    return buildSelectRow(select);
   }
 
   private async startNowPlayingIgdbImport(

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -3,7 +3,6 @@ import {
   ApplicationCommandOptionType,
   type User,
   PermissionsBitField,
-  ActionRowBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
   userMention,
@@ -36,7 +35,7 @@ import {
   buildTitledContainer,
   safeV2TextContent,
 } from "../functions/ComponentsV2Utils.js";
-import { buildUserHeaderContainer } from "../functions/uiComponents.js";
+import { buildUserHeaderContainer , buildSelectRow } from "../functions/uiComponents.js";
 import {
   formatDiscordTimestamp,
   formatPlaytimeHours,
@@ -661,7 +660,7 @@ export class ProfileCommand {
 
     const selectChunks = chunk(selectOptions, 25);
     const components = selectChunks.slice(0, 5).map((chunkPart, idx) =>
-      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+      buildSelectRow(
         new StringSelectMenuBuilder()
           .setCustomId(`profile-search-select-${idx}`)
           .setPlaceholder("Select a member to view their profile")

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -61,6 +61,7 @@ import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../conf
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError } from "../utilities/LogUtils.js";
+import { buildSelectRow } from "../functions/uiComponents.js";
 
 type CompletionAddContext = {
   targetUserId: string;
@@ -139,7 +140,7 @@ function buildSuperAdminHelpButtons(
     )
     .addOptions({ label: "Back to Help Main Menu", value: "help-main" });
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 type ImageBufferResult = { buffer: Buffer; mimeType: string | null };
@@ -384,7 +385,7 @@ export class SuperAdmin {
 
       await safeReply(interaction, {
         content: `Select the game for "${searchTerm}".`,
-        components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
+        components: [buildSelectRow(select)],
         flags: MessageFlags.Ephemeral,
       });
       return;
@@ -454,7 +455,7 @@ export class SuperAdmin {
       : `Select the platform for **${game.title}**.`;
     await safeReply(interaction, {
       content,
-      components: [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)],
+      components: [buildSelectRow(select)],
       flags: MessageFlags.Ephemeral,
     });
   }

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -62,7 +62,12 @@ import { decodeBase64Url, encodeWithMaxLength } from "../functions/CustomIdUtils
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeV2TextContent } from "../functions/ComponentsV2Utils.js";
 import { formatDiscordTimestamp } from "../functions/DateFormatUtils.js";
-import { buildActionButton, buildButtonRow, buildTextInputRow } from "../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildTextInputRow,
+  buildSelectRow,
+} from "../functions/uiComponents.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { DISCORD_TEXT_INPUT_MAX } from "../config/textLimits.js";
 import { TODO_DEFAULT_PAGE_SIZE, TODO_MAX_PAGE_SIZE } from "../config/pagination.js";
@@ -1057,7 +1062,7 @@ function buildIssueListComponents(
         })),
       ],
     );
-  const labelRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(labelSelect);
+  const labelRow = buildSelectRow(labelSelect);
 
   const queryButton = buildActionButton({
     customId: buildTodoQueryButtonId(payloadToken, payload.page),
@@ -1545,7 +1550,7 @@ export class TodoCommand {
           value: String(issue.number),
         })),
       );
-    const selectRow = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+    const selectRow = buildSelectRow(select);
 
     const cancelRow = buildButtonRow(
       buildActionButton({
@@ -2489,7 +2494,7 @@ export class TodoCommand {
     await safeReply(
       interaction,
       buildTodoTextReply("Select labels to apply to this issue.", true, [
-        new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+        buildSelectRow(select),
       ]),
     );
   }

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -35,7 +35,12 @@ import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtil
 import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
-import { buildActionButton, buildButtonRow, buildTextInputRow } from "../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildTextInputRow,
+  buildSelectRow,
+} from "../functions/uiComponents.js";
 import { logError } from "../utilities/LogUtils.js";
 
 const PUSH_PIN_EMOJI = "📌";
@@ -73,7 +78,7 @@ const buildCompletionTypeRow = (sessionId: string): ActionRowBuilder<StringSelec
         value: type,
       })),
     );
-  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  return buildSelectRow(select);
 };
 
 const buildCompletionTitleRow = (sessionId: string): ActionRowBuilder<ButtonBuilder> =>
@@ -90,7 +95,7 @@ const buildCompletionGameRow = (
     .setCustomId(`completion-react-game:${sessionId}`)
     .setPlaceholder("Select the game")
     .addOptions(gameOptions);
-  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  return buildSelectRow(select);
 };
 
 const buildCompletionPlatformRow = (
@@ -102,7 +107,7 @@ const buildCompletionPlatformRow = (
     .setCustomId(`${COMPLETION_REACTION_PLATFORM_SELECT_PREFIX}:${sessionId}`)
     .setPlaceholder("Select the platform")
     .addOptions(platformOptions);
-  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+  return buildSelectRow(select);
 };
 
 const parseCompletionQuery = (content: string): string => {

--- a/src/functions/NominationAdminHelpers.ts
+++ b/src/functions/NominationAdminHelpers.ts
@@ -21,7 +21,7 @@ import {
   safeV2TextContent,
 } from "./ComponentsV2Utils.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
-import { buildTextInputRow } from "./uiComponents.js";
+import { buildTextInputRow , buildSelectRow } from "./uiComponents.js";
 import {
   buildNominationListPayload,
   type NominationListPayload,
@@ -84,7 +84,7 @@ export function buildDeletionSelectControls(
     .setMaxValues(1)
     .addOptions(options);
 
-  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+  return [buildSelectRow(select)];
 }
 
 export function buildDeletionSelectCustomId(kind: NominationKind, round: number): string {

--- a/src/functions/NominationListComponents.ts
+++ b/src/functions/NominationListComponents.ts
@@ -21,7 +21,7 @@ import {
   buildTextContainer,
   safeV2TextContent,
 } from "./ComponentsV2Utils.js";
-import { buildActionButton } from "./uiComponents.js";
+import { buildActionButton , buildSelectRow } from "./uiComponents.js";
 import { composeVoteImage, type VoteImageType } from "../services/collageGenerator.js";
 import { getUserEmojiString } from "../services/UserEmojiService.js";
 import {
@@ -192,7 +192,7 @@ function buildNominationSelectRows(
       .setMinValues(1)
       .setMaxValues(1)
       .addOptions(slice);
-    rows.push(new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select));
+    rows.push(buildSelectRow(select));
   }
   return rows;
 }

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -146,6 +146,12 @@ export function buildJournalSelectRow(
   return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
 }
 
+export function buildSelectRow(
+  select: StringSelectMenuBuilder,
+): ActionRowBuilder<StringSelectMenuBuilder> {
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+}
+
 export function buildTitleHeaderContainer(title: string): ContainerBuilder {
   return buildTextContainer(safeV2TextContent(`## ${title}`, 250));
 }

--- a/src/services/IGDB/IgdbSelectService.ts
+++ b/src/services/IGDB/IgdbSelectService.ts
@@ -16,7 +16,11 @@ import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
-import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import {
+  buildActionButton,
+  buildButtonRow,
+  buildSelectRow,
+} from "../../functions/uiComponents.js";
 
 export type IgdbSelectOption = { id: number; label: string; description?: string };
 
@@ -127,7 +131,7 @@ export function buildIgdbComponents(
   }
 
   const rows: ActionRowBuilder<any>[] = [
-    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select),
+    buildSelectRow(select),
   ];
 
   if (hasOptions) {


### PR DESCRIPTION
## Summary
- Added `buildSelectRow(select)` helper to `src/functions/uiComponents.ts` to eliminate 63 inline `new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)` patterns across 27 files
- Migrated all call sites to use the new helper, removing now-unused `ActionRowBuilder` imports where applicable
- Split long uiComponents import lines to stay under the 100-character limit

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] No functional behavior changed -- refactor only

Closes #703

🤖 Generated with [Claude Code](https://claude.com/claude-code)