### PR TITLE
refactor: replace userMention display uses with renderUsernameWithEmoji

### DIFF
--- a/src/commands/avatar-history.command.ts
+++ b/src/commands/avatar-history.command.ts
@@ -8,7 +8,6 @@ import {
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
   User,
-  userMention,
 } from "discord.js";
 import {
   ContainerBuilder,
@@ -314,7 +313,7 @@ export class AvatarHistoryCommand {
     const pageResult = await buildAvatarHistoryV2Page(target, 0);
     if (!pageResult) {
       const noResultContainer = buildTextContainer(
-          safeV2TextContent(`No avatar history found for ${userMention(target.id)}.`, 1000),
+          safeV2TextContent(`No avatar history found for ${renderUsernameWithEmoji(target.id, target.displayName ?? target.username ?? target.id)}.`, 1000),
         );
       await safeReply(interaction, {
         components: [noResultContainer],
@@ -419,7 +418,7 @@ export class AvatarHistoryCommand {
       await safeUpdate(interaction, {
         components: [
           buildTextContainer(
-              safeV2TextContent(`No avatar history found for ${userMention(targetId)}.`, 1000),
+              safeV2TextContent(`No avatar history found for ${renderUsernameWithEmoji(targetId, target.displayName ?? target.username ?? targetId)}.`, 1000),
             ),
         ],
         flags: buildComponentsV2EditFlags(),

--- a/src/commands/mp-info.command.ts
+++ b/src/commands/mp-info.command.ts
@@ -7,7 +7,6 @@ import {
   ButtonBuilder,
   ButtonStyle,
   ButtonInteraction,
-  userMention,
 } from "discord.js";
 import {
   ButtonComponent,
@@ -43,6 +42,7 @@ import { parseCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { truncateLabel } from "../config/textLimits.js";
 import { chunk } from "../utilities/ArrayUtils.js";
 import { buildActionButton, buildButtonRow , buildSelectRow } from "../functions/uiComponents.js";
+import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 
 const MAX_OPTIONS = 25;
 
@@ -136,7 +136,7 @@ function buildSummaryEmbed(
   const lines = pageMembers.map((member, idx) => {
     const displayIndex = offset + idx + 1;
     const platforms = formatPlatforms(member, filters);
-    return `${displayIndex}. ${userMention(member.userId)} - ${platforms}`;
+    return `${displayIndex}. ${renderUsernameWithEmoji(member.userId, member.globalName ?? member.username ?? member.userId)} - ${platforms}`;
   });
 
   const footer = totalPages > 1
@@ -335,7 +335,7 @@ export class MultiplayerInfoCommand {
       if (!result.payload) {
         const notFoundContainer = buildTextContainer(
         safeV2TextContent(
-          result.notFoundMessage ?? `No profile data found for ${userMention(userId)}.`,
+          result.notFoundMessage ?? `No profile data found for ${renderUsernameWithEmoji(userId, user.displayName ?? user.username ?? userId)}.`,
           1000,
             ),
           );

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -15,7 +15,6 @@ import {
   type ActionRow,
   type MessageActionRowComponent,
   type Message,
-  userMention,
 } from "discord.js";
 import {
   Discord,
@@ -2433,7 +2432,7 @@ export class NowPlayingCommand {
 
       const container = buildNowPlayingMessageContainer(
         "Now Playing",
-        `No Now Playing entries found for ${userMention(target.id)}.`,
+        `No Now Playing entries found for ${renderUsernameWithEmoji(target.id, target.displayName ?? target.username ?? target.id)}.`,
       );
       const reply = await safeReply(interaction, {
         components: [container],
@@ -2504,7 +2503,7 @@ export class NowPlayingCommand {
       );
       const container = buildNowPlayingMessageContainer(
         "Now Playing - Everyone",
-        `No Now Playing entries found for ${userMention(selectedUserId)}.`,
+        `No Now Playing entries found for ${renderUsernameWithEmoji(selectedUserId, ownerName)}.`,
       );
       const updated = await safeReply(interaction, {
         components: [header, container],

--- a/src/commands/now-playing/nowPlayingListRenderer.ts
+++ b/src/commands/now-playing/nowPlayingListRenderer.ts
@@ -7,7 +7,6 @@ import {
   ButtonBuilder,
   ButtonStyle,
   type Client,
-  userMention,
 } from "discord.js";
 import {
   ContainerBuilder,
@@ -428,7 +427,7 @@ export async function refreshNowPlayingListFromContext(
           );
           const emptyMessage = ownerId === interaction.user.id
             ? "Your Now Playing list is empty."
-            : `No Now Playing entries found for ${userMention(ownerId)}.`;
+            : `No Now Playing entries found for ${renderUsernameWithEmoji(ownerId, ownerName)}.`;
           const container = buildNowPlayingMessageContainer(title, emptyMessage);
           const components = [header, container];
           await message.edit({
@@ -507,7 +506,7 @@ export async function refreshNowPlayingListFromContext(
           );
           const container = buildNowPlayingMessageContainer(
             "Now Playing - Everyone",
-            `No Now Playing entries found for ${userMention(selectedUserId)}.`,
+            `No Now Playing entries found for ${renderUsernameWithEmoji(selectedUserId, ownerName)}.`,
           );
           await message.edit({
             components: [header, container],

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -7,7 +7,6 @@ import {
   type Message,
   type ModalSubmitInteraction,
   type StringSelectMenuInteraction,
-  userMention,
 } from "discord.js";
 import {
   ContainerBuilder,
@@ -27,6 +26,7 @@ import {
   buildTextContainer,
 } from "./ComponentsV2Utils.js";
 import { isInteractionSettled, safeReply, safeUpdate, safeUserFetch } from "./InteractionUtils.js";
+import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError } from "../utilities/LogUtils.js";
 import { buildActionButton, buildButtonRow } from "./uiComponents.js";
@@ -154,7 +154,7 @@ export async function notifyUnknownCompletionPlatform(
     await (channel as any).send({
       content:
         `Unknown completion platform selected.\n` +
-        `User: ${username} (${userMention(interaction.user.id)})\n` +
+        `User: ${renderUsernameWithEmoji(interaction.user.id, username)}\n` +
         `Game: ${gameTitle} (GameDB #${gameId})`,
       allowedMentions: { parse: [] },
     });
@@ -199,13 +199,18 @@ export async function announceCompletion(
       const yearlyCount = await Member.countCompletions(userId, completionYear);
       yearlySummary = `\nGame completion #${yearlyCount} for ${completionYear}`;
     }
+    const userName = user.displayName ?? user.username ?? user.id;
     let desc =
-      `${userMention(user.id)} has added a game completion: **${game.title}** - ` +
+      `${renderUsernameWithEmoji(user.id, userName)} has added a game completion: **${game.title}** - ` +
       `${completionType} - ${dateStr}${hoursStr}` +
       yearlySummary;
     if (isAdminOverride && interaction.user.id !== userId) {
+      const admin = interaction.user;
+      const adminName = admin.displayName ?? admin.username ?? admin.id;
+      const adminMention = renderUsernameWithEmoji(admin.id, adminName);
+      const userMentionStr = renderUsernameWithEmoji(user.id, userName);
       desc =
-        `${userMention(interaction.user.id)} added a game completion for ${userMention(user.id)}: ` +
+        `${adminMention} added a game completion for ${userMentionStr}: ` +
         `**${game.title}** - ${completionType} - ${dateStr}${hoursStr}` +
         yearlySummary;
     }


### PR DESCRIPTION
## Summary
- Replaces non-ping `userMention` calls with `renderUsernameWithEmoji` across 5 files for consistent user display with emoji support
- Fixed sites: "not found" messages in avatar-history and now-playing, member list in mp-info, completion announcements in CompletionHelpers, and list renderer empty states
- Removes now-unused `userMention` imports from all affected files

## Intentionally kept as `userMention`
- Admin prompts and DM-style messages (PresenceUpdate, admin wizard, suggestion author pings) -- these are real notification pings
- Mod-log embeds (GuildBanLog, GuildMemberAdd/Remove) -- deliberate `<@id>\nusername` pattern for clickability
- Sites where no display name is available without significant refactoring (round-setup nominator lists, reaction-add admin display, nomination-admin service for the target user)

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/now-playing` "not found" messages show emoji username instead of raw mention tag
- [ ] `/mp-info` member list shows emoji username
- [ ] `/avatar-history` "not found" messages show emoji username
- [ ] Completion announcements show emoji username for completer and admin override

Closes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)