### PR TITLE
Gate bot-dev channel controls by dev role instead of server owner

### DIFF
--- a/src/config/roles.ts
+++ b/src/config/roles.ts
@@ -13,3 +13,6 @@ export const MODERATOR_ROLE_NAME = "moderators";
 export const MEMBER_ROLE_ID = "747520789003239530";
 export const MEMBER_ROLE_NAME = "members";
 
+export const DEV_ROLE_ID = "1500977607473103039";
+export const DEV_ROLE_NAME = "dev";
+

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -11,6 +11,7 @@ import type {
   User,
 } from "discord.js";
 import { BOT_DEV_CHANNEL_ID } from "../config/channels.js";
+import { DEV_ROLE_ID } from "../config/roles.js";
 import {
   buildComponentsV2Flags,
   buildTextContainer,
@@ -225,6 +226,15 @@ function getCommandOwnerId(interaction: AnyRepliable): string | null {
   return ownerId ?? null;
 }
 
+function memberHasDevRole(interaction: AnyRepliable): boolean {
+  const roles = (interaction as any)?.member?.roles;
+  if (!roles) return false;
+  // Cached GuildMember exposes a role manager; raw API members expose a string[].
+  if (typeof roles.cache?.has === "function") return roles.cache.has(DEV_ROLE_ID);
+  if (Array.isArray(roles)) return roles.includes(DEV_ROLE_ID);
+  return false;
+}
+
 function shouldBlockDevChannelInteraction(interaction: AnyRepliable): boolean {
   const anyInteraction = interaction as any;
   const channelId = anyInteraction?.channelId;
@@ -235,17 +245,18 @@ function shouldBlockDevChannelInteraction(interaction: AnyRepliable): boolean {
     anyInteraction.isModalSubmit();
   if (!isComponent && !isModal) return false;
 
-  const ownerId = anyInteraction?.guild?.ownerId ?? null;
   const commandOwnerId = getCommandOwnerId(interaction);
   const userId = anyInteraction?.user?.id ?? null;
   if (!userId) return true;
-  return userId !== ownerId && userId !== commandOwnerId;
+  if (userId === commandOwnerId) return false;
+  return !memberHasDevRole(interaction);
 }
 
 async function sendDevChannelBlockResponse(interaction: AnyRepliable): Promise<void> {
   const anyInteraction = interaction as any;
   const payload = {
-    content: "Only the command owner or server owner can use controls in this channel.",
+    content:
+      "Only the command owner or members with the dev role can use controls in this channel.",
     flags: MessageFlags.Ephemeral,
   };
 


### PR DESCRIPTION
## What

Restriction #2 on the bot dev channel (`BOT_DEV_CHANNEL_ID`) previously limited button/select/modal controls to the **command owner or the server owner**. This swaps the server-owner check for a **dev-role** check.

After this change, controls in the bot dev channel are usable by:
- the original command owner, or
- anyone holding the dev role

## Changes

- `src/config/roles.ts`: add `DEV_ROLE_ID` / `DEV_ROLE_NAME` (`1500977607473103039`).
- `src/functions/InteractionUtils.ts`:
  - new `memberHasDevRole` helper (handles both cached `GuildMemberRoleManager` and raw API `string[]` roles).
  - `shouldBlockDevChannelInteraction` now allows the command owner or any dev-role holder instead of the server owner.
  - updated the block message text accordingly.

## Verification

- `tsc --noEmit`: clean
- `npm run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)