### PR TITLE
fix: GameDB View title autocomplete does not work

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -1246,7 +1246,9 @@ export default class Game {
       const titleCol = isOracle ? "TITLE" : "title";
       const titleFoldExpr =
         `REPLACE(REPLACE(REPLACE(REPLACE(LOWER(${titleCol}), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')`;
-      const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '')`;
+      const titleNormExpr = isOracle
+        ? `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '')`
+        : `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '', 'g')`;
 
       const binds = {
         exactRaw: foldedLowerQuery,
@@ -1348,7 +1350,9 @@ export default class Game {
       const titleCol = isOracle ? "TITLE" : "title";
       const titleFoldExpr =
         `REPLACE(REPLACE(REPLACE(REPLACE(LOWER(${titleCol}), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')`;
-      const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '')`;
+      const titleNormExpr = isOracle
+        ? `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '')`
+        : `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '', 'g')`;
 
       const clauses: string[] = [];
       const binds: Record<string, string | number> = {};


### PR DESCRIPTION
## Summary
- In Postgres, \`REGEXP_REPLACE(expr, '[^a-z0-9]', '')\` only strips the FIRST
  non-alphanumeric character; Oracle strips all by default. \`Game.ts\` was building
  \`titleNormExpr\` without branching on dialect, so normalized-title searches (e.g.
  typing \`nierautomata\` to find "Nier: Automata") returned no results on Postgres.
- Fixed by branching on \`isOracle\` at both sites and appending the \`'g'\` flag in the
  Postgres form. The same fix pattern was already used in \`member.sql.ts:228\`.

## Test plan
- [ ] Type-check passes (\`npx tsc --noEmit\`)
- [ ] Smoke test passes (\`bash .claude/skills/run-rpgclubbot/smoke.sh\`)
- [ ] \`/gamedb view\` autocomplete returns results when typing a normalized game title
  with no spaces (e.g. \`nierautomata\`, \`finalfantasy\`) against Postgres

Closes #764

🤖 Generated with [Claude Code](https://claude.com/claude-code)