### PR TITLE
refactor: migrate simple ContainerBuilder/TextDisplayBuilder patterns to shared helpers

### DIFF
--- a/src/commands/admin/gotm-audit-ui.service.ts
+++ b/src/commands/admin/gotm-audit-ui.service.ts
@@ -8,14 +8,14 @@ import {
   buildButtonRow,
   buildSelectRow,
 } from "../../functions/uiComponents.js";
-import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
+import { ContainerBuilder } from "@discordjs/builders";
 import { type IGotmAuditImport, type IGotmAuditItem } from "../../classes/GotmAuditImport.js";
 import {
   GOTM_AUDIT_SELECT_PREFIX,
   GOTM_AUDIT_ACTION_PREFIX,
   GOTM_AUDIT_RESULT_LIMIT,
 } from "./admin.types.js";
-import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
+import { buildTextContainer } from "../../functions/ComponentsV2Utils.js";
 import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
 
 export function buildGotmAuditPromptContent(
@@ -51,11 +51,7 @@ export function buildGotmAuditPromptContent(
 }
 
 export function buildGotmAuditPromptContainer(content: string): ContainerBuilder {
-  const container = new ContainerBuilder();
-  container.addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(safeV2TextContent(content, 3500)),
-  );
-  return container;
+  return buildTextContainer(content);
 }
 
 export function buildGotmAuditPromptComponents(

--- a/src/commands/gamedb/gamedb-csv-import.service.ts
+++ b/src/commands/gamedb/gamedb-csv-import.service.ts
@@ -8,16 +8,13 @@ import {
   buildButtonRow,
   buildSelectRow,
 } from "../../functions/uiComponents.js";
-import {
-  ContainerBuilder,
-  TextDisplayBuilder,
-} from "@discordjs/builders";
+import { ContainerBuilder } from "@discordjs/builders";
 import {
   normalizePlatformKey,
   normalizeTitleKey,
   stripTitleDateSuffix,
 } from "../../functions/CsvUtils.js";
-import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
+import { buildTextContainer } from "../../functions/ComponentsV2Utils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { igdbService, type IGDBGame } from "../../services/IGDB/IgdbService.js";
@@ -27,7 +24,7 @@ import { type IGameDbCsvImportItem } from "../../classes/GameDbCsvImport.js";
 import { GAMEDB_CSV_PLATFORM_MAP } from "../../config/gamedbCsvPlatformMap.js";
 import { buildIgdbSearchLink } from "./gamedb-utils.js";
 import { type IGameDbCsvImport } from "../../classes/GameDbCsvImport.js";
-import { isPositiveInt, truncateWithEllipsis } from "../../utilities/ValidationUtils.js";
+import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import {
   DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
@@ -108,12 +105,7 @@ export function buildCsvPromptContent(
 }
 
 export function buildCsvPromptContainer(content: string): ContainerBuilder {
-  const container = new ContainerBuilder();
-  const safeContent = truncateWithEllipsis(content, 4000);
-  container.addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(safeV2TextContent(safeContent, 3500)),
-  );
-  return container;
+  return buildTextContainer(content);
 }
 
 export function buildCsvPromptComponents(

--- a/src/functions/ComponentsV2Utils.ts
+++ b/src/functions/ComponentsV2Utils.ts
@@ -1,5 +1,10 @@
 import { MessageFlags, MessageFlagsBitField } from "discord.js";
-import { ContainerBuilder, TextDisplayBuilder } from "@discordjs/builders";
+import {
+  ContainerBuilder,
+  SectionBuilder,
+  TextDisplayBuilder,
+  ThumbnailBuilder,
+} from "@discordjs/builders";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
@@ -23,6 +28,22 @@ export function buildTextContainer(content: string): ContainerBuilder {
   return new ContainerBuilder().addTextDisplayComponents(
     new TextDisplayBuilder().setContent(safeV2TextContent(content, 3500)),
   );
+}
+
+export function buildContentContainer(
+  content: string,
+  thumbnailUrl?: string | null,
+): ContainerBuilder {
+  const text = new TextDisplayBuilder().setContent(safeV2TextContent(content, 3500));
+  const container = new ContainerBuilder();
+  if (thumbnailUrl) {
+    const section = new SectionBuilder().addTextDisplayComponents(text);
+    section.setThumbnailAccessory(new ThumbnailBuilder().setURL(thumbnailUrl));
+    container.addSectionComponents(section);
+  } else {
+    container.addTextDisplayComponents(text);
+  }
+  return container;
 }
 
 export function buildTextReply(

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -4,17 +4,12 @@ import {
   ButtonBuilder,
   ButtonStyle,
 } from "discord.js";
-import {
-  ContainerBuilder,
-  SectionBuilder,
-  TextDisplayBuilder,
-  ThumbnailBuilder,
-} from "@discordjs/builders";
+import { ContainerBuilder } from "@discordjs/builders";
 import Member, { type ICompletionRecord } from "../classes/Member.js";
 import Game from "../classes/Game.js";
 import Thread from "../classes/Thread.js";
 import { formatTableDate, formatPlaytimeHours } from "./DateFormatUtils.js";
-import { buildComponentsV2EditFlags, safeV2TextContent } from "./ComponentsV2Utils.js";
+import { buildComponentsV2EditFlags, buildContentContainer } from "./ComponentsV2Utils.js";
 import { buildActionButton, buildButtonRow, buildUserHeaderContainer } from "./uiComponents.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
@@ -175,17 +170,7 @@ export async function buildJournalView(options: IJournalViewOptions): Promise<{
 
   entryParts.push(footer);
 
-  const gameContainer = new ContainerBuilder();
-  const entriesText = new TextDisplayBuilder().setContent(
-    safeV2TextContent(entryParts.join(`\n\u00A0\n`), 3500),
-  );
-  if (coverUrl) {
-    const section = new SectionBuilder().addTextDisplayComponents(entriesText);
-    section.setThumbnailAccessory(new ThumbnailBuilder().setURL(coverUrl));
-    gameContainer.addSectionComponents(section);
-  } else {
-    gameContainer.addTextDisplayComponents(entriesText);
-  }
+  const gameContainer = buildContentContainer(entryParts.join(`\n\u00A0\n`), coverUrl);
 
   // Nav row
   const navButtons: ButtonBuilder[] = [];


### PR DESCRIPTION
## Summary
- Adds `buildContentContainer(content, thumbnailUrl?)` helper to `ComponentsV2Utils.ts` -- creates a section+thumbnail container when a URL is provided, plain text container otherwise
- Migrates `buildGotmAuditPromptContainer` and `buildCsvPromptContainer` to `buildTextContainer` (removes redundant manual builder chains and an unnecessary pre-truncation)
- Migrates `journalView.ts` inline conditional section/text block to `buildContentContainer`

## What was NOT migrated (from #704) and why

| File | Reason |
|------|--------|
| `DiscordConsoleLogger.ts` | Two text displays + `setAccentColor` -- `buildAccentContainer` covers the color case but can't handle the two-display pattern |
| `CompletionHelpers.ts` | Always uses a section (even without thumbnail); thumbnail has caller-specific `setDescription(game.title)` |
| `import-scaffold.service.ts` | Has a `try/catch` fallback that uses a different char limit (1000 vs 3500) -- can't be generalized without caller-specific error logging |

Issue #704 should stay open for these three files.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) -- 53/53 tests pass
- [x] No functional behavior changed -- refactor only

Relates to #704

🤖 Generated with [Claude Code](https://claude.com/claude-code)