### PR TITLE
fix: /game-completion list fails with 42P01 (FROM DUAL is not valid in PostgreSQL)

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -707,7 +707,7 @@ export default class Member {
     const uniqueIds = [...new Set(gameIds.filter(isPositiveInt))];
     if (!uniqueIds.length) return [];
     const inlineTable = uniqueIds
-      .map((_, idx) => `SELECT :id${idx} AS GAME_ID FROM DUAL`)
+      .map((_, idx) => `SELECT :id${idx} AS GAME_ID`)
       .join(" UNION ALL ");
     const binds: Record<string, string | number> = { userId };
     uniqueIds.forEach((id, idx) => {


### PR DESCRIPTION
## Summary
- `/game-completion list` threw a PostgreSQL `42P01` (undefined_table) at query
  position 156 because `getJournalStatusForGames` built its inline value list with
  `SELECT :idN AS GAME_ID FROM DUAL`.
- `DUAL` is an Oracle pseudo-table and does not exist in PostgreSQL.
- PostgreSQL permits `SELECT <expr>` without a `FROM`, so dropping `FROM DUAL` fixes
  the query. This was the only `FROM DUAL` occurrence in `src/`.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] Lint passes (`npm run lint`)
- [ ] `/game-completion list` renders against the Postgres backend without error

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)