### PR TITLE
feat: implement game backlog commands (/backlog add, edit, remove, list)

### DIFF
--- a/src/classes/UserGameBacklog.ts
+++ b/src/classes/UserGameBacklog.ts
@@ -1,0 +1,209 @@
+import { apiGet, apiPost, apiPatch, apiDelete } from "../services/RpgClubApiClient.js";
+import Game from "./Game.js";
+import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
+
+export interface IUserGameBacklogEntry {
+  entryId: number;
+  userId: string;
+  gameId: number;
+  title: string;
+  platformId: number | null;
+  platformName: string | null;
+  platformAbbreviation: string | null;
+  sortOrder: number | null;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+type BacklogApiData = {
+  id: number;
+  user_id: string;
+  gamedb_game_id: number;
+  platform_id: number | null;
+  sort_order: number | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type BacklogSingleResponse = { data: BacklogApiData };
+type BacklogListResponse = {
+  data: BacklogApiData[];
+  meta: { page: number; pages: number; count: number; per: number };
+};
+
+async function mapEntries(rawEntries: BacklogApiData[]): Promise<IUserGameBacklogEntry[]> {
+  if (!rawEntries.length) return [];
+
+  const gameIds = Array.from(new Set(rawEntries.map((e) => Number(e.gamedb_game_id))));
+  const games = await Game.getGamesByIds(gameIds);
+  const gameMap = new Map(games.map((g) => [g.id, g]));
+
+  const uniquePlatformIds = Array.from(
+    new Set(
+      rawEntries
+        .filter((e) => e.platform_id != null)
+        .map((e) => Number(e.platform_id)),
+    ),
+  );
+  const platformResults = await Promise.all(
+    uniquePlatformIds.map((id) => Game.getPlatformById(id)),
+  );
+  const platformMap = new Map(
+    uniquePlatformIds.map((id, idx) => [id, platformResults[idx]]),
+  );
+
+  return rawEntries.map((raw) => {
+    const game = gameMap.get(Number(raw.gamedb_game_id));
+    const platform = raw.platform_id != null
+      ? platformMap.get(Number(raw.platform_id))
+      : null;
+    return {
+      entryId: Number(raw.id),
+      userId: raw.user_id,
+      gameId: Number(raw.gamedb_game_id),
+      title: game?.title ?? `Game #${raw.gamedb_game_id}`,
+      platformId: raw.platform_id != null ? Number(raw.platform_id) : null,
+      platformName: platform?.name ?? null,
+      platformAbbreviation: platform?.abbreviation ?? null,
+      sortOrder: raw.sort_order != null ? Number(raw.sort_order) : null,
+      notes: raw.notes ?? null,
+      createdAt: new Date(raw.created_at),
+      updatedAt: new Date(raw.updated_at),
+    };
+  });
+}
+
+export default class UserGameBacklog {
+  static async addEntry(params: {
+    userId: string;
+    gameId: number;
+    platformId?: number | null;
+    notes?: string | null;
+    sortOrder?: number | null;
+  }): Promise<IUserGameBacklogEntry> {
+    const { userId, gameId, platformId } = params;
+    requirePositiveInt(gameId, "GameDB id");
+    if (platformId != null && !isPositiveInt(platformId)) {
+      throw new Error("Invalid platform id.");
+    }
+    const notes = params.notes?.trim() ? params.notes.trim() : null;
+    if (notes && notes.length > 500) {
+      throw new Error("Notes must be 500 characters or fewer.");
+    }
+
+    let response: BacklogSingleResponse | null;
+    try {
+      response = await apiPost<BacklogSingleResponse>(
+        `/api/v1/users/${userId}/backlog`,
+        {
+          data: {
+            gamedb_game_id: gameId,
+            platform_id: platformId ?? null,
+            notes,
+            sort_order: params.sortOrder ?? null,
+          },
+        },
+      );
+    } catch (err: any) {
+      const msg = String(err?.response?.data?.error ?? err?.message ?? "");
+      if (/unique|duplicate|already been taken/i.test(msg)) {
+        throw new Error("That game is already in your backlog.");
+      }
+      throw err;
+    }
+
+    if (!response) throw new Error("Failed to create backlog entry.");
+    const entries = await mapEntries([response.data]);
+    return entries[0]!;
+  }
+
+  static async getEntryForUser(
+    entryId: number,
+    userId: string,
+  ): Promise<IUserGameBacklogEntry | null> {
+    requirePositiveInt(entryId, "entry id");
+    const response = await apiGet<BacklogSingleResponse>(`/api/v1/backlog/${entryId}`);
+    if (!response) return null;
+    if (response.data.user_id !== userId) return null;
+    const entries = await mapEntries([response.data]);
+    return entries[0] ?? null;
+  }
+
+  static async listForUser(
+    userId: string,
+    limit = 200,
+  ): Promise<IUserGameBacklogEntry[]> {
+    const response = await apiGet<BacklogListResponse>(
+      `/api/v1/users/${userId}/backlog`,
+      { params: { limit } },
+    );
+    return mapEntries(response?.data ?? []);
+  }
+
+  static async updateEntryForUser(
+    entryId: number,
+    userId: string,
+    updates: {
+      platformId?: number | null;
+      notes?: string | null;
+      sortOrder?: number | null;
+    },
+  ): Promise<IUserGameBacklogEntry | null> {
+    requirePositiveInt(entryId, "entry id");
+
+    const body: Record<string, string | number | null | undefined> = {};
+
+    if (updates.platformId !== undefined) {
+      if (updates.platformId != null && !isPositiveInt(updates.platformId)) {
+        throw new Error("Invalid platform id.");
+      }
+      body.platform_id = updates.platformId;
+    }
+
+    if (updates.notes !== undefined) {
+      const notes = updates.notes?.trim() ? updates.notes.trim() : null;
+      if (notes && notes.length > 500) {
+        throw new Error("Notes must be 500 characters or fewer.");
+      }
+      body.notes = notes;
+    }
+
+    if (updates.sortOrder !== undefined) {
+      body.sort_order = updates.sortOrder;
+    }
+
+    if (!Object.keys(body).length) {
+      throw new Error("No backlog fields were provided to update.");
+    }
+
+    const existing = await apiGet<BacklogSingleResponse>(`/api/v1/backlog/${entryId}`);
+    if (!existing || existing.data.user_id !== userId) return null;
+
+    let response: BacklogSingleResponse | null;
+    try {
+      response = await apiPatch<BacklogSingleResponse>(`/api/v1/backlog/${entryId}`, {
+        data: body,
+      });
+    } catch (err: any) {
+      const msg = String(err?.response?.data?.error ?? err?.message ?? "");
+      if (/unique|duplicate|already been taken/i.test(msg)) {
+        throw new Error("That game/platform entry already exists in your backlog.");
+      }
+      throw err;
+    }
+
+    if (!response) return null;
+    const entries = await mapEntries([response.data]);
+    return entries[0] ?? null;
+  }
+
+  static async removeEntryForUser(entryId: number, userId: string): Promise<boolean> {
+    requirePositiveInt(entryId, "entry id");
+    const existing = await apiGet<BacklogSingleResponse>(`/api/v1/backlog/${entryId}`);
+    if (!existing || existing.data.user_id !== userId) return false;
+    const result = await apiDelete<{ deleted: boolean }>(`/api/v1/backlog/${entryId}`);
+    return result?.deleted === true;
+  }
+}

--- a/src/commands/backlog.command.ts
+++ b/src/commands/backlog.command.ts
@@ -1,0 +1,2 @@
+export { BacklogCrudCommand } from "./backlog/backlog-crud.command.js";
+export { BacklogViewCommand } from "./backlog/backlog-view.command.js";

--- a/src/commands/backlog/backlog-autocomplete.utils.ts
+++ b/src/commands/backlog/backlog-autocomplete.utils.ts
@@ -1,0 +1,71 @@
+import { type AutocompleteInteraction } from "discord.js";
+import Game from "../../classes/Game.js";
+import UserGameBacklog from "../../classes/UserGameBacklog.js";
+import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
+import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
+
+export const BACKLOG_ENTRY_VALUE_PREFIX = "backlog";
+
+export function parseBacklogEntryAutocompleteValue(raw: string): number | null {
+  const value = raw.trim();
+  const match = /^backlog:(\d+)$/i.exec(value);
+  if (!match) return null;
+  const entryId = Number(match[1]);
+  if (!isPositiveInt(entryId)) return null;
+  return entryId;
+}
+
+export function buildBacklogEntryAutocompleteValue(entryId: number): string {
+  return `${BACKLOG_ENTRY_VALUE_PREFIX}:${entryId}`;
+}
+
+export async function autocompleteBacklogGameTitle(
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  const rawQuery = focused?.value ? String(focused.value) : "";
+  const query = sanitizeUserInput(rawQuery, { preserveNewlines: false }).trim();
+  if (!query) {
+    await interaction.respond([]);
+    return;
+  }
+
+  const results = await Game.searchGamesAutocomplete(query);
+  await interaction.respond(
+    results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
+      name: truncateLabel(formatGameTitleWithYear(game)),
+      value: String(game.id),
+    })),
+  );
+}
+
+export async function autocompleteBacklogEntry(
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  const focused = interaction.options.getFocused(true);
+  const rawQuery = focused?.value ? String(focused.value) : "";
+  const query = sanitizeUserInput(rawQuery, { preserveNewlines: false }).trim().toLowerCase();
+
+  const entries = await UserGameBacklog.listForUser(interaction.user.id, 100);
+
+  const filtered = query
+    ? entries.filter(
+      (e) =>
+        e.title.toLowerCase().includes(query) ||
+        (e.platformName?.toLowerCase().includes(query) ?? false),
+    )
+    : entries;
+
+  await interaction.respond(
+    filtered.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((entry) => {
+      const platform = entry.platformName ?? "No platform";
+      const label = truncateLabel(`${entry.title} | ${platform}`);
+      return {
+        name: label,
+        value: buildBacklogEntryAutocompleteValue(entry.entryId),
+      };
+    }),
+  );
+}

