### PR TITLE
chore: make /backlog list a continuous numbered list across pages

### DIFF
--- a/src/commands/backlog/backlog-list.service.ts
+++ b/src/commands/backlog/backlog-list.service.ts
@@ -237,10 +237,11 @@ export async function buildBacklogListResponse(params: {
   const pageEntries = filtered.slice(start, start + BACKLOG_LIST_PAGE_SIZE);
 
   const listText = pageEntries
-    .map((entry) => {
+    .map((entry, index) => {
+      const number = start + index + 1;
       const platform = entry.platformName ?? "No platform";
       const noteTag = entry.note ? ` · _${safeV2TextContent(entry.note, 500)}_` : "";
-      return `**${safeV2TextContent(entry.title, 100)}** · ${platform}${noteTag}`;
+      return `${number}. **${safeV2TextContent(entry.title, 100)}** · ${platform}${noteTag}`;
     })
     .join("\n");
 


### PR DESCRIPTION
## Summary
- `/backlog list` entries are now rendered as a numbered list for easier reference.
- Numbering is continuous across pagination using the absolute index
  (`start + index + 1`), so page 2 continues from page 1 rather than restarting.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] Each backlog entry line is prefixed with its sequential number
- [x] On page 2+, numbering continues instead of resetting to 1
- [x] Title/note/platform formatting and truncation unchanged

Closes #890

🤖 Generated with [Claude Code](https://claude.com/claude-code)