### PR TITLE
refactor: extract withErrorReply wrapper to eliminate repeated try/catch pattern

### DIFF
--- a/src/commands/admin.command.ts
+++ b/src/commands/admin.command.ts
@@ -18,7 +18,7 @@ import {
   SlashOption,
 } from "discordx";
 import {
-  extractErrorMessage,
+  withErrorReply,
   safeDeferReply,
   safeReply,
   safeUpdate,
@@ -81,13 +81,10 @@ export class Admin {
       return;
     }
 
-    try {
+    await withErrorReply(interaction, async () => {
       await bot.initApplicationCommands();
       await safeReply(interaction, buildTextReply("✅ Commands synchronized with Discord.", true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Failed to sync commands: ${msg}`, true));
-    }
+    }, "Failed to sync commands");
   }
 
   @Slash({
@@ -126,7 +123,7 @@ export class Admin {
       return;
     }
 
-    try {
+    await withErrorReply(interaction, async () => {
       const current = await BotVotingInfo.getCurrentRound();
       if (!current) {
         await safeReply(
@@ -146,10 +143,7 @@ export class Admin {
         interaction,
         buildTextReply(`Next vote date updated to <t:${voteUnix}:D> (America/New_York).`, false),
       );
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Error updating next vote date: ${msg}`, true));
-    }
+    }, "Error updating next vote date");
   }
 
   @Slash({

--- a/src/commands/admin/gotm-admin.service.ts
+++ b/src/commands/admin/gotm-admin.service.ts
@@ -1,6 +1,6 @@
 import type { CommandInteraction } from "discord.js";
 import { ButtonStyle } from "discord.js";
-import { extractErrorMessage, safeReply } from "../../functions/InteractionUtils.js";
+import { withErrorReply, safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import Gotm, {
   type IGotmEntry,
@@ -21,17 +21,10 @@ import {
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 
 export async function handleAddGotm(interaction: CommandInteraction): Promise<void> {
-  let allEntries: IGotmEntry[];
-  try {
-    allEntries = Gotm.all();
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(
-      interaction,
-      buildTextReply(`Error loading existing GOTM data: ${msg}`, false),
-    );
-    return;
-  }
+  const allEntries = await withErrorReply(
+    interaction, async () => Gotm.all(), "Error loading existing GOTM data", false,
+  );
+  if (allEntries === undefined) return;
 
   const nextRound =
     allEntries.length > 0 ? Math.max(...allEntries.map((e) => e.round)) + 1 : 1;
@@ -109,7 +102,7 @@ export async function handleAddGotm(interaction: CommandInteraction): Promise<vo
     });
   }
 
-  try {
+  await withErrorReply(interaction, async () => {
     await insertGotmRoundInDatabase(nextRound, monthYear, games);
     const newEntry = Gotm.addRound(nextRound, monthYear, games);
     const embedAssets = await buildGotmEntryEmbed(
@@ -124,13 +117,7 @@ export async function handleAddGotm(interaction: CommandInteraction): Promise<vo
       components: [...createReply.components, embedAssets.container],
       files: embedAssets.files?.length ? embedAssets.files : undefined,
     });
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(
-      interaction,
-      buildTextReply(`Failed to create GOTM round ${nextRound}: ${msg}`, false),
-    );
-  }
+  }, `Failed to create GOTM round ${nextRound}`, false);
 }
 
 export async function handleEditGotm(
@@ -143,17 +130,10 @@ export async function handleEditGotm(
     return;
   }
 
-  let entries: IGotmEntry[];
-  try {
-    entries = Gotm.getByRound(roundNumber);
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(
-      interaction,
-      buildTextReply(`Error loading GOTM data: ${msg}`, false),
-    );
-    return;
-  }
+  const entries = await withErrorReply(
+    interaction, async () => Gotm.getByRound(roundNumber), "Error loading GOTM data", false,
+  );
+  if (entries === undefined) return;
 
   if (!entries.length) {
     await safeReply(
@@ -265,7 +245,7 @@ export async function handleEditGotm(
     newValue = parsed;
   }
 
-  try {
+  await withErrorReply(interaction, async () => {
     await updateGotmGameFieldInDatabase(roundNumber, gameIndex, field!, newValue);
 
     let updatedEntry: IGotmEntry | null = null;
@@ -288,11 +268,5 @@ export async function handleEditGotm(
       components: [...updatedReply.components, updatedAssets.container],
       files: updatedAssets.files?.length ? updatedAssets.files : undefined,
     });
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(
-      interaction,
-      buildTextReply(`Failed to update GOTM round ${roundNumber}: ${msg}`, false),
-    );
-  }
+  }, `Failed to update GOTM round ${roundNumber}`, false);
 }

--- a/src/commands/admin/nr-gotm-admin.service.ts
+++ b/src/commands/admin/nr-gotm-admin.service.ts
@@ -1,6 +1,6 @@
 import type { CommandInteraction } from "discord.js";
 import { ButtonStyle } from "discord.js";
-import { extractErrorMessage, safeReply } from "../../functions/InteractionUtils.js";
+import { withErrorReply, safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import NrGotm, {
   type INrGotmEntry,
@@ -21,17 +21,10 @@ import {
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 
 export async function handleAddNrGotm(interaction: CommandInteraction): Promise<void> {
-  let allEntries: INrGotmEntry[];
-  try {
-    allEntries = NrGotm.all();
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(
-      interaction,
-      buildTextReply(`Error loading existing NR-GOTM data: ${msg}`, false),
-    );
-    return;
-  }
+  const allEntries = await withErrorReply(
+    interaction, async () => NrGotm.all(), "Error loading existing NR-GOTM data", false,
+  );
+  if (allEntries === undefined) return;
 
   const nextRound =
     allEntries.length > 0 ? Math.max(...allEntries.map((e) => e.round)) + 1 : 1;
@@ -112,7 +105,7 @@ export async function handleAddNrGotm(interaction: CommandInteraction): Promise<
     });
   }
 
-  try {
+  await withErrorReply(interaction, async () => {
     const insertedIds = await insertNrGotmRoundInDatabase(nextRound, monthYear, games);
     const gamesWithIds = games.map((g, idx) => ({ ...g, id: insertedIds[idx] ?? null }));
     const newEntry = NrGotm.addRound(nextRound, monthYear, gamesWithIds);
@@ -128,13 +121,7 @@ export async function handleAddNrGotm(interaction: CommandInteraction): Promise<
       components: [...createReply.components, embedAssets.container],
       files: embedAssets.files?.length ? embedAssets.files : undefined,
     });
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(
-      interaction,
-      buildTextReply(`Failed to create NR-GOTM round ${nextRound}: ${msg}`, false),
-    );
-  }
+  }, `Failed to create NR-GOTM round ${nextRound}`, false);
 }
 
 export async function handleEditNrGotm(
@@ -147,17 +134,10 @@ export async function handleEditNrGotm(
     return;
   }
 
-  let entries: INrGotmEntry[];
-  try {
-    entries = NrGotm.getByRound(roundNumber);
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(
-      interaction,
-      buildTextReply(`Error loading NR-GOTM data: ${msg}`, false),
-    );
-    return;
-  }
+  const entries = await withErrorReply(
+    interaction, async () => NrGotm.getByRound(roundNumber), "Error loading NR-GOTM data", false,
+  );
+  if (entries === undefined) return;
 
   if (!entries.length) {
     await safeReply(
@@ -272,7 +252,7 @@ export async function handleEditNrGotm(
     newValue = parsed;
   }
 
-  try {
+  await withErrorReply(interaction, async () => {
     await updateNrGotmGameFieldInDatabase({
       rowId: entry.gameOfTheMonth?.[gameIndex]?.id ?? null,
       round: roundNumber,
@@ -296,17 +276,13 @@ export async function handleEditNrGotm(
       interaction.client as any,
     );
 
-    const updatedReply = buildTextReply(`NR-GOTM round ${roundNumber} updated successfully.`, false);
+    const updatedReply = buildTextReply(
+      `NR-GOTM round ${roundNumber} updated successfully.`, false,
+    );
     await safeReply(interaction, {
       ...updatedReply,
       components: [...updatedReply.components, updatedAssets.container],
       files: updatedAssets.files?.length ? updatedAssets.files : undefined,
     });
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(
-      interaction,
-      buildTextReply(`Failed to update NR-GOTM round ${roundNumber}: ${msg}`, false),
-    );
-  }
+  }, `Failed to update NR-GOTM round ${roundNumber}`, false);
 }

--- a/src/commands/admin/voting-admin.service.ts
+++ b/src/commands/admin/voting-admin.service.ts
@@ -1,6 +1,6 @@
 import { DateTime } from "luxon";
 import type { CommandInteraction } from "discord.js";
-import { extractErrorMessage, safeReply } from "../../functions/InteractionUtils.js";
+import { withErrorReply, safeReply } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { listNominationsForRound } from "../../classes/Nomination.js";
 import { getUpcomingNominationWindow } from "../../functions/NominationWindow.js";
@@ -11,7 +11,7 @@ import { promptUserForInput } from "./admin-prompt.utils.js";
 import { VOTING_TITLE_MAX_LEN } from "./admin.types.js";
 
 export async function handleVotingSetup(interaction: CommandInteraction): Promise<void> {
-  try {
+  await withErrorReply(interaction, async () => {
     const window = await getUpcomingNominationWindow();
     const roundNumber = window.targetRound;
     const nextMonth = (() => {
@@ -97,10 +97,7 @@ export async function handleVotingSetup(interaction: CommandInteraction): Promis
     } else {
       await safeReply(interaction, buildTextReply(messageContent, true));
     }
-  } catch (err: any) {
-    const msg = extractErrorMessage(err);
-    await safeReply(interaction, buildTextReply(`Could not generate vote commands: ${msg}`, true));
-  }
+  }, "Could not generate vote commands");
 }
 
 async function normalizeVotingTitles(

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -24,6 +24,7 @@ import {
   deferWithPrivateFlag,
   ephemeralFlag,
   extractErrorMessage,
+  withErrorReply,
   safeDeferReply,
   safeReply,
   sanitizeUserInput,
@@ -769,7 +770,7 @@ export class ProfileCommand {
       return;
     }
 
-    try {
+    await withErrorReply(interaction, async () => {
       const existing = (await Member.getByUserId(target.id)) ?? buildBaseMemberRecord(target);
 
       const updated: IMemberRecord = {
@@ -793,11 +794,14 @@ export class ProfileCommand {
       if (nsw !== undefined) changedFields.push("Switch");
       if (steam !== undefined) changedFields.push("Steam");
 
-      await safeReply(interaction, buildTextReply(`Updated profile for ${userMention(target.id)} (${changedFields.join(", ")}).`, true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Error updating profile: ${msg}`, true));
-    }
+      await safeReply(
+        interaction,
+        buildTextReply(
+          `Updated profile for ${userMention(target.id)} (${changedFields.join(", ")}).`,
+          true,
+        ),
+      );
+    }, "Error updating profile");
   }
 
 }

--- a/src/commands/publicreminder.command.ts
+++ b/src/commands/publicreminder.command.ts
@@ -2,7 +2,7 @@ import type { Channel, CommandInteraction } from "discord.js";
 import { ApplicationCommandOptionType, channelMention, MessageFlags } from "discord.js";
 import { Discord, Slash, SlashChoice, SlashGroup, SlashOption } from "discordx";
 import {
-  extractErrorMessage,
+  withErrorReply,
   safeDeferReply,
   safeReply,
   sanitizeUserInput,
@@ -141,7 +141,7 @@ export class PublicReminderCommand {
       return;
     }
 
-    try {
+    await withErrorReply(interaction, async () => {
       const reminder = await createReminder(
         channel.id,
         message,
@@ -156,10 +156,7 @@ export class PublicReminderCommand {
         `Created reminder #${reminder.reminderId} for ${channelMention(channel.id)} at <t:${timestamp}:F>.` +
         `${recurEvery && recurUnit ? ` (repeats every ${recurEvery} ${recurUnit})` : ""}`;
       await safeReply(interaction, buildTextReply(createdMsg, true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Failed to create reminder: ${msg}`, true));
-    }
+    }, "Failed to create reminder");
   }
 
   @Slash({ description: "List upcoming public reminders", name: "list" })
@@ -169,7 +166,7 @@ export class PublicReminderCommand {
     const ok = await isAdmin(interaction);
     if (!ok) return;
 
-    try {
+    await withErrorReply(interaction, async () => {
       const reminders = await listUpcomingReminders(20);
       if (!reminders.length) {
         await safeReply(
@@ -187,10 +184,7 @@ export class PublicReminderCommand {
       });
 
       await safeReply(interaction, buildTextReply(lines.join("\n"), true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Failed to list reminders: ${msg}`, true));
-    }
+    }, "Failed to list reminders");
   }
 
   @Slash({ description: "Delete a public reminder", name: "delete" })
@@ -209,15 +203,12 @@ export class PublicReminderCommand {
     const ok = await isAdmin(interaction);
     if (!ok) return;
 
-    try {
+    await withErrorReply(interaction, async () => {
       const removed = await deleteReminder(reminderId);
       const deleteMsg = removed
         ? `Deleted reminder #${reminderId}.`
         : `Reminder #${reminderId} not found.`;
       await safeReply(interaction, buildTextReply(deleteMsg, true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Failed to delete reminder: ${msg}`, true));
-    }
+    }, "Failed to delete reminder");
   }
 }

--- a/src/commands/round.command.ts
+++ b/src/commands/round.command.ts
@@ -2,7 +2,7 @@ import { type CommandInteraction, ApplicationCommandOptionType } from "discord.j
 import { Discord, Slash, SlashOption } from "discordx";
 import {
   deferWithPrivateFlag,
-  extractErrorMessage,
+  withErrorReply,
   safeReply,
 } from "../functions/InteractionUtils.js";
 import { buildComponentsV2Flags, buildTextReply } from "../functions/ComponentsV2Utils.js";
@@ -33,7 +33,7 @@ export class CurrentRoundCommand {
     const ephemeral = privateFlag ?? false;
     await deferWithPrivateFlag(interaction, privateFlag);
 
-    try {
+    await withErrorReply(interaction, async () => {
       const current = await BotVotingInfo.getCurrentRound();
       if (!current) {
         await safeReply(interaction, buildTextReply("No voting round information is available.", true));
@@ -94,12 +94,6 @@ export class CurrentRoundCommand {
           ...(i > 0 ? { __forceFollowUp: true } : {}),
         });
       }
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(
-        `Error fetching current round information: ${msg}`,
-        true,
-      ));
-    }
+    }, "Error fetching current round information");
   }
 }

--- a/src/commands/rss.command.ts
+++ b/src/commands/rss.command.ts
@@ -7,7 +7,7 @@ import {
 } from "discord.js";
 import { Discord, Slash, SlashGroup, SlashOption } from "discordx";
 import {
-  extractErrorMessage,
+  withErrorReply,
   safeDeferReply,
   safeReply,
   sanitizeUserInput,
@@ -84,7 +84,7 @@ export class RssCommand {
     const ok = await isAdmin(interaction);
     if (!ok) return;
 
-    try {
+    await withErrorReply(interaction, async () => {
       url = sanitizeUserInput(url, { preserveNewlines: false });
       const sanitizedName = feedName
         ? sanitizeUserInput(feedName, { preserveNewlines: false })
@@ -106,10 +106,7 @@ export class RssCommand {
       const addedMsg =
         `Added feed #${id} (${sanitizedName ?? "unnamed"}) -> ${channelMention(channelId)} (url=${url}).`;
       await safeReply(interaction, buildTextReply(addedMsg, true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Failed to add feed: ${msg}`, true));
-    }
+    }, "Failed to add feed");
   }
 
   @Slash({ description: "Remove an RSS feed relay", name: "remove" })
@@ -128,14 +125,11 @@ export class RssCommand {
     const ok = await isAdmin(interaction);
     if (!ok) return;
 
-    try {
+    await withErrorReply(interaction, async () => {
       const removed = await removeFeed(feedId);
       const removeMsg = removed ? `Removed feed #${feedId}.` : `Feed #${feedId} not found.`;
       await safeReply(interaction, buildTextReply(removeMsg, true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Failed to remove feed: ${msg}`, true));
-    }
+    }, "Failed to remove feed");
   }
 
   @Slash({ description: "Edit an RSS feed relay", name: "edit" })
@@ -206,7 +200,7 @@ export class RssCommand {
       return;
     }
 
-    try {
+    await withErrorReply(interaction, async () => {
       const sanitizedUrl = url ? sanitizeUserInput(url, { preserveNewlines: false }) : undefined;
       const sanitizedName = feedName
         ? sanitizeUserInput(feedName, { preserveNewlines: false })
@@ -230,10 +224,7 @@ export class RssCommand {
         ? `Updated feed #${feedId}.`
         : `Feed #${feedId} not found or no changes applied.`;
       await safeReply(interaction, buildTextReply(editMsg, true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Failed to edit feed: ${msg}`, true));
-    }
+    }, "Failed to edit feed");
   }
 
   @Slash({ description: "List RSS feed relays", name: "list" })
@@ -243,7 +234,7 @@ export class RssCommand {
     const ok = await isAdmin(interaction);
     if (!ok) return;
 
-    try {
+    await withErrorReply(interaction, async () => {
       const feeds = await listFeeds();
       if (!feeds.length) {
         await safeReply(interaction, buildTextReply("No feeds configured.", true));
@@ -258,9 +249,6 @@ export class RssCommand {
       );
 
       await safeReply(interaction, buildTextReply(lines.join("\n"), true));
-    } catch (err: any) {
-      const msg = extractErrorMessage(err);
-      await safeReply(interaction, buildTextReply(`Failed to list feeds: ${msg}`, true));
-    }
+    }, "Failed to list feeds");
   }
 }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -520,6 +520,20 @@ export function extractErrorMessage(err: unknown): string {
   return e?.message ?? String(e);
 }
 
+export async function withErrorReply<T>(
+  interaction: AnyRepliable,
+  fn: () => Promise<T>,
+  errorPrefix = "Error",
+  ephemeral = true,
+): Promise<T | void> {
+  try {
+    return await fn();
+  } catch (err: unknown) {
+    const msg = extractErrorMessage(err);
+    await safeReply(interaction, buildTextReply(`${errorPrefix}: ${msg}`, ephemeral));
+  }
+}
+
 export const OWNER_ONLY_MESSAGE = "This list isn't for you.";
 export const ACCESS_DENIED_ADMIN = "Access denied. Command requires Administrator role.";
 export const ACCESS_DENIED_MOD = "Access denied. Command requires Moderator role or above.";


### PR DESCRIPTION
## Summary
- Adds `withErrorReply(interaction, fn, errorPrefix, ephemeral)` to `InteractionUtils.ts` to encapsulate the repeated `extractErrorMessage` + `safeReply(buildTextReply(...))` catch pattern
- Replaces 20 call sites across 8 files (`admin.command.ts`, `publicreminder.command.ts`, `round.command.ts`, `rss.command.ts`, `profile.command.ts`, `voting-admin.service.ts`, `gotm-admin.service.ts`, `nr-gotm-admin.service.ts`)
- Initialization patterns (`let x; try { x = load(); } catch { return; }`) are refactored to `const x = await withErrorReply(...); if (x === undefined) return;`

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] All error replies still send ephemerally where expected (most sites) or publicly where expected (GOTM/NR-GOTM admin sites)

Closes #725

🤖 Generated with [Claude Code](https://claude.com/claude-code)