### PR TITLE
fix: remove stale 4th arg from startNowPlayingIgdbImportFromInteraction call

### DIFF
--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -420,7 +420,6 @@ export class NowPlayingCommand {
             note: noteRaw.length ? noteRaw : null,
           },
           "reply",
-          this.promptNowPlayingAddPlatformSelection.bind(this),
         );
         return;
       }


### PR DESCRIPTION
## Summary

- `nowPlayingIgdbImport.service.ts` (added in the recent refactor) dropped the `promptAddPlatform` callback parameter and calls `promptNowPlayingAddPlatformSelection` directly from `nowPlayingAddService.ts`
- `now-playing.command.ts` still passed `this.promptNowPlayingAddPlatformSelection.bind(this)` as a 4th argument, which no longer exists on the class and doesn't match the new 3-param signature
- Removed the stale argument so the call matches the current signature

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run lint` passes with no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)