### PR TITLE
fix: /backlog list public by default; show full notes

### DIFF
--- a/src/commands/backlog/backlog-list.service.ts
+++ b/src/commands/backlog/backlog-list.service.ts
@@ -239,7 +239,7 @@ export async function buildBacklogListResponse(params: {
   const listText = pageEntries
     .map((entry) => {
       const platform = entry.platformName ?? "No platform";
-      const noteTag = entry.note ? ` · _${safeV2TextContent(entry.note, 60)}_` : "";
+      const noteTag = entry.note ? ` · _${safeV2TextContent(entry.note, 500)}_` : "";
       return `**${safeV2TextContent(entry.title, 100)}** · ${platform}${noteTag}`;
     })
     .join("\n");

--- a/src/commands/backlog/backlog-view.command.ts
+++ b/src/commands/backlog/backlog-view.command.ts
@@ -58,14 +58,14 @@ export class BacklogViewCommand {
     title: string | undefined,
     @SlashOption({
       name: "private",
-      description: "Send reply privately (only visible to you). Defaults to true.",
+      description: "Send reply privately (only visible to you). Defaults to false.",
       type: ApplicationCommandOptionType.Boolean,
       required: false,
     })
     privateFlag: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
-    const isEphemeral = privateFlag ?? true;
+    const isEphemeral = privateFlag ?? false;
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(isEphemeral) });
 
     const userId = interaction.user.id;


### PR DESCRIPTION
## Summary
- `/backlog list` previously replied ephemerally by default. It now posts a public
  reply by default; the `private` option still lets a user keep it to themselves.
- List rows truncated notes at 60 characters. They now render the full stored note
  (up to the 500-char write-time limit).

## Changes
- `backlog-view.command.ts`: `isEphemeral` defaults to `false`; updated the `private`
  option description.
- `backlog-list.service.ts`: note display limit raised from 60 to 500 (matches the
  note write limit). The overall body remains capped at 3500 chars by PaginationUtils.

## Verification
- `tsc --noEmit` clean
- `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)