### PR TITLE
fix: handle 422 + rename to download-missing-images, skip games with existing API images

### DIFF
--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -61,7 +61,7 @@ import { apiPost } from "../services/RpgClubApiClient.js";
 import { truncateDescription, truncateLabel } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
-import { logError } from "../utilities/LogUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
 import { buildSelectRow } from "../functions/uiComponents.js";
 
 type CompletionAddContext = {
@@ -867,11 +867,12 @@ export class SuperAdmin {
     const gameIds = await Game.getAllGameIdsWithIgdb();
     const total = gameIds.length;
     let successCount = 0;
+    let skipCount = 0;
     let failCount = 0;
 
     const progressText = (): string =>
-      `Refreshing GameDB images: ${successCount + failCount}/${total} processed` +
-      ` (${successCount} ok, ${failCount} failed)`;
+      `Refreshing GameDB images: ${successCount + skipCount + failCount}/${total} processed` +
+      ` (${successCount} ok, ${skipCount} skipped, ${failCount} failed)`;
 
     await safeReply(interaction, buildTextReply(progressText(), true));
 
@@ -881,8 +882,22 @@ export class SuperAdmin {
         await apiPost(`/api/v1/games/${gameId}/refresh-images`);
         successCount++;
       } catch (err) {
-        failCount++;
-        logError("SuperadminCommand.gamedbRefreshImages", { gameId, err });
+        const apiError = axios.isAxiosError(err) ? err.response?.data?.error : undefined;
+        const apiMessage = axios.isAxiosError(err) ? err.response?.data?.message : undefined;
+        const status = axios.isAxiosError(err) ? err.response?.status : undefined;
+
+        if (apiError === "missing_igdb_id") {
+          skipCount++;
+          logWarn("SuperadminCommand.gamedbRefreshImages", { gameId, apiError, apiMessage });
+        } else {
+          failCount++;
+          logError("SuperadminCommand.gamedbRefreshImages", {
+            gameId,
+            status,
+            apiError,
+            apiMessage,
+          });
+        }
       }
 
       if ((i + 1) % 10 === 0 || i === gameIds.length - 1) {
@@ -894,7 +909,7 @@ export class SuperAdmin {
 
     await safeReply(interaction, buildTextReply(
       `GameDB image refresh complete. ${total} games processed:` +
-        ` ${successCount} succeeded, ${failCount} failed.`,
+        ` ${successCount} succeeded, ${skipCount} skipped (no IGDB ID on API), ${failCount} failed.`,
       true,
     ));
   }

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -855,10 +855,10 @@ export class SuperAdmin {
   }
 
   @Slash({
-    description: "Fetch missing images from IGDB for all GameDB titles",
-    name: "gamedb-refresh-images",
+    description: "Download images from IGDB for GameDB titles that have no API images yet",
+    name: "download-missing-images",
   })
-  async gamedbRefreshImages(interaction: CommandInteraction): Promise<void> {
+  async downloadMissingImages(interaction: CommandInteraction): Promise<void> {
     await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
 
     const okToUseCommand = await isSuperAdmin(interaction);
@@ -871,16 +871,21 @@ export class SuperAdmin {
     let failCount = 0;
 
     const progressText = (): string =>
-      `Refreshing GameDB images: ${successCount + skipCount + failCount}/${total} processed` +
-      ` (${successCount} ok, ${skipCount} skipped, ${failCount} failed)`;
+      `Downloading missing GameDB images: ${successCount + skipCount + failCount}/${total} checked` +
+      ` (${successCount} downloaded, ${skipCount} already have images, ${failCount} failed)`;
 
     await safeReply(interaction, buildTextReply(progressText(), true));
 
     for (let i = 0; i < gameIds.length; i++) {
       const gameId = gameIds[i];
       try {
-        await apiPost(`/api/v1/games/${gameId}/refresh-images`);
-        successCount++;
+        const existing = await Game.getGamePrimaryImageUrl(gameId);
+        if (existing) {
+          skipCount++;
+        } else {
+          await apiPost(`/api/v1/games/${gameId}/refresh-images`);
+          successCount++;
+        }
       } catch (err) {
         const apiError = axios.isAxiosError(err) ? err.response?.data?.error : undefined;
         const apiMessage = axios.isAxiosError(err) ? err.response?.data?.message : undefined;
@@ -888,10 +893,10 @@ export class SuperAdmin {
 
         if (apiError === "missing_igdb_id") {
           skipCount++;
-          logWarn("SuperadminCommand.gamedbRefreshImages", { gameId, apiError, apiMessage });
+          logWarn("SuperadminCommand.downloadMissingImages", { gameId, apiError, apiMessage });
         } else {
           failCount++;
-          logError("SuperadminCommand.gamedbRefreshImages", {
+          logError("SuperadminCommand.downloadMissingImages", {
             gameId,
             status,
             apiError,
@@ -908,8 +913,8 @@ export class SuperAdmin {
     }
 
     await safeReply(interaction, buildTextReply(
-      `GameDB image refresh complete. ${total} games processed:` +
-        ` ${successCount} succeeded, ${skipCount} skipped (no IGDB ID on API), ${failCount} failed.`,
+      `Done. ${total} games checked:` +
+        ` ${successCount} downloaded, ${skipCount} already had images, ${failCount} failed.`,
       true,
     ));
   }


### PR DESCRIPTION
## Problems

1. `/superadmin gamedb-refresh-images` was counting `missing_igdb_id` 422s as failures and logging them at error level. These occur when the bot's local DB has an `igdb_id` but the API DB does not -- a legitimate data divergence, not a bug.
2. The command was calling refresh-images for every game regardless of whether it already had images in the API.
3. The command name didn't reflect the intent.

## Changes

**Commit 1 -- 422 handling:**
- `missing_igdb_id` 422s are counted as skips and logged at warn level
- Other errors include `status`, `apiError`, and `apiMessage` from the response body in the log

**Commit 2 -- rename + missing-only filter:**
- Renamed `/superadmin gamedb-refresh-images` to `/superadmin download-missing-images`
- Before calling refresh-images, checks `GET /api/v1/games/:id/images` and skips any game that already has images in the API
- Progress and summary messages updated to reflect the new semantics

## Test plan

- [ ] Run `/superadmin download-missing-images` -- games with existing API images should appear in the skip count
- [ ] Games without API images should be downloaded and appear in the downloaded count
- [ ] Games with `missing_igdb_id` API error should appear in skips with a warn log (not fail)
- [ ] Real failures should appear in the fail count with full context in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)