--- a/src/commands/backlog/backlog-crud.command.ts
+++ b/src/commands/backlog/backlog-crud.command.ts
@@ -1,0 +1,277 @@
+import {
+  ApplicationCommandOptionType,
+  CommandInteraction,
+  MessageFlags,
+} from "discord.js";
+import {
+  Discord,
+  Slash,
+  SlashGroup,
+  SlashOption,
+} from "discordx";
+import UserGameBacklog from "../../classes/UserGameBacklog.js";
+import {
+  autocompleteGameCompletionPlatformStandardFirst,
+  resolveGameCompletionPlatformId,
+} from "../game-completion/completion-autocomplete.utils.js";
+import {
+  safeDeferReply,
+  safeReply,
+  sanitizeUserInput,
+} from "../../functions/InteractionUtils.js";
+import { resolveCollectionGameForAdd } from "../collection/collection-game-resolve.utils.js";
+import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
+import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
+import Game from "../../classes/Game.js";
+import {
+  autocompleteBacklogEntry,
+  autocompleteBacklogGameTitle,
+  parseBacklogEntryAutocompleteValue,
+} from "./backlog-autocomplete.utils.js";
+
+@Discord()
+@SlashGroup({ description: "Manage your game backlog", name: "backlog" })
+@SlashGroup("backlog")
+export class BacklogCrudCommand {
+  @Slash({ name: "add", description: "Add a game to your backlog" })
+  async add(
+    @SlashOption({
+      name: "title",
+      description: "Game title from GameDB",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: autocompleteBacklogGameTitle,
+    })
+    gameIdRaw: string,
+    @SlashOption({
+      name: "platform",
+      description: "Platform you plan to play on",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      autocomplete: autocompleteGameCompletionPlatformStandardFirst,
+    })
+    platformRaw: string | undefined,
+    @SlashOption({
+      name: "notes",
+      description: "Optional notes",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    })
+    notes: string | undefined,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
+
+    const platformId = platformRaw !== undefined
+      ? await resolveGameCompletionPlatformId(platformRaw)
+      : null;
+
+    if (platformRaw !== undefined && !platformId) {
+      await safeReply(interaction, "Invalid platform selection.");
+      return;
+    }
+
+    const sanitizedNotes = notes
+      ? sanitizeUserInput(notes, { preserveNewlines: true, maxLength: 500 })
+      : null;
+
+    let resolution;
+    try {
+      resolution = await resolveCollectionGameForAdd(gameIdRaw);
+    } catch (err: any) {
+      await safeReply(interaction, err?.message ?? "Invalid game selection.");
+      return;
+    }
+
+    if (resolution.kind === "choose") {
+      const { components } = createIgdbSession(
+        interaction.user.id,
+        resolution.options,
+        async (selectionInteraction, igdbId) => {
+          try {
+            const imported = await Game.importGameFromIgdb(igdbId);
+            const created = await UserGameBacklog.addEntry({
+              userId: interaction.user.id,
+              gameId: imported.gameId,
+              platformId,
+              notes: sanitizedNotes,
+            });
+
+            const platformLabel = created.platformName ?? (platformId ? `Platform #${platformId}` : "");
+            const platformSuffix = platformLabel ? ` (${platformLabel})` : "";
+            await safeReply(selectionInteraction, {
+              ...buildTextReply(
+                `Imported and added **${created.title}**${platformSuffix} to your backlog.`,
+                true,
+              ),
+              __forceFollowUp: true,
+            });
+          } catch (err: any) {
+            await safeReply(selectionInteraction, {
+              ...buildTextReply(
+                err?.message ?? "Failed to import from IGDB and add backlog entry.",
+                true,
+              ),
+              __forceFollowUp: true,
+            });
+          }
+        },
+      );
+
+      await safeReply(interaction, {
+        content:
+          `No exact GameDB match found for "${resolution.titleQuery}". ` +
+          "Select the correct IGDB game to import:",
+        components,
+      });
+      return;
+    }
+
+    try {
+      const created = await UserGameBacklog.addEntry({
+        userId: interaction.user.id,
+        gameId: resolution.gameId,
+        platformId,
+        notes: sanitizedNotes,
+      });
+
+      const platformLabel = created.platformName ?? (platformId ? `Platform #${platformId}` : "");
+      const platformSuffix = platformLabel ? ` (${platformLabel})` : "";
+      await safeReply(interaction, `Added **${created.title}**${platformSuffix} to your backlog.`);
+    } catch (err: any) {
+      await safeReply(interaction, err?.message ?? "Failed to add backlog entry.");
+    }
+  }
+
+  @Slash({ name: "edit", description: "Edit one of your backlog entries" })
+  async edit(
+    @SlashOption({
+      name: "entry",
+      description: "Backlog entry",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: autocompleteBacklogEntry,
+    })
+    entryRaw: string,
+    @SlashOption({
+      name: "platform",
+      description: "New platform",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      autocomplete: autocompleteGameCompletionPlatformStandardFirst,
+    })
+    platformRaw: string | undefined,
+    @SlashOption({
+      name: "notes",
+      description: "New notes",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    })
+    notes: string | undefined,
+    @SlashOption({
+      name: "clear_notes",
+      description: "Clear notes",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    })
+    clearNotes: boolean | undefined,
+    @SlashOption({
+      name: "sort_order",
+      description: "Sort order (lower numbers appear first)",
+      type: ApplicationCommandOptionType.Integer,
+      required: false,
+    })
+    sortOrder: number | undefined,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
+
+    const entryId = parseBacklogEntryAutocompleteValue(entryRaw);
+    if (!entryId) {
+      await safeReply(interaction, "Invalid backlog entry selection.");
+      return;
+    }
+
+    const updates: {
+      platformId?: number | null;
+      notes?: string | null;
+      sortOrder?: number | null;
+    } = {};
+
+    if (platformRaw !== undefined) {
+      const platformId = await resolveGameCompletionPlatformId(platformRaw);
+      if (!platformId) {
+        await safeReply(interaction, "Invalid platform selection.");
+        return;
+      }
+      updates.platformId = platformId;
+    }
+
+    if (clearNotes) {
+      updates.notes = null;
+    } else if (notes !== undefined) {
+      updates.notes = sanitizeUserInput(notes, { preserveNewlines: true, maxLength: 500 });
+    }
+
+    if (sortOrder !== undefined) {
+      updates.sortOrder = sortOrder;
+    }
+
+    if (!Object.keys(updates).length) {
+      await safeReply(interaction, "Provide at least one field to update.");
+      return;
+    }
+
+    try {
+      const updated = await UserGameBacklog.updateEntryForUser(
+        entryId,
+        interaction.user.id,
+        updates,
+      );
+      if (!updated) {
+        await safeReply(interaction, "Backlog entry was not found.");
+        return;
+      }
+
+      const platformLabel = updated.platformName ?? "No platform";
+      await safeReply(interaction, `Updated **${updated.title}** (${platformLabel}) in your backlog.`);
+    } catch (err: any) {
+      await safeReply(interaction, err?.message ?? "Failed to update backlog entry.");
+    }
+  }
+
+  @Slash({ name: "remove", description: "Remove one of your backlog entries" })
+  async remove(
+    @SlashOption({
+      name: "entry",
+      description: "Backlog entry",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: autocompleteBacklogEntry,
+    })
+    entryRaw: string,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
+
+    const entryId = parseBacklogEntryAutocompleteValue(entryRaw);
+    if (!entryId) {
+      await safeReply(interaction, "Invalid backlog entry selection.");
+      return;
+    }
+
+    const existing = await UserGameBacklog.getEntryForUser(entryId, interaction.user.id);
+    if (!existing) {
+      await safeReply(interaction, "Backlog entry was not found.");
+      return;
+    }
+
+    const deleted = await UserGameBacklog.removeEntryForUser(entryId, interaction.user.id);
+    if (!deleted) {
+      await safeReply(interaction, "Failed to remove that backlog entry.");
+      return;
+    }
+
+    await safeReply(interaction, `Removed **${existing.title}** from your backlog.`);
+  }
+}

