### PR TITLE
fix: check user exists in API before writing socials in profile edit

### DIFF
--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -570,6 +570,19 @@ export class ProfileCommand {
     }
 
     await withErrorReply(interaction, async () => {
+      const userExists = await apiGet<{ data: unknown }>(`/api/v1/users/${target.id}`);
+      if (!userExists) {
+        await safeReply(
+          interaction,
+          buildTextReply(
+            `${userMention(target.id)} doesn't have a profile in the database yet. ` +
+            "They need to be seen by the bot first (send a message, have an admin sync them, etc.).",
+            true,
+          ),
+        );
+        return;
+      }
+
       const platforms = await getSocialPlatforms();
       if (!platforms.length) {
         await safeReply(


### PR DESCRIPTION
## Summary
- `POST /api/v1/users/{id}/socials` returns a 500 when the user has no record in `rpg_club_users` yet (FK violation during the Postgres migration period)
- Adds a `GET /api/v1/users/{id}` check upfront; if the user doesn't exist (404) a clear message is shown instead of a generic 500

## Test plan
- [ ] `/profile edit psn:merph-518` on a user not yet in the Postgres DB shows the "doesn't have a profile yet" message instead of 500
- [ ] `/profile edit psn:merph-518` on a user who exists in the DB succeeds normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)