### PR TITLE
feat: use Backblaze listing to find missing game images in bulk

### DIFF
--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -58,6 +58,10 @@ import {
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { sleep } from "../utilities/DelayUtils.js";
 import { apiPost } from "../services/RpgClubApiClient.js";
+import {
+  getBackblazeBucketConfig,
+  listGameIdsWithImages,
+} from "../services/BackblazeB2Service.js";
 import { truncateDescription, truncateLabel } from "../config/textLimits.js";
 import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
@@ -864,28 +868,35 @@ export class SuperAdmin {
     const okToUseCommand = await isSuperAdmin(interaction);
     if (!okToUseCommand) return;
 
-    const gameIds = await Game.getAllGameIdsWithIgdb();
-    const total = gameIds.length;
+    await safeReply(interaction, buildTextReply("Scanning Backblaze for existing game images...", true));
+
+    const { bucketId } = getBackblazeBucketConfig();
+    const [gameIds, gamesWithImages] = await Promise.all([
+      Game.getAllGameIdsWithIgdb(),
+      listGameIdsWithImages(bucketId),
+    ]);
+
+    const missing = gameIds.filter((id) => !gamesWithImages.has(id));
+    const total = missing.length;
     let successCount = 0;
     let skipCount = 0;
     let failCount = 0;
 
     const progressText = (): string =>
-      `Downloading missing GameDB images: ${successCount + skipCount + failCount}/${total} checked` +
-      ` (${successCount} downloaded, ${skipCount} already have images, ${failCount} failed)`;
+      `Downloading missing GameDB images: ${successCount + skipCount + failCount}/${total} processed` +
+      ` (${successCount} downloaded, ${skipCount} skipped, ${failCount} failed)`;
 
-    await safeReply(interaction, buildTextReply(progressText(), true));
+    await safeReply(interaction, buildTextReply(
+      `Found ${gamesWithImages.size} games with images in Backblaze.` +
+        ` ${total} need downloading.\n\n${progressText()}`,
+      true,
+    ));
 
-    for (let i = 0; i < gameIds.length; i++) {
-      const gameId = gameIds[i];
+    for (let i = 0; i < missing.length; i++) {
+      const gameId = missing[i];
       try {
-        const existing = await Game.getGamePrimaryImageUrl(gameId);
-        if (existing) {
-          skipCount++;
-        } else {
-          await apiPost(`/api/v1/games/${gameId}/refresh-images`);
-          successCount++;
-        }
+        await apiPost(`/api/v1/games/${gameId}/refresh-images`);
+        successCount++;
       } catch (err) {
         const apiError = axios.isAxiosError(err) ? err.response?.data?.error : undefined;
         const apiMessage = axios.isAxiosError(err) ? err.response?.data?.message : undefined;
@@ -905,7 +916,7 @@ export class SuperAdmin {
         }
       }
 
-      if ((i + 1) % 10 === 0 || i === gameIds.length - 1) {
+      if ((i + 1) % 10 === 0 || i === missing.length - 1) {
         await safeReply(interaction, buildTextReply(progressText(), true));
       }
 
@@ -913,8 +924,8 @@ export class SuperAdmin {
     }
 
     await safeReply(interaction, buildTextReply(
-      `Done. ${total} games checked:` +
-        ` ${successCount} downloaded, ${skipCount} already had images, ${failCount} failed.`,
+      `Done. ${total} games processed:` +
+        ` ${successCount} downloaded, ${skipCount} skipped (no IGDB ID on API), ${failCount} failed.`,
       true,
     ));
   }

--- a/src/services/BackblazeB2Service.ts
+++ b/src/services/BackblazeB2Service.ts
@@ -47,6 +47,7 @@ type BackblazeB2ListFileNamesResponse = {
     fileName: string;
     fileInfo?: Record<string, string>;
   }>;
+  nextFileName?: string | null;
 };
 
 type BackblazeB2DownloadAuthorizationResponse = {
@@ -344,4 +345,34 @@ async function buildBackblazeDownloadUrl(
     },
   );
   return `${baseUrl}?Authorization=${encodeURIComponent(tokenResponse.data.authorizationToken)}&v=${encodeURIComponent(sourceHash)}`;
+}
+
+const GAME_ID_FROM_KEY = /^games\/(\d+)-/;
+
+export async function listGameIdsWithImages(bucketId: string): Promise<Set<number>> {
+  const auth = await authorizeBackblazeB2();
+  const gameIds = new Set<number>();
+  let startFileName: string | undefined;
+
+  do {
+    const response = await axios.post<BackblazeB2ListFileNamesResponse>(
+      `${auth.apiUrl}/b2api/v2/b2_list_file_names`,
+      {
+        bucketId,
+        maxFileCount: 10000,
+        prefix: "games/",
+        ...(startFileName ? { startFileName } : {}),
+      },
+      { headers: { Authorization: auth.authorizationToken } },
+    );
+
+    for (const file of response.data.files) {
+      const match = GAME_ID_FROM_KEY.exec(file.fileName);
+      if (match) gameIds.add(Number(match[1]));
+    }
+
+    startFileName = response.data.nextFileName ?? undefined;
+  } while (startFileName);
+
+  return gameIds;
 }


### PR DESCRIPTION
## Summary

Replaces the per-game `GET /api/v1/games/:id/images` check in `/superadmin download-missing-images` with a single paginated Backblaze bucket listing.

**Before:** N GET calls (one per game) to check for existing images, then M POST calls for missing ones.

**After:** 1-2 Backblaze `b2_list_file_names` calls (paginated, 10k files per page) + 1 local DB query run in parallel, then M POST calls only for games absent from Backblaze.

## Changes

**`BackblazeB2Service.ts`**
- Added `nextFileName` to `BackblazeB2ListFileNamesResponse` type to support pagination
- Added `listGameIdsWithImages(bucketId)` -- paginates `b2_list_file_names` under `games/` prefix, parses game IDs from object keys (`games/{id}-{slug}/...`), returns a `Set<number>`

**`superadmin.command.ts`**
- Runs `getAllGameIdsWithIgdb()` and `listGameIdsWithImages()` in parallel via `Promise.all`
- Diffs the two sets to get only games missing from Backblaze
- Reports how many already had images before starting the download loop
- Progress updates and error handling unchanged

## Test plan

- [ ] Run `/superadmin download-missing-images` -- confirm initial message shows correct counts from Backblaze scan
- [ ] Confirm only games with no Backblaze images are processed in the download loop
- [ ] Confirm pagination works correctly if there are more than 10,000 files in the bucket

🤖 Generated with [Claude Code](https://claude.com/claude-code)