### PR TITLE
fix: /admin sync hangs indefinitely with no error reported

### DIFF
--- a/src/commands/admin.command.ts
+++ b/src/commands/admin.command.ts
@@ -83,7 +83,16 @@ export class Admin {
     }
 
     await withErrorReply(interaction, async () => {
-      await bot.initApplicationCommands();
+      const timeoutMs = 30_000;
+      await Promise.race([
+        bot.initApplicationCommands(),
+        new Promise<never>((_, reject) =>
+          setTimeout(
+            () => reject(new Error(`initApplicationCommands timed out after ${timeoutMs}ms`)),
+            timeoutMs,
+          ),
+        ),
+      ]);
       await safeReply(interaction, buildTextReply("✅ Commands synchronized with Discord.", true));
     }, "Failed to sync commands");
   }


### PR DESCRIPTION
## Summary
- Wrapped `bot.initApplicationCommands()` in a `Promise.race` with a 30-second timeout so the `/admin sync` command can no longer hang indefinitely
- If `initApplicationCommands` stalls (network timeout, rate limit, bot not ready), the race rejects with a descriptive error that `withErrorReply` surfaces to the user
- On success, the existing confirmation reply is sent as before

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/admin sync` completes with a success message when the bot is ready
- [ ] If `initApplicationCommands` hangs past 30 seconds, the user receives an error reply rather than a frozen deferred interaction

Closes #866

🤖 Generated with [Claude Code](https://claude.com/claude-code)