### PR TITLE
refactor: API Migration Step 17: Migrate /game-journal command to API (partial)

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -11,6 +11,7 @@ import {
 import { MemberSql } from "../db/sql/index.js";
 import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
+import { apiGet, apiPost, apiPatch, apiDelete } from "../services/RpgClubApiClient.js";
 
 export interface IMemberRecord {
   userId: string;
@@ -154,6 +155,54 @@ export interface IJournalSearchResult {
   entryTitle: string | null;
   body: string;
   createdAt: Date;
+}
+
+// --- Journal API types (data: as_json from JournalEntry*/JournaledGame) ---
+
+type JournalEntryApiData = {
+  entry_id: number;
+  user_id: string;
+  gamedb_game_id: number;
+  entry_title: string | null;
+  entry_body: string;
+  created_at: string;
+  updated_at: string;
+};
+
+type JournalEntryListResponse = {
+  data: JournalEntryApiData[];
+  meta: { count: number };
+};
+
+type JournalEntryShowResponse = {
+  data: JournalEntryApiData;
+};
+
+type JournaledGameApiData = {
+  game: { game_id: number; title: string };
+  entry_count: number;
+  last_entry_at: string | null;
+};
+
+type JournaledGameListResponse = {
+  data: JournaledGameApiData[];
+  meta: { count: number; pages: number };
+};
+
+function mapJournalEntry(
+  raw: JournalEntryApiData,
+  entryNumber: number,
+): IGameJournalEntry {
+  return {
+    entryId: Number(raw.entry_id),
+    entryNumber,
+    userId: raw.user_id,
+    gameId: Number(raw.gamedb_game_id),
+    title: raw.entry_title ?? null,
+    body: raw.entry_body,
+    createdAt: new Date(raw.created_at),
+    updatedAt: new Date(raw.updated_at),
+  };
 }
 
 export interface IAvatarHistoryRecord {
@@ -665,28 +714,19 @@ export default class Member {
   ): Promise<IGameJournalEntry[]> {
     const safeLimit = Math.min(Math.max(params?.limit ?? 5, 1), 25);
     const safeOffset = Math.max(params?.offset ?? 0, 0);
-    return dbQuery<{
-      ENTRY_ID: number;
-      USER_ID: string;
-      GAMEDB_GAME_ID: number;
-      ENTRY_TITLE: string | null;
-      ENTRY_BODY: string;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-      ENTRY_NUMBER: number;
-    }, IGameJournalEntry>(
-      MemberSql.getGameJournalEntries,
-      { userId, gameId, offset: safeOffset, limit: safeLimit },
-      (row) => ({
-        entryId: Number(row.ENTRY_ID),
-        entryNumber: Number(row.ENTRY_NUMBER),
-        userId: row.USER_ID,
-        gameId: Number(row.GAMEDB_GAME_ID),
-        title: row.ENTRY_TITLE ?? null,
-        body: row.ENTRY_BODY,
-        createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT),
-        updatedAt: row.UPDATED_AT instanceof Date ? row.UPDATED_AT : new Date(row.UPDATED_AT),
-      }),
+    // Callers always pass an offset that is a multiple of limit (page-aligned),
+    // so per/page slicing returns the same window as the old LIMIT/OFFSET query.
+    const page = Math.floor(safeOffset / safeLimit) + 1;
+    const response = await apiGet<JournalEntryListResponse>(
+      `/api/v1/games/${gameId}/journal`,
+      { params: { user_id: userId, page, per: safeLimit } },
+    );
+    if (!response) return [];
+    const total = Number(response.meta?.count ?? 0);
+    // API list is created_at DESC; entry_number is the ascending (oldest = 1)
+    // rank, so the newest entry carries the highest number.
+    return response.data.map((raw, idx) =>
+      mapJournalEntry(raw, total - safeOffset - idx),
     );
   }
 
@@ -695,14 +735,13 @@ export default class Member {
     gameId: number,
     viewerUserId?: string | null,
   ): Promise<number> {
-    // viewerUserId is reserved for viewer-scoped filtering; not yet used in the query
+    // viewerUserId is reserved for viewer-scoped filtering; not yet used here
     void viewerUserId;
-    const rows = await dbQuery<{ CNT: number }, number>(
-      MemberSql.countGameJournalEntries,
-      { userId, gameId },
-      (row) => Number(row.CNT),
+    const response = await apiGet<JournalEntryListResponse>(
+      `/api/v1/games/${gameId}/journal`,
+      { params: { user_id: userId, per: 1 } },
     );
-    return rows[0] ?? 0;
+    return Number(response?.meta?.count ?? 0);
   }
 
   static async addGameJournalEntry(params: {
@@ -716,13 +755,14 @@ export default class Member {
     if (!bodyValue) {
       throw new Error("Journal body cannot be empty.");
     }
-    await dbMutate(
-      MemberSql.addGameJournalEntry,
+    await apiPost<JournalEntryShowResponse>(
+      `/api/v1/users/${params.userId}/journal`,
       {
-        userId: params.userId,
-        gameId: params.gameId,
-        title: titleValue,
-        body: bodyValue,
+        data: {
+          gamedb_game_id: params.gameId,
+          entry_title: titleValue,
+          entry_body: bodyValue,
+        },
       },
     );
   }
@@ -731,32 +771,38 @@ export default class Member {
     userId: string,
     entryId: number,
   ): Promise<IGameJournalEntry | null> {
-    const rows = await dbQuery<{
-      ENTRY_ID: number;
-      USER_ID: string;
-      GAMEDB_GAME_ID: number;
-      ENTRY_TITLE: string | null;
-      ENTRY_BODY: string;
-      CREATED_AT: Date | string;
-      UPDATED_AT: Date | string;
-      ENTRY_NUMBER: number;
-    }, IGameJournalEntry>(
-      MemberSql.getGameJournalEntryForUser,
-      { userId, entryId },
-      (row) => ({
-        entryId: Number(row.ENTRY_ID),
-        entryNumber: Number(row.ENTRY_NUMBER),
-        userId: row.USER_ID,
-        gameId: Number(row.GAMEDB_GAME_ID),
-        title: row.ENTRY_TITLE ?? null,
-        body: row.ENTRY_BODY,
-        createdAt: row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT),
-        updatedAt: row.UPDATED_AT instanceof Date ? row.UPDATED_AT : new Date(row.UPDATED_AT),
-      }),
+    const response = await apiGet<JournalEntryShowResponse>(
+      `/api/v1/journal_entries/${entryId}`,
     );
-    const row = rows[0];
-    if (!row) return null;
-    return row;
+    if (!response || response.data.user_id !== userId) return null;
+    const raw = response.data;
+    const entryNumber = await this.resolveJournalEntryNumber(
+      userId,
+      Number(raw.gamedb_game_id),
+      Number(raw.entry_id),
+    );
+    return mapJournalEntry(raw, entryNumber);
+  }
+
+  // entry_number is the ascending (oldest = 1) rank within the user's entries
+  // for a game; the API does not return it, so derive it from the DESC-ordered
+  // list. Approximate above 500 entries -- it only feeds an `Entry #N` label.
+  private static async resolveJournalEntryNumber(
+    userId: string,
+    gameId: number,
+    entryId: number,
+  ): Promise<number> {
+    const response = await apiGet<JournalEntryListResponse>(
+      `/api/v1/games/${gameId}/journal`,
+      { params: { user_id: userId, per: 500 } },
+    );
+    if (!response) return 1;
+    const total = Number(response.meta?.count ?? response.data.length);
+    const descIndex = response.data.findIndex(
+      (item) => Number(item.entry_id) === entryId,
+    );
+    if (descIndex < 0) return 1;
+    return total - descIndex;
   }
 
   static async updateGameJournalEntry(params: {
@@ -765,40 +811,43 @@ export default class Member {
     title?: string | null;
     body?: string;
   }): Promise<boolean> {
-    const fields: string[] = [];
-    const binds: Record<string, unknown> = {
-      userId: params.userId,
-      entryId: params.entryId,
-    };
+    const data: Record<string, string | null> = {};
 
     if (params.title !== undefined) {
-      fields.push("ENTRY_TITLE = :title");
-      binds.title = params.title?.trim() ? params.title.trim() : null;
+      data.entry_title = params.title?.trim() ? params.title.trim() : null;
     }
     if (params.body !== undefined) {
       const bodyValue = params.body.trim();
       if (!bodyValue) {
         throw new Error("Journal body cannot be empty.");
       }
-      fields.push("ENTRY_BODY = :body");
-      binds.body = bodyValue;
+      data.entry_body = bodyValue;
     }
-    if (!fields.length) return false;
-    fields.push("UPDATED_AT = SYSTIMESTAMP");
+    if (!Object.keys(data).length) return false;
 
-    const count = await dbMutate(
-      MemberSql.updateGameJournalEntry(fields),
-      binds as Record<string, any>,
+    // Verify ownership before mutating -- the API keys edits off the entry id.
+    const existing = await apiGet<JournalEntryShowResponse>(
+      `/api/v1/journal_entries/${params.entryId}`,
     );
-    return count > 0;
+    if (!existing || existing.data.user_id !== params.userId) return false;
+
+    const response = await apiPatch<JournalEntryShowResponse>(
+      `/api/v1/journal_entries/${params.entryId}`,
+      { data },
+    );
+    return response != null;
   }
 
   static async deleteGameJournalEntry(userId: string, entryId: number): Promise<boolean> {
-    const count = await dbMutate(
-      MemberSql.deleteGameJournalEntry,
-      { userId, entryId },
+    // Verify ownership before deleting -- the API keys deletes off the entry id.
+    const existing = await apiGet<JournalEntryShowResponse>(
+      `/api/v1/journal_entries/${entryId}`,
     );
-    return count > 0;
+    if (!existing || existing.data.user_id !== userId) return false;
+    const result = await apiDelete<{ deleted: boolean }>(
+      `/api/v1/journal_entries/${entryId}`,
+    );
+    return result?.deleted === true;
   }
 
   static async updateNowPlayingSort(
@@ -1683,19 +1732,27 @@ export default class Member {
   }
 
   static async getGameJournalList(userId: string): Promise<IGameJournalListEntry[]> {
-    return dbQuery<{
-      GAME_ID: number;
-      TITLE: string;
-      TOTAL_ENTRIES: number;
-    }, IGameJournalListEntry>(
-      MemberSql.getGameJournalList,
-      { userId },
-      (row) => ({
-        gameId: Number(row.GAME_ID),
-        title: row.TITLE,
-        totalEntries: Number(row.TOTAL_ENTRIES ?? 0),
-      }),
-    );
+    const perPage = 500;
+    const entries: IGameJournalListEntry[] = [];
+    let page = 1;
+    let pages = 1;
+    do {
+      const response = await apiGet<JournaledGameListResponse>(
+        `/api/v1/users/${userId}/journal`,
+        { params: { page, per: perPage } },
+      );
+      if (!response) break;
+      for (const row of response.data) {
+        entries.push({
+          gameId: Number(row.game.game_id),
+          title: row.game.title,
+          totalEntries: Number(row.entry_count ?? 0),
+        });
+      }
+      pages = Number(response.meta?.pages ?? 1);
+      page += 1;
+    } while (page <= pages);
+    return entries;
   }
 
   static async getAllJournalUsers(): Promise<IJournalUserSummary[]> {

--- a/src/db/sql/member.sql.ts
+++ b/src/db/sql/member.sql.ts
@@ -190,83 +190,6 @@ export const MemberSql = {
         GROUP BY gids.game_id`,
     }) satisfies ISqlEntry,
 
-  getGameJournalEntries: {
-    postgres: `WITH all_entries AS (
-         SELECT entry_id,
-                user_id,
-                gamedb_game_id,
-                entry_title,
-                entry_body,
-                created_at,
-                updated_at,
-                ROW_NUMBER() OVER (ORDER BY created_at ASC, entry_id ASC) AS entry_number
-           FROM user_game_journal_entries
-          WHERE user_id = :userId
-            AND gamedb_game_id = :gameId
-       )
-       SELECT entry_id,
-              user_id,
-              gamedb_game_id,
-              entry_title,
-              entry_body,
-              created_at,
-              updated_at,
-              entry_number
-         FROM all_entries
-        ORDER BY created_at DESC, entry_id DESC
-        LIMIT :limit OFFSET :offset`,
-  } satisfies ISqlEntry,
-
-  countGameJournalEntries: {
-    postgres: `SELECT COUNT(*) AS cnt
-         FROM user_game_journal_entries
-        WHERE user_id = :userId
-          AND gamedb_game_id = :gameId`,
-  } satisfies ISqlEntry,
-
-  addGameJournalEntry: {
-    postgres: `INSERT INTO user_game_journal_entries
-        (user_id, gamedb_game_id, entry_title, entry_body, is_public)
-       VALUES
-        (:userId, :gameId, :title, :body, true)`,
-  } satisfies ISqlEntry,
-
-  getGameJournalEntryForUser: {
-    postgres: `SELECT e.entry_id,
-              e.user_id,
-              e.gamedb_game_id,
-              e.entry_title,
-              e.entry_body,
-              e.created_at,
-              e.updated_at,
-              (SELECT COUNT(*) + 1
-                 FROM user_game_journal_entries e2
-                WHERE e2.user_id = e.user_id
-                  AND e2.gamedb_game_id = e.gamedb_game_id
-                  AND (e2.created_at < e.created_at
-                       OR (e2.created_at = e.created_at AND e2.entry_id < e.entry_id))
-              ) AS entry_number
-         FROM user_game_journal_entries e
-        WHERE e.user_id = :userId
-          AND e.entry_id = :entryId
-        LIMIT 1`,
-  } satisfies ISqlEntry,
-
-  // Caller must pass lowercase column=value expressions for Postgres
-  updateGameJournalEntry: (fields: string[]) =>
-    ({
-      postgres: `UPDATE user_game_journal_entries
-          SET ${fields.join(", ")}
-        WHERE user_id = :userId
-          AND entry_id = :entryId`,
-    }) satisfies ISqlEntry,
-
-  deleteGameJournalEntry: {
-    postgres: `DELETE FROM user_game_journal_entries
-        WHERE user_id = :userId
-          AND entry_id = :entryId`,
-  } satisfies ISqlEntry,
-
   updateNowPlayingSort: {
     postgres: `UPDATE user_now_playing
             SET sort_order = :sortOrder
@@ -490,17 +413,6 @@ export const MemberSql = {
            WHERE server_left_at IS NULL
              AND user_id NOT IN (${placeholders})`,
     }) satisfies ISqlEntry,
-
-  getGameJournalList: {
-    postgres: `SELECT g.game_id,
-              g.title,
-              COUNT(e.entry_id) AS total_entries
-         FROM user_game_journal_entries e
-         JOIN gamedb_games g ON g.game_id = e.gamedb_game_id
-        WHERE e.user_id = :userId
-        GROUP BY g.game_id, g.title
-        ORDER BY g.title`,
-  } satisfies ISqlEntry,
 
   getAllJournalUsers: {
     postgres: `SELECT u.user_id,


### PR DESCRIPTION
## Summary
- Migrates the journal methods whose API endpoints already exist to the TheRPGClub Rails API: `getGameJournalEntries`, `countGameJournalEntries`, `addGameJournalEntry`, `getGameJournalEntryForUser`, `updateGameJournalEntry`, `deleteGameJournalEntry`, and `getGameJournalList`.
- `entry_number` (not returned by the API) is derived client-side from the DESC-ordered list and the `meta.count` total; the single-entry path resolves it from the user's game-scoped list (approximate above 500 entries, only feeds an `Entry #N` label).
- Removes the seven now-unused journal SQL entries from `member.sql.ts`.
- Leaves three methods on SQL because their endpoints do not exist yet (`getJournalStatusForGames`, `getAllJournalUsers`, `searchJournalEntries`) plus the bot-internal `journal_message_contexts` methods. Remaining work is tracked as a blocked followup ("API Migration Step 17b") and the missing endpoints are requested in the TheRPGClub API repo.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/game-journal` lists entries; `all` flag shows all members; `game` filter narrows by game
- [ ] Journal entry button/modal flow (add/edit/delete via component interactions) still works post-restart

Closes #804

🤖 Generated with [Claude Code](https://claude.com/claude-code)