### PR TITLE
fix: surface full API request/response in backlog command errors

### DIFF
--- a/src/commands/backlog/backlog-crud.command.ts
+++ b/src/commands/backlog/backlog-crud.command.ts
@@ -28,6 +28,8 @@ import {
   autocompleteBacklogGameTitle,
   parseBacklogEntryAutocompleteValue,
 } from "./backlog-autocomplete.utils.js";
+import { buildApiErrorMessage } from "../../utilities/ApiErrorUtils.js";
+import { logError } from "../../utilities/LogUtils.js";
 
 @Discord()
 @SlashGroup({ description: "Manage your game backlog", name: "backlog" })
@@ -78,8 +80,10 @@ export class BacklogCrudCommand {
     let resolution;
     try {
       resolution = await resolveCollectionGameForAdd(gameIdRaw);
-    } catch (err: any) {
-      await safeReply(interaction, err?.message ?? "Invalid game selection.");
+    } catch (err: unknown) {
+      logError("backlog add.resolve_game_failed", err);
+      const msg = err instanceof Error ? err.message : "Invalid game selection.";
+      await safeReply(interaction, buildTextReply(msg, true));
       return;
     }
 
@@ -106,12 +110,11 @@ export class BacklogCrudCommand {
               ),
               __forceFollowUp: true,
             });
-          } catch (err: any) {
+          } catch (err: unknown) {
+            logError("backlog add.igdb_import_failed", err);
+            const detail = buildApiErrorMessage("Failed to import from IGDB and add backlog entry.", err);
             await safeReply(selectionInteraction, {
-              ...buildTextReply(
-                err?.message ?? "Failed to import from IGDB and add backlog entry.",
-                true,
-              ),
+              ...buildTextReply(detail, true),
               __forceFollowUp: true,
             });
           }
@@ -138,8 +141,12 @@ export class BacklogCrudCommand {
       const platformLabel = created.platformName ?? (platformId ? `Platform #${platformId}` : "");
       const platformSuffix = platformLabel ? ` (${platformLabel})` : "";
       await safeReply(interaction, `Added **${created.title}**${platformSuffix} to your backlog.`);
-    } catch (err: any) {
-      await safeReply(interaction, err?.message ?? "Failed to add backlog entry.");
+    } catch (err: unknown) {
+      logError("backlog add.add_entry_failed", err);
+      await safeReply(
+        interaction,
+        buildTextReply(buildApiErrorMessage("Failed to add backlog entry.", err), true),
+      );
     }
   }
 
@@ -235,8 +242,12 @@ export class BacklogCrudCommand {
 
       const platformLabel = updated.platformName ?? "No platform";
       await safeReply(interaction, `Updated **${updated.title}** (${platformLabel}) in your backlog.`);
-    } catch (err: any) {
-      await safeReply(interaction, err?.message ?? "Failed to update backlog entry.");
+    } catch (err: unknown) {
+      logError("backlog edit.update_entry_failed", err);
+      await safeReply(
+        interaction,
+        buildTextReply(buildApiErrorMessage("Failed to update backlog entry.", err), true),
+      );
     }
   }
 

--- a/src/utilities/ApiErrorUtils.ts
+++ b/src/utilities/ApiErrorUtils.ts
@@ -1,0 +1,39 @@
+import axios from "axios";
+
+export function formatApiError(
+  method: string,
+  url: string,
+  requestBody: unknown,
+  status: number | undefined,
+  responseBody: unknown,
+): string {
+  const req = JSON.stringify(
+    { method: method.toUpperCase(), url, body: requestBody ?? null },
+    null, 2,
+  );
+  const res = JSON.stringify({ status: status ?? null, body: responseBody ?? null }, null, 2);
+  return `Request:\n\`\`\`json\n${req}\n\`\`\`\nResponse:\n\`\`\`json\n${res}\n\`\`\``;
+}
+
+function tryParseJson(raw: string | null | undefined): unknown {
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+export function buildApiErrorMessage(label: string, err: unknown): string {
+  if (!axios.isAxiosError(err)) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return `${label}: ${msg}`;
+  }
+  return `${label}\n${formatApiError(
+    err.config?.method ?? "?",
+    err.config?.url ?? "?",
+    tryParseJson(err.config?.data as string | null | undefined),
+    err.response?.status,
+    err.response?.data,
+  )}`;
+}


### PR DESCRIPTION
## Summary
- Adds `src/utilities/ApiErrorUtils.ts` with `buildApiErrorMessage` and `formatApiError` helpers
- Replaces bare `err?.message` error replies in all three backlog command handlers with full
  request (method, URL, body) + response (status, body) formatted as JSON code blocks
- Adds `logError` calls so API failures now appear in bot logs

## Root Cause
The catch blocks in `backlog-crud.command.ts` called `safeReply(interaction, err?.message)`, which
surfaces only the axios status line ("Request failed with status code 500") and never calls
`logError`, leaving the bot logs silent on API failures.

## Test plan
- [ ] `/backlog add <game>` with a valid game succeeds as before
- [ ] When the API returns an error, the bot reply includes the full request and response
  each formatted as a JSON code block
- [ ] Bot console logs show the error via `logError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)