### PR TITLE
fix: /game-completion list fails with 42883 (untyped bind param in journal-status join)

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -707,7 +707,7 @@ export default class Member {
     const uniqueIds = [...new Set(gameIds.filter(isPositiveInt))];
     if (!uniqueIds.length) return [];
     const inlineTable = uniqueIds
-      .map((_, idx) => `SELECT :id${idx} AS GAME_ID`)
+      .map((_, idx) => `SELECT :id${idx}::int AS GAME_ID`)
       .join(" UNION ALL ");
     const binds: Record<string, string | number> = { userId };
     uniqueIds.forEach((id, idx) => {


### PR DESCRIPTION
## Summary
- Follow-up to #876 / #877. Removing `FROM DUAL` left the journal-status inline table
  projecting `SELECT $N AS GAME_ID` with no type context, so Postgres inferred `text`
  and the join `je.gamedb_game_id = gids.game_id` became `integer = text` -> `42883`.
- Cast the projected param to `::int` so the integer column join operator resolves.
  Ids are already validated via `isPositiveInt`.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] Lint passes (`npm run lint`)
- [ ] `/game-completion list` renders against the Postgres backend without error

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)