### PR TITLE
refactor: Complete Game read paths migration (consolidate /relations)

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -49,6 +49,11 @@ export interface IRelease {
   notes: string | null;
 }
 
+export interface IReleaseWithNames extends IRelease {
+  platformName: string | null;
+  regionName: string | null;
+}
+
 export interface IPlatformDef {
   id: number;
   code: string;
@@ -378,7 +383,17 @@ type CompletionGameApiEntry = {
   user: { user_id: string; username: string | null; global_name: string | null };
 };
 
+type RelationReleaseApiData = ReleaseApiData & {
+  platform_name: string | null;
+  region_name: string | null;
+  platform_code: string | null;
+  region_code: string | null;
+};
+
 type GameRelationsApiData = {
+  releases: RelationReleaseApiData[];
+  platforms: PlatformApiData[];
+  collection: { name: string } | null;
   companies: Array<CompanyApiData & { role: string | null }>;
   franchises: Array<{ name: string }>;
   genres: Array<{ name: string }>;
@@ -386,7 +401,7 @@ type GameRelationsApiData = {
   modes: Array<{ name: string }>;
   perspectives: Array<{ name: string }>;
   themes: Array<{ name: string }>;
-  alternates: any[];
+  alternates: Array<Record<string, unknown>>;
 };
 
 // --- API mapper functions ---
@@ -1012,12 +1027,8 @@ export default class Game {
   }
 
   static async getGameSeries(gameId: number): Promise<string | null> {
-    const rows = await dbQuery(
-      GameSql.getGameSeries,
-      { gameId },
-      (row: { NAME: string }) => row.NAME,
-    );
-    return rows[0] ?? null;
+    const relations = await Game.getGameRelations(gameId);
+    return relations?.collection?.name ?? null;
   }
 
   static async addReleaseInfo(
@@ -1066,13 +1077,45 @@ export default class Game {
     return results;
   }
 
+  private static readonly relationsCache = new Map<
+    number,
+    { promise: Promise<GameRelationsApiData | null>; expires: number }
+  >();
+
+  private static readonly RELATIONS_CACHE_TTL_MS = 2000;
+
   private static async getGameRelations(
     gameId: number,
   ): Promise<GameRelationsApiData | null> {
-    const result = await apiGet<{ data: GameRelationsApiData }>(
-      `/api/v1/games/${gameId}/relations`,
-    );
-    return result?.data ?? null;
+    const now = Date.now();
+    const cached = Game.relationsCache.get(gameId);
+    if (cached && cached.expires > now) return cached.promise;
+
+    const promise = (async () => {
+      const result = await apiGet<{ data: GameRelationsApiData }>(
+        `/api/v1/games/${gameId}/relations`,
+      );
+      return result?.data ?? null;
+    })();
+    promise.catch(() => Game.relationsCache.delete(gameId));
+
+    Game.relationsCache.set(gameId, {
+      promise,
+      expires: now + Game.RELATIONS_CACHE_TTL_MS,
+    });
+    return promise;
+  }
+
+  static async getGameReleasesDetailed(
+    gameId: number,
+  ): Promise<IReleaseWithNames[]> {
+    const relations = await Game.getGameRelations(gameId);
+    if (!relations?.releases?.length) return [];
+    return relations.releases.map((r) => ({
+      ...mapReleaseFromApi(r),
+      platformName: r.platform_name ?? null,
+      regionName: r.region_name ?? null,
+    }));
   }
 
   static async getReleaseById(id: number): Promise<IRelease | null> {

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -184,18 +184,13 @@ export async function buildGameProfile(
       return null;
     }
 
-    const releases = await Game.getGameReleases(gameId);
-    const platforms = await Game.getAllPlatforms();
-    const regions = await Game.getAllRegions();
+    const releases = await Game.getGameReleasesDetailed(gameId);
     const associations = await Game.getGameAssociations(gameId);
     const nowPlayingMembers = await Game.getNowPlayingMembers(gameId);
     const collectionOwners = await Game.getGameCollectionOwners(gameId);
     const completions = await Game.getGameCompletions(gameId);
     const alternateVersions = await Game.getAlternateVersions(gameId);
     const linkedThreads = await getThreadsByGameId(gameId);
-
-    const platformMap = new Map(platforms.map((p) => [p.id, p.name]));
-    const regionMap = new Map(regions.map((r) => [r.id, r.name]));
 
     const description = game.description || "No description available.";
     const container = new ContainerBuilder();
@@ -366,9 +361,9 @@ export async function buildGameProfile(
 
       const releaseMap = new Map<string, string[]>();
       sortedReleases.forEach((r) => {
-        const platformName = (formatPlatformDisplayName(platformMap.get(r.platformId))
+        const platformName = (formatPlatformDisplayName(r.platformName)
           ?? "Unknown Platform").trim();
-        const regionName = (regionMap.get(r.regionId) || "Unknown Region").trim();
+        const regionName = (r.regionName || "Unknown Region").trim();
         const regionSuffix = regionName === "Worldwide" ? "" : ` (${regionName})`;
         const releaseDate = r.releaseDate ? formatTableDate(r.releaseDate) : "TBD";
         const format = r.format ? `(${r.format}) ` : "";


### PR DESCRIPTION
## Summary
- Memoize `Game.getGameRelations` with a short (2s) request-scoped promise cache keyed by `gameId`, so the `/gamedb view` profile's developers/publishers/series/alternate-versions getters share a single `GET /api/v1/games/:id/relations` HTTP call instead of three-plus. The cached promise dedups concurrent and sequential callers; a rejected fetch is evicted immediately so a transient error does not poison the TTL window.
- Migrate `getGameSeries` off the Oracle `GameSql.getGameSeries` query to read `relations.collection?.name ?? null`.
- Source the profile's releases from `relations.releases` (which flattens `platform_name` / `region_name` onto each row) via the new `getGameReleasesDetailed` getter, and drop the separate `getGameReleases`, `getAllPlatforms`, and `getAllRegions` fetches plus their label maps from `buildGameProfile`.
- Extend `GameRelationsApiData` with `releases`, `platforms`, and `collection`, and type `alternates` as `Array<Record<string, unknown>>` instead of `any[]`.

## Notes / scope
- `getGameReleases` (separate `/releases` endpoint) is unchanged and still used by the audit/add/completionator flows; only `buildGameProfile` was switched onto `/relations`.
- The 2s memo TTL spans a single render. Edit-then-immediately-render flows mutate via separate endpoints and render the profile once afterward, so they are not served stale relations.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) -- lint clean, 59/59 tests
- [ ] Runtime (user to confirm against live API): `/gamedb view` issues one `/relations` request for the metadata block; rendered embed (Developer, Publisher, Series/Collection, Releases with platform/region labels, Alternate Versions) is unchanged
- [ ] Runtime: franchises-but-no-collection game shows no Series line
- [ ] Runtime: Developer/Publisher role casing compare remains correct

Closes #851

🤖 Generated with [Claude Code](https://claude.com/claude-code)