### PR TITLE
feat: render /gamedb view from a single /games/:id/profile API call

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -19,6 +19,7 @@ import {
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
+import type { HltbCacheEntry } from "./HltbCache.js";
 
 // Interfaces
 export interface IGame {
@@ -165,6 +166,22 @@ export interface ICollectionOwnerMember {
   userId: string;
   username: string | null;
   globalName: string | null;
+}
+
+export interface IMappedGameProfile {
+  game: IGame;
+  releases: IReleaseWithNames[];
+  associations: IGameAssociationSummary;
+  nowPlayingMembers: INowPlayingMember[];
+  collectionOwners: ICollectionOwnerMember[];
+  completions: ICompletedMember[];
+  alternateVersions: IGame[];
+  threadIds: string[];
+  hltbCache: HltbCacheEntry | null;
+  primaryImageUrl: string | null;
+  series: string | null;
+  developers: string[];
+  publishers: string[];
 }
 
 const IGDB_REGION_MAP: Record<number, { code: string; name: string }> = {
@@ -404,6 +421,58 @@ type GameRelationsApiData = {
   alternates: Array<Record<string, unknown>>;
 };
 
+type HltbProfileApiData = {
+  name: string | null;
+  url: string | null;
+  image_url: string | null;
+  main: string | null;
+  main_sides: string | null;
+  completionist: string | null;
+  single_player: string | null;
+  co_op: string | null;
+  vs: string | null;
+  source_query: string | null;
+  scraped_at: string | null;
+  updated_at: string | null;
+};
+
+type ProfileCollectionOwnerApiData = {
+  user_id: string;
+  username: string | null;
+};
+
+type ProfileGotmWinApiData = {
+  round: number;
+};
+
+type ProfileGotmNominationApiData = {
+  round: number;
+  user_id: string;
+  username: string | null;
+};
+
+type ProfileThreadApiData = {
+  thread_id: string;
+  jump_url: string | null;
+};
+
+export type GameProfileApiData = {
+  game: Record<string, unknown>;
+  relations: GameRelationsApiData;
+  now_playing: NowPlayingApiEntry[];
+  completions: CompletionGameApiEntry[];
+  threads: ProfileThreadApiData[];
+  primary_image: { url: string } | null;
+  associations: {
+    gotm_wins: ProfileGotmWinApiData[];
+    nr_gotm_wins: ProfileGotmWinApiData[];
+    gotm_nominations: ProfileGotmNominationApiData[];
+    nr_gotm_nominations: ProfileGotmNominationApiData[];
+  };
+  collection_owners: ProfileCollectionOwnerApiData[];
+  hltb: HltbProfileApiData | null;
+};
+
 // --- API mapper functions ---
 
 function mapReleaseFromApi(data: ReleaseApiData): IRelease {
@@ -434,6 +503,28 @@ function mapRegionFromApi(data: RegionApiData): IRegionDef {
     code: String(data.region_code),
     name: String(data.region_name),
     igdbRegionId: data.igdb_region_id != null ? Number(data.igdb_region_id) : null,
+  };
+}
+
+function mapHltbFromProfileApi(
+  data: HltbProfileApiData,
+  gameId: number,
+): HltbCacheEntry {
+  const toDate = (v: string | null): Date | null => (v ? new Date(v) : null);
+  return {
+    gameId,
+    name: data.name ?? null,
+    url: data.url ?? null,
+    imageUrl: data.image_url ?? null,
+    main: data.main ?? null,
+    mainSides: data.main_sides ?? null,
+    completionist: data.completionist ?? null,
+    singlePlayer: data.single_player ?? null,
+    coOp: data.co_op ?? null,
+    vs: data.vs ?? null,
+    sourceQuery: data.source_query ?? null,
+    scrapedAt: toDate(data.scraped_at),
+    updatedAt: toDate(data.updated_at),
   };
 }
 
@@ -1934,5 +2025,102 @@ export default class Game {
         globalName: row.GLOBAL_NAME ?? null,
       }),
     );
+  }
+
+  static async getGameProfile(gameId: number): Promise<IMappedGameProfile | null> {
+    const result = await apiGet<{ data: GameProfileApiData }>(
+      `/api/v1/games/${gameId}/profile`,
+    );
+    const d = result?.data;
+    if (!d) return null;
+
+    const game = mapGameFromApi(d.game);
+    const relations = d.relations;
+
+    const releases: IReleaseWithNames[] = (relations.releases ?? []).map((r) => ({
+      ...mapReleaseFromApi(r),
+      platformName: r.platform_name ?? null,
+      regionName: r.region_name ?? null,
+    }));
+
+    const associations: IGameAssociationSummary = {
+      gotmWins: (d.associations.gotm_wins ?? []).map((w) => ({
+        round: Number(w.round),
+        threadId: null,
+        redditUrl: null,
+        monthYear: "",
+      })),
+      nrGotmWins: (d.associations.nr_gotm_wins ?? []).map((w) => ({
+        round: Number(w.round),
+        threadId: null,
+        redditUrl: null,
+        monthYear: "",
+      })),
+      gotmNominations: (d.associations.gotm_nominations ?? []).map((n) => ({
+        round: Number(n.round),
+        userId: String(n.user_id),
+        username: String(n.username || n.user_id),
+      })),
+      nrGotmNominations: (d.associations.nr_gotm_nominations ?? []).map((n) => ({
+        round: Number(n.round),
+        userId: String(n.user_id),
+        username: String(n.username || n.user_id),
+      })),
+    };
+
+    const nowPlayingMembers: INowPlayingMember[] = (d.now_playing ?? []).map((entry) => ({
+      userId: String(entry.user_id),
+      username: entry.user?.username ?? null,
+      globalName: entry.user?.global_name ?? null,
+      threadId: null,
+      addedAt: null,
+    }));
+
+    const collectionOwners: ICollectionOwnerMember[] = (d.collection_owners ?? []).map(
+      (o) => ({
+        userId: String(o.user_id),
+        username: o.username ?? null,
+        globalName: null,
+      }),
+    );
+
+    const completions: ICompletedMember[] = (d.completions ?? []).map((entry) => ({
+      userId: String(entry.user_id),
+      username: entry.user?.username ?? null,
+      globalName: entry.user?.global_name ?? null,
+      completionType: String(entry.completion_type),
+      completedAt: entry.completed_at ? new Date(entry.completed_at) : null,
+      finalPlaytimeHours: entry.final_playtime_hrs != null
+        ? Number(entry.final_playtime_hrs)
+        : null,
+    }));
+
+    const alternateVersions: IGame[] = (relations.alternates ?? []).map(mapGameFromApi);
+    const threadIds = (d.threads ?? []).map((t) => String(t.thread_id));
+    const hltbCache = d.hltb ? mapHltbFromProfileApi(d.hltb, gameId) : null;
+    const primaryImageUrl = d.primary_image?.url ?? null;
+    const series = relations.collection?.name ?? null;
+    const developers = (relations.companies ?? [])
+      .filter((c) => c.role === "Developer")
+      .map((c) => String(c.name));
+    const publishers = (relations.companies ?? [])
+      .filter((c) => c.role === "Publisher")
+      .map((c) => String(c.name));
+
+    return {
+      game,
+      releases,
+      associations,
+      nowPlayingMembers,
+      collectionOwners,
+      completions,
+      alternateVersions,
+      threadIds,
+      hltbCache,
+      primaryImageUrl,
+      series,
+      developers,
+      publishers,
+    };
   }
 }

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -22,11 +22,9 @@ import { buildTextReply, safeV2TextContent } from "../../functions/ComponentsV2U
 import { truncateWithEllipsis } from "../../utilities/ValidationUtils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
