### PR TITLE
fix: replace userMention with renderUsernameWithEmoji in profile commands

### DIFF
--- a/src/commands/profile.command.ts
+++ b/src/commands/profile.command.ts
@@ -5,7 +5,6 @@ import {
   PermissionsBitField,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
-  userMention,
 } from "discord.js";
 import {
   Discord,
@@ -270,7 +269,8 @@ export async function buildProfileViewPayload(
     ]);
 
     if (!profileResp) {
-      return { notFoundMessage: `No profile data found for ${userMention(target.id)}.` };
+      const name = target.globalName ?? target.username ?? "Unknown";
+      return { notFoundMessage: `No profile data found for ${renderUsernameWithEmoji(target.id, name)}.` };
     }
 
     const user = profileResp.data;
@@ -341,11 +341,12 @@ export class ProfileCommand {
 
     if (!result.payload) {
       const notFoundContainer = buildTextContainer(
-      safeV2TextContent(
-        result.notFoundMessage ?? `No profile data found for ${userMention(target.id)}.`,
-        1000,
-          ),
-        );
+        safeV2TextContent(
+          result.notFoundMessage ??
+            `No profile data found for ${renderUsernameWithEmoji(target.id, target.globalName ?? target.username ?? "Unknown")}.`,
+          1000,
+        ),
+      );
       await safeReply(interaction, {
         components: [notFoundContainer],
         flags: buildComponentsV2Flags(ephemeral),
@@ -390,11 +391,12 @@ export class ProfileCommand {
 
       if (!result.payload) {
         const notFoundContainer = buildTextContainer(
-        safeV2TextContent(
-          result.notFoundMessage ?? `No profile data found for ${userMention(userId)}.`,
-          1000,
-            ),
-          );
+          safeV2TextContent(
+            result.notFoundMessage ??
+              `No profile data found for ${renderUsernameWithEmoji(userId, user.globalName ?? user.username ?? "Unknown")}.`,
+            1000,
+          ),
+        );
         await safeReply(interaction, {
           components: [notFoundContainer],
           flags: buildComponentsV2Flags(true),
@@ -583,7 +585,8 @@ export class ProfileCommand {
         await safeReply(
           interaction,
           buildTextReply(
-            `${userMention(target.id)} doesn't have a profile in the database yet. ` +
+            `${renderUsernameWithEmoji(target.id, target.globalName ?? target.username ?? "Unknown")} ` +
+            "doesn't have a profile in the database yet. " +
             "They need to be seen by the bot first (send a message, have an admin sync them, etc.).",
             true,
           ),
@@ -665,8 +668,8 @@ export class ProfileCommand {
         interaction,
         buildTextReply(
           parts.length
-            ? `Profile result for ${userMention(target.id)} -- ${parts.join(" | ")}.`
-            : `No fields were updated for ${userMention(target.id)}.`,
+            ? `Profile result for ${renderUsernameWithEmoji(target.id, target.globalName ?? target.username ?? "Unknown")} -- ${parts.join(" | ")}.`
+            : `No fields were updated for ${renderUsernameWithEmoji(target.id, target.globalName ?? target.username ?? "Unknown")}.`,
           true,
         ),
       );


### PR DESCRIPTION
## Summary

- Removes all Discord user pings (`userMention`) from profile view, edit, and search responses
- Not-found messages, no-update messages, and user-existence errors now use `renderUsernameWithEmoji` to display names without pinging
- Drops the unused `userMention` import from `discord.js`

## Test plan

- [ ] `/profile view @user` -- not-found message shows display name, no ping
- [ ] `/profile edit psn:handle` -- success/failure result shows display name, no ping
- [ ] Admin `/profile edit member:@user ...` -- same, no ping on target user
- [ ] Admin edit of a user not yet in the DB -- error message shows display name, no ping
- [ ] `/profile search query` -- search select handler not-found shows display name, no ping

🤖 Generated with [Claude Code](https://claude.com/claude-code)