### PR TITLE
feat: surface selected repo in /todo title and issue view

### DIFF
--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -1161,6 +1161,9 @@ function buildIssueViewComponents(
 ): { components: Array<ContainerBuilder | ActionRowBuilder<ButtonBuilder>> } {
   const container = new ContainerBuilder();
   const textBudget = { remaining: DISCORD_TEXT_INPUT_MAX };
+  const repoTarget = getTodoRepo(payload.repo);
+  const repoLabel = `${repoTarget.owner}/${repoTarget.name}`;
+  addTextDisplayWithBudget(container, textBudget, `-# ${repoLabel}`);
   const titleText = issue.htmlUrl
     ? `## [${formatIssueTitle(issue)}](${issue.htmlUrl})`
     : `## ${formatIssueTitle(issue)}`;
@@ -1186,7 +1189,8 @@ function buildIssueViewComponents(
 
   const assignee = issue.assignee ?? "Unassigned";
   const footerLine = [
-    `-# **State:** ${issue.state}`,
+    `-# **Repo:** ${repoLabel}`,
+    `**State:** ${issue.state}`,
     `**Author:** ${issue.author ?? "Unknown"}`,
     `**Assignee:** ${assignee}`,
     `**Created:** ${formatDiscordTimestamp(issue.createdAt)}`,

--- a/src/commands/todo.command.ts
+++ b/src/commands/todo.command.ts
@@ -100,7 +100,10 @@ type ListDirection = (typeof LIST_DIRECTIONS)[number];
 
 const MAX_COMMENT_PREVIEW_LENGTH = 500;
 const MAX_TODO_IMAGES_PER_VIEW = 10;
-const ISSUE_LIST_TITLE = "RPGClub GameDB GitHub Issues";
+function buildIssueListTitle(repo: TodoRepoCode): string {
+  const target = getTodoRepo(repo);
+  return `${target.owner}/${target.name} GitHub Issues`;
+}
 const TODO_LIST_ID_PREFIX = "todo-list-page";
 const TODO_LIST_BACK_ID_PREFIX = "todo-list-back";
 const TODO_VIEW_ID_PREFIX = "todo-view";
@@ -1034,7 +1037,10 @@ function buildIssueListComponents(
   const container = new ContainerBuilder()
     .addTextDisplayComponents(
       new TextDisplayBuilder().setContent(
-        safeV2TextContent(`## ${ISSUE_LIST_TITLE}`, DISCORD_TEXT_INPUT_MAX),
+        safeV2TextContent(
+          `## ${buildIssueListTitle(payload.repo)}`,
+          DISCORD_TEXT_INPUT_MAX,
+        ),
       ),
     );
 


### PR DESCRIPTION
## Summary
- `/todo` issue list title now reflects the selected repository (`owner/name GitHub Issues`) instead of a fixed string.
- The single-issue view now shows the source repo in two places:
  - a small, non-linked subtext line (`-# owner/name`) above the linked issue title
  - a `**Repo:**` field prepended to the metadata footer line

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) - 51/51
- [x] Lint clean (`npm run lint`)
- [ ] Manual: switch the repo dropdown and confirm the list title updates
- [ ] Manual: open an issue and confirm the small repo line above the title and the Repo field in the footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
