### PR TITLE
feat: add /superadmin gamedb-refresh-images bulk image fetch command

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -664,6 +664,15 @@ export default class Game {
     return pairs.length;
   }
 
+  static async getAllGameIdsWithIgdb(): Promise<number[]> {
+    const rows = await dbQuery<{ GAME_ID: number }, number>(
+      GameSql.getAllGameIdsWithIgdb,
+      {},
+      (row) => row.GAME_ID,
+    );
+    return rows;
+  }
+
   static async getGameByIgdbId(igdbId: number): Promise<IGame | null> {
     return dbWithConnection(async (conn) => {
       const rows = await dbQueryConn(

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -57,6 +57,7 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { sleep } from "../utilities/DelayUtils.js";
+import { apiPost } from "../services/RpgClubApiClient.js";
 import { truncateDescription, truncateLabel } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
@@ -851,6 +852,51 @@ export class SuperAdmin {
 
     await safeReply(interaction, buildTextReply(`Member scan complete. Upserts succeeded: ${successCount}. Failed: ${failCount}. ` +
         `Marked departed: ${departedCount}.`, true));
+  }
+
+  @Slash({
+    description: "Fetch missing images from IGDB for all GameDB titles",
+    name: "gamedb-refresh-images",
+  })
+  async gamedbRefreshImages(interaction: CommandInteraction): Promise<void> {
+    await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
+
+    const okToUseCommand = await isSuperAdmin(interaction);
+    if (!okToUseCommand) return;
+
+    const gameIds = await Game.getAllGameIdsWithIgdb();
+    const total = gameIds.length;
+    let successCount = 0;
+    let failCount = 0;
+
+    const progressText = (): string =>
+      `Refreshing GameDB images: ${successCount + failCount}/${total} processed` +
+      ` (${successCount} ok, ${failCount} failed)`;
+
+    await safeReply(interaction, buildTextReply(progressText(), true));
+
+    for (let i = 0; i < gameIds.length; i++) {
+      const gameId = gameIds[i];
+      try {
+        await apiPost(`/api/v1/games/${gameId}/refresh-images`);
+        successCount++;
+      } catch (err) {
+        failCount++;
+        logError("SuperadminCommand.gamedbRefreshImages", { gameId, err });
+      }
+
+      if ((i + 1) % 10 === 0 || i === gameIds.length - 1) {
+        await safeReply(interaction, buildTextReply(progressText(), true));
+      }
+
+      await sleep(250);
+    }
+
+    await safeReply(interaction, buildTextReply(
+      `GameDB image refresh complete. ${total} games processed:` +
+        ` ${successCount} succeeded, ${failCount} failed.`,
+      true,
+    ));
   }
 
   @Slash({ description: "Show help for server owner commands", name: "help" })

--- a/src/db/sql/game.sql.ts
+++ b/src/db/sql/game.sql.ts
@@ -69,6 +69,10 @@ export const GameSql = {
            ON CONFLICT (game_id, alt_game_id) DO NOTHING`,
   } satisfies ISqlEntry,
 
+  getAllGameIdsWithIgdb: {
+    postgres: `SELECT game_id FROM gamedb_games WHERE igdb_id IS NOT NULL ORDER BY game_id`,
+  } satisfies ISqlEntry,
+
   getGameByIgdbId: {
     postgres: `SELECT ${GAME_COLS_PG}
            FROM gamedb_games


### PR DESCRIPTION
## Summary

- Adds `/superadmin gamedb-refresh-images` to bulk-fetch missing images for all GameDB titles with an IGDB ID
- Reports ephemeral progress every 10 games with running success/fail counts
- Final summary message on completion
- 250ms delay between API calls to avoid hammering the API
- Per-game errors are logged and counted but do not abort the loop

## Changes

- `src/commands/superadmin.command.ts` -- new `gamedb-refresh-images` slash command
- `src/classes/Game.ts` -- add `Game.getAllGameIdsWithIgdb()` static method
- `src/db/sql/game.sql.ts` -- add `getAllGameIdsWithIgdb` SQL entry

## Test plan

- [ ] Run `/superadmin gamedb-refresh-images` -- confirm ephemeral progress updates every 10 games
- [ ] Confirm final summary with totals is sent on completion
- [ ] Verify per-game errors are logged but the loop continues

Closes #905

🤖 Generated with [Claude Code](https://claude.com/claude-code)