### PR TITLE
refactor: add toUnixTimestamp helper to DateFormatUtils

### DIFF
--- a/src/commands/admin.command.ts
+++ b/src/commands/admin.command.ts
@@ -32,6 +32,7 @@ import {
 import {
   parseVoteDateInput,
 } from "../functions/VoteDateUtils.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 import { bot } from "../RPGClub_GameDB.js";
 import BotVotingInfo from "../classes/BotVotingInfo.js";
 import { isAdmin } from "./admin/admin-auth.utils.js";
@@ -137,7 +138,7 @@ export class Admin {
       }
 
       await BotVotingInfo.updateNextVoteAt(current.roundNumber, parsed);
-      const voteUnix = Math.floor(parsed.getTime() / 1000);
+      const voteUnix = toUnixTimestamp(parsed);
 
       await safeReply(
         interaction,

--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -28,7 +28,7 @@ import Gotm, { insertGotmRoundInDatabase, type IGotmGame } from "../../classes/G
 import NrGotm, { insertNrGotmRoundInDatabase, type INrGotmGame } from "../../classes/NrGotm.js";
 import BotVotingInfo from "../../classes/BotVotingInfo.js";
 import { calculateNextVoteDate } from "./voting-admin.service.js";
-import { formatMonthYear } from "../../functions/DateFormatUtils.js";
+import { formatMonthYear, toUnixTimestamp } from "../../functions/DateFormatUtils.js";
 import { formatVoteDateForDisplay, parseVoteDateInput } from "../../functions/VoteDateUtils.js";
 import {
   addCancelOption,
@@ -443,7 +443,7 @@ export async function handleNextRoundSetup(
       testMode,
     };
     await wizardLog(
-      `Found unfinished setup from <t:${Math.floor(activeSession.lastUpdatedAt.getTime() / 1000)}:R>.`,
+      `Found unfinished setup from <t:${toUnixTimestamp(activeSession.lastUpdatedAt)}:R>.`,
     );
     const resumeChoice = await wizardChoice(
       "Resume previous setup state?",
@@ -888,7 +888,7 @@ export async function handleNextRoundSetup(
     },
     {
       description:
-        `Set next vote date to <t:${Math.floor(finalDate.getTime() / 1000)}:D> (America/New_York)`,
+        `Set next vote date to <t:${toUnixTimestamp(finalDate)}:D> (America/New_York)`,
       execute: async () => {
         if (testMode) {
           await wizardLog("[Test] Would set round info.");
@@ -957,7 +957,7 @@ export async function handleNextRoundSetup(
     await updateEmbed(
       `\n**Summary**\n` +
       `Month label: **${monthYear}**\n` +
-      `Next vote date: <t:${Math.floor(finalDate.getTime() / 1000)}:D>\n` +
+      `Next vote date: <t:${toUnixTimestamp(finalDate)}:D>\n` +
       `Test mode: **${testMode ? "ON" : "OFF"}**\n\n` +
       `**Selected GOTM**\n${gotmSummary}\n\n` +
       `**Selected NR-GOTM**\n${nrSummary}\n\n` +

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -93,6 +93,7 @@ import {
 import Game from "../classes/Game.js";
 import Member from "../classes/Member.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 
 // Note: This is a simplified working version that delegates complex Completionator logic
 // to service files. The full implementation would import and delegate all handlers.
@@ -670,7 +671,7 @@ export class GameCompletionCommands {
     }
     if (updates.completedAt !== undefined) {
       const dateLabel = updated.completedAt
-        ? `<t:${Math.floor(updated.completedAt.getTime() / 1000)}:D>`
+        ? `<t:${toUnixTimestamp(updated.completedAt)}:D>`
         : "No date";
       changedLines.push(`- Completion Date: **${dateLabel}**`);
     }

--- a/src/commands/mod.command.ts
+++ b/src/commands/mod.command.ts
@@ -25,6 +25,7 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import { truncateDescription } from "../config/textLimits.js";
 import { buildSelectRow } from "../functions/uiComponents.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 
 type ModHelpTopicId = "presence" | "presence-history";
 
@@ -140,7 +141,7 @@ export class Mod {
     const lines = entries.map((entry) => {
       const timestamp =
         entry.setAt instanceof Date
-          ? `<t:${Math.floor(entry.setAt.getTime() / 1000)}:F>`
+          ? `<t:${toUnixTimestamp(entry.setAt)}:F>`
           : String(entry.setAt);
       const userDisplay = entry.setByUsername ?? entry.setByUserId ?? "unknown user";
       return `• ${timestamp} ${entry.activityName} (set by ${userDisplay})`;

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -38,6 +38,7 @@ import {
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
 import { buildTextReply, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 import {
   GOTM_NOMINATION_CHANNEL_ID,
   NR_GOTM_NOMINATION_CHANNEL_ID,
@@ -212,7 +213,7 @@ export class NominateCommand {
     try {
       const window = await getUpcomingNominationWindow();
       if (areNominationsClosed(window)) {
-        const voteUnix = Math.floor(window.nextVoteAt.getTime() / 1000);
+        const voteUnix = toUnixTimestamp(window.nextVoteAt);
         const closedMsg =
           `Nominations for Round ${window.targetRound} are closed. ` +
           `Voting is scheduled for <t:${voteUnix}:F>.`;

--- a/src/commands/publicreminder.command.ts
+++ b/src/commands/publicreminder.command.ts
@@ -16,6 +16,7 @@ import {
   type RecurrenceUnit,
 } from "../classes/PublicReminder.js";
 import { DateTime } from "luxon";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 
 const RECURRENCE_CHOICES: { name: string; value: RecurrenceUnit }[] = [
   { name: "Minutes", value: "minutes" },
@@ -151,7 +152,7 @@ export class PublicReminderCommand {
         interaction.user.id,
       );
 
-      const timestamp = Math.floor(parsedDate.getTime() / 1000);
+      const timestamp = toUnixTimestamp(parsedDate);
       const createdMsg =
         `Created reminder #${reminder.reminderId} for ${channelMention(channel.id)} at <t:${timestamp}:F>.` +
         `${recurEvery && recurUnit ? ` (repeats every ${recurEvery} ${recurUnit})` : ""}`;
@@ -179,7 +180,7 @@ export class PublicReminderCommand {
       const lines = reminders.map((r) => {
         const recur =
           r.recurEvery && r.recurUnit ? ` (repeats every ${r.recurEvery} ${r.recurUnit})` : "";
-        const timestamp = Math.floor(r.dueAt.getTime() / 1000);
+        const timestamp = toUnixTimestamp(r.dueAt);
         return `#${r.reminderId}: ${channelMention(r.channelId)} at <t:${timestamp}:F>${recur} - ${r.message}`;
       });
 

--- a/src/commands/suggestion.command.ts
+++ b/src/commands/suggestion.command.ts
@@ -53,6 +53,7 @@ import { logRawModal } from "../services/raw-modal/RawModalLogging.js";
 import { isPositiveInt, truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { buildActionButton, buildButtonRow } from "../functions/uiComponents.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 
 const SUGGESTION_APPROVE_PREFIX = "suggestion-approve";
 const SUGGESTION_CREATE_MODAL_ID = "suggestion-create-modal";
@@ -264,8 +265,7 @@ async function openSuggestionReviewDecisionModal(
 
 function formatSuggestionTimestampPlain(date: Date | null | undefined): string {
   if (!date) return "Unknown";
-  const unixSeconds = Math.floor(date.getTime() / 1000);
-  return `<t:${unixSeconds}:F>`;
+  return `<t:${toUnixTimestamp(date)}:F>`;
 }
 
 function buildSuggestionReviewSummaryText(

--- a/src/events/GuildBanLog.command.ts
+++ b/src/events/GuildBanLog.command.ts
@@ -4,6 +4,7 @@ import { Discord, On } from "discordx";
 import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { BAN_LOG_CHANNEL_ID, UNBAN_LOG_CHANNEL_ID } from "../config/channels.js";
 import { buildIdTimestampFooter } from "../functions/InteractionUtils.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 import { COLOR_INFO, COLOR_ERROR } from "../config/colors.js";
 import {
   buildTitledContainer,
@@ -19,7 +20,7 @@ async function resolveLogChannel(client: Client, channelId: string): Promise<any
 }
 
 function formatAccountCreated(date: Date): string {
-  return `<t:${Math.floor(date.getTime() / 1000)}:F>`;
+  return `<t:${toUnixTimestamp(date)}:F>`;
 }
 
 function buildBanContainer(

--- a/src/events/GuildMemberAdd.command.ts
+++ b/src/events/GuildMemberAdd.command.ts
@@ -5,6 +5,7 @@ import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { recordCurrentAvatarIfNew } from "../utilities/AvatarLogUtils.js";
 import { COLOR_SUCCESS } from "../config/colors.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 import { logError } from "../utilities/LogUtils.js";
 import {
   buildTitledContainer,
@@ -13,7 +14,7 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 
 function formatDiscordDateTime(date: Date): string {
-  return `<t:${Math.floor(date.getTime() / 1000)}:F>`;
+  return `<t:${toUnixTimestamp(date)}:F>`;
 }
 
 async function resolveLogChannel(client: Client): Promise<any | null> {

--- a/src/events/GuildMemberRemove.command.ts
+++ b/src/events/GuildMemberRemove.command.ts
@@ -5,6 +5,7 @@ import { formatTimestampWithDay } from "../utilities/DiscordLogUtils.js";
 import { JOIN_LEAVE_LOG_CHANNEL_ID } from "../config/channels.js";
 import { COLOR_WARNING, COLOR_NEUTRAL } from "../config/colors.js";
 import { sleep } from "../utilities/DelayUtils.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 import {
   buildTitledContainer,
   buildContainerSend,
@@ -16,7 +17,7 @@ const KICK_LOG_RETRY_COUNT = 3;
 const KICK_LOG_RETRY_DELAY_MS = 750;
 
 function formatDiscordDateTime(date: Date): string {
-  return `<t:${Math.floor(date.getTime() / 1000)}:F>`;
+  return `<t:${toUnixTimestamp(date)}:F>`;
 }
 
 async function resolveLogChannel(client: Client): Promise<any | null> {

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -42,6 +42,7 @@ import {
   buildSelectRow,
 } from "../functions/uiComponents.js";
 import { logError } from "../utilities/LogUtils.js";
+import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 
 const PUSH_PIN_EMOJI = "📌";
 const PLUS_EMOJI = "➕";
@@ -427,7 +428,7 @@ export class MessageReactionAdd {
       return;
     }
 
-    const completedAtUnix = Math.floor(session.completedAt.getTime() / 1000);
+    const completedAtUnix = toUnixTimestamp(session.completedAt);
     safeIgnore(safeUpdate(interaction, {
       content: [
         "Completion added.",

--- a/src/functions/DateFormatUtils.ts
+++ b/src/functions/DateFormatUtils.ts
@@ -12,12 +12,15 @@ export function formatTableDate(date: Date | null): string {
   return `${month}/${day}/${year}`;
 }
 
+export function toUnixTimestamp(date: Date): number {
+  return Math.floor(date.getTime() / 1000);
+}
+
 export function formatDiscordTimestamp(value: Date | string | null | undefined): string {
   if (!value) return "Unknown";
   const date = value instanceof Date ? value : new Date(value);
   if (isNaN(date.getTime())) return "Unknown";
-  const seconds = Math.floor(date.getTime() / 1000);
-  return `<t:${seconds}:F>`;
+  return `<t:${toUnixTimestamp(date)}:F>`;
 }
 
 export function formatLocalNumber(value: number): string {

--- a/src/functions/NominationListComponents.ts
+++ b/src/functions/NominationListComponents.ts
@@ -22,6 +22,7 @@ import {
   safeV2TextContent,
 } from "./ComponentsV2Utils.js";
 import { buildActionButton , buildSelectRow } from "./uiComponents.js";
+import { toUnixTimestamp } from "./DateFormatUtils.js";
 import { composeVoteImage, type VoteImageType } from "../services/collageGenerator.js";
 import { getUserEmojiString } from "../services/UserEmojiService.js";
 import {
@@ -229,7 +230,7 @@ function trimReason(reason: string): string {
 }
 
 function formatDate(date: Date): string {
-  return `<t:${Math.floor(date.getTime() / 1000)}:D>`;
+  return `<t:${toUnixTimestamp(date)}:D>`;
 }
 
 async function buildNominatorDisplayNames(

--- a/src/functions/ReminderUi.ts
+++ b/src/functions/ReminderUi.ts
@@ -1,6 +1,7 @@
 import {
   ButtonStyle,
 } from "discord.js";
+import { toUnixTimestamp } from "./DateFormatUtils.js";
 import type { ActionRowBuilder, ButtonBuilder } from "discord.js";
 import { buildActionButton, buildButtonRow } from "./uiComponents.js";
 import type { IReminderRecord } from "../classes/Reminder.js";
@@ -13,7 +14,7 @@ export type ReminderButton =
   | { kind: "snooze"; reminderId: number; minutes: number };
 
 export function formatReminderTime(date: Date): string {
-  const seconds = Math.floor(date.getTime() / 1000);
+  const seconds = toUnixTimestamp(date);
   return `<t:${seconds}:f> (<t:${seconds}:R>)`;
 }
 


### PR DESCRIPTION
## Summary
- Added `toUnixTimestamp(date: Date): number` helper to `src/functions/DateFormatUtils.ts`
- Replaced 17 inline `Math.floor(date.getTime() / 1000)` occurrences across 13 files with the new helper
- Updated `formatDiscordTimestamp` in DateFormatUtils to use the helper internally

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] No remaining inline `Math.floor(...getTime() / 1000)` patterns outside of the helper itself

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)