-import { getHltbCacheByGameId } from "../../classes/HltbCache.js";
-import { getThreadsByGameId } from "../../classes/Thread.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 import { padCommandName } from "../help.command.js";
-import Game, { type GameSource, type IGame, type IRelease } from "../../classes/Game.js";
+import Game, { type IGame, type IRelease } from "../../classes/Game.js";
 import {
   buildComponentsV2Flags,
   getSearchRowsFromComponents,
@@ -156,21 +154,28 @@ export async function buildGameProfile(
     | ButtonInteraction
     | ModalSubmitInteraction
     | GameProfileRenderContext,
-  source?: GameSource,
 ): Promise<GameProfileResult | null> {
   try {
-    const game = await Game.getGameById(gameId, source);
-    if (!game) {
+    const profile = await Game.getGameProfile(gameId);
+    if (!profile) {
       return null;
     }
 
-    const releases = await Game.getGameReleasesDetailed(gameId);
-    const associations = await Game.getGameAssociations(gameId);
-    const nowPlayingMembers = await Game.getNowPlayingMembers(gameId);
-    const collectionOwners = await Game.getGameCollectionOwners(gameId);
-    const completions = await Game.getGameCompletions(gameId);
-    const alternateVersions = await Game.getAlternateVersions(gameId);
-    const linkedThreads = await getThreadsByGameId(gameId);
+    const {
+      game,
+      releases,
+      associations,
+      nowPlayingMembers,
+      collectionOwners,
+      completions,
+      alternateVersions,
+      threadIds,
+      hltbCache,
+      primaryImageUrl,
+      series,
+      developers,
+      publishers,
+    } = profile;
 
     const description = game.description || "No description available.";
     const container = new ContainerBuilder();
@@ -184,9 +189,7 @@ export async function buildGameProfile(
     if (primaryArt) {
       files.push(new AttachmentBuilder(primaryArt, { name: "game_image.png" }));
     }
-    const apiImageUrl = primaryArt
-      ? null
-      : await Game.getGamePrimaryImageUrl(gameId).catch(() => null);
+    const apiImageUrl = primaryArt ? null : primaryImageUrl;
 
     const rpgClubSections: string[] = [];
     const pushRpgClubSection = (title: string, value: string | null): void => {
@@ -229,12 +232,7 @@ export async function buildGameProfile(
       pushRpgClubSection("NR-GOTM Round(s)", lines.join("\n"));
     }
 
-    const threadId =
-      associations.gotmWins.find((w) => w.threadId)?.threadId ??
-      associations.nrGotmWins.find((w) => w.threadId)?.threadId ??
-      nowPlayingMembers.find((p) => p.threadId)?.threadId ??
-      linkedThreads[0] ??
-      null;
+    const threadId = threadIds[0] ?? null;
     const headerLink = threadId
       ? `https://discord.com/channels/${interaction?.guildId ?? "@me"}/${threadId}`
       : null;
@@ -355,7 +353,6 @@ export async function buildGameProfile(
       releasesByDate = releaseMap;
     }
 
-    const hltbCache = await getHltbCacheByGameId(gameId);
     const canImportHltb = isHltbImportEligible(game, Boolean(hltbCache));
     const hltbLabels: string[] = [];
 
@@ -426,11 +423,6 @@ export async function buildGameProfile(
       });
     }
 
-    const series = await Game.getGameSeries(gameId);
-    const [developers, publishers] = await Promise.all([
-      Game.getGameDevelopers(gameId),
-      Game.getGamePublishers(gameId),
-    ]);
     const detailSections: string[] = [];
 
     if (developers.length) {
@@ -562,9 +554,8 @@ export async function showGameProfile(
   interaction: CommandInteraction | StringSelectMenuInteraction,
   gameId: number,
   includeActionsOverride?: boolean,
-  source?: GameSource,
 ): Promise<void> {
-  const profile = await buildGameProfile(gameId, interaction, source);
+  const profile = await buildGameProfile(gameId, interaction);
   if (!profile) {
     await safeReply(interaction, buildTextReply(`No game found with ID ${gameId}.`, true));
     return;

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -78,7 +78,7 @@ export class GameDbViewCommand {
         await safeReply(interaction, buildTextReply("API source requires a numeric game ID.", false));
         return;
       }
-      await showGameProfile(interaction, gameId, undefined, "API");
+      await showGameProfile(interaction, gameId, undefined);
       return;
     }
 
@@ -87,7 +87,7 @@ export class GameDbViewCommand {
       if (isPositiveInt(gameId)) {
         const game = await Game.getGameById(gameId, source);
         if (game) {
-          await showGameProfile(interaction, gameId, undefined, source);
+          await showGameProfile(interaction, gameId, undefined);
           return;
         }
       }


### PR DESCRIPTION
## Summary
- Replaces six API round-trips and three direct SQL reads in `buildGameProfile` with a single `GET /api/v1/games/:id/profile` call
- Adds `Game.getGameProfile()` which fetches the aggregate profile endpoint and maps the full response to domain types (game, releases, now-playing, completions, threads, associations, collection owners, HLTB cache, primary image, series, developers, publishers)
- Drops the `source` parameter from `buildGameProfile` and `showGameProfile` since the view path is now API-only; removes the now-redundant `getHltbCacheByGameId` and `getThreadsByGameId` calls from the service

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)
- [ ] All 59 tests pass (`node --loader ts-node/esm/transpile-only --test src/tests/*.test.ts`)
- [ ] `/gamedb view <id>` renders embed unchanged: Developer, Publisher, Series/Collection, Releases, Alternate Versions, Now Playing, Completions, linked threads, GOTM associations, collection owners, HowLongToBeat times, primary image
- [ ] Verify via logs that a single `GET /api/v1/games/:id/profile` request is made (zero SQL queries)
- [ ] A game with no HLTB cache row renders with no HLTB section
- [ ] A franchises-but-no-collection game shows no Series line

**Known gap:** `reddit_url` per GOTM win is not exposed by `GotmWinResource` in the profile endpoint (only `round` is included), so the Reddit Discussion Thread link is not rendered on the view path. This requires an API change to `GotmWinResource` to expose `reddit_url`.

Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)