### PR TITLE
docs: update functionality inventory with API migration status

### DIFF
--- a/functionality-inventory.md
+++ b/functionality-inventory.md
@@ -3,6 +3,126 @@
 Comprehensive inventory of every Discord bot command (with subcommands and parameter variants) and
 every service that uses SQL. Sourced from `src/commands/`, `src/services/`, and `src/db/sql/`.
 
+The bot is mid-migration from direct SQL to the RPG Club HTTP API
+(`src/services/RpgClubApiClient.ts`, helpers `apiGet`/`apiPost`/`apiPatch`/`apiDelete`). The
+**API Migration Status** section below answers: which commands and services now read/write through the
+API instead of SQL, and how many API calls each command makes. The per-command **SQL Operations**
+tables further down describe the underlying data tables touched; where a path has migrated, the data
+now flows through the API endpoint rather than a raw query, even though the table is unchanged.
+
+---
+
+## API Migration Status (as of 2026-06-12)
+
+Migration happens at the data-class layer. A command's API status is inherited from the class methods
+it calls. Counts below are taken from call sites in `src/classes/` and
+`src/commands/profile.command.ts` (the only command that calls the API client directly).
+
+### Class-level status
+
+"API" counts `await apiGet/apiPost/apiPatch/apiDelete/apiGetRaw` call sites. "SQL" counts
+`dbQuery/dbMutate/dbInsert/dbWithConnection/dbQueryConn/dbMutateConn/dbInsertConn` call sites.
+
+| Class | API sites | SQL sites | Status | What is still SQL |
+|---|---|---|---|---|
+| `BotVotingInfo` | 8 | 0 | Full API | -- |
+| `Thread` | 8 | 0 | Full API | -- |
+| `Suggestion` | 5 | 0 | Full API | -- |
+| `PublicReminder` | 5 | 0 | Full API | -- |
+| `Starboard` | 2 | 0 | Full API | -- |
+| `GameSearchSynonymDraft` | 4 | 0 | Full API | -- |
+| `GameKey` | 5 | 2 | Mostly API | a couple of read/autocomplete paths |
+| `UserGameCollection` | 6 | 7 | Partial | `searchEntries`, `getOverviewFor*`, `autocompleteEntries` (list/overview reads) |
+| `Member` | 17 | 25 | Partial | journal + completion CRUD are API; now-playing, profile, socials, avatar/nick history still SQL |
+| `RssFeed` | 4 | 6 | Partial | feed CRUD is API; feed-item seen/mark tracking still SQL |
+| `Game` | 10 | 52 | Partial | game/release/platform/region/company/image **reads** are API; search, IGDB writes, completions/now-playing aggregates still SQL |
+| `Nomination` | 1 | 3 | Partial | `listNominationsForRound` is API; per-user get/upsert/delete still SQL |
+| `Gotm` | 1 | 4 | Partial | round list **read** is API; insert/update/delete still SQL |
+| `NrGotm` | 1 | 5 | Partial | round list **read** is API; insert/update/delete still SQL |
+| `GameSearchSynonym` | 6 | 21 | Partial | group/term create + draft promote are API; lookups/expansion still SQL |
+
+### Per-command API usage
+
+"API calls (primary path)" is the number of API requests on the normal success path of a single
+invocation. `+N` marks a call inside a loop (once per release, platform, nominee, term, etc.).
+"None" means the command still runs entirely on SQL or makes no DB call.
+
+| Command / subcommand | API status | API calls (primary path) | Endpoints hit |
+|---|---|---|---|
+| `/admin set-nextvote` | Partial | ~2 | GET + PATCH `/voting_info/{round}` |
+| `/admin voting-setup` | Partial | ~3 | GET `/voting_info`, GET `/gotm_entries/{r}/nominations`, GET `/nr_gotm_entries/{r}/nominations` |
+| `/admin add-gotm` / `add-nr-gotm` | Partial | ~2 | voting_info GET/POST/PATCH (entry insert still SQL) |
+| `/admin edit-gotm` / `edit-nr-gotm` | Partial | 1 | GET `/gotm_entries` (update still SQL) |
+| `/admin delete-gotm-noms` / `delete-nr-gotm-noms` | None | 0 | nomination DELETE still SQL |
+| `/admin nextround-setup`, `gotm-audit`, `sql-health-check`, `sync`, `help` | None | 0 | SQL / Discord / import only |
+| `/avatar-history` | None | 0 | avatar history still SQL |
+| `/collection add` | Partial | 1 | POST `/users/{id}/collections` |
+| `/collection edit` | Partial | 2 | GET + PATCH `/collections/{id}` |
+| `/collection remove` | Partial | 2 | GET + DELETE `/collections/{id}` |
+| `/collection to-completion` | Partial | 2 | GET `/collections/{id}` + POST `/users/{id}/completions` |
+| `/collection list` / `overview` / `import-*` | None | 0 | list/overview reads + imports still SQL |
+| `/create-thread` | Partial | 2+ | GET `/games/{id}` + POST `/threads` (+ POST `/threads/{id}/links`) |
+| `/game-completion add` | Partial | 1 | POST `/users/{id}/completions` |
+| `/game-completion edit` | Partial | 2 | GET + PATCH `/completions/{id}` |
+| `/game-completion delete` | Partial | 2 | GET + DELETE `/completions/{id}` |
+| `/game-completion list` / `common` / `export` / `import-completionator` | None | 0 | completion list reads + import still SQL |
+| `/game-journal` (and journal CRUD) | Partial | 1-2 | GET `/users/{id}/journal`, GET `/games/{id}/journal`; entry CRUD POST/PATCH/DELETE `/journal_entries` |
+| `/gamedb view` | Partial | ~6 +N | GET `/games/{id}`, `/games/{id}/releases`, `/platforms/{id}` (+N), `/regions/{id}` (+N), `/companies/{id}` (+N), `/games/{id}/images`, `/games/{id}/threads` (completions/now-playing aggregates still SQL) |
+| `/gamedb search` | None | 0 | full-text + synonym search still SQL |
+| `/gamedb add` / `refresh-release-info` / `csv-import` / `audit` | None | 0 | IGDB write paths still SQL |
+| `/gamedb synonym-add` | Partial | 2+ | POST `/search_synonym_groups` + POST `/search_synonyms` (+N per term) |
+| `/gamedb synonym-list` | None | 0 | synonym lookup still SQL |
+| `/gamedb link-versions` | None | 0 | alternates insert still SQL |
+| `/generate-vote-image` | Partial | 1 +N | GET `/gotm_entries/{r}/nominations` (or nr) + GET `/games/{id}/images` per nominee |
+| `/giveaway list` | Mostly API | 1 | GET `/game_keys` |
+| `/giveaway donate` | Mostly API | 1+ | POST `/game_keys` (+ game lookup) |
+| `/giveaway revoke` | Partial | varies | own-key lookup still partly SQL |
+| `/hltb` | None | 0 | HLTB cache table still SQL |
+| `/mod presence` / `presence-history` | None | 0 | presence history still SQL |
+| `/moderator create-live-event` | Partial | 1+ | POST `/threads` (+ link) |
+| `/mp-info` | None | 0 | socials lookup still SQL |
+| `/nominate` (write) | Partial | 1+ | GET `/games/{id}` + voting_info GET (upsert still SQL) |
+| `/nominate noms` (display) | Full API | 1 | GET `/gotm_entries/{r}/nominations` or `/nr_gotm_entries/{r}/nominations` |
+| `/now-playing add` | Partial | 1+ | GET `/games/{id}` (now-playing insert still SQL) |
+| `/now-playing list` / `search` | None | 0 | now-playing reads still SQL |
+| `/profile view` | Mostly API | 2 | GET `/users/{id}`, GET `/users/{id}/nick_history` |
+| `/profile search` | Full API | 1 | GET `/users` |
+| `/profile edit` | Full API | 2-3 | GET `/social_platforms`, then POST/PATCH/DELETE `/users/{id}/socials` or `/user_socials/{id}` |
+| `/publicreminder create` | Full API | 1 | POST `/public_reminders` |
+| `/publicreminder list` | Full API | 1 | GET `/public_reminders` |
+| `/publicreminder delete` | Full API | 1-2 | DELETE `/public_reminders/{id}` |
+| `/round` | Full API | 3 | GET `/gotm_entries`, `/nr_gotm_entries`, `/voting_info` |
+| `/round-history` | Full API | 2 | GET `/gotm_entries`, `/nr_gotm_entries` |
+| `/rss add` | Full API | 1 | POST `/rss_feeds` |
+| `/rss remove` | Full API | 1 | DELETE `/rss_feeds/{id}` |
+| `/rss edit` | Full API | 1 | PATCH `/rss_feeds/{id}` |
+| `/rss list` | Full API | 1 | GET `/rss_feeds` |
+| `/suggestion` (submit) | Full API | 1 | POST `/suggestions` |
+| `/suggestion` review flow | Full API | 1-2 | GET `/suggestions/{id}`, DELETE `/suggestions/{id}` |
+| `/superadmin completion-add-other` | Partial | 1 | POST `/users/{id}/completions` |
+| `/superadmin memberscan` / `say` / `help` | None | 0 | memberscan upsert still SQL |
+| `/thread link` | Full API | 1 | POST `/threads/{id}/links` |
+| `/thread unlink` | Full API | 1 | DELETE `/threads/{id}/links/{game_id}` |
+| `/todo` | None | 0 | todo table still SQL (proxies GitHub Issues) |
+| `/help`, `/timestamp` | None | 0 | no DB / pure compute |
+
+### Service-level status
+
+- `GameImageService` -- **Full API**: calls `apiGet` `/games/{id}/images` directly (the only service that
+  uses the API client without going through a data class).
+- `GiveawayHubService` -- **Mostly API**: via `GameKey` (API key list/count).
+- `NominationReminderService` -- **Full API**: via `BotVotingInfo` (API).
+- `PublicReminderService` -- **Full API**: via `PublicReminder` (API).
+- `ThreadSyncService` -- **Full API**: via `Thread.upsertThreadRecord` (API).
+- `ThreadLinkPromptService` -- **Partial**: via `Game` (API reads).
+- `GamedbAuditService` -- **Partial**: via `Game` (reads API, audit writes still SQL).
+- `RssFeedService` -- **Partial**: routes entirely through the `RssFeed` class (no direct DB/API calls
+  of its own); feed list/CRUD is API, while feed-item seen/mark tracking inside `RssFeed` is still SQL.
+- `ReminderService` -- **SQL**: `user_reminders` not yet migrated (API endpoints exist).
+- `GameReleaseAnnouncementService` -- **SQL**: `gamedb_release_announcements` not yet migrated.
+- `UserEmojiService` -- **SQL**: `rpg_club_users.emoji_name` not yet migrated.
+- `IgdbScanService` -- **SQL**: IGDB persistence path not yet migrated.
+
 ---
 
 ## Commands
