### PR TITLE
fix: clear embeds in GiveawayHubService PATCH to avoid IS_COMPONENTS_V2 conflict

### DIFF
--- a/src/services/GiveawayHubService.ts
+++ b/src/services/GiveawayHubService.ts
@@ -232,6 +232,7 @@ async function updateGiveawayHubMessages(
       Routes.channelMessage(hubMsg.channelId, hubMsg.id),
       {
         body: {
+          embeds: [],
           components: allComponents.map((c) => c.toJSON()),
           flags: buildComponentsV2EditFlags(),
         },


### PR DESCRIPTION
## Summary
- The giveaway hub message PATCH was failing with error `MESSAGE_CANNOT_USE_LEGACY_FIELDS_WITH_COMPONENTS_V2` because the existing message had embeds from before the Components V2 migration
- Discord rejects a PATCH with `IS_COMPONENTS_V2` flag on any message that still has embeds, even if embeds are not included in the new request body
- Fix: explicitly include `embeds: []` in the PATCH body to clear legacy embeds

## Test plan
- [ ] Trigger a giveaway hub refresh when the existing hub message has embeds
- [ ] Confirm no error in logs for `GiveawayHubService.edit`
- [ ] Confirm message updates correctly with components V2 layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)