### PR TITLE
fix: /backlog edit & remove dropdown passes entry as NaN (#881)

### DIFF
--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -3260,5 +3260,43 @@ export default {
         };
       },
     },
+    "entry-id-from-api-entry-id": {
+      meta: {
+        type: "problem",
+        docs: {
+          description:
+            "Require API row mappers to read entryId from `entry_id`, not `id`.",
+        },
+        schema: [],
+        messages: {
+          useEntryId:
+            "Map `entryId` from the API row's `entry_id` field, not `id`. RPG Club list serializers expose the primary key as `entry_id`; reading `id` yields NaN.",
+        },
+      },
+      create(context) {
+        const isNumberCall = (node) =>
+          node &&
+          node.type === "CallExpression" &&
+          node.callee.type === "Identifier" &&
+          node.callee.name === "Number";
+        const readsDotId = (node) =>
+          node &&
+          node.type === "MemberExpression" &&
+          node.property.type === "Identifier" &&
+          node.property.name === "id";
+        return {
+          Property(node) {
+            if (node.key.type !== "Identifier" || node.key.name !== "entryId") {
+              return;
+            }
+            if (!isNumberCall(node.value)) return;
+            const arg = node.value.arguments[0];
+            if (readsDotId(arg)) {
+              context.report({ node: node.value, messageId: "useEntryId" });
+            }
+          },
+        };
+      },
+    },
   },
 };

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -120,6 +120,7 @@ export default [
       "local/custom-id-has-matching-handler": "error",
       "local/custom-id-builder-matches-handler": "error",
       "local/split-long-import": "error",
+      "local/entry-id-from-api-entry-id": "error",
     },
   },
   {

--- a/src/classes/UserGameBacklog.ts
+++ b/src/classes/UserGameBacklog.ts
@@ -17,7 +17,7 @@ export interface IUserGameBacklogEntry {
 }
 
 type BacklogApiData = {
-  id: number;
+  entry_id: number;
   user_id: string;
   gamedb_game_id: number;
   platform_id: number | null;
@@ -60,7 +60,7 @@ async function mapEntries(rawEntries: BacklogApiData[]): Promise<IUserGameBacklo
       ? platformMap.get(Number(raw.platform_id))
       : null;
     return {
-      entryId: Number(raw.id),
+      entryId: Number(raw.entry_id),
       userId: raw.user_id,
       gameId: Number(raw.gamedb_game_id),
       title: game?.title ?? `Game #${raw.gamedb_game_id}`,

--- a/src/commands/backlog/backlog-autocomplete.utils.ts
+++ b/src/commands/backlog/backlog-autocomplete.utils.ts
@@ -18,6 +18,9 @@ export function parseBacklogEntryAutocompleteValue(raw: string): number | null {
 }
 
 export function buildBacklogEntryAutocompleteValue(entryId: number): string {
+  if (!isPositiveInt(entryId)) {
+    throw new Error(`Cannot build backlog autocomplete value from invalid id: ${entryId}`);
+  }
   return `${BACKLOG_ENTRY_VALUE_PREFIX}:${entryId}`;
 }
 
@@ -59,13 +62,16 @@ export async function autocompleteBacklogEntry(
     : entries;
 
   await interaction.respond(
-    filtered.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((entry) => {
-      const platform = entry.platformName ?? "No platform";
-      const label = truncateLabel(`${entry.title} | ${platform}`);
-      return {
-        name: label,
-        value: buildBacklogEntryAutocompleteValue(entry.entryId),
-      };
-    }),
+    filtered
+      .filter((entry) => isPositiveInt(entry.entryId))
+      .slice(0, DISCORD_SELECT_OPTIONS_MAX)
+      .map((entry) => {
+        const platform = entry.platformName ?? "No platform";
+        const label = truncateLabel(`${entry.title} | ${platform}`);
+        return {
+          name: label,
+          value: buildBacklogEntryAutocompleteValue(entry.entryId),
+        };
+      }),
   );
 }

--- a/src/tests/backlog-autocomplete.utils.test.ts
+++ b/src/tests/backlog-autocomplete.utils.test.ts
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  buildBacklogEntryAutocompleteValue,
+  parseBacklogEntryAutocompleteValue,
+} from "../commands/backlog/backlog-autocomplete.utils.js";
+
+test("buildBacklogEntryAutocompleteValue round-trips through the parser", () => {
+  const value = buildBacklogEntryAutocompleteValue(42);
+  assert.equal(value, "backlog:42");
+  assert.equal(parseBacklogEntryAutocompleteValue(value), 42);
+});
+
+test("buildBacklogEntryAutocompleteValue rejects non-finite ids (NaN regression)", () => {
+  assert.throws(() => buildBacklogEntryAutocompleteValue(Number(undefined)));
+  assert.throws(() => buildBacklogEntryAutocompleteValue(0));
+  assert.throws(() => buildBacklogEntryAutocompleteValue(-1));
+});
+
+test("parseBacklogEntryAutocompleteValue rejects backlog:NaN and malformed input", () => {
+  assert.equal(parseBacklogEntryAutocompleteValue("backlog:NaN"), null);
+  assert.equal(parseBacklogEntryAutocompleteValue("backlog:"), null);
+  assert.equal(parseBacklogEntryAutocompleteValue("backlog:1.5"), null);
+  assert.equal(parseBacklogEntryAutocompleteValue("nope:1"), null);
+});


### PR DESCRIPTION
## Summary
- `/backlog edit` and `/backlog remove` autocomplete sent every selected entry as
  `backlog:NaN`, so the command rejected it with "Invalid backlog entry selection."
- Root cause: `UserGameBacklog.mapEntries` read the primary key from `Number(raw.id)`,
  but the RPG Club list serializer exposes it as `entry_id` (matching `Member` and
  `UserGameCollection`). `raw.id` was `undefined`, so `entryId` became `NaN`.

## Changes
- `UserGameBacklog.ts`: map `entryId` from `raw.entry_id`; rename the `BacklogApiData`
  field accordingly.
- `backlog-autocomplete.utils.ts`: guard `buildBacklogEntryAutocompleteValue` against
  non-finite ids and skip invalid entries when building the response, so a single bad
  row cannot break the whole dropdown.
- New custom lint rule `local/entry-id-from-api-entry-id` flags mappers that derive
  `entryId` from `.id` instead of `entry_id`.
- New unit tests covering the build/parse round-trip and the `backlog:NaN` regression.

## Verification
- `tsc --noEmit` clean
- New tests pass (3/3)
- `npm run lint` clean; confirmed the new rule fires on the bad pattern

Closes #881

🤖 Generated with [Claude Code](https://claude.com/claude-code)