### PR TITLE
fix: add Postgres migration for journal_message_contexts table

### DIFF
--- a/docs/db/postgres/journal_message_contexts.md
+++ b/docs/db/postgres/journal_message_contexts.md
@@ -1,0 +1,23 @@
+# public.journal_message_contexts
+
+**Type:** BASE TABLE
+
+Tracks active journal message contexts so they can be restored after a bot restart.
+Each row maps a Discord message (identified by channel + message ID) to the owner
+and game whose journal view is rendered in that message.
+
+## Columns
+
+| # | Column | Type | Nullable | Description |
+| - | ------ | ---- | -------- | ----------- |
+| 1 | channel_id | character varying(30) | No | Discord channel snowflake |
+| 2 | message_id | character varying(30) | No | Discord message snowflake |
+| 3 | created_at_ms | bigint | No | Unix epoch ms when the context was first created |
+| 4 | owner_user_id | character varying(30) | No | Discord user snowflake of the journal owner |
+| 5 | game_id | bigint | No | GameDB game ID |
+
+## Indexes
+
+| Name | Type | Unique | Primary | Columns |
+| ---- | ---- | ------ | ------- | ------- |
+| pk_journal_message_contexts | btree | Yes | Yes | channel_id, message_id |

--- a/scripts/sql/2026/20260611_create_journal_message_contexts_postgres.sql
+++ b/scripts/sql/2026/20260611_create_journal_message_contexts_postgres.sql
@@ -1,0 +1,11 @@
+-- Create journal_message_contexts table for Postgres.
+-- The Oracle equivalent was created in 20260516_create_journal_message_contexts.sql,
+-- but that script uses PL/SQL syntax and was never applied to the Postgres database.
+CREATE TABLE IF NOT EXISTS journal_message_contexts (
+  channel_id     VARCHAR(30)  NOT NULL,
+  message_id     VARCHAR(30)  NOT NULL,
+  created_at_ms  BIGINT       NOT NULL,
+  owner_user_id  VARCHAR(30)  NOT NULL,
+  game_id        BIGINT       NOT NULL,
+  CONSTRAINT pk_journal_message_contexts PRIMARY KEY (channel_id, message_id)
+);


### PR DESCRIPTION
## Summary
- The `journal_message_contexts` table was only ever created via an Oracle PL/SQL
  migration (`20260516_create_journal_message_contexts.sql`), which cannot run on Postgres.
- On bot startup, `restoreJournalMessageContextsFromDb` fails with Postgres error `42P01`
  (undefined relation) because the table does not exist.
- This PR adds a `CREATE TABLE IF NOT EXISTS` Postgres migration and the corresponding
  table doc in `docs/db/postgres/`.

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Run `20260611_create_journal_message_contexts_postgres.sql` against the Postgres DB
- [ ] Restart the bot and confirm no `restore_contexts_failed` log error on startup

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)