### PR TITLE
fix: guard safeReply in withErrorReply to prevent unhandled 10008 errors

### DIFF
--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -541,7 +541,11 @@ export async function withErrorReply<T>(
     return await fn();
   } catch (err: unknown) {
     const msg = extractErrorMessage(err);
-    await safeReply(interaction, buildTextReply(`${errorPrefix}: ${msg}`, ephemeral));
+    try {
+      await safeReply(interaction, buildTextReply(`${errorPrefix}: ${msg}`, ephemeral));
+    } catch {
+      // error reply itself failed (e.g. interaction token expired); nothing more to do
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- Wraps the `safeReply` call inside `withErrorReply`'s catch block in a try/catch.
- Prevents a failed error reply (e.g. DiscordAPIError 10008 from an expired interaction
  token) from escaping unhandled and firing as a `discordClientError` event.

## What was happening
When `/admin sync` calls `bot.initApplicationCommands()` and that throws 10008
"Unknown Message", `withErrorReply` catches it and calls `safeReply` to report
the error. If `safeReply`'s `editReply` also returns 10008 (interaction token
expired or deferred message gone), `safeReply` re-throws because 10008 is not in
`isAckError`. The unguarded `safeReply` call then escapes the catch block, propagates
through discordx, and is emitted as the client `error` event -- logged as
`RPGClub_GameDB.discordClientError`.

## Change
`src/functions/InteractionUtils.ts` -- `withErrorReply`: added inner try/catch
around the `safeReply` call so a thrown error from the error-reply path is silently
swallowed rather than propagated.

Closes #867