### PR TITLE
fix: use renderUsernameWithEmoji with bold for user name displays in command output

### DIFF
--- a/src/commands/collection/collection-list.service.ts
+++ b/src/commands/collection/collection-list.service.ts
@@ -594,7 +594,7 @@ export async function applyFiltersToSourceMessage(params: {
   }
 
   const memberLabel = params.targetUserId === params.viewerUserId
-    ? params.interaction.user.username
+    ? params.interaction.user.globalName ?? params.interaction.user.username
     : "Member";
   const response = await buildCollectionListResponse({
     viewerUserId: params.viewerUserId,

--- a/src/commands/collection/collection-view.command.ts
+++ b/src/commands/collection/collection-view.command.ts
@@ -291,7 +291,7 @@ export class CollectionViewCommand {
     const overviewTitle = extractOverviewTitleFromMessage(interaction.message);
     const memberLabel = resolveMemberLabelFromOverviewTitle(
       overviewTitle ?? "",
-      interaction.user.username,
+      interaction.user.globalName ?? interaction.user.username,
     );
 
     await safeDeferUpdate(interaction);

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -530,8 +530,10 @@ export class GameJournalCommand {
     const entries = await Member.getGameJournalList(target.id);
 
     if (!entries.length) {
-      const name = target.displayName ?? target.username;
-      await safeReply(interaction, buildTextReply(`${name} has no game journals.`, ephemeral));
+      const name = renderUsernameWithEmoji(
+        target.id, target.displayName ?? target.username ?? "User",
+      );
+      await safeReply(interaction, buildTextReply(`**${name}** has no game journals.`, ephemeral));
       return;
     }
 
@@ -625,7 +627,7 @@ export class GameJournalCommand {
     const entries = await Member.getGameJournalList(targetUserId);
     if (!entries.length) {
       await safeUpdate(interaction, {
-        content: `${target.displayName ?? target.username} has no game journals.`,
+        content: `**${renderUsernameWithEmoji(target.id, target.displayName ?? target.username ?? "User")}** has no game journals.`,
         embeds: [],
         components: [],
       });

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -31,6 +31,7 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 
 const GAMEDB_THREAD_MODAL_PREFIX = "gamedb-thread-modal";
 const GAMEDB_THREAD_TITLE_INPUT_ID = "gamedb-thread-title";
@@ -43,7 +44,7 @@ function buildDefaultNowPlayingThreadTitle(gameTitle: string): string {
 }
 
 function buildDefaultNowPlayingThreadBody(memberDisplayName: string): string {
-  return `Now Playing thread created by ${memberDisplayName}.`;
+  return `Now Playing thread created by **${memberDisplayName}**.`;
 }
 
 function buildNowPlayingThreadModalCustomId(
@@ -68,8 +69,11 @@ export async function showNowPlayingThreadModal(
     return;
   }
 
-  const memberDisplayName =
-    (interaction.member as any)?.displayName ?? interaction.user.username ?? "User";
+  const memberDisplayName = renderUsernameWithEmoji(
+    interaction.user.id,
+    (interaction.member as any)?.displayName
+      ?? interaction.user.globalName ?? interaction.user.username ?? "User",
+  );
   const defaultTitle = buildDefaultNowPlayingThreadTitle(gameTitle);
   const defaultBody = buildDefaultNowPlayingThreadBody(memberDisplayName);
 
@@ -142,8 +146,11 @@ async function runNowPlayingThreadWizard(
   const threadTitle =
     options?.threadTitle ?? buildDefaultNowPlayingThreadTitle(gameTitle);
 
-  const memberDisplayName =
-    (interaction.member as any)?.displayName ?? interaction.user.username ?? "User";
+  const memberDisplayName = renderUsernameWithEmoji(
+    interaction.user.id,
+    (interaction.member as any)?.displayName
+      ?? interaction.user.globalName ?? interaction.user.username ?? "User",
+  );
   const initialPost =
     options?.initialPost ?? buildDefaultNowPlayingThreadBody(memberDisplayName);
   const game = await Game.getGameById(gameId);

--- a/src/commands/now-playing/nowPlayingListRenderer.ts
+++ b/src/commands/now-playing/nowPlayingListRenderer.ts
@@ -423,7 +423,7 @@ export async function refreshNowPlayingListFromContext(
         const isEphemeral = message.flags?.has(MessageFlags.Ephemeral) ?? false;
         const title = ownerId === interaction.user.id && isEphemeral
           ? "Your Now Playing List"
-          : `${target.displayName ?? target.username ?? "User"}'s Now Playing List`;
+          : `**${renderUsernameWithEmoji(ownerId, target.displayName ?? target.username ?? "User")}**'s Now Playing List`;
         const entries = getDisplayNowPlayingEntries(await Member.getNowPlaying(ownerId));
 
         if (!entries.length) {


### PR DESCRIPTION
## Summary

- `game-journal.command.ts` (534, 628): replace raw `displayName ?? username` in "has no game journals" replies with `**renderUsernameWithEmoji()**`
- `now-playing/nowPlayingListRenderer.ts` (426): replace raw name in the list title with `**renderUsernameWithEmoji()**`
- `gamedb/gamedb-thread.command.ts` (72, 146, 244): replace raw `displayName ?? username` for the modal body default with `renderUsernameWithEmoji()`; bold the name inside `buildDefaultNowPlayingThreadBody`
- `collection/collection-list.service.ts` (597): use `globalName ?? username` instead of just `username` -- note: this is a button label, `buildUserHeaderContainer` handles the emoji via `setEmoji()` so markup is not used here
- `collection/collection-view.command.ts` (294): same treatment for the `resolveMemberLabelFromOverviewTitle` fallback

`suggestion.command.ts` and `todo.command.ts` left as-is per instructions.

## Test plan

- [ ] View another user's game journal list -- "has no game journals" message should show bolded name with emoji
- [ ] Trigger the now-playing list for another user -- title should show bolded name with emoji
- [ ] Create a now-playing thread via the modal -- default body text should show bolded name with emoji
- [ ] View your own game collection -- header button should show globalName instead of username

🤖 Generated with [Claude Code](https://claude.com/claude-code)