### PR TITLE
fix: Avatar History not working

### DIFF
--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -77,14 +77,14 @@ export class GuildMemberUpdate {
       }
     }
 
-    if (!user.bot && guildAvatarChanged) {
+    if (!user.bot && guildAvatarChanged && newGuildAvatar) {
       const avatarUrl = newMember.displayAvatarURL({
         extension: "png",
         size: 512,
         forceStatic: true,
       });
       if (avatarUrl) {
-        const updated = await updateAvatarRecordFromUrl(user, avatarUrl);
+        const updated = await updateAvatarRecordFromUrl(user, avatarUrl, newGuildAvatar);
         if (updated) {
           await logAvatarChange(_client, user, "Server avatar changed");
         }

--- a/src/events/UserUpdate.command.ts
+++ b/src/events/UserUpdate.command.ts
@@ -26,14 +26,14 @@ export class UserUpdate {
     const usernameChanged = oldUsername !== newUsername;
     const globalNameChanged = oldGlobalName !== newGlobalName;
 
-    if (avatarChanged) {
+    if (avatarChanged && newAvatarHash) {
       const avatarUrl = newUser.displayAvatarURL({
         extension: "png",
         size: 512,
         forceStatic: true,
       });
       if (avatarUrl) {
-        const updated = await updateAvatarRecordFromUrl(newUser, avatarUrl);
+        const updated = await updateAvatarRecordFromUrl(newUser, avatarUrl, newAvatarHash);
         if (updated) {
           await logAvatarChange(client, newUser, "Avatar changed");
         }

--- a/src/utilities/AvatarLogUtils.ts
+++ b/src/utilities/AvatarLogUtils.ts
@@ -1,13 +1,16 @@
 import axios from "axios";
-import { AttachmentBuilder } from "discord.js";
 import type { GuildMember, User } from "discord.js";
 import { MediaGalleryBuilder, MediaGalleryItemBuilder } from "@discordjs/builders";
-import Member, { type IMemberRecord } from "../classes/Member.js";
+import { AttachmentBuilder } from "discord.js";
+import Member, { type IAvatarHistoryRecord } from "../classes/Member.js";
 import { formatTimestampWithDay, resolveLogChannel } from "./DiscordLogUtils.js";
 import { COLOR_INFO } from "../config/colors.js";
 import { buildTitledContainer, buildContainerSend } from "../functions/ComponentsV2Utils.js";
-
-type AvatarHistoryRecord = Awaited<ReturnType<typeof Member.getAvatarHistory>>[number];
+import {
+  getOrReplaceBackblazeImage,
+  hasBackblazeB2Config,
+} from "../services/BackblazeB2Service.js";
+import { logWarn } from "./LogUtils.js";
 
 async function downloadAvatarBuffer(url: string): Promise<Buffer | null> {
   try {
@@ -19,63 +22,69 @@ async function downloadAvatarBuffer(url: string): Promise<Buffer | null> {
 }
 
 function resolveAvatarImage(
-  record: AvatarHistoryRecord | null | undefined,
+  record: IAvatarHistoryRecord | null | undefined,
   label: string,
   userId: string,
 ): { url: string | null; attachment: AttachmentBuilder | null } {
   if (!record) return { url: null, attachment: null };
+  if (record.avatarUrl) {
+    return { url: record.avatarUrl, attachment: null };
+  }
   if (record.avatarBlob) {
     const name = `avatar-${label}-${userId}.png`;
     const attachment = new AttachmentBuilder(record.avatarBlob, { name });
     return { url: `attachment://${name}`, attachment };
   }
-  if (record.avatarUrl) {
-    return { url: record.avatarUrl, attachment: null };
-  }
   return { url: null, attachment: null };
 }
 
-async function upsertAvatarRecord(
-  user: User,
-  avatarBlob: Buffer | null,
-  opts?: { username?: string | null; globalName?: string | null },
-): Promise<void> {
-  const existing = await Member.getByUserId(user.id);
-  const record: IMemberRecord = {
-    userId: user.id,
-    isBot: user.bot ? 1 : 0,
-    username: opts?.username ?? user.username ?? existing?.username ?? null,
-    globalName: opts?.globalName ?? user.globalName ?? existing?.globalName ?? null,
-    avatarBlob,
-    serverJoinedAt: existing?.serverJoinedAt ?? null,
-    serverLeftAt: existing?.serverLeftAt ?? null,
-    lastSeenAt: existing?.lastSeenAt ?? null,
-    roleAdmin: existing?.roleAdmin ?? 0,
-    roleModerator: existing?.roleModerator ?? 0,
-    roleRegular: existing?.roleRegular ?? 0,
-    roleMember: existing?.roleMember ?? 0,
-    roleNewcomer: existing?.roleNewcomer ?? 0,
-    messageCount: existing?.messageCount ?? null,
-    completionatorUrl: existing?.completionatorUrl ?? null,
-    psnUsername: existing?.psnUsername ?? null,
-    xblUsername: existing?.xblUsername ?? null,
-    nswFriendCode: existing?.nswFriendCode ?? null,
-    steamUrl: existing?.steamUrl ?? null,
-    profileImage: existing?.profileImage ?? null,
-    profileImageAt: existing?.profileImageAt ?? null,
-  };
+async function uploadAvatarToBackblaze(
+  userId: string,
+  avatarHash: string,
+  discordUrl: string,
+): Promise<string | null> {
+  try {
+    const { url } = await getOrReplaceBackblazeImage(
+      `avatars/${userId}/${avatarHash}`,
+      avatarHash,
+      async () => {
+        const buf = await downloadAvatarBuffer(discordUrl);
+        if (!buf) throw new Error("Failed to download avatar from Discord");
+        return buf;
+      },
+    );
+    return url;
+  } catch (err) {
+    logWarn("AvatarLogUtils.uploadToBackblaze", (err as Error).message ?? String(err));
+    return null;
+  }
+}
 
-  await Member.upsert(record);
+async function storeAvatarRecord(
+  userId: string,
+  avatarHash: string,
+  discordUrl: string,
+): Promise<boolean> {
+  if (hasBackblazeB2Config()) {
+    const storedUrl = await uploadAvatarToBackblaze(userId, avatarHash, discordUrl);
+    if (storedUrl) {
+      await Member.insertAvatarHistoryRecord(userId, avatarHash, storedUrl, null);
+      return true;
+    }
+  }
+
+  const blob = await downloadAvatarBuffer(discordUrl);
+  if (!blob) return false;
+  await Member.insertAvatarHistoryRecord(userId, avatarHash, discordUrl, blob);
+  return true;
 }
 
 export async function updateAvatarRecordFromUrl(
   user: User,
   avatarUrl: string,
+  avatarHash: string,
 ): Promise<boolean> {
-  const avatarBlob = await downloadAvatarBuffer(avatarUrl);
-  if (!avatarBlob) return false;
-  await upsertAvatarRecord(user, avatarBlob);
-  return true;
+  return storeAvatarRecord(user.id, avatarHash, avatarUrl);
 }
 
 export async function recordCurrentAvatarIfNew(member: GuildMember): Promise<boolean> {
@@ -86,12 +95,8 @@ export async function recordCurrentAvatarIfNew(member: GuildMember): Promise<boo
   const latest = await Member.getAvatarHistory(member.user.id, 1, 0);
   if (latest.length && latest[0].avatarHash === avatarHash) return false;
 
-  const avatarUrl = member.displayAvatarURL({ extension: "png", size: 512, forceStatic: true });
-  const avatarBlob = await downloadAvatarBuffer(avatarUrl);
-  if (!avatarBlob) return false;
-
-  await Member.insertAvatarHistoryRecord(member.user.id, avatarHash, avatarUrl, avatarBlob);
-  return true;
+  const discordUrl = member.displayAvatarURL({ extension: "png", size: 512, forceStatic: true });
+  return storeAvatarRecord(member.user.id, avatarHash, discordUrl);
 }
 
 export async function logAvatarChange(
@@ -116,7 +121,7 @@ export async function logAvatarChange(
   const beforeLabel = beforeImage.url ? "" : "Unknown";
   const afterLabel = afterImage.url ? "" : "Unknown";
   const body =
-    `*${authorName}* (<@${user.id}>)\n` +
+    `*${authorName}*\n` +
     `**Before:** ${beforeLabel}\n**After:** ${afterLabel}\n` +
     `-# ID: ${user.id} • ${formatTimestampWithDay(afterRecord.changedAt.getTime())}`;
   const container = buildTitledContainer(title, body, { color: COLOR_INFO });


### PR DESCRIPTION
## Summary
- Avatar change events (`userUpdate`, `guildMemberUpdate`) now insert into the avatar history table -- previously they only updated the member table blob, so `logAvatarChange` had nothing new to read
- Avatar images are uploaded to Backblaze B2 when configured; falls back to blob storage if Backblaze credentials are absent
- Removed the `<@userId>` ping from the avatar change log channel entry

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Avatar change triggers a log entry without pinging the user
- [ ] Avatar history command shows the new avatar after a change
- [ ] When Backblaze is configured, avatar URL is a Backblaze URL (not a blob attachment)

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)