@@ -270,14 +390,17 @@ SQL: SELECT `rpg_club_todos`; proxies GitHub Issues API for live data
 
 ---
 
-## Services with SQL Access
+## Services with Data Access
+
+Data-path status per service is summarized in **API Migration Status** above. The breakdowns below
+describe the tables each service ultimately touches, whether via API or SQL.
 
 ### `RssFeedService` (`src/services/RssFeedService.ts`)
 
-Uses `dbWithConnection` directly. Orchestrates:
-- SELECT `rpg_club_rss_feeds` -- load all active feeds on each poll cycle
-- SELECT `rpg_club_rss_feed_items` -- check which items have already been posted (`isItemSeen`)
-- INSERT `rpg_club_rss_feed_items` -- mark new items as seen after posting
+Routes through the `RssFeed` class (no direct `dbWithConnection` of its own anymore). Orchestrates:
+- GET `/api/v1/rss_feeds` (API) -- load all active feeds on each poll cycle
+- SELECT `rpg_club_rss_feed_items` (SQL) -- check which items have already been posted (`isItemSeen`)
+- INSERT `rpg_club_rss_feed_items` (SQL) -- mark new items as seen after posting
 
 ---
 


### PR DESCRIPTION
## Summary

Updates `functionality-inventory.md` to reflect the in-progress SQL-to-API migration.

- New **API Migration Status** section: class-level status (API vs SQL call-site counts), per-command API status with primary-path API call counts, and per-service status.
- Per-command counts use the normal success path; calls inside loops are marked `+N` (once per release/platform/nominee/term).
- Fixes the stale `RssFeedService` note: it routes through the `RssFeed` class now, not `dbWithConnection` directly.

## Method

- SQL call sites counted across all seven `SqlManager` executors (`dbQuery/dbMutate/dbInsert/dbWithConnection` + `*Conn` variants), not just `dbWithConnection` — the narrower count would have falsely marked `Gotm`/`Nomination`/`UserGameCollection` as fully migrated.
- API call sites counted from `apiGet/apiPost/apiPatch/apiDelete/apiGetRaw` usages in `src/classes/` and `profile.command.ts`.

## Note

Per-command integer counts are derived from class-method call sites, not a line-by-line trace of every handler, so conditional branches may add calls beyond the listed primary path.

Docs-only change. No code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)