### PR TITLE
chore: set api-reference skill to use claude-haiku-4-5

### DIFF
--- a/.claude/skills/api-reference/SKILL.md
+++ b/.claude/skills/api-reference/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: api-reference
+model: claude-haiku-4-5
 description: >
   Reference for The RPG Club API endpoints. Use when writing or reviewing code that calls the
   API, when asked what endpoints exist, or when choosing which endpoint to use for a feature.

--- a/.claude/skills/api-reference/generate.py
+++ b/.claude/skills/api-reference/generate.py
@@ -96,6 +96,7 @@ def build_skill(spec: dict) -> str:
     return f"""\
 ---
 name: api-reference
+model: claude-haiku-4-5
 description: >
   Reference for The RPG Club API endpoints. Use when writing or reviewing code that calls the
   API, when asked what endpoints exist, or when choosing which endpoint to use for a feature.


### PR DESCRIPTION
## Summary

- Adds `model: claude-haiku-4-5` to the `/api-reference` skill frontmatter in `SKILL.md`
- Updates `generate.py` template so the model field persists through future `refresh.sh` runs

The api-reference skill is read-only (no actions, just endpoint docs), so Haiku is the right model for cost efficiency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)