### PR TITLE
refactor: migrate simple ContainerBuilder patterns to buildTextContainer/buildAccentContainer

### DIFF
--- a/src/commands/game-completion/completion-edit.service.ts
+++ b/src/commands/game-completion/completion-edit.service.ts
@@ -7,10 +7,7 @@ import {
   type ButtonInteraction,
   type Message,
 } from "discord.js";
-import {
-  ContainerBuilder,
-  TextDisplayBuilder,
-} from "@discordjs/builders";
+import { ContainerBuilder } from "@discordjs/builders";
 import Member from "../../classes/Member.js";
 import {
   COMPLETION_TYPES,
@@ -125,12 +122,10 @@ export async function handleCompletionFieldEdit(interaction: ButtonInteraction):
       .addOptions(COMPLETION_TYPES.map((t) => ({ label: t, value: t })));
 
     const currentEmbedText = extractEditPromptText(interaction);
-    const container = new ContainerBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent("Select the new completion type:"),
-      ...(currentEmbedText
-        ? [new TextDisplayBuilder().setContent(safeV2TextContent(currentEmbedText, 1000))]
-        : []),
-    );
+    const typeSelectContent = currentEmbedText
+      ? `Select the new completion type:\n${safeV2TextContent(currentEmbedText, 1000)}`
+      : "Select the new completion type:";
+    const container = buildTextContainer(typeSelectContent);
 
     await safeUpdate(interaction, {
       components: [
@@ -415,9 +410,8 @@ function buildCompletionEditPrompt(
   const headerText = `${noticeLine}Editing **${completion.title}** - choose a field to update:`;
   const detailText = `Current: ${currentParts.join(" - ")}${noteLine}`;
 
-  const infoContainer = new ContainerBuilder().addTextDisplayComponents(
-    new TextDisplayBuilder().setContent(safeV2TextContent(headerText, 1000)),
-    new TextDisplayBuilder().setContent(safeV2TextContent(detailText, 3500)),
+  const infoContainer = buildTextContainer(
+    `${safeV2TextContent(headerText, 1000)}\n${safeV2TextContent(detailText, 3500)}`,
   );
 
   return {

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -34,6 +34,7 @@ import {
 } from "../functions/InteractionUtils.js";
 import { decodeBase64Url, encodeWithMaxLength } from "../functions/CustomIdUtils.js";
 import {
+  buildAccentContainer,
   buildComponentsV2Flags,
   buildComponentsV2EditFlags,
   buildTextContainer,
@@ -45,7 +46,6 @@ import {
   ContainerBuilder,
   MediaGalleryBuilder,
   MediaGalleryItemBuilder,
-  TextDisplayBuilder,
 } from "@discordjs/builders";
 import {
   performAutoAcceptImages,
@@ -1195,13 +1195,10 @@ export class GameDbAdmin {
 
     fieldLines.push(`**Thread** ${threadId ? `✅ ${channelMention(threadId)}` : "❌ Missing"}`);
 
-    const container = new ContainerBuilder()
-      .addTextDisplayComponents(
-        new TextDisplayBuilder().setContent(
-          safeV2TextContent(`# Audit: ${game.title}\n${fieldLines.join("\n")}`, 3500),
-        ),
-      );
-    container.setAccentColor(COLOR_HIGHLIGHT);
+    const container = buildAccentContainer(
+      `# Audit: ${game.title}\n${fieldLines.join("\n")}`,
+      COLOR_HIGHLIGHT,
+    );
     if (files.length > 0) {
       container.addMediaGalleryComponents(
         new MediaGalleryBuilder().addItems(


### PR DESCRIPTION
## Summary
- Replaced manual `new ContainerBuilder().addTextDisplayComponents(new TextDisplayBuilder()...)` patterns with `buildTextContainer` in `completion-edit.service.ts` (two sites)
- Replaced manual container construction + `setAccentColor` with `buildAccentContainer` in `gamedb-admin.command.ts`, then media gallery is still appended via chaining
- Removed now-unused `TextDisplayBuilder` imports from both files
- `DiscordConsoleLogger.ts:132` was intentionally skipped: `MAX_DESCRIPTION_LENGTH = 3900` but `buildAccentContainer` truncates internally at 3500, which would silently drop log output and the timestamp footer in the worst case -- not a safe refactor without a helper extension

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Verify completion edit type-select UI still renders header + current embed text
- [ ] Verify completion edit field-select UI still renders header + current detail
- [ ] Verify audit command container still shows correct accent color and media gallery

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)