### PR TITLE
fix: remove 15-minute TTL from suggestion review sessions

### DIFF
--- a/src/classes/SuggestionReviewSession.ts
+++ b/src/classes/SuggestionReviewSession.ts
@@ -119,9 +119,3 @@ export async function deleteSuggestionReviewSessionsForReviewer(
 ): Promise<number> {
   return dbMutate(SuggestionReviewSessionSql.deleteForReviewer, { reviewerId });
 }
-
-export async function deleteExpiredSuggestionReviewSessions(
-  cutoffDate: Date,
-): Promise<number> {
-  return dbMutate(SuggestionReviewSessionSql.deleteExpired, { cutoff: cutoffDate });
-}

--- a/src/commands/suggestion.command.ts
+++ b/src/commands/suggestion.command.ts
@@ -67,7 +67,6 @@ const SUGGESTION_REVIEW_DECISION_MODAL_PREFIX = "suggestion-review-decision";
 const SUGGESTION_REVIEW_SUMMARY_ID = "suggestion-review-summary";
 const SUGGESTION_REVIEW_DECISION_ID = "suggestion-review-decision-choice";
 const SUGGESTION_REVIEW_REASON_ID = "suggestion-review-decision-reason";
-const SUGGESTION_REVIEW_TTL_MS = 15 * 60 * 1000;
 type SuggestionReviewSession = ISuggestionReviewSession;
 const MAX_MODAL_TEXT_INPUT_VALUE = 4000;
 
@@ -102,11 +101,6 @@ function logSuggestion(
   logInfo("suggestion", line);
 }
 
-function isSuggestionReviewSessionExpired(session: SuggestionReviewSession): boolean {
-  const lastActivity = session.updatedAt ?? session.createdAt;
-  return Date.now() - lastActivity.getTime() > SUGGESTION_REVIEW_TTL_MS;
-}
-
 async function loadSuggestionReviewSession(
   sessionId: string,
   reviewerId: string,
@@ -114,10 +108,6 @@ async function loadSuggestionReviewSession(
   const session = await getSuggestionReviewSession(sessionId);
   if (!session) return null;
   if (session.reviewerId !== reviewerId) return null;
-  if (isSuggestionReviewSessionExpired(session)) {
-    await deleteSuggestionReviewSession(sessionId);
-    return null;
-  }
   return session;
 }
 
@@ -715,7 +705,7 @@ export class SuggestionCommand {
     const session = await loadSuggestionReviewSession(parsed.sessionId, parsed.reviewerId);
     if (!session) {
       const container = buildTextContainer(
-          "This suggestion review has expired. Start again from /todo.",
+          "This review session is no longer available. Start again from /todo.",
         );
       await safeUpdate(interaction, {
         components: [container],

--- a/src/db/sql/suggestion.sql.ts
+++ b/src/db/sql/suggestion.sql.ts
@@ -35,8 +35,4 @@ export const SuggestionReviewSessionSql = {
   deleteForReviewer: {
     postgres: `DELETE FROM rpg_club_suggestion_review_sessions WHERE reviewer_id = :reviewerId`,
   } satisfies ISqlEntry,
-
-  deleteExpired: {
-    postgres: `DELETE FROM rpg_club_suggestion_review_sessions WHERE created_at < :cutoff`,
-  } satisfies ISqlEntry,
 };


### PR DESCRIPTION
## Summary
- Removed `SUGGESTION_REVIEW_TTL_MS`, `isSuggestionReviewSessionExpired`, and the TTL expiry
  check from `loadSuggestionReviewSession` -- sessions now persist until explicitly deleted,
  satisfying the bot-restart-resumable requirement
- Removed `deleteExpiredSuggestionReviewSessions` from `SuggestionReviewSession.ts` and its
  corresponding `deleteExpired` SQL entry -- both were dead code with no callers
- Updated the null-session reply from "expired" language to "no longer available" since
  missing sessions now only indicate a deleted or missing record, not a TTL timeout

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `loadSuggestionReviewSession` returns null only for missing session or wrong reviewer, not TTL
- [ ] No callers of `deleteExpiredSuggestionReviewSessions` remain

Closes #871

🤖 Generated with [Claude Code](https://claude.com/claude-code)