### PR TITLE
fix: skip Postgres :: cast operator in namedToPositional

### DIFF
--- a/src/db/postgresClient.ts
+++ b/src/db/postgresClient.ts
@@ -76,7 +76,7 @@ export function namedToPositional(
   }
   const values: unknown[] = [];
   const seen = new Map<string, number>();
-  const text = sql.replace(/:([A-Za-z_]\w*)/g, (_, name: string) => {
+  const text = sql.replace(/(?<!:):([A-Za-z_]\w*)/g, (_, name: string) => {
     if (!seen.has(name)) {
       seen.set(name, values.length + 1);
       values.push(params[name]);


### PR DESCRIPTION
## Summary
- After #779 added \`(:exactNorm)::text IS NOT NULL\` casts to the autocomplete SQL,
  the bot started throwing error \`42601\` (syntax error) at position 224.
- Root cause: \`namedToPositional\` used \`/:([A-Za-z_]\w*)/g\` which matched \`:text\`
  inside \`::text\` (the Postgres cast operator), injecting \`undefined\` as a bind
  value and producing invalid SQL like \`($2)::$3\`.
- Fix: add \`(?<!:)\` negative lookbehind so any \`:word\` token preceded by \`:\`
  is skipped, leaving \`::type\` casts untouched.

## Test plan
- [ ] Type-check passes (\`npx tsc --noEmit\`)
- [ ] Smoke test passes (\`bash .claude/skills/run-rpgclubbot/smoke.sh\`)
- [ ] \`/gamedb view\` autocomplete no longer throws \`42601\` on Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)