### PR TITLE
feat: Add Event Creation to /admin nextround-setup

### DIFF
--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -5,6 +5,8 @@ import {
   ButtonStyle,
   ComponentType,
   ForumChannel,
+  GuildScheduledEventEntityType,
+  GuildScheduledEventPrivacyLevel,
   StringSelectMenuBuilder,
   type Message,
   type MessageCreateOptions,
@@ -23,7 +25,11 @@ import {
   buildComponentsV2EditFlags,
   buildComponentsV2Flags,
 } from "../../functions/ComponentsV2Utils.js";
-import { ADMIN_CHANNEL_ID, NOW_PLAYING_FORUM_ID } from "../../config/channels.js";
+import {
+  ADMIN_CHANNEL_ID,
+  ANNOUNCEMENT_CHANNEL_ID,
+  NOW_PLAYING_FORUM_ID,
+} from "../../config/channels.js";
 import Gotm, { insertGotmRoundInDatabase, type IGotmGame } from "../../classes/Gotm.js";
 import NrGotm, { insertNrGotmRoundInDatabase, type INrGotmGame } from "../../classes/NrGotm.js";
 import BotVotingInfo from "../../classes/BotVotingInfo.js";
@@ -900,6 +906,42 @@ export async function handleNextRoundSetup(
           return;
         }
         await BotVotingInfo.setRoundInfo(nextRound, finalDate, null);
+      },
+    },
+    {
+      description:
+        `Create vote reminder event for <t:${toUnixTimestamp(finalDate)}:F>`,
+      execute: async () => {
+        if (testMode) {
+          await wizardLog("[Test] Would create vote reminder scheduled event.");
+          return;
+        }
+        const guild = interaction.guild;
+        if (!guild) {
+          await wizardLog("No guild context; skipping vote reminder event.");
+          return;
+        }
+        const voteChannelUrl =
+          `https://discord.com/channels/${guild.id}/${ANNOUNCEMENT_CHANNEL_ID}`;
+        // External events require an end time; give the reminder a 1-hour window.
+        const endsAt = new Date(finalDate.getTime() + 60 * 60 * 1000);
+        try {
+          const event = await guild.scheduledEvents.create({
+            description: `Cast your GOTM and NR-GOTM votes for ${monthYear}.`,
+            entityMetadata: { location: voteChannelUrl },
+            entityType: GuildScheduledEventEntityType.External,
+            name: `Round ${nextRound} Vote (${monthYear})`,
+            privacyLevel: GuildScheduledEventPrivacyLevel.GuildOnly,
+            scheduledEndTime: endsAt,
+            scheduledStartTime: finalDate,
+          });
+          const eventUrl = `https://discord.com/events/${guild.id}/${event.id}`;
+          await wizardLog(`Created vote reminder event: ${eventUrl}`);
+        } catch (err: any) {
+          await wizardLog(
+            `Vote reminder event creation failed: ${err?.message ?? String(err)}`,
+          );
+        }
       },
     },
     ];


### PR DESCRIPTION
## Summary
- `/admin nextround-setup` now creates a Discord guild scheduled event that
  reminds the server when the next vote will be, using the chosen vote date
  as the event start time.
- Implemented as a new `WizardAction` appended to the commit action list, so it
  appears in the review summary before commit and respects `testMode` (logs
  only). Event creation is wrapped in try/catch so a failure does not abort the
  rest of the commit.

## Design defaults (open to adjustment)
- Event name: `Round <N> Vote (<MonthYear>)`.
- Location: link to `#announcements` (`ANNOUNCEMENT_CHANNEL_ID`), where the
  Subo `/poll` vote is posted.
- Type: External event with a 1-hour window (External events require an end
  time); `GuildOnly` privacy.

## Notes
- Follow-up opportunity: a shared `createGuildScheduledEvent` helper could fold
  this and the existing inline call in `live-stream-admin.service.ts` together.
  Left out here to keep the change scoped to the issue.
- Re-running the wizard creates a second event (no idempotency), matching the
  existing non-idempotent DB-insert actions in the same list.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) -- 56/56
- [x] Lint clean (`npm run lint`)
- [ ] Manual: run `/admin nextround-setup`, commit, confirm a scheduled event
      appears for the vote date

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