--- a/src/commands/backlog/backlog-list.service.ts
+++ b/src/commands/backlog/backlog-list.service.ts
@@ -1,0 +1,331 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+} from "discord.js";
+import UserGameBacklog from "../../classes/UserGameBacklog.js";
+import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
+import { safeDeferUpdate } from "../../functions/InteractionUtils.js";
+import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import {
+  buildPaginatedUserListResponse,
+  buildUserListNavId,
+  parseUserListNavId,
+} from "../../functions/PaginationUtils.js";
+import {
+  encodeVisibility,
+  decodeVisibility,
+  parseCustomIdSegments,
+} from "../../utilities/CustomIdUtils.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import {
+  BACKLOG_LIST_NAV_PREFIX,
+  BACKLOG_LIST_FILTER_PREFIX,
+  BACKLOG_LIST_FILTER_MODAL_PREFIX,
+} from "../../config/customIdPrefixes.js";
+import { BACKLOG_LIST_PAGE_SIZE } from "../../config/pagination.js";
+
+export const BACKLOG_FILTER_TITLE_INPUT_ID = "backlog-filter-title";
+
+export function buildBacklogListNavId(params: {
+  viewerUserId: string;
+  targetUserId: string;
+  page: number;
+  isEphemeral: boolean;
+  direction: "prev" | "next";
+}): string {
+  return buildUserListNavId(BACKLOG_LIST_NAV_PREFIX, params);
+}
+
+export function parseBacklogListNavId(customId: string): {
+  viewerUserId: string;
+  targetUserId: string;
+  page: number;
+  isEphemeral: boolean;
+  direction: "prev" | "next";
+} | null {
+  return parseUserListNavId(BACKLOG_LIST_NAV_PREFIX, customId);
+}
+
+export function buildBacklogFilterActionId(params: {
+  viewerUserId: string;
+  targetUserId: string;
+  isEphemeral: boolean;
+}): string {
+  return [
+    BACKLOG_LIST_FILTER_PREFIX,
+    params.viewerUserId,
+    params.targetUserId,
+    encodeVisibility(params.isEphemeral),
+    "open",
+  ].join(":");
+}
+
+export function parseBacklogFilterActionId(customId: string): {
+  viewerUserId: string;
+  targetUserId: string;
+  isEphemeral: boolean;
+} | null {
+  if (!customId.startsWith(`${BACKLOG_LIST_FILTER_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [viewerUserId, targetUserId, visibility, action] = segs;
+  if (action !== "open") return null;
+  const isEphemeral = decodeVisibility(visibility);
+  if (isEphemeral === null) return null;
+  return { viewerUserId, targetUserId, isEphemeral };
+}
+
+export function buildBacklogFilterModalId(params: {
+  viewerUserId: string;
+  targetUserId: string;
+  sourceMessageId: string;
+  isEphemeral: boolean;
+}): string {
+  return [
+    BACKLOG_LIST_FILTER_MODAL_PREFIX,
+    params.viewerUserId,
+    params.targetUserId,
+    params.sourceMessageId,
+    encodeVisibility(params.isEphemeral),
+  ].join(":");
+}
+
+export function parseBacklogFilterModalId(customId: string): {
+  viewerUserId: string;
+  targetUserId: string;
+  sourceMessageId: string;
+  isEphemeral: boolean;
+} | null {
+  if (!customId.startsWith(`${BACKLOG_LIST_FILTER_MODAL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 4);
+  if (!segs) return null;
+  const [viewerUserId, targetUserId, sourceMessageId, visibility] = segs;
+  const isEphemeral = decodeVisibility(visibility);
+  if (isEphemeral === null) return null;
+  return { viewerUserId, targetUserId, sourceMessageId, isEphemeral };
+}
+
+export function buildBacklogFilterPanelContent(title: string | undefined): string {
+  const titleText = title ?? "(any)";
+  return (
+    "### Filter backlog\n" +
+    `> Title: ${titleText}\n\n` +
+    "Use **Edit Title** to filter by game name, then **Apply**."
+  );
+}
+
+export function buildBacklogFilterPanelButtons(params: {
+  viewerUserId: string;
+  targetUserId: string;
+  sourceMessageId: string;
+  isEphemeral: boolean;
+}): ActionRowBuilder<ButtonBuilder>[] {
+  const base = {
+    viewerUserId: params.viewerUserId,
+    targetUserId: params.targetUserId,
+    sourceMessageId: params.sourceMessageId,
+    isEphemeral: params.isEphemeral,
+  };
+  const editId = ["backlog-filter-panel", params.viewerUserId, params.targetUserId,
+    params.sourceMessageId, encodeVisibility(params.isEphemeral), "text"].join(":");
+  const applyId = ["backlog-filter-panel", params.viewerUserId, params.targetUserId,
+    params.sourceMessageId, encodeVisibility(params.isEphemeral), "apply"].join(":");
+  const clearId = ["backlog-filter-panel", params.viewerUserId, params.targetUserId,
+    params.sourceMessageId, encodeVisibility(params.isEphemeral), "clear"].join(":");
+  const cancelId = ["backlog-filter-panel", params.viewerUserId, params.targetUserId,
+    params.sourceMessageId, encodeVisibility(params.isEphemeral), "cancel"].join(":");
+  void base;
+  return [
+    buildButtonRow(
+      buildActionButton("edit", editId, "Edit Title"),
+      buildActionButton("confirm", applyId, "Apply"),
+      buildActionButton({ customId: clearId, label: "Clear", style: ButtonStyle.Secondary }),
+      buildActionButton({ customId: cancelId, label: "Cancel", style: ButtonStyle.Secondary }),
+    ),
+  ];
+}
+
+export const BACKLOG_FILTER_PANEL_PREFIX = "backlog-filter-panel";
+
+export function parseBacklogFilterPanelActionId(customId: string): {
+  viewerUserId: string;
+  targetUserId: string;
+  sourceMessageId: string;
+  isEphemeral: boolean;
+  action: "text" | "apply" | "clear" | "cancel";
+} | null {
+  if (!customId.startsWith(`${BACKLOG_FILTER_PANEL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 5);
+  if (!segs) return null;
+  const [viewerUserId, targetUserId, sourceMessageId, visibility, actionCode] = segs;
+  const isEphemeral = decodeVisibility(visibility);
+  if (isEphemeral === null) return null;
+  const action = actionCode === "text" ? "text"
+    : actionCode === "apply" ? "apply"
+    : actionCode === "clear" ? "clear"
+    : actionCode === "cancel" ? "cancel"
+    : null;
+  if (!action) return null;
+  return { viewerUserId, targetUserId, sourceMessageId, isEphemeral, action };
+}
+
+export function parseBacklogFilterStateFromContent(content: string): {
+  title: string | undefined;
+} {
+  const match = content.match(/^> Title:\s*(.+)$/mi);
+  const value = match?.[1]?.trim();
+  return { title: value && value !== "(any)" ? value : undefined };
+}
+
+function collectTextDisplayContent(
+  components: any[] | undefined,
+  output: string[],
+): void {
+  if (!components?.length) return;
+  for (const component of components) {
+    if (component && typeof component.content === "string") {
+      output.push(component.content);
+    }
+    if (Array.isArray(component?.components)) {
+      collectTextDisplayContent(component.components, output);
+    }
+  }
+}
+
+export function parseBacklogFiltersFromListMessage(message: any): {
+  title: string | undefined;
+} {
+  const textBlocks: string[] = [];
+  collectTextDisplayContent(message?.components, textBlocks);
+  const filterBlock = textBlocks.find((b) => b.includes("Filter:"));
+  if (!filterBlock) return { title: undefined };
+  const titleMatch = filterBlock.match(/title~([^|\n]+)/i);
+  return { title: titleMatch?.[1]?.trim() || undefined };
+}
+
+export async function buildBacklogListResponse(params: {
+  viewerUserId: string;
+  targetUserId: string;
+  memberLabel: string;
+  title: string | undefined;
+  page: number;
+  isEphemeral: boolean;
+}): Promise<{ components: Array<any>; content?: string }> {
+  const allEntries = await UserGameBacklog.listForUser(params.targetUserId);
+
+  const filtered = params.title
+    ? allEntries.filter((e) =>
+      e.title.toLowerCase().includes(params.title!.toLowerCase()),
+    )
+    : allEntries;
+
+  const total = filtered.length;
+  if (!total) {
+    const msg = params.title
+      ? "No backlog entries matched your filter."
+      : params.targetUserId === params.viewerUserId
+        ? "Your backlog is empty."
+        : "That member has no backlog entries.";
+    return { content: msg, components: [] };
+  }
+
+  const pageCount = Math.max(1, Math.ceil(total / BACKLOG_LIST_PAGE_SIZE));
+  const safePage = Math.min(Math.max(params.page, 0), pageCount - 1);
+  const start = safePage * BACKLOG_LIST_PAGE_SIZE;
+  const pageEntries = filtered.slice(start, start + BACKLOG_LIST_PAGE_SIZE);
+
+  const listText = pageEntries
+    .map((entry) => {
+      const platform = entry.platformName ?? "No platform";
+      const noteTag = entry.notes ? ` · _${safeV2TextContent(entry.notes, 60)}_` : "";
+      return `**${safeV2TextContent(entry.title, 100)}** · ${platform}${noteTag}`;
+    })
+    .join("\n");
+
+  const footerParts = [`Page ${safePage + 1}/${pageCount}`, `${total} total entries`];
+  if (params.title) footerParts.push(`Filter: title~${params.title}`);
+
+  const components = buildPaginatedUserListResponse({
+    headerUserId: params.targetUserId,
+    headerLabel: params.memberLabel,
+    headerTitle: "Game Backlog",
+    bodyText: listText,
+    footerParts,
+    prevCustomId: buildBacklogListNavId({
+      viewerUserId: params.viewerUserId,
+      targetUserId: params.targetUserId,
+      page: safePage,
+      isEphemeral: params.isEphemeral,
+      direction: "prev",
+    }),
+    nextCustomId: buildBacklogListNavId({
+      viewerUserId: params.viewerUserId,
+      targetUserId: params.targetUserId,
+      page: safePage,
+      isEphemeral: params.isEphemeral,
+      direction: "next",
+    }),
+    page: safePage,
+    pageCount,
+    extraButtons: [
+      buildActionButton({
+        customId: buildBacklogFilterActionId({
+          viewerUserId: params.viewerUserId,
+          targetUserId: params.targetUserId,
+          isEphemeral: params.isEphemeral,
+        }),
+        label: "Filter",
+        style: ButtonStyle.Primary,
+      }),
+    ],
+  });
+
+  // eslint-disable-next-line local/dynamic-components-require-chunking
+  return { components };
+}
+
+export async function applyBacklogFiltersToSourceMessage(params: {
+  interaction: ButtonInteraction;
+  sourceMessageId: string;
+  viewerUserId: string;
+  targetUserId: string;
+  isEphemeral: boolean;
+  title: string | undefined;
+}): Promise<boolean> {
+  const channel = params.interaction.channel;
+  if (!channel || !("messages" in channel)) return false;
+
+  const memberLabel = params.targetUserId === params.viewerUserId
+    ? params.interaction.user.globalName ?? params.interaction.user.username
+    : "Member";
+
+  const response = await buildBacklogListResponse({
+    viewerUserId: params.viewerUserId,
+    targetUserId: params.targetUserId,
+    memberLabel,
+    title: params.title,
+    page: 0,
+    isEphemeral: params.isEphemeral,
+  });
+
+  const sourceMessage = await (channel as any).messages
+    .fetch(params.sourceMessageId)
+    .catch(() => null);
+  if (!sourceMessage) return false;
+
+  if (response.content) {
+    await sourceMessage.edit({ content: response.content, components: [] });
+  } else {
+    await sourceMessage.edit({ content: null, components: response.components });
+  }
+  return true;
+}
+
+export async function closeBacklogFilterPanel(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  await safeDeferUpdate(interaction);
+  safeIgnore((interaction.message as any)?.delete?.());
+}

--- a/src/commands/backlog/backlog-view.command.ts
+++ b/src/commands/backlog/backlog-view.command.ts
@@ -1,0 +1,286 @@
+import {
+  ApplicationCommandOptionType,
+  ButtonInteraction,
+  CommandInteraction,
+  ModalBuilder,
+  ModalSubmitInteraction,
+} from "discord.js";
+import {
+  ButtonComponent,
+  Discord,
+  ModalComponent,
+  Slash,
+  SlashGroup,
+  SlashOption,
+} from "discordx";
+import {
+  replyIfNotOwner,
+  safeDeferReply,
+  safeDeferUpdate,
+  safeReply,
+  safeUpdate,
+  sanitizeUserInput,
+} from "../../functions/InteractionUtils.js";
+import {
+  buildComponentsV2Flags,
+  buildTextReply,
+} from "../../functions/ComponentsV2Utils.js";
+import { buildTextInputRow } from "../../functions/uiComponents.js";
+import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
+import {
+  applyBacklogFiltersToSourceMessage,
+  buildBacklogFilterModalId,
+  buildBacklogFilterPanelButtons,
+  buildBacklogFilterPanelContent,
+  buildBacklogListResponse,
+  closeBacklogFilterPanel,
+  BACKLOG_FILTER_TITLE_INPUT_ID,
+  parseBacklogFilterActionId,
+  parseBacklogFilterModalId,
+  parseBacklogFilterPanelActionId,
+  parseBacklogFilterStateFromContent,
+  parseBacklogFiltersFromListMessage,
+  parseBacklogListNavId,
+} from "./backlog-list.service.js";
+
+@Discord()
+@SlashGroup("backlog")
+export class BacklogViewCommand {
+  @Slash({ name: "list", description: "View your game backlog" })
+  async list(
+    @SlashOption({
+      name: "title",
+      description: "Filter by title",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    })
+    title: string | undefined,
+    @SlashOption({
+      name: "private",
+      description: "Send reply privately (only visible to you). Defaults to true.",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    })
+    privateFlag: boolean | undefined,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    const isEphemeral = privateFlag ?? true;
+    await safeDeferReply(interaction, { flags: buildComponentsV2Flags(isEphemeral) });
+
+    const userId = interaction.user.id;
+    const memberLabel = interaction.user.globalName ?? interaction.user.username;
+    const titleFilter = title
+      ? sanitizeUserInput(title, { preserveNewlines: false })
+      : undefined;
+
+    let response: Awaited<ReturnType<typeof buildBacklogListResponse>>;
+    try {
+      response = await buildBacklogListResponse({
+        viewerUserId: userId,
+        targetUserId: userId,
+        memberLabel,
+        title: titleFilter,
+        page: 0,
+        isEphemeral,
+      });
+    } catch (err) {
+      logError("backlog list.build_response_failed", err);
+      await safeReply(
+        interaction,
+        buildTextReply("Failed to load your backlog. Please try again.", isEphemeral),
+      );
+      return;
+    }
+
+    if (response.content) {
+      await safeReply(interaction, buildTextReply(response.content, isEphemeral));
+      return;
+    }
+
+    try {
+      await safeReply(interaction, {
+        components: response.components,
+        flags: buildComponentsV2Flags(isEphemeral),
+      });
+    } catch (err) {
+      logError("backlog list.safe_reply_failed", err);
+      safeIgnore(
+        safeReply(interaction, buildTextReply("Failed to display backlog. Please try again.", isEphemeral)),
+      );
+    }
+  }
+
+  @ButtonComponent({
+    id: /^backlog-list-nav-v1:[^:]+:[^:]+:\d+:[ep]:(prev|next)$/,
+  })
+  async onBacklogListNav(interaction: ButtonInteraction): Promise<void> {
+    const parsed = parseBacklogListNavId(interaction.customId);
+    if (!parsed) {
+      safeIgnore(safeReply(interaction, buildTextReply("This backlog view control is invalid.", true)));
+      return;
+    }
+
+    if (await replyIfNotOwner(interaction, parsed.viewerUserId, "This backlog view is not for you.")) return;
+
+    await safeDeferUpdate(interaction);
+
+    const nextPage = parsed.direction === "next"
+      ? parsed.page + 1
+      : Math.max(parsed.page - 1, 0);
+
+    const currentFilters = parseBacklogFiltersFromListMessage(interaction.message);
+
+    const memberLabel = interaction.user.globalName ?? interaction.user.username;
+    const response = await buildBacklogListResponse({
+      viewerUserId: parsed.viewerUserId,
+      targetUserId: parsed.targetUserId,
+      memberLabel,
+      title: currentFilters.title,
+      page: nextPage,
+      isEphemeral: parsed.isEphemeral,
+    });
+
+    if (response.content) {
+      safeIgnore(safeUpdate(interaction, { content: response.content, components: [] }));
+      return;
+    }
+
+    try {
+      await safeUpdate(interaction, {
+        components: response.components,
+        flags: buildComponentsV2Flags(parsed.isEphemeral),
+      });
+    } catch (err) {
+      logError("backlog list nav.update_failed", err);
+      throw err;
+    }
+  }
+
+  @ButtonComponent({
+    id: /^backlog-list-filter-v1:[^:]+:[^:]+:[ep]:open$/,
+  })
+  async onBacklogFilterOpen(interaction: ButtonInteraction): Promise<void> {
+    const parsed = parseBacklogFilterActionId(interaction.customId);
+    if (!parsed) {
+      safeIgnore(safeReply(interaction, buildTextReply("This filter control is invalid.", true)));
+      return;
+    }
+
+    if (await replyIfNotOwner(interaction, parsed.viewerUserId, "This backlog view is not for you.")) return;
+
+    const currentFilters = parseBacklogFiltersFromListMessage(interaction.message);
+    const filterPanelReply = buildTextReply(
+      buildBacklogFilterPanelContent(currentFilters.title),
+      true,
+    );
+
+    safeIgnore(safeReply(interaction, {
+      ...filterPanelReply,
+      components: [
+        ...filterPanelReply.components,
+        ...buildBacklogFilterPanelButtons({
+          viewerUserId: parsed.viewerUserId,
+          targetUserId: parsed.targetUserId,
+          sourceMessageId: interaction.message.id,
+          isEphemeral: parsed.isEphemeral,
+        }),
+      ],
+    }));
+  }
+
+  @ButtonComponent({
+    id: /^backlog-filter-panel:[^:]+:[^:]+:[^:]+:[ep]:(text|apply|clear|cancel)$/,
+  })
+  async onBacklogFilterAction(interaction: ButtonInteraction): Promise<void> {
+    const parsed = parseBacklogFilterPanelActionId(interaction.customId);
+    if (!parsed) {
+      safeIgnore(safeReply(interaction, buildTextReply("This filter control is invalid.", true)));
+      return;
+    }
+
+    if (await replyIfNotOwner(interaction, parsed.viewerUserId, "This filter control is not for you.")) return;
+
+    if (parsed.action === "cancel") {
+      await closeBacklogFilterPanel(interaction);
+      return;
+    }
+
+    const currentState = parseBacklogFilterStateFromContent(interaction.message.content ?? "");
+
+    if (parsed.action === "text") {
+      const modal = new ModalBuilder()
+        .setCustomId(buildBacklogFilterModalId({
+          viewerUserId: parsed.viewerUserId,
+          targetUserId: parsed.targetUserId,
+          sourceMessageId: parsed.sourceMessageId,
+          isEphemeral: parsed.isEphemeral,
+        }))
+        .setTitle("Backlog filter");
+
+      modal.addComponents(
+        buildTextInputRow({
+          customId: BACKLOG_FILTER_TITLE_INPUT_ID,
+          label: "Title contains",
+          required: false,
+          maxLength: 100,
+          value: currentState.title ?? "",
+        }),
+      );
+      safeIgnore(interaction.showModal(modal));
+      return;
+    }
+
+    const nextTitle = parsed.action === "clear" ? undefined : currentState.title;
+
+    if (parsed.action === "apply" || parsed.action === "clear") {
+      await safeDeferUpdate(interaction);
+      const applied = await applyBacklogFiltersToSourceMessage({
+        interaction,
+        sourceMessageId: parsed.sourceMessageId,
+        viewerUserId: parsed.viewerUserId,
+        targetUserId: parsed.targetUserId,
+        isEphemeral: parsed.isEphemeral,
+        title: nextTitle,
+      });
+      safeIgnore((interaction.message as any)?.delete?.() ?? Promise.resolve());
+      if (!applied) {
+        safeIgnore(
+          safeReply(interaction, buildTextReply("Could not apply filter -- the backlog message was not found.", true)),
+        );
+      }
+    }
+  }
+
+  @ModalComponent({
+    id: /^blm1:[^:]+:[^:]+:[^:]+:[ep]$/,
+  })
+  async onBacklogFilterModal(interaction: ModalSubmitInteraction): Promise<void> {
+    const parsed = parseBacklogFilterModalId(interaction.customId);
+    if (!parsed) {
+      safeIgnore(safeReply(interaction, buildTextReply("This filter modal is invalid.", true)));
+      return;
+    }
+
+    if (await replyIfNotOwner(interaction, parsed.viewerUserId, "This filter modal is not for you.")) return;
+
+    const rawTitle = interaction.fields.getTextInputValue(BACKLOG_FILTER_TITLE_INPUT_ID);
+    const title = rawTitle
+      ? sanitizeUserInput(rawTitle, { preserveNewlines: false }).trim() || undefined
+      : undefined;
+
+    const panelReply = buildTextReply(buildBacklogFilterPanelContent(title), true);
+    await safeUpdate(interaction, {
+      ...panelReply,
+      components: [
+        ...panelReply.components,
+        ...buildBacklogFilterPanelButtons({
+          viewerUserId: parsed.viewerUserId,
+          targetUserId: parsed.targetUserId,
+          sourceMessageId: parsed.sourceMessageId,
+          isEphemeral: parsed.isEphemeral,
+        }),
+      ],
+    });
+  }
+}

--- a/src/config/customIdPrefixes.ts
+++ b/src/config/customIdPrefixes.ts
@@ -4,6 +4,11 @@ export const COLLECTION_LIST_FILTER_PREFIX = "collection-list-filter-v1";
 export const COLLECTION_LIST_FILTER_PANEL_PREFIX = "clf1";
 export const COLLECTION_LIST_FILTER_MODAL_PREFIX = "clfm1";
 
+// Backlog list pagination and filter interaction IDs
+export const BACKLOG_LIST_NAV_PREFIX = "backlog-list-nav-v1";
+export const BACKLOG_LIST_FILTER_PREFIX = "backlog-list-filter-v1";
+export const BACKLOG_LIST_FILTER_MODAL_PREFIX = "blm1";
+
 // Completionator CSV import interaction IDs
 export const COMPLETIONATOR_CHOOSE_PREFIX = "comp-import-choose-v1";
 

--- a/src/config/pagination.ts
+++ b/src/config/pagination.ts
@@ -14,5 +14,6 @@ export const CLAIM_MENU_CHUNK_SIZE     = 25;
 export const TODO_DEFAULT_PAGE_SIZE        = 15;
 export const TODO_MAX_PAGE_SIZE            = 15;
 export const COLLECTION_LIST_PAGE_SIZE     = 20;
+export const BACKLOG_LIST_PAGE_SIZE        = 20;
 export const GAMEDB_CSV_RESULT_LIMIT       = 15;
 export const GOTM_AUDIT_RESULT_LIMIT       = 25;


### PR DESCRIPTION
## Summary
- Adds `/backlog add`, `/backlog edit`, `/backlog remove`, and `/backlog list` slash commands
- `UserGameBacklog` class wraps the backlog REST API with batch game/platform enrichment
- List view follows the `/collection list` pagination and filter panel pattern, using the shared `buildPaginatedUserListResponse` helper from the refactor PR (#864)

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/backlog add <game>` adds an entry; duplicate is rejected with a clear message
- [ ] `/backlog add <game>` with an unknown title triggers IGDB import chooser
- [ ] `/backlog edit <entry>` updates platform, notes, or sort_order
- [ ] `/backlog remove <entry>` removes the entry
- [ ] `/backlog list` shows paginated entries; defaults to private (ephemeral)
- [ ] Filter button opens panel; Edit Title modal updates panel state; Apply applies filter to list
- [ ] Clear button clears filter and refreshes list; Cancel closes panel without changing list
- [ ] Prev/Next navigation preserves active filter state from footer text
- [ ] All interactions resume correctly after bot restart (stable custom IDs)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)