### PR TITLE
fix: cast exactNorm to text in Postgres autocomplete SQL (42P08)

### DIFF
--- a/src/db/sql/game.sql.ts
+++ b/src/db/sql/game.sql.ts
@@ -454,15 +454,15 @@ export const GameSql = {
            FROM gamedb_games
           WHERE ${titleFoldExpr} LIKE :rawContains
              OR (
-               :exactNorm IS NOT NULL AND
+               (:exactNorm)::text IS NOT NULL AND
                ${titleNormExpr} LIKE :normContains
              )
           ORDER BY CASE
                      WHEN ${titleFoldExpr} = :exactRaw THEN 0
                      WHEN ${titleFoldExpr} LIKE :rawPrefix THEN 1
-                     WHEN :exactNorm IS NOT NULL AND
+                     WHEN (:exactNorm)::text IS NOT NULL AND
                           ${titleNormExpr} = :exactNorm THEN 2
-                     WHEN :exactNorm IS NOT NULL AND
+                     WHEN (:exactNorm)::text IS NOT NULL AND
                           ${titleNormExpr} LIKE :normPrefix THEN 3
                      ELSE 4
                    END,


### PR DESCRIPTION
## Summary
- After #778, autocomplete was still throwing Postgres error \`42P08\`
  (ambiguous_parameter) at position 711 in the query.
- Root cause: \`:exactNorm IS NOT NULL\` checks in the Postgres SQL give the planner no
  type information for the \`\$N\` parameter. Postgres cannot infer the type of a parameter
  used only in \`IS NOT NULL\` -- it needs at least one typed context.
- Fix: add \`::text\` casts -- \`(:exactNorm)::text IS NOT NULL\` -- on all three guards in
  the Postgres variant of \`searchGamesAutocomplete\`. Oracle variant is unchanged.

## Test plan
- [ ] Type-check passes (\`npx tsc --noEmit\`)
- [ ] Smoke test passes (\`bash .claude/skills/run-rpgclubbot/smoke.sh\`)
- [ ] \`/gamedb view\` autocomplete no longer throws \`42P08\` on Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)