### PR TITLE
feat: call refresh-images API after adding a new game to GameDB

### DIFF
--- a/src/commands/gamedb/gamedb-add.command.ts
+++ b/src/commands/gamedb/gamedb-add.command.ts
@@ -35,6 +35,7 @@ import { buildIgdbSelectOptions } from "./gamedb-csv-import.service.js";
 import { showGameProfile, trimTextDisplayContent } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { logError, logWarn } from "../../utilities/LogUtils.js";
+import { apiPost } from "../../services/RpgClubApiClient.js";
 
 async function fetchIgdbCoverImage(details: IGDBGameDetails): Promise<Buffer | null> {
   if (!details.cover?.image_id) return null;
@@ -182,6 +183,10 @@ export async function addGameToDatabase(
       // ignore cleanup failures
     }
   }
+
+  await apiPost(`/api/v1/games/${newGame.id}/refresh-images`).catch((err) => {
+    logError("GamedbAddCommand.addGameToDatabase.refreshImages", err);
+  });
 
   await showGameProfile(interaction, newGame.id, true);
 }


### PR DESCRIPTION
## Summary

- After creating a new game in `addGameToDatabase()`, calls `POST /api/v1/games/:id/refresh-images` before rendering the game profile, ensuring Backblaze images are populated for the initial view. Errors are logged but do not block the profile display.
- Adds `/superadmin gamedb-refresh-images` command to bulk-refresh images for all GameDB titles with an IGDB ID. Reports progress every 10 games and a final summary on completion. Includes a 250ms delay between calls to avoid hammering the API.

## Changes

- `src/commands/gamedb/gamedb-add.command.ts` -- call `apiPost` to refresh-images after game creation
- `src/commands/superadmin.command.ts` -- new `gamedb-refresh-images` slash command
- `src/classes/Game.ts` -- add `getAllGameIdsWithIgdb()` static method
- `src/db/sql/game.sql.ts` -- add `getAllGameIdsWithIgdb` SQL entry

## Test plan

- [ ] Add a game via `/gamedb add` -- confirm images appear in Backblaze and render in the profile
- [ ] Verify `/gamedb add` still completes normally if the refresh-images API call fails
- [ ] Run `/superadmin gamedb-refresh-images` -- confirm progress updates every 10 games and a final summary is sent
- [ ] Confirm errors per game are logged but do not abort the bulk loop

Closes #903
Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)