### PR TITLE
fix: "Add to Backlog" button fails with empty-string component validation error

### DIFF
--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -119,9 +119,7 @@ export function isGameReleased(game: IGame, releases: IRelease[]): boolean {
 
 export function buildGameProfileActionRow(
   gameId: number,
-  hasThread: boolean,
   featuredVideoUrl: string | null,
-  isReleased: boolean,
   disableVideo = false,
 ): ActionRowBuilder<ButtonBuilder>[] {
    
@@ -138,33 +136,15 @@ export function buildGameProfileActionRow(
   }).setDisabled(disableVideo);
   const rows: ActionRowBuilder<ButtonBuilder>[] = [];
   const primaryButtons: ButtonBuilder[] = [addNowPlaying];
-  if (isReleased) {
-     
-    primaryButtons.push(buildActionButton({
-      customId: `gamedb-action:completion:${gameId}`,
-      label: "Add Completion",
-      style: ButtonStyle.Primary,
-    }));
-  }
-  if (!hasThread) {
-     
-    primaryButtons.push(buildActionButton({
-      customId: `gamedb-action:thread:${gameId}`,
-      label: "Create Now Playing Thread",
-      style: ButtonStyle.Primary,
-    }));
-  }
   if (featuredVideoUrl) {
     primaryButtons.push(viewFeaturedVideo);
   }
-  rows.push(buildButtonRow(...primaryButtons));
-
-  const addBacklog = buildActionButton({
+  primaryButtons.push(buildActionButton({
     customId: `gamedb-action:backlog:${gameId}`,
     label: "Add to Backlog",
     style: ButtonStyle.Secondary,
-  });
-  rows.push(buildButtonRow(addBacklog));
+  }));
+  rows.push(buildButtonRow(...primaryButtons));
   return rows;
 }
 
@@ -599,9 +579,7 @@ export async function showGameProfile(
     components.push(
       ...buildGameProfileActionRow(
         gameId,
-        profile.hasThread,
         profile.featuredVideoUrl,
-        profile.isReleased,
       ),
     );
   }
