### PR TITLE
refactor: migrate GOTM/NR-GOTM startup load to API (read endpoints)

### DIFF
--- a/src/classes/Gotm.ts
+++ b/src/classes/Gotm.ts
@@ -6,6 +6,7 @@ import {
   dbMutateConn,
 } from "../db/SqlManager.js";
 import { GotmSql } from "../db/sql/index.js";
+import { apiGet } from "../services/RpgClubApiClient.js";
 import Game from "./Game.js";
 import { getThreadsByGameId } from "./Thread.js";
 import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
@@ -61,30 +62,34 @@ async function getPrimaryThreadIdForGame(gameId: number): Promise<string | null>
   return threadIds[0] ?? null;
 }
 
-type GotmEntryRow = {
-  ROUND_NUMBER: number;
-  MONTH_YEAR: string;
-  GAME_INDEX: number;
-  REDDIT_URL: string | null;
-  VOTING_RESULTS_MESSAGE_ID: string | null;
-  GAMEDB_GAME_ID: number | null;
+type GotmEntryApiRow = {
+  gotm_id: number;
+  round_number: number;
+  month_year: string;
+  game_index: number;
+  reddit_url: string | null;
+  voting_results_message_id: string | null;
+  gamedb_game_id: number | null;
+  game?: { title?: string } | null;
 };
 
+type GotmEntryListResponse = { data: GotmEntryApiRow[] };
+
 async function loadFromDatabaseInternal(): Promise<IGotmEntry[]> {
-  const rows = await dbQuery<GotmEntryRow, GotmEntryRow>(
-    GotmSql.loadAll,
-    {},
-    (row) => row,
+  const response = await apiGet<GotmEntryListResponse>(
+    "/api/v1/gotm_entries",
+    { params: { include: "game", per: 500 } },
   );
+  const rows = response?.data ?? [];
 
   const byRound = new Map<number, IGotmEntry>();
 
   for (const row of rows) {
-    const round = Number(row.ROUND_NUMBER);
+    const round = Number(row.round_number);
     if (!Number.isFinite(round)) continue;
 
-    const monthYear = row.MONTH_YEAR;
-    const votingId = row.VOTING_RESULTS_MESSAGE_ID ?? null;
+    const monthYear = row.month_year;
+    const votingId = row.voting_results_message_id ?? null;
 
     let entry = byRound.get(round);
     if (!entry) {
@@ -101,17 +106,23 @@ async function loadFromDatabaseInternal(): Promise<IGotmEntry[]> {
       entry.votingResultsMessageId = votingId;
     }
 
-    const gamedbGameId = Number(row.GAMEDB_GAME_ID);
+    const gamedbGameId = Number(row.gamedb_game_id);
     if (!isPositiveInt(gamedbGameId)) {
-      throw new Error(`GOTM round ${round} game ${row.GAME_INDEX} is missing GAMEDB_GAME_ID.`);
+      throw new Error(`GOTM round ${round} game ${row.game_index} is missing gamedb_game_id.`);
     }
-    const gameDetails = await getGameDetailsCached(gamedbGameId);
+
+    const embeddedTitle = row.game?.title;
+    const title = embeddedTitle ?? (await getGameDetailsCached(gamedbGameId)).title;
+    if (embeddedTitle) {
+      gameCache.set(gamedbGameId, { title: embeddedTitle });
+    }
+
     const derivedThreadId = await getPrimaryThreadIdForGame(gamedbGameId);
 
     const game: IGotmGame = {
-      title: gameDetails.title,
+      title,
       threadId: derivedThreadId,
-      redditUrl: row.REDDIT_URL ?? null,
+      redditUrl: row.reddit_url ?? null,
       gamedbGameId,
     };
 

--- a/src/classes/NrGotm.ts
+++ b/src/classes/NrGotm.ts
@@ -7,6 +7,7 @@ import {
   dbInsertConn,
 } from "../db/SqlManager.js";
 import { NrGotmSql } from "../db/sql/index.js";
+import { apiGet } from "../services/RpgClubApiClient.js";
 import Game from "./Game.js";
 import { getThreadsByGameId } from "./Thread.js";
 import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
@@ -63,31 +64,34 @@ async function getPrimaryThreadIdForGame(gameId: number): Promise<string | null>
   return threadIds[0] ?? null;
 }
 
-type NrGotmEntryRow = {
-  NR_GOTM_ID: number;
-  ROUND_NUMBER: number;
-  MONTH_YEAR: string;
-  GAME_INDEX: number;
-  REDDIT_URL: string | null;
-  VOTING_RESULTS_MESSAGE_ID: string | null;
-  GAMEDB_GAME_ID: number | null;
+type NrGotmEntryApiRow = {
+  nr_gotm_id: number;
+  round_number: number;
+  month_year: string;
+  game_index: number;
+  reddit_url: string | null;
+  voting_results_message_id: string | null;
+  gamedb_game_id: number | null;
+  game?: { title?: string } | null;
 };
 
+type NrGotmEntryListResponse = { data: NrGotmEntryApiRow[] };
+
 async function loadFromDatabaseInternal(): Promise<INrGotmEntry[]> {
-  const rows = await dbQuery<NrGotmEntryRow, NrGotmEntryRow>(
-    NrGotmSql.loadAll,
-    {},
-    (row) => row,
+  const response = await apiGet<NrGotmEntryListResponse>(
+    "/api/v1/nr_gotm_entries",
+    { params: { include: "game", per: 500 } },
   );
+  const rows = response?.data ?? [];
 
   const byRound = new Map<number, INrGotmEntry>();
 
   for (const row of rows) {
-    const round = Number(row.ROUND_NUMBER);
+    const round = Number(row.round_number);
     if (!Number.isFinite(round)) continue;
 
-    const monthYear = row.MONTH_YEAR;
-    const votingId = row.VOTING_RESULTS_MESSAGE_ID ?? null;
+    const monthYear = row.month_year;
+    const votingId = row.voting_results_message_id ?? null;
 
     let entry = byRound.get(round);
     if (!entry) {
@@ -104,20 +108,26 @@ async function loadFromDatabaseInternal(): Promise<INrGotmEntry[]> {
       entry.votingResultsMessageId = votingId;
     }
 
-    const gamedbGameId = Number(row.GAMEDB_GAME_ID);
+    const gamedbGameId = Number(row.gamedb_game_id);
     if (!isPositiveInt(gamedbGameId)) {
       throw new Error(
-        `NR-GOTM round ${round} game ${row.GAME_INDEX} is missing GAMEDB_GAME_ID.`,
+        `NR-GOTM round ${round} game ${row.game_index} is missing gamedb_game_id.`,
       );
     }
-    const gameDetails = await getNrGameDetailsCached(gamedbGameId);
+
+    const embeddedTitle = row.game?.title;
+    const title = embeddedTitle ?? (await getNrGameDetailsCached(gamedbGameId)).title;
+    if (embeddedTitle) {
+      nrGameCache.set(gamedbGameId, { title: embeddedTitle });
+    }
+
     const derivedThreadId = await getPrimaryThreadIdForGame(gamedbGameId);
 
     const game: INrGotmGame = {
-      id: Number(row.NR_GOTM_ID),
-      title: gameDetails.title,
+      id: Number(row.nr_gotm_id),
+      title,
       threadId: derivedThreadId,
-      redditUrl: row.REDDIT_URL ?? null,
+      redditUrl: row.reddit_url ?? null,
       gamedbGameId,
     };
 


### PR DESCRIPTION
## Summary
- Replaces `loadFromDatabaseInternal()` in `Gotm.ts` and `NrGotm.ts` with calls to `GET /api/v1/gotm_entries` and `GET /api/v1/nr_gotm_entries`
- Uses `include=game` to embed game titles, avoiding additional per-game API calls during startup load
- Mutation functions (`insertGotmRoundInDatabase`, `updateGotmGameFieldInDatabase`, `deleteGotmRoundFromDatabase`, and NR variants) remain on direct SQL — the corresponding API write endpoints (`POST`, `PATCH`, `DELETE`) do not exist yet

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/round` displays correct current round GOTM and NR-GOTM entries
- [ ] `/round-history` shows correct historical data

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)