### PR TITLE
refactor: centralize custom ID prefix constants into src/config/customIdPrefixes.ts

### DIFF
--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -24,12 +24,14 @@ import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildDisabledPrevNextRowWithIds } from "../../functions/PaginationUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { logError, logInfo } from "../../utilities/LogUtils.js";
+import {
+  COLLECTION_LIST_NAV_PREFIX,
+  COLLECTION_LIST_FILTER_PREFIX,
+  COLLECTION_LIST_FILTER_PANEL_PREFIX,
+  COLLECTION_LIST_FILTER_MODAL_PREFIX,
+} from "../../config/customIdPrefixes.js";
 
 const COLLECTION_LIST_PAGE_SIZE = 20;
-const COLLECTION_LIST_NAV_PREFIX = "collection-list-nav-v2";
-const COLLECTION_LIST_FILTER_PREFIX = "collection-list-filter-v1";
-const COLLECTION_LIST_FILTER_PANEL_PREFIX = "clf1";
-const COLLECTION_LIST_FILTER_MODAL_PREFIX = "clfm1";
 export const COLLECTION_FILTER_TITLE_INPUT_ID = "collection-filter-title";
 export const COLLECTION_FILTER_PLATFORM_INPUT_ID = "collection-filter-platform";
 

--- a/src/commands/game-completion/completion-helpers.ts
+++ b/src/commands/game-completion/completion-helpers.ts
@@ -9,6 +9,7 @@ import type {
 import Member from "../../classes/Member.js";
 import { promptRemoveFromNowPlaying } from "../../functions/CompletionHelpers.js";
 import { parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import { COMPLETIONATOR_CHOOSE_PREFIX } from "../../config/customIdPrefixes.js";
 
 function shouldPromptNowPlayingRemoval(
   addedAt: Date | null,
@@ -69,7 +70,7 @@ export function buildCompletionatorChooseId(params: {
   itemId: number;
   gameId: number;
 }): string {
-  return `comp-import-choose-v1:${params.ownerId}:${params.importId}:${params.itemId}:${params.gameId}`;
+  return `${COMPLETIONATOR_CHOOSE_PREFIX}:${params.ownerId}:${params.importId}:${params.itemId}:${params.gameId}`;
 }
 
 export function parseCompletionatorChooseId(customId: string): {
@@ -78,7 +79,7 @@ export function parseCompletionatorChooseId(customId: string): {
   itemId: number;
   gameId: number;
 } | null {
-  if (!customId.startsWith("comp-import-choose-v1:")) return null;
+  if (!customId.startsWith(`${COMPLETIONATOR_CHOOSE_PREFIX}:`)) return null;
   const segs = parseCustomIdSegments(customId, 4);
   if (!segs) return null;
   const [ownerId, importIdRaw, itemIdRaw, gameIdRaw] = segs;

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -19,6 +19,7 @@ import { decodeBase64Url, encodeBase64Url } from "../../functions/CustomIdUtils.
 import Game from "../../classes/Game.js";
 import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../../config/textLimits.js";
 import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import { GAMEDB_SEARCH_PREFIX } from "../../config/customIdPrefixes.js";
 
 export interface ISearchFilters {
   upcomingRelease?: boolean;
@@ -162,7 +163,7 @@ export function buildSearchCustomId(
   direction?: "next" | "prev",
   filters?: ISearchFilters,
 ): string {
-  const base = `gamedb-search-${type}:${ownerId}:${page}:`;
+  const base = `${GAMEDB_SEARCH_PREFIX}${type}:${ownerId}:${page}:`;
   const maxQueryLength =
     MAX_COMPONENT_CUSTOM_ID_LENGTH - base.length - (direction ? `:${direction}`.length : 0);
   const encodedQuery = encodeSearchQuery(query, Math.max(maxQueryLength, 0), filters);
@@ -172,7 +173,7 @@ export function buildSearchCustomId(
 }
 
 export function buildSearchRefreshCustomId(ownerId: string, encodedQuery: string): string {
-  return `gamedb-search-refresh:${ownerId}:${encodedQuery}`;
+  return `${GAMEDB_SEARCH_PREFIX}refresh:${ownerId}:${encodedQuery}`;
 }
 
 export function buildSearchRecoveryComponents(
@@ -223,7 +224,7 @@ export function getSearchRowsFromComponents(
     if (!row || typeof row !== "object") return false;
     const rowComponents = "components" in row ? (row as any).components : [];
     return Array.isArray(rowComponents) && rowComponents.some((component) =>
-      component.customId?.startsWith("gamedb-search-"),
+      component.customId?.startsWith(GAMEDB_SEARCH_PREFIX),
     );
   }) as ActionRow<MessageActionRowComponent>[];
 }

--- a/src/config/customIdPrefixes.ts
+++ b/src/config/customIdPrefixes.ts
@@ -1,0 +1,11 @@
+// Collection list pagination and filter interaction IDs
+export const COLLECTION_LIST_NAV_PREFIX = "collection-list-nav-v2";
+export const COLLECTION_LIST_FILTER_PREFIX = "collection-list-filter-v1";
+export const COLLECTION_LIST_FILTER_PANEL_PREFIX = "clf1";
+export const COLLECTION_LIST_FILTER_MODAL_PREFIX = "clfm1";
+
+// Completionator CSV import interaction IDs
+export const COMPLETIONATOR_CHOOSE_PREFIX = "comp-import-choose-v1";
+
+// GameDB search interaction IDs
+export const GAMEDB_SEARCH_PREFIX = "gamedb-search-";


### PR DESCRIPTION
## Summary
- Created `src/config/customIdPrefixes.ts` as the single source of truth for Discord component custom ID prefix strings used as interaction resume keys
- Moved 4 local `const` prefix strings from `collection-list.service.ts` into the new config file and updated imports
- Extracted the inline `"comp-import-choose-v1"` string from `completion-helpers.ts` into a named `COMPLETIONATOR_CHOOSE_PREFIX` constant
- Extracted the inline `"gamedb-search-"` string from `gamedb-utils.ts` into a named `GAMEDB_SEARCH_PREFIX` constant, replacing all 3 usage sites

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] All custom ID strings are functionally identical to before (same string values, just referenced via constants)

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)