### PR TITLE
refactor: remove custom encode/decode in gamedb-utils in favor of existing CustomIdUtils

### DIFF
--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -32,6 +32,7 @@ import {
 } from "../../functions/ComponentsV2Utils.js";
 import { shouldRenderPrevNextButtons } from "../../functions/PaginationUtils.js";
 import Game from "../../classes/Game.js";
+import { decodeBase64Url } from "../../functions/CustomIdUtils.js";
 import {
   autocompleteSearchCompany,
   autocompleteSearchPlatform,
@@ -39,7 +40,6 @@ import {
   buildSearchCustomId,
   buildSearchRecoveryComponents,
   decodeISearchFilters,
-  decodeSearchQuery,
   GAME_SEARCH_PAGE_SIZE,
   type ISearchFilters,
 } from "./gamedb-utils.js";
@@ -337,25 +337,25 @@ export class GameDbSearchCommand {
     }
   }
 
-  @SelectMenuComponent({ id: /^gamedb-search-select:\d+:\d+:[A-Za-z0-9_-]*$/ })
+  @SelectMenuComponent({ id: /^gamedb-search-select:\d+:\d+:[A-Za-z0-9_-]*:[a-z0-9]*$/ })
   async handleSearchSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = assertCustomIdSegments(interaction, 3);
+    const segs = assertCustomIdSegments(interaction, 4);
     if (!segs) return;
-    const [ownerId, pageRaw, encodedQuery] = segs;
+    const [ownerId, pageRaw, encodedQuery, filterStr] = segs;
     const page = Number(pageRaw);
 
     if (await replyIfNotOwner(interaction, ownerId, "This menu isn't for you.")) return;
 
     const searchTerm = sanitizeUserInput(
-      decodeSearchQuery(encodedQuery),
+      decodeBase64Url(encodedQuery),
       { preserveNewlines: false },
     );
-    const filters = decodeISearchFilters(encodedQuery);
+    const filters = decodeISearchFilters(filterStr);
     const hasFilters =
       filters.upcomingRelease || filters.platformId || filters.year ||
       filters.developerId || filters.publisherId;
     if (!searchTerm && !hasFilters) {
-      const recoveryComponents = buildSearchRecoveryComponents(ownerId, encodedQuery);
+      const recoveryComponents = buildSearchRecoveryComponents(ownerId, encodedQuery, filterStr);
       const textParts = buildTextReply(
         "This search request expired. Refresh to run it again.", true,
       );
@@ -408,25 +408,25 @@ export class GameDbSearchCommand {
     }
   }
 