@@ -626,9 +604,7 @@ export async function showGameProfileFromNomination(
     ...profile.components,
     ...buildGameProfileActionRow(
       gameId,
-      profile.hasThread,
       profile.featuredVideoUrl,
-      profile.isReleased,
     ),
   ];
   await safeReply(interaction, {
@@ -664,9 +640,7 @@ export async function buildGameProfileMessagePayload(
     components.push(
       ...buildGameProfileActionRow(
         gameId,
-        profile.hasThread,
         profile.featuredVideoUrl,
-        profile.isReleased,
       ),
     );
   }
@@ -686,9 +660,7 @@ export async function refreshGameProfileMessage(
   if (!profile) return;
   const actionRows = buildGameProfileActionRow(
     gameId,
-    profile.hasThread,
     profile.featuredVideoUrl,
-    profile.isReleased,
   );
   const existingComponents = interaction.message?.components ?? [];
   const searchRows = getSearchRowsFromComponents(existingComponents);
@@ -715,9 +687,7 @@ export async function updateGameProfileMessageById(
   if (!profile) return;
   const actionRows = buildGameProfileActionRow(
     gameId,
-    profile.hasThread,
     profile.featuredVideoUrl,
-    profile.isReleased,
   );
   const searchRows = getSearchRowsFromComponents(message.components ?? []);
   safeIgnore(message.edit({

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -392,9 +392,7 @@ export class GameDbSearchCommand {
     const response = buildSearchResponse(searchTerm, results, ownerId, page, false, filters);
     const actionRows = buildGameProfileActionRow(
       gameId,
-      profile.hasThread,
       profile.featuredVideoUrl,
-      profile.isReleased,
     );
 
     try {

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -40,8 +40,6 @@ import {
   showGameProfile,
 } from "./gamedb-profile.service.js";
 import { runSearchFlow } from "./gamedb-search.command.js";
-import { startCompletionWizard } from "./gamedb-completion.command.js";
-import { showNowPlayingThreadModal } from "./gamedb-thread.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import {
@@ -98,7 +96,7 @@ export class GameDbViewCommand {
   }
 
   @ButtonComponent({
-    id: /^gamedb-action:(nowplaying|completion|thread|video|hltb-import|backlog):\d+$/,
+    id: /^gamedb-action:(nowplaying|video|hltb-import|backlog):\d+$/,
   })
   async handleGameDbAction(interaction: ButtonInteraction): Promise<void> {
     const segs = assertCustomIdSegments(interaction, 2);
@@ -132,9 +130,7 @@ export class GameDbViewCommand {
       if (profile) {
         const actionRows = buildGameProfileActionRow(
           gameId,
-          profile.hasThread,
           profile.featuredVideoUrl,
-          profile.isReleased,
           true,
         );
         const existingComponents = interaction.message?.components ?? [];
@@ -205,16 +201,6 @@ export class GameDbViewCommand {
       return;
     }
 
-    if (action === "completion") {
-      await startCompletionWizard(interaction, gameId, game.title);
-      return;
-    }
-
-    if (action === "thread") {
-      await showNowPlayingThreadModal(interaction, gameId, game.title);
-      return;
-    }
-
     if (action === "backlog") {
       await this.handleAddToBacklog(interaction, gameId);
       return;
@@ -225,24 +211,35 @@ export class GameDbViewCommand {
     interaction: ButtonInteraction,
     gameId: number,
   ): Promise<void> {
-    const platforms = await Game.getPlatformsForGame(gameId);
-    if (!platforms.length) {
-      await this.addBacklogEntry(interaction, gameId, null);
-      return;
+    try {
+      const platforms = await Game.getPlatformsForGame(gameId);
+      const validPlatforms = platforms.filter(
+        (p) => p.name?.trim() && String(p.id)?.trim(),
+      );
+      if (!validPlatforms.length) {
+        await this.addBacklogEntry(interaction, gameId, null);
+        return;
+      }
+
+      const options = buildSelectOptions(
+        validPlatforms.map((p) => ({ label: p.name, value: String(p.id) })),
+      );
+      const select = new StringSelectMenuBuilder()
+        .setCustomId(`gamedb-backlog-platform:${gameId}`)
+        .setPlaceholder("Select a platform for your backlog")
+        .addOptions(options);
+
+      await safeReply(interaction, {
+        components: [buildSelectRow(select)],
+        flags: MessageFlags.Ephemeral,
+      });
+    } catch (err: unknown) {
+      await safeReply(
+        interaction,
+        buildTextReply("Failed to load platform options. Please try again.", true),
+      );
+      throw err;
     }
-
-    const options = buildSelectOptions(
-      platforms.map((p) => ({ label: p.name, value: String(p.id) })),
-    );
-    const select = new StringSelectMenuBuilder()
-      .setCustomId(`gamedb-backlog-platform:${gameId}`)
-      .setPlaceholder("Select a platform for your backlog")
-      .addOptions(options);
-
-    await safeReply(interaction, {
-      components: [buildSelectRow(select)],
-      flags: MessageFlags.Ephemeral,
-    });
   }
 
   @SelectMenuComponent({ id: /^gamedb-backlog-platform:\d+$/ })


### PR DESCRIPTION
## Summary
- Filter platforms with blank name or id before building the backlog platform select, preventing the shapeshift validation error that caused "This interaction failed"
- Wrap `handleAddToBacklog` in try/catch so a build failure surfaces a user-facing ephemeral error instead of leaving the interaction unanswered
- Remove "Add Completion" and "Create Now Playing Thread" buttons from the `/gamedb view` action row; move "Add to Backlog" into the primary row alongside "Add to Now Playing List"
- Remove now-unused `completion`/`thread` handler branches and imports; simplify `buildGameProfileActionRow` signature by removing unused `hasThread` and `isReleased` params

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/gamedb view` for a game with platforms shows only "Add to Now Playing List", "Add to Backlog" (and "View Featured Video" if applicable) in a single action row
- [ ] Clicking "Add to Backlog" shows the platform select and correctly adds to backlog
- [ ] A game whose platform has a blank name no longer causes "This interaction failed"

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)