### PR TITLE
fix: thread link 'Import First Match' says session expired

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -3133,5 +3133,47 @@ export default {
         };
       },
     },
+    "igdb-session-id-built-centrally": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            "Disallow constructing IGDB select session ids or custom ids outside " +
+            "IgdbSelectService. The session id must come from createIgdbSession so it " +
+            "stays unique per call and does not clobber concurrent same-user sessions.",
+        },
+        schema: [],
+        messages: {
+          builtElsewhere:
+            "Do not build IGDB session ids/custom ids here. Use the sessionId/components " +
+            "returned by createIgdbSession (see src/services/IGDB/IgdbSelectService.ts).",
+        },
+      },
+      create(context) {
+        const filename = context.getFilename().replace(/\\/g, "/");
+        if (filename.endsWith("src/services/IGDB/IgdbSelectService.ts")) {
+          return {};
+        }
+        const startsWithSessionCustomId = (value) =>
+          typeof value === "string" &&
+          (value.startsWith("igdb-select:") || value.startsWith("igdb-first:"));
+        return {
+          Literal(node) {
+            if (startsWithSessionCustomId(node.value)) {
+              context.report({ node, messageId: "builtElsewhere" });
+            }
+          },
+          TemplateLiteral(node) {
+            const firstQuasi = node.quasis[0]?.value?.cooked ?? "";
+            const reconstructsCustomId = startsWithSessionCustomId(firstQuasi);
+            const reconstructsSessionId =
+              firstQuasi === "igdb-" && node.expressions.length > 0;
+            if (reconstructsCustomId || reconstructsSessionId) {
+              context.report({ node, messageId: "builtElsewhere" });
+            }
+          },
+        };
+      },
+    },
   },
 };

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -92,6 +92,7 @@ export default [
       "local/component-update-requires-safe-defer": "warn",
       "local/interactive-handler-requires-safe-interaction": "error",
       "local/no-igdb-session-callback-unsafe-response": "error",
+      "local/igdb-session-id-built-centrally": "error",
       "local/no-empty-catch-on-interaction-response": "warn",
       "local/no-edit-reply-on-modal-union": "error",
       "local/require-relative-import-js-extension": "error",

--- a/src/services/IGDB/IgdbSelectService.ts
+++ b/src/services/IGDB/IgdbSelectService.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import {
   ActionRowBuilder,
   ButtonStyle,
@@ -33,6 +34,9 @@ type Session = {
 };
 
 const IGDB_FIRST_MATCH_PREFIX = "igdb-first";
+const IGDB_SESSION_EXPIRED_MESSAGE =
+  "This game selection has expired or was replaced by a newer one. " +
+  "Please re-run the command (or click \"Link a game\" again) to start a fresh selection.";
 // Leave room for prev/next navigation in the 25-option Discord limit.
 const PAGE_SIZE = 22; // 22 options + prev/next (up to 24) stays under 25
 const IGDB_SESSION_KEY = Symbol.for("igdbSelectSessions");
@@ -66,7 +70,10 @@ export function createIgdbSession(
   sessionId: string;
   components: ActionRowBuilder<any>[];
 } {
-  const sessionId = `igdb-${ownerId}`;
+  // Unique per call so concurrent or sequential IGDB selections from the same user
+  // do not clobber each other in the shared session store. The id never contains a
+  // colon, which the custom-id parser relies on for exact segment counting.
+  const sessionId = `igdb-${ownerId}-${crypto.randomUUID()}`;
   const sorted = [...options].sort((a, b) => {
     const lenDiff = a.label.length - b.label.length;
     if (lenDiff !== 0) return lenDiff;
@@ -161,7 +168,7 @@ export async function handleIgdbSelectInteraction(
   const [sessionId, pageRaw] = segs;
   const session = getSessionStore().get(sessionId);
   if (!session) {
-    await safeReply(interaction, buildTextReply("This selection session has expired.", true));
+    await safeReply(interaction, buildTextReply(IGDB_SESSION_EXPIRED_MESSAGE, true));
     return true;
   }
 
@@ -216,7 +223,7 @@ export async function handleIgdbFirstMatchInteraction(
   const [sessionId] = segs;
   const session = getSessionStore().get(sessionId);
   if (!session) {
-    await safeReply(interaction, buildTextReply("This selection session has expired.", true));
+    await safeReply(interaction, buildTextReply(IGDB_SESSION_EXPIRED_MESSAGE, true));
     return true;
   }
 

--- a/src/tests/igdb-select-session.test.ts
+++ b/src/tests/igdb-select-session.test.ts
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  createIgdbSession,
+  getIgdbSession,
+  deleteIgdbSession,
+  buildIgdbComponents,
+  handleIgdbFirstMatchInteraction,
+  type IgdbSelectOption,
+} from "../services/IGDB/IgdbSelectService.js";
+
+const OWNER = "111111111111111111";
+
+const sampleOptions = (): IgdbSelectOption[] => [
+  { id: 10, label: "Final Fantasy VII" },
+  { id: 20, label: "Halo" },
+];
+
+function selectCustomId(components: ReturnType<typeof buildIgdbComponents>): string {
+  const json = JSON.parse(JSON.stringify(components));
+  for (const row of json) {
+    for (const comp of row.components ?? []) {
+      // eslint-disable-next-line local/igdb-session-id-built-centrally
+      if (typeof comp.custom_id === "string" && comp.custom_id.startsWith("igdb-select:")) {
+        return comp.custom_id;
+      }
+    }
+  }
+  throw new Error("no igdb-select custom id found");
+}
+
+test("createIgdbSession yields a unique id per call for the same owner", () => {
+  const a = createIgdbSession(OWNER, sampleOptions(), async () => {});
+  const b = createIgdbSession(OWNER, sampleOptions(), async () => {});
+
+  assert.notEqual(a.sessionId, b.sessionId);
+  assert.ok(getIgdbSession(a.sessionId), "first session should still exist");
+  assert.ok(getIgdbSession(b.sessionId), "second session should still exist");
+
+  deleteIgdbSession(a.sessionId);
+  deleteIgdbSession(b.sessionId);
+});
+
+test("a second same-owner session does not clobber the first", () => {
+  // Reproduces issue #861: two overlapping IGDB flows for one user must both resolve.
+  const first = createIgdbSession(OWNER, sampleOptions(), async () => {});
+  const second = createIgdbSession(OWNER, sampleOptions(), async () => {});
+
+  // Completing/deleting the newer session must leave the older one intact.
+  deleteIgdbSession(second.sessionId);
+  assert.ok(getIgdbSession(first.sessionId), "older session should survive newer one");
+
+  const customId = selectCustomId(buildIgdbComponents(first.sessionId, 0));
+  assert.ok(customId.includes(first.sessionId), "custom id must embed the owning session id");
+  assert.ok(!customId.includes(":igdb-" + OWNER + ":"), "id must not collapse to per-user key");
+
+  deleteIgdbSession(first.sessionId);
+});
+
+test("session id never contains a colon (custom-id parser relies on it)", () => {
+  const { sessionId } = createIgdbSession(OWNER, sampleOptions(), async () => {});
+  assert.ok(!sessionId.includes(":"), "session id must be colon-free");
+  deleteIgdbSession(sessionId);
+});
+
+test("Import First Match on a missing/expired session replies with the expired notice", async () => {
+  const replies: any[] = [];
+  // A custom id whose session was never registered (e.g. wiped by restart).
+  const interaction: any = {
+    // eslint-disable-next-line local/igdb-session-id-built-centrally
+    customId: `igdb-first:igdb-${OWNER}-deadbeef`,
+    user: { id: OWNER },
+    replied: false,
+    deferred: false,
+    reply: async (opts: any) => {
+      replies.push(opts);
+      interaction.replied = true;
+    },
+    deferUpdate: async () => {},
+  };
+
+  const handled = await handleIgdbFirstMatchInteraction(interaction);
+
+  assert.equal(handled, true);
+  assert.equal(replies.length, 1);
+  assert.match(JSON.stringify(replies[0]), /has expired/);
+});
+
+test("Import First Match on a live session imports the first sorted option", async () => {
+  let importedId: number | null = null;
+  const { sessionId } = createIgdbSession(
+    OWNER,
+    // "Halo" sorts before "Final Fantasy VII" (shorter label first).
+    [{ id: 10, label: "Final Fantasy VII" }, { id: 20, label: "Halo" }],
+    async (_interaction, gameId) => {
+      importedId = gameId;
+    },
+  );
+
+  const interaction: any = {
+    // eslint-disable-next-line local/igdb-session-id-built-centrally
+    customId: `igdb-first:${sessionId}`,
+    user: { id: OWNER },
+    replied: false,
+    deferred: false,
+    reply: async () => {},
+    deferUpdate: async () => {},
+  };
+
+  const handled = await handleIgdbFirstMatchInteraction(interaction);
+
+  assert.equal(handled, true);
+  assert.equal(importedId, 20);
+  assert.equal(getIgdbSession(sessionId), undefined, "session is consumed after import");
+});


### PR DESCRIPTION
## Summary
- Fixes #861: clicking "Import First Match" after "Link a game" could reply
  "This selection session has expired." even though the user just opened the prompt.
- Root cause: every IGDB select session was keyed by `igdb-${userId}` alone in a shared
  in-memory store, so any other same-user IGDB flow (now-playing, collection import,
  reaction add, etc.) overwrote/deleted the thread-link session out from under it.
- `createIgdbSession` now mints a unique, colon-free session id per call
  (`igdb-${ownerId}-${uuid}`), so concurrent/sequential same-user flows no longer collide.
  Callers are unchanged (they only consume the returned `components`).
- Clearer expired message that tells the user to re-run the action.
- New lint rule `local/igdb-session-id-built-centrally` forbids constructing IGDB session
  ids / `igdb-select:` / `igdb-first:` custom ids outside `IgdbSelectService.ts`, keeping
  the unique-keying centralized.
- Unit tests cover the no-clobber guarantee, colon-free ids, the expired-session reply,
  and first-match import of the first sorted option.

## Notes / scope
- Bot-restart resume of these sessions is out of scope: the per-session `onSelect` is an
  in-process closure used by ~12 flows and cannot be serialized without a larger redesign.
  After a restart the user now sees the clearer expired message and can re-run the action.
- No TTL was added: the reported symptom is a *spurious* expired notice, and a lifetime
  cap would only add more store-miss cases.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) -- 56/56 tests
- [x] Lint rule verified to fire on session id/custom-id literals and ignore its home file
- [ ] Manual: two overlapping same-user IGDB flows both resolve; thread-link
      "Import First Match" links correctly

Closes #861

🤖 Generated with [Claude Code](https://claude.com/claude-code)