### PR TITLE
feat: source game cover images via API for /noms and /now-playing

### DIFF
--- a/src/commands/now-playing/nowPlayingListRenderer.ts
+++ b/src/commands/now-playing/nowPlayingListRenderer.ts
@@ -21,7 +21,7 @@ import {
 import { SeparatorSpacingSize } from "discord-api-types/v10";
 import crypto from "node:crypto";
 import Member, { type IMemberNowPlayingEntry } from "../../classes/Member.js";
-import Game from "../../classes/Game.js";
+import { fetchGameCoverBuffer } from "../../services/GameImageService.js";
 import {
   safeReply,
   safeUpdate,
@@ -138,7 +138,7 @@ export async function buildNowPlayingAttachments(
 ): Promise<{
   files: AttachmentBuilder[];
   thumbnailsByGameId: Map<number, string>;
-  covers: Array<{ gameId: number; title: string; imageData: Buffer }>;
+  covers: Array<{ gameId: number; title: string; imageData: Buffer; imageUrl: string }>;
 }> {
   if (!includeImages) {
     return {
@@ -147,33 +147,27 @@ export async function buildNowPlayingAttachments(
       covers: [],
     };
   }
-  const files: AttachmentBuilder[] = [];
   const seen = new Set<number>();
-  const thumbnailsByGameId = new Map<number, string>();
-  const covers: Array<{ gameId: number; title: string; imageData: Buffer }> = [];
-  let imageCount = 0;
+  const uniqueEntries: IMemberNowPlayingEntry[] = [];
   for (const entry of entries) {
     if (!entry.gameId || seen.has(entry.gameId)) continue;
     seen.add(entry.gameId);
-    if (imageCount >= maxImages) {
-      break;
-    }
-    const gameRecord = await Game.getGameById(entry.gameId);
-    if (gameRecord?.imageData) {
-      covers.push({
-        gameId: entry.gameId,
-        title: entry.title,
-        imageData: gameRecord.imageData,
-      });
-      const filename = `now_playing_${entry.gameId}.png`;
-      files.push(
-        new AttachmentBuilder(gameRecord.imageData, { name: filename }),
-      );
-      thumbnailsByGameId.set(entry.gameId, `attachment://${filename}`);
-      imageCount += 1;
-    }
+    if (uniqueEntries.length >= maxImages) break;
+    uniqueEntries.push(entry);
   }
-  return { files, thumbnailsByGameId, covers };
+
+  const results = await Promise.all(
+    uniqueEntries.map(async (entry) => {
+      const cover = await fetchGameCoverBuffer(entry.gameId!);
+      if (!cover) return null;
+      return {
+        gameId: entry.gameId!, title: entry.title, imageData: cover.buffer, imageUrl: cover.url,
+      };
+    }),
+  );
+  const covers = results.filter((c): c is NonNullable<typeof c> => c !== null);
+
+  return { files: [], thumbnailsByGameId: new Map<number, string>(), covers };
 }
 
 export async function buildNowPlayingListPayload(
@@ -231,7 +225,7 @@ export function buildNowPlayingJournalSelectRow(
 
 export async function buildNowPlayingCompositeImageUrl(
   files: AttachmentBuilder[],
-  covers: Array<{ gameId: number; title: string; imageData: Buffer }>,
+  covers: Array<{ gameId: number; title: string; imageData: Buffer; imageUrl: string }>,
   ownerId: string,
 ): Promise<string | null> {
   if (!covers.length) {
@@ -270,16 +264,14 @@ export async function buildNowPlayingCompositeImageUrl(
 
 export function buildNowPlayingCompositeSourceHash(
   ownerId: string,
-  covers: Array<{ gameId: number; title: string; imageData: Buffer }>,
+  covers: Array<{ gameId: number; title: string; imageUrl: string }>,
 ): string {
   const hash = crypto.createHash("sha256");
   // eslint-disable-next-line local/no-direct-interaction-response-methods
   hash.update(`owner:${ownerId}|count:${covers.length}|`);
   covers.forEach((cover) => {
     // eslint-disable-next-line local/no-direct-interaction-response-methods
-    hash.update(`id:${cover.gameId}|title:${cover.title}|`);
-    // eslint-disable-next-line local/no-direct-interaction-response-methods
-    hash.update(cover.imageData);
+    hash.update(`id:${cover.gameId}|title:${cover.title}|url:${cover.imageUrl}|`);
   });
   return hash.digest("hex");
 }

--- a/src/functions/NominationListComponents.ts
+++ b/src/functions/NominationListComponents.ts
@@ -16,7 +16,7 @@ import { SeparatorSpacingSize } from "discord-api-types/v10";
 import crypto from "node:crypto";
 import Member from "../classes/Member.js";
 import type { INominationEntry } from "../classes/Nomination.js";
-import Game from "../classes/Game.js";
+import { fetchGameCoverBuffer } from "../services/GameImageService.js";
 import {
   buildTextContainer,
   safeV2TextContent,
@@ -256,25 +256,26 @@ async function buildNominationAttachments(
   voteImageUrl: string | null;
 }> {
   const files: AttachmentBuilder[] = [];
-  const covers: Array<{ gameId: number; title: string; imageData: Buffer }> = [];
   const seen = new Set<number>();
+  const uniqueNominations = nominations.filter((nom) => {
+    if (!nom.gamedbGameId || seen.has(nom.gamedbGameId)) return false;
+    seen.add(nom.gamedbGameId);
+    return true;
+  });
 
-  for (const nomination of nominations) {
-    const gameId = nomination.gamedbGameId;
-    if (!gameId || seen.has(gameId)) {
-      continue;
-    }
-    seen.add(gameId);
-    const game = await Game.getGameById(gameId);
-    if (!game?.imageData) {
-      continue;
-    }
-    covers.push({
-      gameId,
-      title: nomination.gameTitle,
-      imageData: game.imageData,
-    });
-  }
+  const results = await Promise.all(
+    uniqueNominations.map(async (nom) => {
+      const cover = await fetchGameCoverBuffer(nom.gamedbGameId!);
+      if (!cover) return null;
+      return {
+        gameId: nom.gamedbGameId!,
+        title: nom.gameTitle,
+        imageData: cover.buffer,
+        imageUrl: cover.url,
+      };
+    }),
+  );
+  const covers = results.filter((c): c is NonNullable<typeof c> => c !== null);
 
   const voteImageUrl = await appendVoteImageAttachment(files, kindLabel, roundNumber, covers);
   return { files, voteImageUrl };
@@ -284,7 +285,7 @@ async function appendVoteImageAttachment(
   files: AttachmentBuilder[],
   kindLabel: string,
   roundNumber: number,
-  covers: Array<{ gameId: number; title: string; imageData: Buffer }>,
+  covers: Array<{ gameId: number; title: string; imageData: Buffer; imageUrl: string }>,
 ): Promise<string | null> {
   const voteType = toVoteImageType(kindLabel);
   if (!voteType || !covers.length) {
@@ -325,16 +326,14 @@ function toVoteImageType(kindLabel: string): VoteImageType | null {
 function buildNominationImageSourceHash(
   voteType: VoteImageType,
   roundNumber: number,
-  covers: Array<{ gameId: number; title: string; imageData: Buffer }>,
+  covers: Array<{ gameId: number; title: string; imageUrl: string }>,
 ): string {
   const hash = crypto.createHash("sha256");
   // eslint-disable-next-line local/no-direct-interaction-response-methods
   hash.update(`type:${voteType}|round:${roundNumber}|count:${covers.length}|`);
   covers.forEach((cover) => {
     // eslint-disable-next-line local/no-direct-interaction-response-methods
-    hash.update(`id:${cover.gameId}|title:${cover.title}|`);
-    // eslint-disable-next-line local/no-direct-interaction-response-methods
-    hash.update(cover.imageData);
+    hash.update(`id:${cover.gameId}|title:${cover.title}|url:${cover.imageUrl}|`);
   });
   return hash.digest("hex");
 }

--- a/src/services/GameImageService.ts
+++ b/src/services/GameImageService.ts
@@ -1,0 +1,44 @@
+import axios from "axios";
+import { apiGet } from "./RpgClubApiClient.js";
+import { logError } from "../utilities/LogUtils.js";
+
+export type ApiGameImage = {
+  image_id: number;
+  game_id: number;
+  kind: string;
+  object_key: string;
+  is_primary: boolean;
+  position: number;
+  url: string;
+};
+
+export type GameCoverResult = {
+  buffer: Buffer;
+  url: string;
+};
+
+function selectPrimaryCover(images: ApiGameImage[]): ApiGameImage | null {
+  const covers = images.filter((img) => img.kind === "cover");
+  return covers.find((img) => img.is_primary) ?? covers[0] ?? null;
+}
+
+export async function fetchGameCoverBuffer(
+  gameId: number,
+): Promise<GameCoverResult | null> {
+  try {
+    const result = await apiGet<{ data: ApiGameImage[] }>(
+      `/api/v1/games/${gameId}/images`,
+    );
+    const cover = selectPrimaryCover(result?.data ?? []);
+    if (!cover) {
+      return null;
+    }
+    const response = await axios.get<ArrayBuffer>(cover.url, {
+      responseType: "arraybuffer",
+    });
+    return { buffer: Buffer.from(response.data), url: cover.url };
+  } catch (error) {
+    logError(`GameImageService.fetchGameCoverBuffer(${gameId})`, error);
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces direct database blob reads (`Game.getGameById` + `imageData`) with calls to `GET /api/v1/games/{id}/images`, downloading cover images from their Backblaze CDN URLs
- Introduces `src/services/GameImageService.ts` with `fetchGameCoverBuffer` as the single entry point for cover image retrieval
- Cover fetches are now parallelized with `Promise.all` instead of sequential `for...of`, and the composite image hash now uses the CDN URL (which rotates when an image is replaced) instead of hashing the full buffer

## Test plan
- [ ] Run `/noms` for a round that has nominations with cover art -- composite collage image should render correctly
- [ ] Run `/now-playing` for a user with games -- composite collage image should render correctly
- [ ] Verify no cover art = graceful omission (entry still appears in list, composite skips that game)
- [ ] Confirm the Backblaze cache path still works when `BACKBLAZE_B2` env vars are set (hash changes when image is replaced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)