### PR TITLE
fix: skip setDescription in buildSelectOptions when value is empty

### DIFF
--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -234,11 +234,11 @@ export class GameDbViewCommand {
         flags: MessageFlags.Ephemeral,
       });
     } catch (err: unknown) {
+      logError("gamedb view.load_platform_options_failed", err);
       await safeReply(
         interaction,
         buildTextReply("Failed to load platform options. Please try again.", true),
       );
-      throw err;
     }
   }
 

--- a/src/functions/uiComponents.ts
+++ b/src/functions/uiComponents.ts
@@ -109,8 +109,9 @@ export function buildSelectOptions(
   return inputs.slice(0, maxOptions).map((item) => {
     const option = new StringSelectMenuOptionBuilder()
       .setLabel(truncateLabel(item.label))
-      .setValue(item.value)
-      .setDescription(truncateDescription((item.description ?? "")));
+      .setValue(item.value);
+    const desc = truncateDescription(item.description ?? "");
+    if (desc) option.setDescription(desc);
     if (item.emoji != null) option.setEmoji(item.emoji);
     return option;
   });


### PR DESCRIPTION
## Summary
- \`buildSelectOptions\` unconditionally called \`.setDescription("")\` when no description was
  provided, which throws a Sapphire validation error (\`s.string().lengthGreaterThanOrEqual()\`,
  given \`""\`). This was the actual root cause of the \"Add to Backlog\" failure after #887 merged.
- Now skips \`setDescription\` entirely when the truncated value is empty, preventing the throw
  for all callers of \`buildSelectOptions\` that omit description.
- Also replaced \`throw err\` with \`logError\` in \`handleAddToBacklog\` so caught errors are logged
  without being re-escalated to the global \`discordClientError\` handler.

## Test plan
- [ ] Type-check passes (\`npx tsc --noEmit\`)
- [ ] Smoke test passes (\`bash .claude/skills/run-rpgclubbot/smoke.sh\`) -- 59/59 pass
- [ ] Click \"Add to Backlog\" on a game with platform data -- platform select appears with no error
- [ ] Click \"Add to Backlog\" on a game with no valid platform data -- entry is added directly

Closes #888

🤖 Generated with [Claude Code](https://claude.com/claude-code)