### PR TITLE
fix: use key_id not id in GameKeyApiData response mapping

### DIFF
--- a/src/classes/GameKey.ts
+++ b/src/classes/GameKey.ts
@@ -17,7 +17,7 @@ export interface IGameKey {
 // --- API types ---
 
 type GameKeyApiData = {
-  id: number;
+  key_id: number;
   game_title: string;
   platform: string;
   key_value: string;
@@ -36,7 +36,7 @@ type GameKeyListResponse = {
 
 function mapGameKeyApi(d: GameKeyApiData): IGameKey {
   return {
-    keyId: Number(d.id),
+    keyId: Number(d.key_id),
     gameTitle: d.game_title,
     platform: d.platform,
     keyValue: d.key_value,


### PR DESCRIPTION
## Summary
- Fixes a bug introduced in #824 where `GameKeyApiData` declared the primary key field as `id` but the API returns `key_id`
- `mapGameKeyApi` was reading `d.id` (always `undefined`), so every `IGameKey.keyId` returned from API-backed functions was `NaN`
- Affected: `createGameKey`, `listAvailableGameKeys`, `listKeysByDonor` -- any caller that used the returned `keyId` (e.g. to display or claim a key) would see `NaN`

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/giveaway list` shows correct numeric key IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)