### PR TITLE
fix: thread link confirmation crashes on Components V2 message

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -3175,5 +3175,90 @@ export default {
         };
       },
     },
+    "no-content-with-components-v2": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            "Disallow a legacy `content` field alongside Components V2 in the same reply " +
+            "options object. Discord rejects this with error 50035 " +
+            "(MESSAGE_CANNOT_USE_LEGACY_FIELDS_WITH_COMPONENTS_V2).",
+        },
+        schema: [],
+        messages: {
+          contentWithV2:
+            "Do not pass `content` with Components V2. Put the text in a V2 container " +
+            "(e.g. buildTextContainer) instead of a `content` field.",
+        },
+      },
+      create(context) {
+        const V2_FLAG_BUILDERS = new Set([
+          "buildComponentsV2Flags",
+          "buildComponentsV2EditFlags",
+        ]);
+        const V2_CONTAINER_BUILDERS = new Set([
+          "buildTextContainer",
+          "buildContentContainer",
+          "buildAccentContainer",
+          "buildTitledContainer",
+        ]);
+        const isV2FlagValue = (value) => {
+          if (!value) return false;
+          if (value.type === "CallExpression") {
+            const callee = value.callee;
+            if (callee.type === "Identifier" && V2_FLAG_BUILDERS.has(callee.name)) {
+              return true;
+            }
+            if (
+              callee.type === "MemberExpression" &&
+              callee.property.type === "Identifier" &&
+              V2_FLAG_BUILDERS.has(callee.property.name)
+            ) {
+              return true;
+            }
+          }
+          if (
+            value.type === "MemberExpression" &&
+            value.property.type === "Identifier" &&
+            value.property.name === "IsComponentsV2"
+          ) {
+            return true;
+          }
+          return false;
+        };
+        const arrayHasV2Container = (value) => {
+          if (!value || value.type !== "ArrayExpression") return false;
+          return value.elements.some((el) => {
+            if (!el || el.type !== "CallExpression") return false;
+            const callee = el.callee;
+            return callee.type === "Identifier" && V2_CONTAINER_BUILDERS.has(callee.name);
+          });
+        };
+        return {
+          ObjectExpression(node) {
+            const props = node.properties.filter(
+              (p) => p.type === "Property" && p.key.type === "Identifier",
+            );
+            const contentProp = props.find((p) => p.key.name === "content");
+            if (!contentProp) return;
+            // `content: null`/`undefined` is the valid way to clear prior content when
+            // switching to V2 components; only a non-null content value is rejected.
+            const contentValue = contentProp.value;
+            const isNullish =
+              (contentValue.type === "Literal" && contentValue.value === null) ||
+              (contentValue.type === "Identifier" && contentValue.name === "undefined");
+            if (isNullish) return;
+            const flagsProp = props.find((p) => p.key.name === "flags");
+            const componentsProp = props.find((p) => p.key.name === "components");
+            const usesV2 =
+              (flagsProp && isV2FlagValue(flagsProp.value)) ||
+              (componentsProp && arrayHasV2Container(componentsProp.value));
+            if (usesV2) {
+              context.report({ node: contentProp, messageId: "contentWithV2" });
+            }
+          },
+        };
+      },
+    },
   },
 };

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -93,6 +93,7 @@ export default [
       "local/interactive-handler-requires-safe-interaction": "error",
       "local/no-igdb-session-callback-unsafe-response": "error",
       "local/igdb-session-id-built-centrally": "error",
+      "local/no-content-with-components-v2": "error",
       "local/no-empty-catch-on-interaction-response": "warn",
       "local/no-edit-reply-on-modal-union": "error",
       "local/require-relative-import-js-extension": "error",

--- a/src/services/ThreadLinkPromptService.ts
+++ b/src/services/ThreadLinkPromptService.ts
@@ -200,7 +200,11 @@ export class ThreadLinkButtonHandlers {
               const finalId = await finalizeSelection(igdbId);
               if (!finalId) return;
               gameId = finalId;
-              await sel.editReply({ content: `Linked to GameDB #${finalId}.`, components: [] });
+              // The prompt was sent with IS_COMPONENTS_V2, so the edit must use a V2
+              // container; a legacy `content` field is rejected (Discord error 50035).
+              await sel.editReply({
+                components: [buildTextContainer(`Linked to GameDB #${finalId}.`)],
+              });
               await finishLink();
             },
           );


### PR DESCRIPTION
## Summary
- After #862 the "Import First Match" flow reached its confirmation step and crashed:
  Discord error 50035 `MESSAGE_CANNOT_USE_LEGACY_FIELDS_WITH_COMPONENTS_V2`.
- The "Link a game" prompt is sent with `IS_COMPONENTS_V2`, but the select / first-match
  callback edited that message with a legacy `content` field, which Discord forbids on a
  Components V2 message.
- Replaced the content edit with a V2 text container
  (`components: [buildTextContainer("Linked to GameDB #...")]`).
- Added lint rule `local/no-content-with-components-v2` to catch this class of mistake.

## Lint rule
- Flags a non-null `content` field passed in the same reply options object as Components
  V2, recognized by either a V2 flags builder (`buildComponentsV2Flags` /
  `buildComponentsV2EditFlags` / `MessageFlags.IsComponentsV2`) or a V2 container builder
  (`buildTextContainer` / `buildContentContainer` / `buildAccentContainer` /
  `buildTitledContainer`) inside `components`.
- Allows `content: null` / `content: undefined`, which is the valid way to clear prior
  content when switching a message to V2 components (verified against existing call sites
  in collection imports and mp-info, which all use `content: null`).
- Note: the exact crashing line used `components: []` (empty) with no V2 marker in the same
  object, so it is not statically detectable on its own; the rule covers the detectable and
  far more common forms (V2 flag or V2 container present alongside a string `content`).

## Scope
- This is the only IGDB select flow whose prompt is sent with `IS_COMPONENTS_V2`; the
  sibling flows send legacy messages where `content` is valid, so they are unaffected.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) -- 56/56 tests
- [x] Lint rule verified: fires on `content` + V2 flag and `content` + V2 container;
      ignores `content: null` and legacy `content` + empty components
- [ ] Manual: thread "Link a game" -> "Import First Match" links and shows the
      "Linked to GameDB #N" confirmation without a 50035 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)