### PR TITLE
fix: /now-playing search should use renderUsernameWithEmoji, not userMention tag

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -441,19 +441,26 @@ export default class Member {
 
   static async getNowPlayingByTitleSearch(
     query: string,
-  ): Promise<{ gameId: number; title: string; userId: string }[]> {
+  ): Promise<{ gameId: number; title: string; userId: string; username: string | null;
+    globalName: string | null }[]> {
     const trimmed = query.trim().toLowerCase();
     if (!trimmed) return [];
     const searchQuery = `%${trimmed}%`;
     const normalizedQuery = `%${trimmed.replace(/[^a-z0-9]/g, "")}%`;
-    return dbQuery<{ GAME_ID: number; TITLE: string; USER_ID: string },
-      { gameId: number; title: string; userId: string }>(
+    return dbQuery<
+      { GAME_ID: number; TITLE: string; USER_ID: string; USERNAME: string | null;
+        GLOBAL_NAME: string | null },
+      { gameId: number; title: string; userId: string; username: string | null;
+        globalName: string | null }
+    >(
       MemberSql.getNowPlayingByTitleSearch,
       { searchQuery, normalizedQuery },
       (row) => ({
         gameId: Number(row.GAME_ID),
         title: row.TITLE,
         userId: row.USER_ID,
+        username: row.USERNAME ?? null,
+        globalName: row.GLOBAL_NAME ?? null,
       }),
     );
   }

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -420,24 +420,36 @@ export class NowPlayingCommand {
       return;
     }
 
-    const usersByGameId = new Map<number, { title: string; users: string[] }>();
+    const usersByGameId = new Map<number, { title: string; userIds: Set<string>;
+      userMap: Map<string, string> }>();
     for (const row of nowPlayingRows) {
-      const record = usersByGameId.get(row.gameId) ?? { title: row.title, users: [] };
-      record.users.push(userMention(row.userId));
+      const record = usersByGameId.get(row.gameId) ?? {
+        title: row.title,
+        userIds: new Set<string>(),
+        userMap: new Map<string, string>(),
+      };
+      if (!record.userIds.has(row.userId)) {
+        record.userIds.add(row.userId);
+        const displayName = row.globalName ?? row.username ?? row.userId;
+        record.userMap.set(row.userId, renderUsernameWithEmoji(row.userId, displayName));
+      }
       usersByGameId.set(row.gameId, record);
     }
 
     const sortedGames = Array.from(usersByGameId.entries())
-      .map(([gameId, record]) => ({ gameId, title: record.title, users: record.users }))
+      .map(([gameId, record]) => ({
+        gameId,
+        title: record.title,
+        users: Array.from(record.userMap.values()),
+      }))
       .sort((a, b) => a.title.localeCompare(b.title));
     const totalGames = sortedGames.length;
     const limitedGames = sortedGames.slice(0, NOW_PLAYING_SEARCH_LIMIT);
 
     const lines: string[] = [];
     for (const game of limitedGames) {
-      const uniqueUsers = Array.from(new Set(game.users));
-      const displayedUsers = uniqueUsers.slice(0, 30);
-      const remaining = uniqueUsers.length - displayedUsers.length;
+      const displayedUsers = game.users.slice(0, 30);
+      const remaining = game.users.length - displayedUsers.length;
       const userList = `${displayedUsers.join(", ")}${remaining > 0 ? ` (+${remaining} more)` : ""}`;
       lines.push(`- **${game.title}**: ${userList}`);
     }

--- a/src/db/sql/member.sql.ts
+++ b/src/db/sql/member.sql.ts
@@ -115,7 +115,9 @@ export const MemberSql = {
   getNowPlayingByTitleSearch: {
     postgres: `SELECT u.gamedb_game_id AS game_id,
               g.title,
-              u.user_id
+              u.user_id,
+              ru.username,
+              ru.global_name
          FROM user_now_playing u
          JOIN rpg_club_users ru ON ru.user_id = u.user_id
          JOIN gamedb_games g ON g.game_id = u.gamedb_game_id


### PR DESCRIPTION
## Summary
- Updated `getNowPlayingByTitleSearch` SQL query to include `username` and `global_name` columns from `rpg_club_users`
- Updated the return type and row mapper in `Member.ts` to expose those fields
- Replaced `userMention(row.userId)` with `renderUsernameWithEmoji(row.userId, displayName)` in `searchNowPlaying`, consistent with how other user lists in the same command render names

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/now-playing search` results display formatted usernames (with emoji if applicable) instead of raw `<@userId>` mention tags

Closes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)