### PR TITLE
fix: Gamedb View Images not rendering

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -1623,6 +1623,30 @@ export default class Game {
     });
   }
 
+  static async getGamePrimaryImageUrl(gameId: number): Promise<string | null> {
+    type GameImage = {
+      image_id: number; kind: string; is_primary: boolean; position: number; url: string;
+    };
+    const result = await apiGet<{ data: GameImage[] }>(`/api/v1/games/${gameId}/images`);
+    if (!result?.data?.length) return null;
+    const primary =
+      result.data.find((img) => img.kind === "cover" && img.is_primary) ??
+      result.data.find((img) => img.is_primary) ??
+      result.data[0];
+    return primary?.url ?? null;
+  }
+
+  static async getGamePrimaryImageBuffer(gameId: number): Promise<Buffer | null> {
+    const url = await Game.getGamePrimaryImageUrl(gameId);
+    if (!url) return null;
+    try {
+      const resp = await axios.get<ArrayBuffer>(url, { responseType: "arraybuffer" });
+      return Buffer.from(resp.data);
+    } catch {
+      return null;
+    }
+  }
+
   static async updateGameImage(
     gameId: number,
     imageData: Buffer,

--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -123,8 +123,10 @@ async function ensureWinnerThreadLinked(params: {
   }
 
   const threadTitle = `${params.gameTitle} [${params.kindLabel} Round ${params.roundNumber}]`;
-  const files = game.imageData
-    ? [new AttachmentBuilder(game.imageData, { name: `gamedb_${params.gameId}.png` })]
+  const imageBuffer =
+    game.imageData ?? await Game.getGamePrimaryImageBuffer(params.gameId).catch(() => null);
+  const files = imageBuffer
+    ? [new AttachmentBuilder(imageBuffer, { name: `gamedb_${params.gameId}.png` })]
     : [];
   const messagePayload: MessageCreateOptions = {
     allowedMentions: { parse: [] },
@@ -171,7 +173,10 @@ async function planWinnerThread(params: {
   const game = await Game.getGameById(params.gameId);
   const title = `${params.gameTitle} [${params.kindLabel} Round ${params.roundNumber}]`;
   const tagLabel = params.kindLabel;
-  const hasCoverImage = Boolean(game?.imageData);
+  const apiImageUrl = game?.imageData
+    ? null
+    : await Game.getGamePrimaryImageUrl(params.gameId).catch(() => null);
+  const hasCoverImage = Boolean(game?.imageData) || Boolean(apiImageUrl);
   return {
     existingThreadId,
     title,

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -202,6 +202,9 @@ export async function buildGameProfile(
     if (primaryArt) {
       files.push(new AttachmentBuilder(primaryArt, { name: "game_image.png" }));
     }
+    const apiImageUrl = primaryArt
+      ? null
+      : await Game.getGamePrimaryImageUrl(gameId).catch(() => null);
 
     const rpgClubSections: string[] = [];
     const pushRpgClubSection = (title: string, value: string | null): void => {
@@ -499,7 +502,9 @@ export async function buildGameProfile(
       );
     }
 
-    const thumbnailUrl = primaryArt ? "attachment://game_image.png" : (game.coverUrl ?? null);
+    const thumbnailUrl = primaryArt
+      ? "attachment://game_image.png"
+      : (apiImageUrl ?? game.coverUrl ?? null);
 
     if (thumbnailUrl) {
       if (headerBlock.length > 0) {

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -147,8 +147,10 @@ async function runNowPlayingThreadWizard(
   const initialPost =
     options?.initialPost ?? buildDefaultNowPlayingThreadBody(memberDisplayName);
   const game = await Game.getGameById(gameId);
-  const files = game?.imageData
-    ? [new AttachmentBuilder(game.imageData, { name: `gamedb_${gameId}.png` })]
+  const imageBuffer =
+    game?.imageData ?? await Game.getGamePrimaryImageBuffer(gameId).catch(() => null);
+  const files = imageBuffer
+    ? [new AttachmentBuilder(imageBuffer, { name: `gamedb_${gameId}.png` })]
     : [];
   const messagePayload: MessageCreateOptions = {
     content: initialPost,

--- a/src/functions/GotmEntryEmbeds.ts
+++ b/src/functions/GotmEntryEmbeds.ts
@@ -158,6 +158,10 @@ async function resolveEntryImage(
       const file = new AttachmentBuilder(buf, { name });
       return { thumbnailUrl: `attachment://${name}`, files: [file] };
     }
+    const apiUrl = await Game.getGamePrimaryImageUrl(g.gamedbGameId).catch(() => null);
+    if (apiUrl) {
+      return { thumbnailUrl: apiUrl, files: [] };
+    }
   }
 
   return { thumbnailUrl: undefined, files: [] };

--- a/src/functions/GotmSearchComponents.ts
+++ b/src/functions/GotmSearchComponents.ts
@@ -57,6 +57,7 @@ type BuildGotmSearchMessagesOptions = {
 
 const threadImageCache = new Map<string, Promise<string | undefined>>();
 const gameImageDataCache = new Map<number, Promise<Buffer | null>>();
+const gameApiImageUrlCache = new Map<number, Promise<string | null>>();
 
 export function buildGotmCardsFromEntries(
   entries: GotmLikeEntry[],
@@ -228,16 +229,14 @@ async function resolveAccessoryThumbnail(
   }
 
   const imageData = await getGameImageData(card.gamedbGameId);
-  if (!imageData) {
-    return { thumbnailUrl: undefined };
+  if (imageData) {
+    const fileName = `gotm-thumb-${chunkIndex}-${itemIndex}-${card.gamedbGameId}.png`;
+    const file = new AttachmentBuilder(imageData, { name: fileName });
+    return { file, thumbnailUrl: `attachment://${fileName}` };
   }
 
-  const fileName = `gotm-thumb-${chunkIndex}-${itemIndex}-${card.gamedbGameId}.png`;
-  const file = new AttachmentBuilder(imageData, { name: fileName });
-  return {
-    file,
-    thumbnailUrl: `attachment://${fileName}`,
-  };
+  const apiUrl = await getGameApiImageUrl(card.gamedbGameId);
+  return { thumbnailUrl: apiUrl ?? undefined };
 }
 
 async function getGameImageData(gameId: number): Promise<Buffer | null> {
@@ -251,6 +250,13 @@ async function getGameImageData(gameId: number): Promise<Buffer | null> {
     );
   }
   return gameImageDataCache.get(gameId) ?? Promise.resolve(null);
+}
+
+async function getGameApiImageUrl(gameId: number): Promise<string | null> {
+  if (!gameApiImageUrlCache.has(gameId)) {
+    gameApiImageUrlCache.set(gameId, Game.getGamePrimaryImageUrl(gameId).catch(() => null));
+  }
+  return gameApiImageUrlCache.get(gameId) ?? Promise.resolve(null);
 }
 
 async function getThreadStarterImage(


### PR DESCRIPTION
## Summary
- Added `Game.getGamePrimaryImageUrl(gameId)` and `Game.getGamePrimaryImageBuffer(gameId)` static helpers that call `GET /api/v1/games/{game_id}/images` (primary cover first, then any primary, then first)
- `buildGameProfile` now falls back to the API image URL when `game.imageData` (Oracle blob) is null, taking priority over `game.coverUrl`
- `GotmSearchComponents` and `GotmEntryEmbeds` use the API URL as fallback when no local blob exists
- `gamedb-thread` and `round-setup-wizard` download the API image buffer as fallback for forum thread attachments; `hasCoverImage` also reflects API image availability

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/gamedb view <game>` shows cover art for games whose images are stored in the API
- [ ] GOTM search cards render thumbnails for games with API images but no local Oracle blob
- [ ] Creating a now-playing thread attaches the cover image when the API has one
- [ ] Note: live rendering requires the bot token and live API -- not verifiable in this environment

Closes #766

🤖 Generated with [Claude Code](https://claude.com/claude-code)