### PR TITLE
fix: remove all references to deprecated user_game_journal_prefs table

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -134,12 +134,6 @@ export interface IGameJournalEntry {
   updatedAt: Date;
 }
 
-export interface IGameJournalPreference {
-  userId: string;
-  gameId: number;
-  isEnabled: boolean;
-}
-
 export interface IGameJournalListEntry {
   gameId: number;
   title: string;
@@ -611,7 +605,6 @@ export default class Member {
           MemberSql.insertNowPlaying,
           { userId, gameId, platformId, note: noteValue, noteUpdatedAt, sortOrder: nextSort },
         );
-        await dbMutateConn(conn, MemberSql.mergeJournalPrefs, { userId, gameId });
       });
     } catch (err: any) {
       const msg = err?.message ?? String(err);
@@ -620,43 +613,6 @@ export default class Member {
       }
       throw err;
     }
-  }
-
-  static async getGameJournalPreference(
-    userId: string,
-    gameId: number,
-  ): Promise<IGameJournalPreference | null> {
-    const rows = await dbQuery<{
-      USER_ID: string;
-      GAMEDB_GAME_ID: number;
-      IS_ENABLED: number;
-    }, IGameJournalPreference>(
-      MemberSql.getGameJournalPreference,
-      { userId, gameId },
-      (row) => ({
-        userId: row.USER_ID,
-        gameId: Number(row.GAMEDB_GAME_ID),
-        isEnabled: Number(row.IS_ENABLED) === 1,
-      }),
-    );
-    const row = rows[0];
-    if (!row) return null;
-    return row;
-  }
-
-  static async upsertGameJournalPreference(
-    userId: string,
-    gameId: number,
-    isEnabled: boolean,
-  ): Promise<void> {
-    await dbMutate(
-      MemberSql.upsertGameJournalPreference,
-      {
-        userId,
-        gameId,
-        isEnabled: isEnabled ? 1 : 0,
-      },
-    );
   }
 
   static async getJournalStatusForGames(

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -943,7 +943,6 @@ export class GameJournalCommand {
     );
     const gameId = Number(gameIdRaw);
     await Member.addGameJournalEntry({ userId: ownerId, gameId, title: title || null, body });
-    await Member.upsertGameJournalPreference(ownerId, gameId, true);
     const container = buildTextContainer("## Manage Journal");
     const row = buildHmenuActionRow(ownerId, gameId);
     await safeUpdate(interaction, {

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -2019,7 +2019,6 @@ export class NowPlayingCommand {
       title: title || null,
       body,
     });
-    await Member.upsertGameJournalPreference(ownerId, gameId, true);
     const page = Number(pageRaw);
     const row = await this.buildManageJournalButtonRow(ownerId, gameId, page);
     if (!hasExistingTracked && interaction.guildId) {

--- a/src/db/sql/member.sql.ts
+++ b/src/db/sql/member.sql.ts
@@ -313,56 +313,6 @@ export const MemberSql = {
            VALUES (:userId, :gameId, :platformId, :note, :noteUpdatedAt, :sortOrder)`,
   } satisfies ISqlEntry,
 
-  mergeJournalPrefs: {
-    oracle: `MERGE INTO USER_GAME_JOURNAL_PREFS p
-           USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
-              ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
-           WHEN MATCHED THEN
-             UPDATE SET IS_ENABLED = 1, UPDATED_AT = SYSTIMESTAMP
-           WHEN NOT MATCHED THEN
-             INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
-             VALUES (:userId, :gameId, 1, 0)`,
-    postgres: `INSERT INTO user_game_journal_prefs (user_id, gamedb_game_id, is_enabled, default_is_public)
-           VALUES (:userId, :gameId, true, false)
-           ON CONFLICT (user_id, gamedb_game_id) DO UPDATE SET
-             is_enabled = true,
-             updated_at = NOW()`,
-  } satisfies ISqlEntry,
-
-  getGameJournalPreference: {
-    oracle: `SELECT USER_ID,
-              GAMEDB_GAME_ID,
-              IS_ENABLED
-         FROM USER_GAME_JOURNAL_PREFS
-        WHERE USER_ID = :userId
-          AND GAMEDB_GAME_ID = :gameId`,
-    postgres: `SELECT user_id,
-              gamedb_game_id,
-              is_enabled
-         FROM user_game_journal_prefs
-        WHERE user_id = :userId
-          AND gamedb_game_id = :gameId`,
-  } satisfies ISqlEntry,
-
-  upsertGameJournalPreference: {
-    oracle: `MERGE INTO USER_GAME_JOURNAL_PREFS p
-       USING (SELECT :userId AS USER_ID, :gameId AS GAMEDB_GAME_ID FROM dual) src
-          ON (p.USER_ID = src.USER_ID AND p.GAMEDB_GAME_ID = src.GAMEDB_GAME_ID)
-        WHEN MATCHED THEN
-          UPDATE SET IS_ENABLED = :isEnabled,
-                     DEFAULT_IS_PUBLIC = 1,
-                     UPDATED_AT = SYSTIMESTAMP
-        WHEN NOT MATCHED THEN
-          INSERT (USER_ID, GAMEDB_GAME_ID, IS_ENABLED, DEFAULT_IS_PUBLIC)
-          VALUES (:userId, :gameId, :isEnabled, 1)`,
-    postgres: `INSERT INTO user_game_journal_prefs (user_id, gamedb_game_id, is_enabled, default_is_public)
-          VALUES (:userId, :gameId, :isEnabled, true)
-          ON CONFLICT (user_id, gamedb_game_id) DO UPDATE SET
-            is_enabled = EXCLUDED.is_enabled,
-            default_is_public = true,
-            updated_at = NOW()`,
-  } satisfies ISqlEntry,
-
   getJournalStatusForGames: (inlineTable: string) =>
     ({
       oracle: `SELECT gids.GAME_ID,

--- a/src/tests/now-playing-journal-components.test.ts
+++ b/src/tests/now-playing-journal-components.test.ts
@@ -170,7 +170,6 @@ test("journal single-page view omits pager buttons and page count", async () => 
   const originalGetByUserId = Member.getByUserId;
   const originalGetMeta = Member.getNowPlayingEntryMeta;
   const originalGetCompletions = Member.getCompletionsForGame;
-  const originalGetPref = Member.getGameJournalPreference;
   const originalCount = Member.countGameJournalEntries;
   const originalEntries = Member.getGameJournalEntries;
   const originalGetThreads = Thread.getThreadsByGameId;
@@ -180,11 +179,6 @@ test("journal single-page view omits pager buttons and page count", async () => 
     Member.getByUserId = (async () => ({ globalName: "owner", username: "owner" })) as any;
     Member.getNowPlayingEntryMeta = (async () => null) as any;
     Member.getCompletionsForGame = (async () => []) as any;
-    Member.getGameJournalPreference = (async () => ({
-      userId: "123",
-      gameId: 1,
-      isEnabled: true,
-    })) as any;
     Member.countGameJournalEntries = (async () => 1) as any;
     Member.getGameJournalEntries = (async () => ([{
       entryId: 10,
@@ -210,7 +204,6 @@ test("journal single-page view omits pager buttons and page count", async () => 
     Member.getByUserId = originalGetByUserId;
     Member.getNowPlayingEntryMeta = originalGetMeta;
     Member.getCompletionsForGame = originalGetCompletions;
-    Member.getGameJournalPreference = originalGetPref;
     Member.countGameJournalEntries = originalCount;
     Member.getGameJournalEntries = originalEntries;
     Thread.getThreadsByGameId = originalGetThreads;
@@ -222,7 +215,6 @@ test("journal public view redacts private entry content and count", async () => 
   const originalGetByUserId = Member.getByUserId;
   const originalGetMeta = Member.getNowPlayingEntryMeta;
   const originalGetCompletions = Member.getCompletionsForGame;
-  const originalGetPref = Member.getGameJournalPreference;
   const originalCount = Member.countGameJournalEntries;
   const originalEntries = Member.getGameJournalEntries;
   const originalGetThreads = Thread.getThreadsByGameId;
@@ -234,11 +226,6 @@ test("journal public view redacts private entry content and count", async () => 
     Member.getByUserId = (async () => ({ globalName: "merph518", username: "merph518" })) as any;
     Member.getNowPlayingEntryMeta = (async () => ({ addedAt: new Date("2026-05-07T00:00:00.000Z") })) as any;
     Member.getCompletionsForGame = (async () => []) as any;
-    Member.getGameJournalPreference = (async () => ({
-      userId: "123",
-      gameId: 1,
-      isEnabled: true,
-    })) as any;
     Member.countGameJournalEntries =
       (async (_userId: string, _gameId: number, viewerUserId?: string | null) => {
       countViewerArg = viewerUserId;
@@ -277,7 +264,6 @@ test("journal public view redacts private entry content and count", async () => 
     Member.getByUserId = originalGetByUserId;
     Member.getNowPlayingEntryMeta = originalGetMeta;
     Member.getCompletionsForGame = originalGetCompletions;
-    Member.getGameJournalPreference = originalGetPref;
     Member.countGameJournalEntries = originalCount;
     Member.getGameJournalEntries = originalEntries;
     Thread.getThreadsByGameId = originalGetThreads;
@@ -390,7 +376,6 @@ test("journal delete confirm removes entry on yes and skips removal on no", asyn
   const originalGetByUserId = Member.getByUserId;
   const originalGetMeta = Member.getNowPlayingEntryMeta;
   const originalGetCompletions = Member.getCompletionsForGame;
-  const originalGetPref = Member.getGameJournalPreference;
   const originalCount = Member.countGameJournalEntries;
   const originalEntries = Member.getGameJournalEntries;
 
@@ -405,11 +390,6 @@ test("journal delete confirm removes entry on yes and skips removal on no", asyn
     Member.getByUserId = (async () => ({ globalName: "merph518", username: "merph518" })) as any;
     Member.getNowPlayingEntryMeta = (async () => null) as any;
     Member.getCompletionsForGame = (async () => []) as any;
-    Member.getGameJournalPreference = (async () => ({
-      userId: "123",
-      gameId: 1,
-      isEnabled: true,
-    })) as any;
     Member.countGameJournalEntries = (async () => 1) as any;
     Member.getGameJournalEntries = (async () => ([{
       entryId: 10,
@@ -445,7 +425,6 @@ test("journal delete confirm removes entry on yes and skips removal on no", asyn
     Member.getByUserId = originalGetByUserId;
     Member.getNowPlayingEntryMeta = originalGetMeta;
     Member.getCompletionsForGame = originalGetCompletions;
-    Member.getGameJournalPreference = originalGetPref;
     Member.countGameJournalEntries = originalCount;
     Member.getGameJournalEntries = originalEntries;
   }


### PR DESCRIPTION
## Summary
- Removes the three SQL entries (`mergeJournalPrefs`, `getGameJournalPreference`,
  `upsertGameJournalPreference`) that write to or read from `user_game_journal_prefs`
- Removes the corresponding `Member` methods and the `IGameJournalPreference` interface
- Removes the two `upsertGameJournalPreference` call sites in `game-journal.command.ts`
  and `now-playing.command.ts` (both were always called with `true` anyway)
- Removes stale `getGameJournalPreference` mocks from three tests -- the function was
  never actually called by `buildJournalComponents`
- Follows up on #772 which removed the SELECT joins but left write paths intact

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/now-playing list` no longer produces a 42P01 error on Postgres

Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)