### PR TITLE
refactor: add truncateLabel/truncateDescription helpers to eliminate repeated .slice() calls

### DIFF
--- a/src/commands/admin/admin-help.service.ts
+++ b/src/commands/admin/admin-help.service.ts
@@ -4,7 +4,7 @@ import {
 } from "discord.js";
 import { ContainerBuilder } from "@discordjs/builders";
 import { type AdminHelpTopic, type AdminHelpTopicId } from "./admin.types.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
+import { truncateDescription } from "../../config/textLimits.js";
 import {
   buildTitledContainer,
   buildComponentsV2EditFlags,
@@ -112,7 +112,7 @@ export function buildAdminHelpButtons(
       ADMIN_HELP_TOPICS.map((topic) => ({
         label: topic.label,
         value: topic.id,
-        description: topic.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(topic.summary),
         default: topic.id === activeId,
       })),
     )

--- a/src/commands/admin/gotm-audit-ui.service.ts
+++ b/src/commands/admin/gotm-audit-ui.service.ts
@@ -16,7 +16,7 @@ import {
   GOTM_AUDIT_RESULT_LIMIT,
 } from "./admin.types.js";
 import { buildTextContainer } from "../../functions/ComponentsV2Utils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 
 export function buildGotmAuditPromptContent(
   session: IGotmAuditImport,
@@ -68,9 +68,9 @@ export function buildGotmAuditPromptComponents(
       .setPlaceholder("Select a GameDB match")
       .addOptions(
         options.slice(0, GOTM_AUDIT_RESULT_LIMIT).map((opt, idx) => ({
-          label: opt.label.slice(0, DISCORD_SELECT_LABEL_MAX),
+          label: truncateLabel(opt.label),
           value: String(opt.id),
-          description: opt.description?.slice(0, DISCORD_SELECT_LABEL_MAX),
+          description: opt.description ? truncateLabel(opt.description) : undefined,
           default: idx === 0,
         })),
       );

--- a/src/commands/admin/live-stream-admin.service.ts
+++ b/src/commands/admin/live-stream-admin.service.ts
@@ -25,7 +25,7 @@ import {
   sanitizeUserInput,
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply, buildComponentsV2Flags } from "../../functions/ComponentsV2Utils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 
 const LIVE_STREAM_MODAL_PREFIX = "admin-live-stream-create";
@@ -290,7 +290,7 @@ export async function handleLiveStreamCreateModal(interaction: ModalSubmitIntera
     }
     const thread = await forum.threads.create({
       message: threadMessage as any,
-      name: topic.slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(topic),
     });
     threadUrl = thread.url;
     threadId = thread.id;

--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -56,7 +56,7 @@ import {
   type WizardNominationOption,
 } from "./round-setup-wizard.utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 const NEXT_ROUND_SETUP_COMMAND_KEY = "nextround-setup";
@@ -81,7 +81,7 @@ function buildSelectionOptions(
     .filter((option) => !pickedIds.includes(option.nominationId))
     .slice(0, MAX_SELECT_OPTIONS)
     .map((option) => ({
-      label: option.gameTitle.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(option.gameTitle),
       value: String(option.nominationId),
       description: `GameDB ${option.gamedbGameId} | ${option.userIds.length} nominee(s)`,
     }));
@@ -256,7 +256,7 @@ async function promptOrderNomination(
 ): Promise<number | null> {
   const remainingOptions = options.filter((option) => remainingIds.includes(option.nominationId));
   const selectOptions = remainingOptions.slice(0, MAX_SELECT_OPTIONS).map((option) => ({
-    label: option.gameTitle.slice(0, DISCORD_SELECT_LABEL_MAX),
+    label: truncateLabel(option.gameTitle),
     value: String(option.nominationId),
     description: `GameDB ${option.gamedbGameId}`,
   }));

--- a/src/commands/collection/collection-autocomplete.utils.ts
+++ b/src/commands/collection/collection-autocomplete.utils.ts
@@ -6,7 +6,7 @@ import UserGameCollection, {
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../../config/textLimits.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
 
 export const COLLECTION_ENTRY_VALUE_PREFIX = "collection";
 
@@ -29,7 +29,7 @@ export function formatCollectionEntryAutocompleteName(entry: {
   ownershipType: CollectionOwnershipType;
 }): string {
   const platform = entry.platformName ?? "Unknown platform";
-  return `${entry.title} | ${platform} | ${entry.ownershipType}`.slice(0, DISCORD_SELECT_LABEL_MAX);
+  return truncateLabel(`${entry.title} | ${platform} | ${entry.ownershipType}`);
 }
 
 export async function autocompleteCollectionGameTitle(
@@ -46,7 +46,7 @@ export async function autocompleteCollectionGameTitle(
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
-      name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(formatGameTitleWithYear(game)),
       value: String(game.id),
     })),
   );

--- a/src/commands/collection/collection-game-resolve.utils.ts
+++ b/src/commands/collection/collection-game-resolve.utils.ts
@@ -3,7 +3,7 @@ import { igdbService, type IGDBGame } from "../../services/IGDB/IgdbService.js";
 import type { IgdbSelectOption } from "../../services/IGDB/IgdbSelectService.js";
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 
 export type ResolvedCollectionGame =
   | { kind: "resolved"; gameId: number; title: string }
@@ -34,11 +34,11 @@ export async function buildCollectionIgdbSelectOptions(
       .join(", ");
     const summary = (game.summary ?? "No summary").replace(/\s+/g, " ").trim();
     const description = platformText
-      ? `${platformText} | ${summary}`.slice(0, DISCORD_SELECT_LABEL_MAX)
-      : summary.slice(0, DISCORD_SELECT_LABEL_MAX);
+      ? truncateLabel(`${platformText} | ${summary}`)
+      : truncateLabel(summary);
     return {
       id: game.id,
-      label: `${game.name} (${year})`.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(`${game.name} (${year})`),
       description,
     };
   });

--- a/src/commands/create-thread.command.ts
+++ b/src/commands/create-thread.command.ts
@@ -19,7 +19,7 @@ import { safeDeferReply, safeReply, sanitizeOptionalInput, sanitizeUserInput } f
   "../functions/InteractionUtils.js";
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { formatGameTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
-import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../config/textLimits.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../config/textLimits.js";
 
 const DEFAULT_FIRST_POST_PREFIX = "Thread created by";
 
@@ -41,7 +41,7 @@ async function autocompleteCreateThreadTitle(
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
-      name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(formatGameTitleWithYear(game)),
       value: String(game.id),
     })),
   );
@@ -65,8 +65,8 @@ async function autocompleteCreateThreadTag(
     .filter((tag) => !query || tag.name.toLowerCase().includes(query))
     .slice(0, DISCORD_SELECT_OPTIONS_MAX)
     .map((tag) => ({
-      name: tag.name.slice(0, DISCORD_SELECT_LABEL_MAX),
-      value: tag.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(tag.name),
+      value: truncateLabel(tag.name),
     }));
   await interaction.respond(filtered);
 }
@@ -173,7 +173,7 @@ export class CreateThreadCommand {
     const thread = await forum.threads.create({
       appliedTags: [selectedTag.id],
       message: messagePayload,
-      name: game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(game.title),
     });
     await upsertThreadRecord({
       createdAt: thread.createdAt ?? new Date(),
@@ -182,7 +182,7 @@ export class CreateThreadCommand {
       lastSeenAt: null,
       skipLinking: "Y",
       threadId: thread.id,
-      threadName: thread.name ?? game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
+      threadName: thread.name ?? truncateLabel(game.title),
     });
     await setThreadGameLink(thread.id, game.id);
 

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -33,7 +33,7 @@ import {
   buildTextReply,
 } from "../../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
+import { truncateDescription } from "../../config/textLimits.js";
 import {
   buildActionButton,
   buildButtonRow,
@@ -138,7 +138,7 @@ export async function promptIgdbSelection(
     return {
       id: game.id,
       label: `${game.name} (${year})`,
-      description: (game.summary || "No summary").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+      description: truncateDescription((game.summary || "No summary")),
     };
   });
 

--- a/src/commands/game-completion/completion-autocomplete.utils.ts
+++ b/src/commands/game-completion/completion-autocomplete.utils.ts
@@ -8,7 +8,7 @@ import Member from "../../classes/Member.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../../config/textLimits.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
 
 const PLATFORM_CACHE_TTL_MS = 5 * 60 * 1000;
 const COMPLETION_TITLE_VALUE_PREFIX = "completion";
@@ -35,7 +35,7 @@ function normalizePlatformSearchText(value: string): string {
 
 function buildPlatformAutocompleteLabel(platform: IPlatformDef): string {
   const detail = platform.abbreviation ? `${platform.name} (${platform.abbreviation})` : platform.name;
-  return detail.slice(0, DISCORD_SELECT_LABEL_MAX);
+  return truncateLabel(detail);
 }
 
 function sortPlatformsForAutocomplete(
@@ -56,7 +56,7 @@ function sortPlatformsForAutocomplete(
 export function buildKeepTypingOption(query: string): { name: string; value: string } {
   const label = `Keep typing: "${query}"`;
   return {
-    name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
+    name: truncateLabel(label),
     value: query,
   };
 }
@@ -73,7 +73,7 @@ export async function autocompleteGameCompletionTitle(
   }
   const results = await Game.searchGamesAutocomplete(query);
   const resultOptions = results.slice(0, 24).map((game) => ({
-    name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
+    name: truncateLabel(formatGameTitleWithYear(game)),
     value: game.title,
   }));
   const options = [buildKeepTypingOption(query), ...resultOptions];
@@ -87,7 +87,7 @@ function buildCompletionTitleAutocompleteName(completion: {
 }): string {
   const dateLabel = completion.completedAt ? formatTableDate(completion.completedAt) : "No date";
   const line = `${completion.title} | ${completion.completionType} | ${dateLabel}`;
-  return line.slice(0, DISCORD_SELECT_LABEL_MAX);
+  return truncateLabel(line);
 }
 
 function buildCompletionTitleAutocompleteValue(completionId: number): string {

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -25,9 +25,9 @@ import {
 } from "../../functions/ComponentsV2Utils.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 import {
-  DISCORD_SELECT_LABEL_MAX,
   DISCORD_SELECT_OPTIONS_MAX,
   MAX_QUERY_LENGTH,
+  truncateLabel,
 } from "../../config/textLimits.js";
 import {
   buildActionButton,
@@ -75,7 +75,7 @@ export async function renderCompletionLeaderboard(
   const container = buildTextContainer(safeV2TextContent(contentParts.join("\n"), 3500));
 
   const options = leaderboard.map((m) => ({
-    label: (m.globalName ?? m.username ?? m.userId).slice(0, DISCORD_SELECT_LABEL_MAX),
+    label: truncateLabel((m.globalName ?? m.username ?? m.userId)),
     value: m.userId,
     description: `${m.count} ${m.count === 1 ? "completion" : "completions"}`,
   }));
@@ -207,11 +207,11 @@ export async function renderSelectionPage(
   const { containers, totalPages, safePage, pageCompletions } = result;
 
   const selectOptions = pageCompletions.map((c) => ({
-    label: c.title.slice(0, DISCORD_SELECT_LABEL_MAX),
+    label: truncateLabel(c.title),
     value: String(c.completionId),
-    description: `${c.completionType} (${
+    description: truncateLabel(`${c.completionType} (${
       c.completedAt ? formatDiscordTimestamp(c.completedAt) : "No date"
-    })`.slice(0, DISCORD_SELECT_LABEL_MAX),
+    })`),
   }));
 
   const selectId = mode === "edit" ? "comp-edit-menu" : "comp-del-menu";

--- a/src/commands/game-completion/completion-platform.service.ts
+++ b/src/commands/game-completion/completion-platform.service.ts
@@ -19,7 +19,7 @@ import {
   completionPlatformSessions,
   type CompletionPlatformContext,
 } from "./completion.types.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { buildSelectRow } from "../../functions/uiComponents.js";
@@ -61,7 +61,7 @@ export async function promptCompletionPlatformSelection(
   }, interaction.user.id);
 
   const baseOptions = platformOptions.map((platform) => ({
-    label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+    label: truncateLabel(platform.name),
     value: String(platform.id),
   }));
   const options = [

--- a/src/commands/game-completion/completionator-thread.service.ts
+++ b/src/commands/game-completion/completionator-thread.service.ts
@@ -7,7 +7,7 @@ import { CompletionatorUiService } from "./completionator-ui.service.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { BOT_DEV_CHANNEL_ID } from "../../config/channels.js";
 import { safeReply } from "../../functions/InteractionUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export class CompletionatorThreadService {
@@ -97,7 +97,7 @@ export class CompletionatorThreadService {
 
     const threadName: string = `Completionator Import #${session.importId}`;
     const thread: ThreadChannel = await parentMessage.startThread({
-      name: threadName.slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(threadName),
       autoArchiveDuration: 60,
     });
 

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -53,10 +53,7 @@ import {
   buildTextInputRow,
   buildSelectRow,
 } from "../../functions/uiComponents.js";
-import {
-  DISCORD_AUTOCOMPLETE_DESC_MAX,
-  DISCORD_SELECT_LABEL_MAX,
-} from "../../config/textLimits.js";
+import { truncateDescription, truncateLabel } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export class CompletionatorUiService {
@@ -222,7 +219,7 @@ export class CompletionatorUiService {
       return {
         id: game.id,
         label: `${game.name} (${year})`,
-        description: (game.summary || "No summary").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription((game.summary || "No summary")),
       };
     });
 
@@ -378,7 +375,7 @@ export class CompletionatorUiService {
       .setPlaceholder("Completion type")
       .addOptions(
         COMPLETION_TYPES.map((value: string) => ({
-          label: value.slice(0, DISCORD_SELECT_LABEL_MAX),
+          label: truncateLabel(value),
           value,
           default: state.completionType === value,
         })),
@@ -426,7 +423,7 @@ export class CompletionatorUiService {
       a.name.localeCompare(b.name, "en", { sensitivity: "base" }),
     );
     const platformOptions = sortedPlatforms.map((platform) => ({
-      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(platform.name),
       value: String(platform.id),
       default: state.platformId === platform.id,
     }));
@@ -582,7 +579,7 @@ export class CompletionatorUiService {
       return {
         id: game.id,
         label: `${game.name} (${year})`,
-        description: (game.summary || "No summary").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription((game.summary || "No summary")),
       };
     });
      
@@ -737,7 +734,7 @@ export class CompletionatorUiService {
     modal.addComponents(buildTextInputRow({
       customId: "completionator-input",
       label: label.slice(0, 45),
-      placeholder: (itemTitle ?? placeholder).slice(0, DISCORD_SELECT_LABEL_MAX),
+      placeholder: truncateLabel((itemTitle ?? placeholder)),
     }));
     return modal;
   }

--- a/src/commands/game-completion/completionator-workflow.service.ts
+++ b/src/commands/game-completion/completionator-workflow.service.ts
@@ -37,7 +37,7 @@ import { runDockerVolumeBackup } from "../../services/DockerVolumeBackupService.
 import { buildImportTextContainer } from "../imports/import-scaffold.service.js";
 import { canSafeReply, safeDeferReply, safeDeferUpdate } from "../../functions/InteractionUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
+import { truncateDescription } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 
 export class CompletionatorWorkflowService {
@@ -920,13 +920,13 @@ export class CompletionatorWorkflowService {
     item: ICompletionatorItem,
   ): Array<{ label: string; value: string; description: string }> {
     const options: Array<{ label: string; value: string; description: string }> = [];
-    const clamp = (value: string): string => value.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX);
-
     if (item.completionType && item.completionType !== existing?.completionType) {
       options.push({
         label: "Completion Type",
         value: "type",
-        description: clamp(`${existing?.completionType ?? "Unknown"} → ${item.completionType}`),
+        description: truncateDescription(
+          `${existing?.completionType ?? "Unknown"} → ${item.completionType}`,
+        ),
       });
     }
 
@@ -939,7 +939,7 @@ export class CompletionatorWorkflowService {
         options.push({
           label: "Completion Date",
           value: "date",
-          description: clamp(`${existingDate} → ${incomingDate}`),
+          description: truncateDescription(`${existingDate} → ${incomingDate}`),
         });
       }
     }
@@ -952,7 +952,7 @@ export class CompletionatorWorkflowService {
         options.push({
           label: "Playtime",
           value: "playtime",
-          description: clamp(
+          description: truncateDescription(
             `${existingPlaytime ?? "Unknown"} hrs → ${item.playtimeHours} hrs`,
           ),
         });

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -82,7 +82,7 @@ import {
   JOURNAL_ALL_PAGE_SIZE as ALL_PAGE_SIZE,
   JOURNAL_SEARCH_PAGE_SIZE as SEARCH_PAGE_SIZE,
 } from "../config/pagination.js";
-import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../config/textLimits.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../config/textLimits.js";
 
 const gjHmenu = new EphemeralOwnerMenu();
 
@@ -327,7 +327,7 @@ async function autocompleteJournalSearchGame(
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
-      name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(formatGameTitleWithYear(game)),
       value: String(game.id),
     })),
   );

--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -55,7 +55,7 @@ import {
 import { trimTextDisplayContent } from "./gamedb-profile.service.js";
 import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 import {
   buildActionButton,
   buildButtonRow,
@@ -140,7 +140,7 @@ function buildCompletionPlatformOptions(
     a.name.localeCompare(b.name, "en", { sensitivity: "base" }),
   );
   const baseOptions = sortedPlatforms.map((platform) => ({
-    label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+    label: truncateLabel(platform.name),
     value: String(platform.id),
   }));
   return [
@@ -159,7 +159,7 @@ function buildCompletionWizardComponents(
     .setPlaceholder("Completion type")
     .addOptions(
       COMPLETION_TYPES.map((value) => ({
-        label: value.slice(0, DISCORD_SELECT_LABEL_MAX),
+        label: truncateLabel(value),
         value,
         default: session.completionType === value,
       })),

--- a/src/commands/gamedb/gamedb-csv-import.command.ts
+++ b/src/commands/gamedb/gamedb-csv-import.command.ts
@@ -70,7 +70,7 @@ import {
 import { GAMEDB_CSV_RESULT_LIMIT } from "../../config/pagination.js";
 import { processReleaseDates } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../../config/textLimits.js";
+import { truncateDescription } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
 
@@ -298,7 +298,7 @@ async function processNextGameDbCsvImportItem(
       return {
         id: game.id,
         label: `${game.name} (${year})`,
-        description: game.summary ? game.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX) : "No summary",
+        description: game.summary ? truncateDescription(game.summary) : "No summary",
       };
     })
     : [];
@@ -807,7 +807,7 @@ export class GameDbCsvImportCommand {
         return {
           id: game.id,
           label: `${game.name} (${year})`,
-          description: game.summary ? game.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX) : "No summary",
+          description: game.summary ? truncateDescription(game.summary) : "No summary",
         };
       })
       : [];

--- a/src/commands/gamedb/gamedb-csv-import.service.ts
+++ b/src/commands/gamedb/gamedb-csv-import.service.ts
@@ -25,10 +25,7 @@ import { GAMEDB_CSV_PLATFORM_MAP } from "../../config/gamedbCsvPlatformMap.js";
 import { buildIgdbSearchLink } from "./gamedb-utils.js";
 import { type IGameDbCsvImport } from "../../classes/GameDbCsvImport.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import {
-  DISCORD_AUTOCOMPLETE_DESC_MAX,
-  DISCORD_SELECT_LABEL_MAX,
-} from "../../config/textLimits.js";
+import { truncateDescription, truncateLabel } from "../../config/textLimits.js";
 import { logWarn } from "../../utilities/LogUtils.js";
 import { GAMEDB_CSV_RESULT_LIMIT } from "../../config/pagination.js";
 
@@ -122,9 +119,9 @@ export function buildCsvPromptComponents(
       .setPlaceholder("Select a match from IGDB")
       .addOptions(
         options.slice(0, GAMEDB_CSV_RESULT_LIMIT).map((opt, idx) => ({
-          label: opt.label.slice(0, DISCORD_SELECT_LABEL_MAX),
+          label: truncateLabel(opt.label),
           value: String(opt.id),
-          description: opt.description?.slice(0, DISCORD_SELECT_LABEL_MAX),
+          description: opt.description ? truncateLabel(opt.description) : undefined,
           default: idx === 0,
         })),
       );
@@ -178,7 +175,7 @@ export async function scoreCsvImportResults(
     return {
       id: game.id,
       label: `${game.name} (${year})`,
-      description: game.summary ? game.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX) : "No summary",
+      description: game.summary ? truncateDescription(game.summary) : "No summary",
     };
   });
 }

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -17,7 +17,7 @@ import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUt
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { encodeWithMaxLength } from "../../functions/CustomIdUtils.js";
 import Game from "../../classes/Game.js";
-import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../../config/textLimits.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
 import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
 import { GAMEDB_SEARCH_PREFIX } from "../../config/customIdPrefixes.js";
 
@@ -212,7 +212,7 @@ export function getSearchRowsFromComponents(
 export function buildKeepTypingOption(query: string): { name: string; value: string } {
   const label = `Keep typing: "${query}"`;
   return {
-    name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
+    name: truncateLabel(label),
     value: query,
   };
 }
@@ -232,7 +232,7 @@ export async function autocompleteSearchPlatform(
     )
     : platforms;
   const options = filtered.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((p) => ({
-    name: (p.abbreviation ? `${p.name} (${p.abbreviation})` : p.name).slice(0, DISCORD_SELECT_LABEL_MAX),
+    name: truncateLabel((p.abbreviation ? `${p.name} (${p.abbreviation})` : p.name)),
     value: String(p.id),
   }));
   await interaction.respond(options);
@@ -249,7 +249,7 @@ export async function autocompleteSearchCompany(
     ? companies.filter((c) => c.name.toLowerCase().includes(query))
     : companies;
   const options = filtered.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((c) => ({
-    name: c.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+    name: truncateLabel(c.name),
     value: String(c.id),
   }));
   await interaction.respond(options);
@@ -269,7 +269,7 @@ export async function autocompleteGameDbViewTitle(
   const resultOptions = results.slice(0, 24).map((game) => {
     const label = formatGameTitleWithYear(game);
     return {
-      name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(label),
       value: String(game.id),
     };
   });

--- a/src/commands/help.command.ts
+++ b/src/commands/help.command.ts
@@ -29,7 +29,7 @@ import { safeDeferReply, safeReply, safeUpdate } from "../functions/InteractionU
 import { decodeBase64Url, encodeBase64Url } from "../functions/CustomIdUtils.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { GIVEAWAY_HUB_CHANNEL_ID } from "../config/channels.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
+import { truncateDescription } from "../config/textLimits.js";
 import { buildActionButton, buildButtonRow , buildSelectRow } from "../functions/uiComponents.js";
 
 type HelpTopicId =
@@ -460,7 +460,7 @@ function buildProfileHelpButtons(
       PROFILE_HELP_TOPICS.map((topic) => ({
         label: topic.label,
         value: topic.id,
-        description: topic.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(topic.summary),
         default: topic.id === activeId,
       })),
     )
@@ -485,7 +485,7 @@ function buildNowPlayingHelpButtons(
       NOW_PLAYING_HELP_TOPICS.map((topic) => ({
         label: topic.label,
         value: topic.id,
-        description: topic.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(topic.summary),
         default: topic.id === activeId,
       })),
     )
@@ -522,7 +522,7 @@ function buildGamedbHelpButtons(
       GAMEDB_HELP_TOPICS.map((topic) => ({
         label: topic.label,
         value: topic.id,
-        description: topic.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(topic.summary),
         default: topic.id === activeId,
       })),
     )
@@ -711,7 +711,7 @@ function buildGameCompletionHelpButtons(
       GAME_COMPLETION_HELP_TOPICS.map((topic) => ({
         label: topic.label,
         value: topic.id,
-        description: topic.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(topic.summary),
         default: topic.id === activeId,
       })),
     )
@@ -842,7 +842,7 @@ function buildRssHelpButtons(
       RSS_HELP_TOPICS.map((topic) => ({
         label: topic.label,
         value: topic.id,
-        description: topic.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(topic.summary),
         default: topic.id === activeId,
       })),
     )

--- a/src/commands/hltb.command.ts
+++ b/src/commands/hltb.command.ts
@@ -22,12 +22,12 @@ import {
   getReleaseYear,
   parseTitleWithYear,
 } from "../functions/GameTitleAutocompleteUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { truncateLabel } from "../config/textLimits.js";
 
 function buildKeepTypingOption(query: string): { name: string; value: string } {
   const label = `Keep typing: "${query}"`;
   return {
-    name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
+    name: truncateLabel(label),
     value: query,
   };
 }
@@ -46,7 +46,7 @@ async function autocompleteHltbTitle(
   const resultOptions = results.slice(0, 24).map((game) => {
     const label = formatGameTitleWithYear(game);
     return {
-      name: label.slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(label),
       value: label,
     };
   });

--- a/src/commands/mod.command.ts
+++ b/src/commands/mod.command.ts
@@ -23,7 +23,7 @@ import {
   buildComponentsV2EditFlags,
   type EmbedField,
 } from "../functions/ComponentsV2Utils.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
+import { truncateDescription } from "../config/textLimits.js";
 import { buildSelectRow } from "../functions/uiComponents.js";
 
 type ModHelpTopicId = "presence" | "presence-history";
@@ -63,7 +63,7 @@ function buildModHelpButtons(
       MOD_HELP_TOPICS.map((topic) => ({
         label: topic.label,
         value: topic.id,
-        description: topic.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(topic.summary),
         default: topic.id === activeId,
       })),
     )

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -40,7 +40,7 @@ import {
   MP_INFO_PAGE_SIZE as PAGE_SIZE,
 } from "../config/pagination.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { truncateLabel } from "../config/textLimits.js";
 import { chunk } from "../utilities/ArrayUtils.js";
 import { buildActionButton, buildButtonRow , buildSelectRow } from "../functions/uiComponents.js";
 
@@ -165,9 +165,9 @@ function buildPageComponents(
     const name = member.globalName ?? member.username ?? "Unknown member";
     const platforms = formatPlatforms(member, filters) || "Platforms not listed";
     return {
-      label: name.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(name),
       value: member.userId,
-      description: platforms.slice(0, DISCORD_SELECT_LABEL_MAX),
+      description: truncateLabel(platforms),
     };
   });
 

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -44,7 +44,7 @@ import {
 } from "../config/nominationChannels.js";
 import { showGameProfileFromNomination } from "./gamedb.command.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX, DISCORD_SELECT_OPTIONS_MAX } from "../config/textLimits.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../config/textLimits.js";
 import { logError } from "../utilities/LogUtils.js";
 
 const NOMINATE_REASON_MAX_LENGTH = 1500;
@@ -63,8 +63,8 @@ async function autocompleteNominationTitle(
   const results = await Game.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
-      name: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
-      value: formatGameTitleWithYear(game).slice(0, DISCORD_SELECT_LABEL_MAX),
+      name: truncateLabel(formatGameTitleWithYear(game)),
+      value: truncateLabel(formatGameTitleWithYear(game)),
     })),
   );
 }

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -87,9 +87,9 @@ import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { logError } from "../utilities/LogUtils.js";
 import {
-  DISCORD_AUTOCOMPLETE_DESC_MAX,
-  DISCORD_SELECT_LABEL_MAX,
   DISCORD_SELECT_OPTIONS_MAX,
+  truncateDescription,
+  truncateLabel,
 } from "../config/textLimits.js";
 import { assertCustomIdSegments, parseCustomIdSegmentsMin } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
@@ -783,7 +783,7 @@ export class NowPlayingCommand {
       sourceSessionId,
     });
     const options = platforms.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((platform) => ({
-      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(platform.name),
       value: String(platform.id),
     }));
     const select = new StringSelectMenuBuilder()
@@ -1084,7 +1084,7 @@ export class NowPlayingCommand {
           });
         }
         return deduped.map((platform, optionIndex) => ({
-          label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+          label: truncateLabel(platform.name),
           value: String(optionIndex),
           platformId: platform.id,
         }));
@@ -1130,7 +1130,7 @@ export class NowPlayingCommand {
     }
 
     const options = platforms.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((platform) => ({
-      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(platform.name),
       value: String(platform.id),
     }));
     const select = new StringSelectMenuBuilder()
@@ -1904,7 +1904,7 @@ export class NowPlayingCommand {
       return;
     }
     const options = entries.map((entry) => ({
-      label: (entry.title ?? `Entry #${entry.entryNumber}`).slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel((entry.title ?? `Entry #${entry.entryNumber}`)),
       value: String(entry.entryId),
       description: formatTableDate(entry.createdAt),
     }));
@@ -2162,7 +2162,7 @@ export class NowPlayingCommand {
       return;
     }
     const options = gamesWithoutJournal.map((e) => ({
-      label: e.title.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(e.title),
       value: String(e.gameId),
     }));
     const select = new StringSelectMenuBuilder()
@@ -2595,7 +2595,7 @@ export class NowPlayingCommand {
       .filter((entry) => isPositiveInt(entry.gameId))
       .slice(0, DISCORD_SELECT_OPTIONS_MAX)
       .map((entry) => ({
-        label: formatEntryTitleWithPlatform(entry).slice(0, DISCORD_SELECT_LABEL_MAX),
+        label: truncateLabel(formatEntryTitleWithPlatform(entry)),
         value: String(entry.gameId),
       }));
     const removeSelect = new StringSelectMenuBuilder()
@@ -2727,8 +2727,8 @@ export class NowPlayingCommand {
       const currentPlatformName =
         selectedIndex >= 0 ? (options[selectedIndex]?.label ?? null) : null;
       const placeholder = currentPlatformName
-        ? `${entry.title.slice(0, 50)} - ${currentPlatformName}`.slice(0, DISCORD_SELECT_LABEL_MAX)
-        : entry.title.slice(0, DISCORD_SELECT_LABEL_MAX);
+        ? truncateLabel(`${entry.title.slice(0, 50)} - ${currentPlatformName}`)
+        : truncateLabel(entry.title);
       const select = new StringSelectMenuBuilder()
         .setCustomId(`${NOW_PLAYING_EDIT_PLATFORM_SLOT_PREFIX}:${ownerId}:${slotIndex}:${stateToken}`)
         .setPlaceholder(placeholder)
@@ -2736,7 +2736,7 @@ export class NowPlayingCommand {
         .setMaxValues(1)
         .addOptions(options.map((option, optionIndex) => ({
           label: optionIndex === selectedIndex
-            ? `${entry.title.slice(0, 50)} - ${option.label}`.slice(0, DISCORD_SELECT_LABEL_MAX)
+            ? truncateLabel(`${entry.title.slice(0, 50)} - ${option.label}`)
             : option.label,
           value: option.value,
           default: selectedIndex === optionIndex,
@@ -2795,7 +2795,7 @@ export class NowPlayingCommand {
         .setMinValues(1)
         .setMaxValues(1)
         .addOptions(entries.map((entry, entryIndex) => ({
-          label: formatEntryTitleWithPlatform(entry).slice(0, DISCORD_SELECT_LABEL_MAX),
+          label: truncateLabel(formatEntryTitleWithPlatform(entry)),
           value: String(entryIndex),
           default: selectedIndex === entryIndex,
         })));
@@ -3001,7 +3001,7 @@ export class NowPlayingCommand {
         return {
           id: game.id,
           label: `${game.name} (${year})`,
-          description: (game.summary || "No summary").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+          description: truncateDescription((game.summary || "No summary")),
         };
       });
 

--- a/src/commands/now-playing/nowPlayingCompletion.handler.ts
+++ b/src/commands/now-playing/nowPlayingCompletion.handler.ts
@@ -70,7 +70,7 @@ import {
 } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 import {
   MAX_NOW_PLAYING_NOTE_LEN,
   NOW_PLAYING_COMPLETE_ANNOUNCE_SELECT_PREFIX,
@@ -502,7 +502,7 @@ async function promptNowPlayingCompletionPlatformSelection(
   });
 
   const baseOptions = platformOptions.map((platform) => ({
-    label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+    label: truncateLabel(platform.name),
     value: String(platform.id),
   }));
   const options = [

--- a/src/commands/now-playing/nowPlayingListRenderer.ts
+++ b/src/commands/now-playing/nowPlayingListRenderer.ts
@@ -49,10 +49,7 @@ import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 import { truncateWithEllipsis } from "../../utilities/ValidationUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
-import {
-  DISCORD_SELECT_LABEL_MAX,
-  DISCORD_SELECT_OPTIONS_MAX,
-} from "../../config/textLimits.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
 import {
   NOW_PLAYING_LIST_EDIT_PREFIX,
   NOW_PLAYING_JOURNAL_VIEW_SELECT_PREFIX,
@@ -650,7 +647,7 @@ export function buildNowPlayingMemberSelect(
   const options = sorted.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((record) => {
     const displayName = record.globalName ?? record.username ?? record.userId;
     return {
-      label: displayName.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(displayName),
       value: record.userId,
       description: `${record.entries.length} ${record.entries.length === 1 ? "game" : "games"}`,
       default: record.userId === selectedUserId,

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -42,7 +42,7 @@ import {
   formatPlaytimeHours,
   formatTableDate,
 } from "../functions/DateFormatUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { truncateLabel } from "../config/textLimits.js";
 import { chunk } from "../utilities/ArrayUtils.js";
 
 export { formatDiscordTimestamp, formatPlaytimeHours, formatTableDate };
@@ -650,12 +650,12 @@ export class ProfileCommand {
     const description = `Filters: ${filterSummary}\n\n${lines.join("\n")}`;
 
     const selectOptions = results.map((record, idx) => {
-      const label = (record.globalName ?? record.username ?? `Member ${idx + 1}`).slice(0, DISCORD_SELECT_LABEL_MAX);
+      const label = truncateLabel((record.globalName ?? record.username ?? `Member ${idx + 1}`));
       const descriptionText = `ID: ${record.userId}${record.isBot ? " | Bot" : ""}`;
       return {
         label,
         value: record.userId,
-        description: descriptionText.slice(0, DISCORD_SELECT_LABEL_MAX),
+        description: truncateLabel(descriptionText),
       };
     });
 

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -57,7 +57,7 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { sleep } from "../utilities/DelayUtils.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { truncateDescription, truncateLabel } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError } from "../utilities/LogUtils.js";
@@ -134,7 +134,7 @@ function buildSuperAdminHelpButtons(
       SUPERADMIN_HELP_TOPICS.map((topic) => ({
         label: topic.label,
         value: topic.id,
-        description: topic.summary.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(topic.summary),
         default: topic.id === activeId,
       })),
     )
@@ -367,7 +367,7 @@ export class SuperAdmin {
       superadminCompletionAddSessions.set(sessionId, ctx);
 
       const options = localResults.slice(0, 24).map((game) => ({
-        label: game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
+        label: truncateLabel(game.title),
         value: String(game.id),
         description: `GameDB #${game.id}`,
       }));
@@ -439,7 +439,7 @@ export class SuperAdmin {
       interaction.id,
     );
     const baseOptions = platformOptions.map((platform) => ({
-      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(platform.name),
       value: String(platform.id),
     }));
     const options = [
@@ -494,7 +494,7 @@ export class SuperAdmin {
       return {
         id: game.id,
         label: `${game.name} (${year})`,
-        description: (game.summary || "No summary").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+        description: truncateDescription(game.summary || "No summary"),
       };
     });
 

--- a/src/config/textLimits.ts
+++ b/src/config/textLimits.ts
@@ -19,3 +19,6 @@ export const MAX_SECTION_TEXT = 1000;
 export const GIVEAWAY_MAX_TITLE_LENGTH    = 200;
 export const GIVEAWAY_MAX_PLATFORM_LENGTH = 50;
 export const GIVEAWAY_MAX_KEY_LENGTH      = 200;
+
+export const truncateLabel = (s: string): string => s.slice(0, DISCORD_SELECT_LABEL_MAX);
+export const truncateDescription = (s: string): string => s.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX);

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -32,7 +32,7 @@ import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { notifyUnknownCompletionPlatform } from "../functions/CompletionHelpers.js";
 import { COMPLETION_REACTION_DEV_CHANNEL_ID } from "../config/channels.js";
 import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX, DISCORD_SELECT_LABEL_MAX } from "../config/textLimits.js";
+import { truncateDescription, truncateLabel } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import {
@@ -144,7 +144,7 @@ const buildIgdbOptions = (
     return {
       id: game.id,
       label: `${game.name} (${year})`,
-      description: (game.summary || "No summary").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+      description: truncateDescription((game.summary || "No summary")),
     };
   });
 
@@ -306,7 +306,7 @@ export class MessageReactionAdd {
     }
 
     const options = matches.slice(0, 24).map((game) => ({
-      label: game.title.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(game.title),
       value: String(game.id),
       description: `GameDB #${game.id}`,
     }));
@@ -473,7 +473,7 @@ export class MessageReactionAdd {
         customId: "completion-react-title-input",
         label: "Game title",
         maxLength: 100,
-        value: session.query.slice(0, DISCORD_SELECT_LABEL_MAX),
+        value: truncateLabel(session.query),
       }));
 
     safeIgnore(interaction.showModal(modal));
@@ -545,7 +545,7 @@ export class MessageReactionAdd {
     }
 
     const baseOptions = platforms.map((platform) => ({
-      label: platform.name.slice(0, DISCORD_SELECT_LABEL_MAX),
+      label: truncateLabel(platform.name),
       value: String(platform.id),
     }));
     const platformOptions = [

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -88,9 +88,10 @@ import {
 } from "./ComponentsV2Utils.js";
 import { formatTableDate } from "./DateFormatUtils.js";
 import {
-  DISCORD_AUTOCOMPLETE_DESC_MAX,
   DISCORD_SELECT_LABEL_MAX,
   DISCORD_SELECT_OPTIONS_MAX,
+  truncateDescription,
+  truncateLabel,
 } from "../config/textLimits.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 
@@ -107,9 +108,9 @@ export function buildSelectOptions(
 ): StringSelectMenuOptionBuilder[] {
   return inputs.slice(0, maxOptions).map((item) => {
     const option = new StringSelectMenuOptionBuilder()
-      .setLabel(item.label.slice(0, DISCORD_SELECT_LABEL_MAX))
+      .setLabel(truncateLabel(item.label))
       .setValue(item.value)
-      .setDescription((item.description ?? "").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX));
+      .setDescription(truncateDescription((item.description ?? "")));
     if (item.emoji != null) option.setEmoji(item.emoji);
     return option;
   });
@@ -136,7 +137,7 @@ export function buildJournalSelectRow(
         : rawLabel;
     const countText = e.journalCount === 1 ? "1 entry" : `${e.journalCount} entries`;
     const lastPart = e.lastJournalAt ? ` · Last entry ${formatTableDate(e.lastJournalAt)}` : "";
-    const description = `${countText}${lastPart}`.slice(0, DISCORD_SELECT_LABEL_MAX);
+    const description = truncateLabel(`${countText}${lastPart}`);
     return { label, description, value: String(e.gameId) };
   });
   const select = new StringSelectMenuBuilder()

--- a/src/services/IGDB/IgdbSelectService.ts
+++ b/src/services/IGDB/IgdbSelectService.ts
@@ -14,7 +14,7 @@ import {
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
-import { DISCORD_SELECT_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateLabel } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import {
   buildActionButton,
@@ -101,9 +101,9 @@ export function buildIgdbComponents(
     .addOptions(
       hasOptions
         ? pageOptions.map((opt, index) => ({
-          label: opt.label.slice(0, DISCORD_SELECT_LABEL_MAX),
+          label: truncateLabel(opt.label),
           value: String(opt.id),
-          description: opt.description?.slice(0, DISCORD_SELECT_LABEL_MAX),
+          description: opt.description ? truncateLabel(opt.description) : undefined,
           default: page === 0 && index === 0,
         }))
         : [{

--- a/src/services/ThreadLinkPromptService.ts
+++ b/src/services/ThreadLinkPromptService.ts
@@ -30,7 +30,7 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import { shouldPrompt, markPrompted, getGameReleaseYear } from "./ThreadLinkPromptCache.js";
 import { COLOR_BLUE_INFO } from "../config/colors.js";
-import { DISCORD_AUTOCOMPLETE_DESC_MAX } from "../config/textLimits.js";
+import { truncateDescription } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError, logInfo, logWarn } from "../utilities/LogUtils.js";
@@ -189,7 +189,7 @@ export class ThreadLinkButtonHandlers {
             return {
               id: game.id,
               label: `${game.name} (${year})`,
-              description: (game.summary || "No summary").slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX),
+              description: truncateDescription((game.summary || "No summary")),
             };
           });
 


### PR DESCRIPTION
## Summary
- Add `truncateLabel` and `truncateDescription` helper functions to `src/config/textLimits.ts`, co-located with the constants they wrap
- Replace all 70+ inline `.slice(0, DISCORD_SELECT_LABEL_MAX)` and `.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX)` call sites across 34 files with the new helpers
- Remove now-unused constant imports per file; optional-chaining sites (`?.slice(...)`) converted to ternary guards to preserve `string | undefined` types

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] No remaining inline `.slice(0, DISCORD_SELECT_LABEL_MAX)` or `.slice(0, DISCORD_AUTOCOMPLETE_DESC_MAX)` call sites outside `textLimits.ts`

Closes #726

🤖 Generated with [Claude Code](https://claude.com/claude-code)