### PR TITLE
refactor: remove dead nick-history SQL code (Step 19 partial)

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -89,12 +89,6 @@ export interface IMemberSearchResult {
   lastSeenAt: Date | null;
 }
 
-export interface IMemberNickHistory {
-  oldNick: string | null;
-  newNick: string | null;
-  changedAt: Date;
-}
-
 export interface IMemberNowPlayingEntry {
   gameId: number;
   title: string;
@@ -1214,32 +1208,6 @@ export default class Member {
     if (!existing || existing.data.user_id !== userId) return false;
     const result = await apiDelete<{ deleted: boolean }>(`/api/v1/completions/${completionId}`);
     return result?.deleted === true;
-  }
-
-  static async getRecentNickHistory(
-    userId: string,
-    limit: number = 5,
-  ): Promise<IMemberNickHistory[]> {
-    const safeLimit = Math.min(Math.max(limit, 1), 20);
-    try {
-      return await dbQuery<{
-        OLD_NICK: string | null;
-        NEW_NICK: string | null;
-        CHANGED_AT: Date;
-      }, IMemberNickHistory>(
-        MemberSql.getRecentNickHistory,
-        { userId, limit: safeLimit },
-        (row) => ({
-          oldNick: row.OLD_NICK ?? null,
-          newNick: row.NEW_NICK ?? null,
-          changedAt: row.CHANGED_AT,
-        }),
-      );
-    } catch (err: any) {
-      const msg = err?.message ?? String(err);
-      logError("Member.loadNickHistory", msg);
-      return [];
-    }
   }
 
   static async getCompletionLeaderboard(

--- a/src/db/sql/member.sql.ts
+++ b/src/db/sql/member.sql.ts
@@ -248,14 +248,6 @@ export const MemberSql = {
        LIMIT 1`,
   } satisfies ISqlEntry,
 
-  getRecentNickHistory: {
-    postgres: `SELECT old_nick, new_nick, changed_at
-           FROM rpg_club_user_nick_history
-          WHERE user_id = :userId
-          ORDER BY changed_at DESC
-          LIMIT :limit`,
-  } satisfies ISqlEntry,
-
   // Caller must pass dialect-appropriate whereClause
   getCompletionLeaderboard: (whereClause: string) =>
     ({


### PR DESCRIPTION
## Summary
- Removes `Member.getRecentNickHistory` and `IMemberNickHistory` -- dead code with no callers; `profile.command.ts` already calls `GET /api/v1/users/:id/nick_history` directly
- Removes the corresponding `MemberSql.getRecentNickHistory` SQL query
- Only the API-backed portion of #806 is implementable today; all remaining SQL methods (`getByUserId`, `upsert`, `markDepartedNotIn`, avatar history, emoji name, leaderboard, etc.) require new API endpoints tracked in #848 (blocked on TheRPGClub/TheRPGClub-api#105)

## Test plan
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run lint` passes
- [ ] All 51 smoke tests pass (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/profile` still displays nick history correctly (calls API directly, not via Member class)

Closes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)