### PR TITLE
fix: include API response body in profile edit errors + CLAUDE.md rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,3 +33,4 @@ Just before opening a PR at the end of a task, run `npm run lint` and correct an
 When a PR closes more than one issue, each issue must be linked in the GitHub Development field. Use separate `Closes #X` lines (one per issue) in the PR body -- comma-separated closes on a single line are not reliably picked up. After opening, verify with `gh pr view <N> --json closingIssuesReferences`.
 Do not use tables in markdown files.
 When doing implementation work, always pull main, then open a fresh branch and commit your changes there. When finished, push to the branch and open a PR.
+When catching API errors in bot commands, always capture the full HTTP response body from the error and include it in the user-facing error message (truncated to ~300 chars). Never surface just the status code or axios message alone.

--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -132,9 +132,17 @@ async function upsertUserSocial(
     }
     return { ok: true };
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
     const op = current ? `PATCH user_socials/${current.id}` : `POST users/${userId}/socials`;
-    return { ok: false, detail: `${op}: ${msg}` };
+    let detail = err instanceof Error ? err.message : String(err);
+    if (
+      typeof err === "object" &&
+      err !== null &&
+      "response" in err &&
+      typeof (err as any).response?.data !== "undefined"
+    ) {
+      detail += ` | body: ${JSON.stringify((err as any).response.data).slice(0, 300)}`;
+    }
+    return { ok: false, detail: `${op}: ${detail}` };
   }
 }
 


### PR DESCRIPTION
## Summary
- POST/PATCH failures in profile edit now include the Rails response body (up to 300 chars) in the error message, making 500s diagnosable without server logs
- Adds the API error surfacing rule to CLAUDE.md so it applies going forward

## Test plan
- [ ] `/profile edit psn:merph-518` -- error now shows the Rails exception body, not just "Request failed with status code 500"

🤖 Generated with [Claude Code](https://claude.com/claude-code)