### PR TITLE
fix: remove deleted force-message-width.png spacer image reference

### DIFF
--- a/src/services/GameReleaseAnnouncementService.ts
+++ b/src/services/GameReleaseAnnouncementService.ts
@@ -1,5 +1,4 @@
 import type { TextBasedChannel } from "discord.js";
-import { AttachmentBuilder } from "discord.js";
 import type { Client } from "discordx";
 import { DateTime } from "luxon";
 import GameReleaseAnnouncement, {
@@ -8,13 +7,11 @@ import GameReleaseAnnouncement, {
 import { NEW_GAME_ANNOUNCEMENT_CHANNEL_ID } from "../config/channels.js";
 import { buildGameProfileMessagePayload } from "../commands/gamedb.command.js";
 import { buildComponentsV2EditFlags } from "../functions/ComponentsV2Utils.js";
-import { resolveAssetPath } from "../functions/AssetPath.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
 
 const CHECK_INTERVAL_MS = 60_000;
 const BATCH_SIZE = 25;
 const RELEASE_SCHEDULING_ZONE = "UTC";
-const RELEASE_SPACER_IMAGE_PATH = resolveAssetPath("images", "force-message-width.png");
 
 let gameReleaseTimer: NodeJS.Timeout | null = null;
 let currentlyChecking = false;
@@ -77,10 +74,7 @@ async function checkAndSendReleaseAnnouncements(client: Client): Promise<void> {
         continue;
       }
       await channel.send({
-        files: [
-          ...payload.files,
-          new AttachmentBuilder(RELEASE_SPACER_IMAGE_PATH, { name: "force-message-width.png" }),
-        ],
+        files: payload.files,
         components: payload.components,
         flags: buildComponentsV2EditFlags(),
       });


### PR DESCRIPTION
## Summary
- Removes the `force-message-width.png` asset reference from `GameReleaseAnnouncementService`
- The file was intentionally deleted but the import, constant, and `AttachmentBuilder` usage were left behind, causing an `ENOENT` crash on every release announcement cycle
- Cleans up the unused `AttachmentBuilder` and `resolveAssetPath` imports from this file

## Test plan
- [ ] Confirm release announcement cycle no longer throws ENOENT on the desktop bot
- [ ] Verify game release announcements still send with their game image files

🤖 Generated with [Claude Code](https://claude.com/claude-code)