### PR TITLE
fix: emoji service throws when user changes avatar

### DIFF
--- a/src/services/UserEmojiService.ts
+++ b/src/services/UserEmojiService.ts
@@ -172,11 +172,14 @@ async function syncAllUserEmoji(client: Client, forceRefresh = false): Promise<v
       }
       // Delete the existing emoji so it can be re-uploaded (force refresh or missing from Discord)
       if (emojiId) {
+        let deleted = true;
         try {
           await app.emojis.delete(emojiId);
         } catch (err) {
           logError("UserEmojiService.deleteEmojiForRefresh", err);
+          deleted = false;
         }
+        if (!deleted) continue;
       }
       const avatarUrl = member.displayAvatarURL({ extension: "png", size: 128, forceStatic: true });
       try {
@@ -265,6 +268,8 @@ export async function syncUserEmojiFromAvatarChange(
     await app.emojis.delete(existing.emojiId);
   } catch (err) {
     logError("UserEmojiService.deleteOldEmoji", err);
+    // If delete fails the old emoji still holds the name -- skip create to avoid ALREADY_TAKEN.
+    return;
   }
   emojiCache.delete(userId);
 


### PR DESCRIPTION
## Summary
- When the Discord emoji delete call throws, the old emoji still occupies its name in Discord
- Previously the code caught the error and continued to POST a new emoji with the same name, triggering `APPLICATION_EMOJI_NAME_ALREADY_TAKEN` (Discord error 50035)
- Now both `syncUserEmojiFromAvatarChange` and the force-refresh path in `syncAllUserEmoji` return/continue early if the delete throws, leaving the cache entry intact and avoiding the duplicate-name error

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] When a Discord delete call fails, no subsequent create is attempted with the same emoji name

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)