-  @ButtonComponent({ id: /^gamedb-search-page:\d+:\d+:[A-Za-z0-9_-]*:(next|prev)$/ })
+  @ButtonComponent({ id: /^gamedb-search-page:\d+:\d+:[A-Za-z0-9_-]*:[a-z0-9]*:(next|prev)$/ })
   async handleSearchPage(interaction: ButtonInteraction): Promise<void> {
-    const segs = assertCustomIdSegments(interaction, 4);
+    const segs = assertCustomIdSegments(interaction, 5);
     if (!segs) return;
-    const [ownerId, pageRaw, encodedQuery, direction] = segs;
+    const [ownerId, pageRaw, encodedQuery, filterStr, direction] = segs;
     const page = Number(pageRaw);
 
     if (await replyIfNotOwner(interaction, ownerId, "This menu isn't for you.")) return;
 
     const searchTerm = sanitizeUserInput(
-      decodeSearchQuery(encodedQuery),
+      decodeBase64Url(encodedQuery),
       { preserveNewlines: false },
     );
-    const filters = decodeISearchFilters(encodedQuery);
+    const filters = decodeISearchFilters(filterStr);
     const hasFilters =
       filters.upcomingRelease || filters.platformId || filters.year ||
       filters.developerId || filters.publisherId;
     if (!searchTerm && !hasFilters) {
-      const recoveryComponents = buildSearchRecoveryComponents(ownerId, encodedQuery);
+      const recoveryComponents = buildSearchRecoveryComponents(ownerId, encodedQuery, filterStr);
       const textParts = buildTextReply(
         "This search request expired. Refresh to run it again.", true,
       );
@@ -465,11 +465,11 @@ export class GameDbSearchCommand {
     }
   }
 
-  @ButtonComponent({ id: /^gamedb-search-refresh:\d+:[A-Za-z0-9_-]*$/ })
+  @ButtonComponent({ id: /^gamedb-search-refresh:\d+:[A-Za-z0-9_-]*:[a-z0-9]*$/ })
   async handleSearchRefresh(interaction: ButtonInteraction): Promise<void> {
-    const segs = assertCustomIdSegments(interaction, 2);
+    const segs = assertCustomIdSegments(interaction, 3);
     if (!segs) return;
-    const [ownerId, encodedQuery] = segs;
+    const [ownerId, encodedQuery, filterStr] = segs;
 
     if (interaction.user.id !== ownerId) {
       await safeReply(interaction, {
@@ -480,10 +480,10 @@ export class GameDbSearchCommand {
     }
 
     const searchTerm = sanitizeUserInput(
-      decodeSearchQuery(encodedQuery),
+      decodeBase64Url(encodedQuery),
       { preserveNewlines: false },
     );
-    const filters = decodeISearchFilters(encodedQuery);
+    const filters = decodeISearchFilters(filterStr);
     const hasFilters =
       filters.upcomingRelease || filters.platformId || filters.year ||
       filters.developerId || filters.publisherId;

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -15,7 +15,7 @@ import {
 } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
-import { decodeBase64Url, encodeBase64Url } from "../../functions/CustomIdUtils.js";
+import { encodeWithMaxLength } from "../../functions/CustomIdUtils.js";
 import Game from "../../classes/Game.js";
 import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../../config/textLimits.js";
 import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
@@ -66,36 +66,8 @@ export type PromptChoiceOption = {
   style?: ButtonStyle;
 };
 
-export function decodeSearchQuery(encoded: string): string {
-  const decoded = decodeBase64Url(encoded);
-  const nullIdx = decoded.indexOf("\0");
-  return nullIdx >= 0 ? decoded.slice(0, nullIdx) : decoded;
-}
-
-export function decodeISearchFilters(encoded: string): ISearchFilters {
-  const decoded = decodeBase64Url(encoded);
-  const nullIdx = decoded.indexOf("\0");
-  if (nullIdx < 0) return {};
-  return parseCompactFilters(decoded.slice(nullIdx + 1));
-}
-
-export function encodeSearchQuery(
-  query: string,
-  maxLength: number,
-  filters?: ISearchFilters,
-): string {
-  const filterStr = filters ? compactFilters(filters) : "";
-  const suffix = filterStr ? `\0${filterStr}` : "";
-  if (!query && !suffix) return "";
-  if (maxLength <= 0) return "";
-  let trimmed = query.trim();
-  while (trimmed.length >= 0) {
-    const encoded = encodeBase64Url(trimmed + suffix);
-    if (encoded.length <= maxLength) return encoded;
-    if (trimmed.length === 0) return "";
-    trimmed = trimmed.slice(0, -1);
-  }
-  return "";
+export function decodeISearchFilters(filterStr: string): ISearchFilters {
+  return filterStr ? parseCompactFilters(filterStr) : {};
 }
 
 export function buildIgdbSearchLink(title: string): string {
@@ -164,24 +136,32 @@ export function buildSearchCustomId(
   filters?: ISearchFilters,
 ): string {
   const base = `${GAMEDB_SEARCH_PREFIX}${type}:${ownerId}:${page}:`;
+  const filterStr = filters ? compactFilters(filters) : "";
+  const filterSuffix = `:${filterStr}`;
+  const directionSuffix = direction ? `:${direction}` : "";
   const maxQueryLength =
-    MAX_COMPONENT_CUSTOM_ID_LENGTH - base.length - (direction ? `:${direction}`.length : 0);
-  const encodedQuery = encodeSearchQuery(query, Math.max(maxQueryLength, 0), filters);
+    MAX_COMPONENT_CUSTOM_ID_LENGTH - base.length - filterSuffix.length - directionSuffix.length;
+  const encodedQuery = encodeWithMaxLength(query, Math.max(maxQueryLength, 0));
   return direction
-    ? `${base}${encodedQuery}:${direction}`
-    : `${base}${encodedQuery}`;
+    ? `${base}${encodedQuery}${filterSuffix}${directionSuffix}`
+    : `${base}${encodedQuery}${filterSuffix}`;
 }
 
-export function buildSearchRefreshCustomId(ownerId: string, encodedQuery: string): string {
-  return `${GAMEDB_SEARCH_PREFIX}refresh:${ownerId}:${encodedQuery}`;
+export function buildSearchRefreshCustomId(
+  ownerId: string,
+  encodedQuery: string,
+  filterStr: string,
+): string {
+  return `${GAMEDB_SEARCH_PREFIX}refresh:${ownerId}:${encodedQuery}:${filterStr}`;
 }
 
 export function buildSearchRecoveryComponents(
   ownerId: string,
   encodedQuery: string,
+  filterStr: string,
 ): ActionRowBuilder<ButtonBuilder>[] {
   const button = buildActionButton({
-    customId: buildSearchRefreshCustomId(ownerId, encodedQuery),
+    customId: buildSearchRefreshCustomId(ownerId, encodedQuery, filterStr),
     label: "Refresh search",
     style: ButtonStyle.Primary,
   });


### PR DESCRIPTION
## Summary
- Removed `encodeSearchQuery`, `decodeSearchQuery` from `gamedb-utils.ts` -- these duplicated logic already in `functions/CustomIdUtils.ts`
- Simplified `decodeISearchFilters` to accept the compact filter string directly instead of a combined base64 blob with null-byte separator
- Updated `buildSearchCustomId`, `buildSearchRefreshCustomId`, and `buildSearchRecoveryComponents` to store query and filters as separate colon-delimited segments, using `encodeWithMaxLength` from `CustomIdUtils.ts`
- Updated all three interaction handlers in `gamedb-search.command.ts` to parse segments via `assertCustomIdSegments` and decode with `decodeBase64Url` directly

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Search select, page, and refresh interactions parse the new colon-delimited format correctly
- [ ] Custom IDs stay within 100-character limit with filters present

Closes #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)