### PR TITLE
fix: uppercase Postgres row keys in dbQuery/dbQueryConn

### DIFF
--- a/src/db/SqlManager.ts
+++ b/src/db/SqlManager.ts
@@ -19,6 +19,10 @@ import {
   pgInsertConn,
 } from "./postgresClient.js";
 
+function toUpperCaseKeys(row: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(row).map(([k, v]) => [k.toUpperCase(), v]));
+}
+
 export { oraQuery, oraMutate, oraWithConnection, oraTransaction } from "./oracleClient.js";
 export {
   pgQuery,
@@ -46,11 +50,11 @@ export async function dbQuery<RowT extends object, R>(
   if (dialect === "oracle") {
     return oraQuery(entry.oracle, params as oracledb.BindParameters, mapper);
   }
-  const rows = await pgQuery<RowT>(
+  const rows = await pgQuery<Record<string, unknown>>(
     entry.postgres,
     params as Record<string, unknown> | unknown[],
   );
-  return rows.map(mapper);
+  return rows.map((row) => mapper(toUpperCaseKeys(row) as RowT));
 }
 
 /**
@@ -132,12 +136,12 @@ export async function dbQueryConn<RowT extends object, R>(
 ): Promise<R[]> {
   const dialect = getDialect();
   if (dialect === "postgres") {
-    const rows = await pgQueryConn<RowT>(
+    const rows = await pgQueryConn<Record<string, unknown>>(
       conn as pg.PoolClient,
       entry.postgres,
       params as Record<string, unknown> | unknown[],
     );
-    return rows.map(mapper);
+    return rows.map((row) => mapper(toUpperCaseKeys(row) as RowT));
   }
   return oraQuery(
     entry.oracle,


### PR DESCRIPTION
## Summary
- All application row mappers expect Oracle-style uppercase column names (e.g. `RELEASE_ID`, `GAME_ID`), but the Postgres driver returns lowercase keys -- causing `Number(undefined)` = `NaN` for every mapped field.
- This manifested as the `[WARN] Missing GameDB profile for release NaN.` log in `GameReleaseAnnouncementService`, where `candidate.releaseId` and `candidate.gameId` were both `NaN`, so `buildGameProfileMessagePayload` returned null for every due release.
- Added `toUpperCaseKeys` helper and applied it in `dbQuery` / `dbQueryConn` (the dialect-agnostic paths in `SqlManager`). Direct `pgQuery` callers like `explore-postgres.ts` that expect lowercase keys are unaffected.

## Test plan
- [ ] Run the bot under `DB_DIALECT=postgres` and confirm no more `Missing GameDB profile for release NaN` warnings are emitted during the announcement cycle
- [ ] Verify a due release announcement is correctly sent when one is eligible
- [ ] Confirm `explore-postgres.ts` still works correctly (it calls `pgQuery` directly and bypasses the transformation)
- [ ] Type-check passes: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)