### PR TITLE
refactor: complete Game.ts split (issue #912)

### DIFF
--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -33,7 +33,23 @@ import {
   type PlatformApiData,
   type RegionApiData,
 } from "../functions/GameMappers.js";
-import type { HltbCacheEntry } from "./HltbCache.js";
+import type {
+  IGame,
+  IRelease,
+  IReleaseWithNames,
+  IPlatformDef,
+  IGameWithPlatforms,
+  IGameSearchResult,
+  IGameAutocompleteResult,
+  IRegionDef,
+  ICompany,
+  IGameAssociationSummary,
+  INowPlayingMember,
+  ICompletedMember,
+  ICollectionOwnerMember,
+  IMappedGameProfile,
+  GameSource,
+} from "../types/GameTypes.js";
 import {
   clearAutocompleteSearchCaches,
   autocompleteSearchCache,
@@ -59,169 +75,6 @@ import {
   updateInitialReleaseDate as _updateInitialReleaseDate,
   saveReleaseDates,
 } from "../functions/GameIgdbSync.js";
-
-// Interfaces
-export interface IGame {
-  id: number;
-  title: string;
-  description: string | null;
-  imageData: Buffer | null; // BLOB
-  thumbnailBad: boolean;
-  thumbnailApproved: boolean;
-  igdbId: number | null;
-  slug: string | null;
-  totalRating: number | null;
-  igdbUrl: string | null;
-  featuredVideoUrl: string | null;
-  initialReleaseDate: Date | null;
-  createdAt: Date;
-  updatedAt: Date;
-  coverUrl: string | null;
-}
-
-export interface IRelease {
-  id: number;
-  gameId: number;
-  platformId: number;
-  regionId: number;
-  format: "Physical" | "Digital" | null;
-  releaseDate: Date | null;
-  notes: string | null;
-}
-
-export interface IReleaseWithNames extends IRelease {
-  platformName: string | null;
-  regionName: string | null;
-}
-
-export interface IPlatformDef {
-  id: number;
-  code: string;
-  name: string;
-  abbreviation: string | null;
-  igdbPlatformId: number | null;
-}
-
-export interface IGameWithPlatforms extends IGame {
-  platforms: IPlatformDef[];
-}
-
-export interface IGameSearchResult extends IGameWithPlatforms {
-  upcomingReleaseDate: Date | null;
-  upcomingReleasePlatforms: string[];
-}
-
-export interface IGameAutocompleteResult {
-  id: number;
-  title: string;
-  initialReleaseDate: Date | null;
-}
-
-export interface IRegionDef {
-  id: number;
-  code: string;
-  name: string;
-  igdbRegionId: number | null;
-}
-
-export interface ICompany {
-  id: number;
-  name: string;
-  igdbId: number | null;
-}
-export interface IGenre {
-  id: number;
-  name: string;
-  igdbId: number | null;
-}
-export interface ITheme {
-  id: number;
-  name: string;
-  igdbId: number | null;
-}
-export interface IGameMode {
-  id: number;
-  name: string;
-  igdbId: number | null;
-}
-export interface IPerspective {
-  id: number;
-  name: string;
-  igdbId: number | null;
-}
-export interface IEngine {
-  id: number;
-  name: string;
-  igdbId: number | null;
-}
-export interface IFranchise {
-  id: number;
-  name: string;
-  igdbId: number | null;
-}
-export interface ICollection {
-  id: number;
-  name: string;
-  igdbId: number | null;
-}
-
-export interface IGameAssociationSummary {
-  gotmWins: {
-    round: number;
-    threadId: string | null;
-    redditUrl: string | null;
-    monthYear: string;
-  }[];
-  nrGotmWins: {
-    round: number;
-    threadId: string | null;
-    redditUrl: string | null;
-    monthYear: string;
-  }[];
-  gotmNominations: { round: number; userId: string; username: string }[];
-  nrGotmNominations: { round: number; userId: string; username: string }[];
-}
-
-export interface INowPlayingMember {
-  userId: string;
-  username: string | null;
-  globalName: string | null;
-  threadId: string | null;
-  addedAt: Date | null;
-}
-
-export interface ICompletedMember {
-  userId: string;
-  username: string | null;
-  globalName: string | null;
-  completionType: string;
-  completedAt: Date | null;
-  finalPlaytimeHours: number | null;
-}
-
-export interface ICollectionOwnerMember {
-  userId: string;
-  username: string | null;
-  globalName: string | null;
-}
-
-export interface IMappedGameProfile {
-  game: IGame;
-  releases: IReleaseWithNames[];
-  associations: IGameAssociationSummary;
-  nowPlayingMembers: INowPlayingMember[];
-  collectionOwners: ICollectionOwnerMember[];
-  completions: ICompletedMember[];
-  alternateVersions: IGame[];
-  threadIds: string[];
-  hltbCache: HltbCacheEntry | null;
-  primaryImageUrl: string | null;
-  series: string | null;
-  developers: string[];
-  publishers: string[];
-}
-
-export type GameSource = "API";
 
 export default class Game {
   static async createGame(

--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -10,7 +10,6 @@ import {
 } from "../db/SqlManager.js";
 import { GameSql } from "../db/sql/index.js";
 import type { IGDBGameDetails } from "../services/IGDB/IgdbService.js";
-import GameSearchSynonym from "./GameSearchSynonym.js";
 import {
   apiGet,
   apiGetRaw,
@@ -27,35 +26,12 @@ import {
 import type {
   IGame,
   IRelease,
-  IReleaseWithNames,
-  IGameSearchResult,
-  IGameAutocompleteResult,
-  ICompany,
-  IGameAssociationSummary,
-  INowPlayingMember,
-  ICompletedMember,
-  ICollectionOwnerMember,
-  IMappedGameProfile,
   GameSource,
 } from "../types/GameTypes.js";
 import {
   clearAutocompleteSearchCaches,
-  autocompleteSearchCache,
-  pendingAutocompleteSearches,
-  foldAccentE,
-  buildAutocompleteCacheKey,
-  pruneAutocompleteCache,
-  AUTOCOMPLETE_CACHE_TTL_MS,
 } from "../functions/GameAutocompleteCache.js";
-import {
-  type GameRelationsApiData,
-  type NowPlayingApiEntry,
-  type CompletionGameApiEntry,
-  type CompanyApiData,
-  type GameProfileApiData,
-  mapGameProfileFromApi,
-} from "../functions/GameProfileMapper.js";
-import GamePlatformRegionService from "./GamePlatformRegionService.js";
+import GameProfileService from "./GameProfileService.js";
 
 export default class Game {
   static async createGame(
@@ -154,7 +130,7 @@ export default class Game {
 
   static async getAlternateVersions(gameId: number): Promise<IGame[]> {
     if (!isPositiveInt(gameId)) return [];
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     if (!relations?.alternates?.length) return [];
     return relations.alternates.map(mapGameFromApi);
   }
@@ -236,7 +212,7 @@ export default class Game {
     gameId: number,
     role: string,
   ): Promise<string[]> {
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     if (!relations) return [];
     return relations.companies
       .filter((c) => c.role === role)
@@ -244,37 +220,37 @@ export default class Game {
   }
 
   static async getGameGenres(gameId: number): Promise<string[]> {
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     return (relations?.genres ?? []).map((g) => String(g.name));
   }
 
   static async getGameThemes(gameId: number): Promise<string[]> {
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     return (relations?.themes ?? []).map((g) => String(g.name));
   }
 
   static async getGameModes(gameId: number): Promise<string[]> {
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     return (relations?.modes ?? []).map((g) => String(g.name));
   }
 
   static async getGamePerspectives(gameId: number): Promise<string[]> {
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     return (relations?.perspectives ?? []).map((g) => String(g.name));
   }
 
   static async getGameEngines(gameId: number): Promise<string[]> {
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     return (relations?.engines ?? []).map((g) => String(g.name));
   }
 
   static async getGameFranchises(gameId: number): Promise<string[]> {
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     return (relations?.franchises ?? []).map((g) => String(g.name));
   }
 
   static async getGameSeries(gameId: number): Promise<string | null> {
-    const relations = await Game.getGameRelations(gameId);
+    const relations = await GameProfileService.getGameRelations(gameId);
     return relations?.collection?.name ?? null;
   }
 
@@ -305,66 +281,6 @@ export default class Game {
     return newRelease;
   }
 
-  private static async fetchAllPages<T>(
-    path: string,
-    params: Record<string, unknown> = {},
-  ): Promise<T[]> {
-    const results: T[] = [];
-    let page = 1;
-    for (;;) {
-      const result = await apiGet<{ data: T[]; meta: { next: number | null } }>(
-        path,
-        { params: { ...params, page, per: 500 } },
-      );
-      if (!result?.data?.length) break;
-      results.push(...result.data);
-      if (!result.meta?.next) break;
-      page++;
-    }
-    return results;
-  }
-
-  private static readonly relationsCache = new Map<
-    number,
-    { promise: Promise<GameRelationsApiData | null>; expires: number }
-  >();
-
-  private static readonly RELATIONS_CACHE_TTL_MS = 2000;
-
-  private static async getGameRelations(
-    gameId: number,
-  ): Promise<GameRelationsApiData | null> {
-    const now = Date.now();
-    const cached = Game.relationsCache.get(gameId);
-    if (cached && cached.expires > now) return cached.promise;
-
-    const promise = (async () => {
-      const result = await apiGet<{ data: GameRelationsApiData }>(
-        `/api/v1/games/${gameId}/relations`,
-      );
-      return result?.data ?? null;
-    })();
-    promise.catch(() => Game.relationsCache.delete(gameId));
-
-    Game.relationsCache.set(gameId, {
-      promise,
-      expires: now + Game.RELATIONS_CACHE_TTL_MS,
-    });
-    return promise;
-  }
-
-  static async getGameReleasesDetailed(
-    gameId: number,
-  ): Promise<IReleaseWithNames[]> {
-    const relations = await Game.getGameRelations(gameId);
-    if (!relations?.releases?.length) return [];
-    return relations.releases.map((r) => ({
-      ...mapReleaseFromApi(r),
-      platformName: r.platform_name ?? null,
-      regionName: r.region_name ?? null,
-    }));
-  }
-
   static async getReleaseById(id: number): Promise<IRelease | null> {
     const rows = await dbQuery(GameSql.getReleaseById, { id }, mapReleaseRow);
     return rows[0] ?? null;
@@ -376,271 +292,6 @@ export default class Game {
     );
     if (!result?.data) return [];
     return result.data.map(mapReleaseFromApi);
-  }
-
-  static async searchGamesAutocomplete(
-    query: string,
-    limit: number = 24,
-  ): Promise<IGameAutocompleteResult[]> {
-    const baseQuery = query.trim();
-    if (!baseQuery) {
-      return [];
-    }
-
-    const safeLimit = Math.min(24, Math.max(1, Math.trunc(limit) || 24));
-    const now = Date.now();
-    pruneAutocompleteCache(now);
-
-    const cacheKey = buildAutocompleteCacheKey(baseQuery, safeLimit);
-    const cached = autocompleteSearchCache.get(cacheKey);
-    if (cached && cached.expiresAt > now) {
-      return cached.results;
-    }
-    const pending = pendingAutocompleteSearches.get(cacheKey);
-    if (pending) {
-      return pending;
-    }
-
-    const lowerQuery = baseQuery.toLowerCase();
-    const foldedLowerQuery = foldAccentE(lowerQuery).toLowerCase();
-    const normalizedQuery = foldedLowerQuery.replace(/[^a-z0-9]/g, "");
-    if (!normalizedQuery && !/[a-z0-9]/.test(foldedLowerQuery)) {
-      return [];
-    }
-
-    const queryPromise = dbWithConnection(async (conn) => {
-      const titleFoldExpr = `REPLACE(REPLACE(REPLACE(REPLACE(LOWER(title), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')`;
-      const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '', 'g')`;
-
-      const binds = {
-        exactRaw: foldedLowerQuery,
-        rawPrefix: `${foldedLowerQuery}%`,
-        rawContains: `%${foldedLowerQuery}%`,
-        exactNorm: normalizedQuery || null,
-        normPrefix: normalizedQuery ? `${normalizedQuery}%` : null,
-        normContains: normalizedQuery ? `%${normalizedQuery}%` : null,
-        limit: safeLimit,
-      };
-
-      const games = await dbQueryConn(
-        conn,
-        GameSql.searchGamesAutocomplete(titleFoldExpr, titleNormExpr),
-        binds,
-        (row: any): IGameAutocompleteResult => {
-          const ird = row.INITIAL_RELEASE_DATE ?? row.initial_release_date;
-          return {
-            id: Number(row.GAME_ID ?? row.game_id),
-            title: String(row.TITLE ?? row.title),
-            initialReleaseDate:
-              ird instanceof Date ? ird : ird ? new Date(ird) : null,
-          };
-        },
-      );
-
-      autocompleteSearchCache.set(cacheKey, {
-        expiresAt: Date.now() + AUTOCOMPLETE_CACHE_TTL_MS,
-        results: games,
-      });
-      pruneAutocompleteCache(Date.now());
-
-      return games;
-    });
-
-    pendingAutocompleteSearches.set(cacheKey, queryPromise);
-    try {
-      return await queryPromise;
-    } finally {
-      pendingAutocompleteSearches.delete(cacheKey);
-    }
-  }
-
-  static async getAllCompanies(): Promise<ICompany[]> {
-    const rows = await Game.fetchAllPages<CompanyApiData>("/api/v1/companies");
-    return rows.map((d) => ({
-      id: Number(d.company_id),
-      name: String(d.name),
-      igdbId: d.igdb_company_id != null ? Number(d.igdb_company_id) : null,
-    }));
-  }
-
-  static async getCompanyById(id: number): Promise<ICompany | null> {
-    const result = await apiGet<{ data: CompanyApiData }>(`/api/v1/companies/${id}`);
-    if (!result?.data) return null;
-    return {
-      id: Number(result.data.company_id),
-      name: String(result.data.name),
-      igdbId: result.data.igdb_company_id != null ? Number(result.data.igdb_company_id) : null,
-    };
-  }
-
-  static async searchGames(
-    query: string,
-    filters: {
-      upcomingRelease?: boolean;
-      platformId?: number;
-      year?: number;
-      developerId?: number;
-      publisherId?: number;
-    } = {},
-  ): Promise<IGameSearchResult[]> {
-    return dbWithConnection(async (connection) => {
-      const baseQuery = query.trim();
-      const hasFilters =
-        filters.upcomingRelease ||
-        filters.platformId ||
-        filters.year ||
-        filters.developerId ||
-        filters.publisherId;
-      if (!baseQuery && !hasFilters) {
-        return [];
-      }
-
-      const titleFoldExpr = `REPLACE(REPLACE(REPLACE(REPLACE(LOWER(title), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')`;
-      const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '', 'g')`;
-
-      const clauses: string[] = [];
-      const binds: Record<string, string | number> = {};
-
-      if (baseQuery) {
-        const queryVariants = new Set<string>();
-        queryVariants.add(baseQuery);
-        const spacedQuery = baseQuery
-          .replace(/([a-zA-Z])(\d)/g, "$1 $2")
-          .replace(/(\d)([a-zA-Z])/g, "$1 $2");
-        queryVariants.add(spacedQuery);
-
-        const tokens = spacedQuery.split(/\s+/).filter(Boolean);
-        const tokenOptions: string[][] = [];
-        for (const token of tokens) {
-          const options = new Set<string>();
-          options.add(token);
-          const tokenSynonyms = await GameSearchSynonym.getTermsForQuery(token);
-          tokenSynonyms.forEach((synonym) => {
-            if (synonym.trim()) {
-              options.add(synonym.trim());
-            }
-          });
-          tokenOptions.push(Array.from(options));
-        }
-
-        if (tokenOptions.length) {
-          let variants: string[] = [""];
-          const MAX_VARIANTS = 50;
-          for (const options of tokenOptions) {
-            const nextVariants: string[] = [];
-            for (const prefix of variants) {
-              for (const option of options) {
-                const next = prefix ? `${prefix} ${option}` : option;
-                nextVariants.push(next);
-                if (nextVariants.length >= MAX_VARIANTS) break;
-              }
-              if (nextVariants.length >= MAX_VARIANTS) break;
-            }
-            variants = nextVariants;
-            if (variants.length >= MAX_VARIANTS) break;
-          }
-          variants.forEach((variant) => queryVariants.add(variant));
-        }
-
-        const termSet = new Map<string, string>();
-        Array.from(queryVariants).forEach((term) => {
-          const folded = foldAccentE(term).toLowerCase();
-          const norm = folded.replace(/[^a-z0-9]/g, "");
-          if (norm) {
-            termSet.set(norm, folded);
-          }
-        });
-
-        if (!termSet.size) {
-          return [];
-        }
-
-        Array.from(termSet.entries()).forEach(([norm, term], index) => {
-          const rawKey = `searchQuery${index}`;
-          const normKey = `normalizedQuery${index}`;
-          binds[rawKey] = `%${term}%`;
-          binds[normKey] = `%${norm}%`;
-          clauses.push(
-            `(${titleFoldExpr} LIKE :${rawKey} OR ${titleNormExpr} LIKE :${normKey})`,
-          );
-        });
-      }
-
-      const filterClauses: string[] = [];
-      if (filters.upcomingRelease) {
-        filterClauses.push("u.upcoming_date IS NOT NULL");
-      }
-      if (filters.platformId) {
-        filterClauses.push(
-          "g.game_id IN (SELECT game_id FROM gamedb_game_platforms WHERE platform_id = :filterPlatformId)",
-        );
-        binds["filterPlatformId"] = filters.platformId;
-      }
-      if (filters.year) {
-        filterClauses.push(
-          "EXTRACT(YEAR FROM g.initial_release_date) = :filterYear",
-        );
-        binds["filterYear"] = filters.year;
-      }
-      if (filters.developerId) {
-        filterClauses.push(
-          `g.game_id IN (SELECT game_id FROM gamedb_game_companies WHERE company_id = :filterDeveloperId AND role = 'Developer')`,
-        );
-        binds["filterDeveloperId"] = filters.developerId;
-      }
-      if (filters.publisherId) {
-        filterClauses.push(
-          `g.game_id IN (SELECT game_id FROM gamedb_game_companies WHERE company_id = :filterPublisherId AND role = 'Publisher')`,
-        );
-        binds["filterPublisherId"] = filters.publisherId;
-      }
-
-      const titlePart = clauses.length ? `(${clauses.join(" OR ")})` : "";
-      const filterPart = filterClauses.length
-        ? `(${filterClauses.join(" AND ")})`
-        : "";
-      const whereClause =
-        titlePart && filterPart
-          ? `${titlePart} AND ${filterPart}`
-          : titlePart || filterPart || "1=0";
-
-      const upcomingCol = "u.upcoming_date";
-      const orderPrefix = filters.upcomingRelease
-        ? `${upcomingCol} ASC NULLS LAST, `
-        : "";
-
-      const entry = GameSql.searchGames(whereClause, orderPrefix);
-
-      const upcomingDates = new Map<number, Date | null>();
-      const upcomingPlatforms = new Map<number, string[]>();
-
-      const rows = await dbQueryConn(connection, entry, binds, (row: any) => {
-        const id = Number(row.game_id);
-        const urd = row.upcoming_release_date;
-        upcomingDates.set(
-          id,
-          urd instanceof Date ? urd : urd ? new Date(urd) : null,
-        );
-        upcomingPlatforms.set(
-          id,
-          row.upcoming_platforms
-            ? String(row.upcoming_platforms)
-                .split(",")
-                .map((s: string) => s.trim())
-                .filter(Boolean)
-            : [],
-        );
-        return mapGameRow(row);
-      });
-      const games: IGame[] = rows;
-
-      const withPlatforms = await GamePlatformRegionService.attachPlatformsToGames(games);
-      return withPlatforms.map((g) => ({
-        ...g,
-        upcomingReleaseDate: upcomingDates.get(g.id) ?? null,
-        upcomingReleasePlatforms: upcomingPlatforms.get(g.id) ?? [],
-      }));
-    });
   }
 
   static async getGamesForAudit(
@@ -815,128 +466,4 @@ export default class Game {
     await dbMutate(GameSql.touchGameUpdatedAt, { gameId });
   }
 
-  static async getGameAssociations(
-    gameId: number,
-  ): Promise<IGameAssociationSummary> {
-    type WinRow = {
-      ROUND_NUMBER: number;
-      THREAD_ID: string | null;
-      REDDIT_URL: string | null;
-      MONTH_YEAR: string;
-    };
-    type NomRow = {
-      ROUND_NUMBER: number;
-      USER_ID: string;
-      USERNAME?: string | null;
-      GLOBAL_NAME?: string | null;
-    };
-
-    const [gotmWins, nrGotmWins, gotmNominations, nrGotmNominations] =
-      await Promise.all([
-        dbQuery<
-          WinRow,
-          {
-            round: number;
-            threadId: string | null;
-            redditUrl: string | null;
-            monthYear: string;
-          }
-        >(GameSql.getGotmWins, { gameId }, (row) => ({
-          round: Number(row.ROUND_NUMBER),
-          threadId: row.THREAD_ID ?? null,
-          redditUrl: row.REDDIT_URL ?? null,
-          monthYear: String(row.MONTH_YEAR),
-        })),
-        dbQuery<
-          WinRow,
-          {
-            round: number;
-            threadId: string | null;
-            redditUrl: string | null;
-            monthYear: string;
-          }
-        >(GameSql.getNrGotmWins, { gameId }, (row) => ({
-          round: Number(row.ROUND_NUMBER),
-          threadId: row.THREAD_ID ?? null,
-          redditUrl: row.REDDIT_URL ?? null,
-          monthYear: String(row.MONTH_YEAR),
-        })),
-        dbQuery<NomRow, { round: number; userId: string; username: string }>(
-          GameSql.getGotmNominations,
-          { gameId },
-          (row) => ({
-            round: Number(row.ROUND_NUMBER),
-            userId: String(row.USER_ID),
-            username: String(row.GLOBAL_NAME || row.USERNAME || row.USER_ID),
-          }),
-        ),
-        dbQuery<NomRow, { round: number; userId: string; username: string }>(
-          GameSql.getNrGotmNominations,
-          { gameId },
-          (row) => ({
-            round: Number(row.ROUND_NUMBER),
-            userId: String(row.USER_ID),
-            username: String(row.GLOBAL_NAME || row.USERNAME || row.USER_ID),
-          }),
-        ),
-      ]);
-
-    return { gotmWins, nrGotmWins, gotmNominations, nrGotmNominations };
-  }
-
-  static async getNowPlayingMembers(
-    gameId: number,
-  ): Promise<INowPlayingMember[]> {
-    const rows = await Game.fetchAllPages<NowPlayingApiEntry>(
-      `/api/v1/games/${gameId}/now_playing`,
-    );
-    return rows.map((d) => ({
-      userId: String(d.user_id),
-      username: d.user?.username ?? null,
-      globalName: d.user?.global_name ?? null,
-      threadId: null,
-      addedAt: null,
-    }));
-  }
-
-  static async getGameCompletions(gameId: number): Promise<ICompletedMember[]> {
-    const rows = await Game.fetchAllPages<CompletionGameApiEntry>(
-      `/api/v1/games/${gameId}/completions`,
-    );
-    return rows.map((d) => ({
-      userId: String(d.user_id),
-      username: d.user?.username ?? null,
-      globalName: d.user?.global_name ?? null,
-      completionType: String(d.completion_type),
-      completedAt: d.completed_at ? new Date(d.completed_at) : null,
-      finalPlaytimeHours: d.final_playtime_hrs != null ? Number(d.final_playtime_hrs) : null,
-    }));
-  }
-
-  static async getGameCollectionOwners(
-    gameId: number,
-  ): Promise<ICollectionOwnerMember[]> {
-    return dbQuery(
-      GameSql.getGameCollectionOwners,
-      { gameId },
-      (row: {
-        USER_ID: string;
-        USERNAME: string | null;
-        GLOBAL_NAME: string | null;
-      }) => ({
-        userId: String(row.USER_ID),
-        username: row.USERNAME ?? null,
-        globalName: row.GLOBAL_NAME ?? null,
-      }),
-    );
-  }
-
-  static async getGameProfile(gameId: number): Promise<IMappedGameProfile | null> {
-    const result = await apiGet<{ data: GameProfileApiData }>(
-      `/api/v1/games/${gameId}/profile`,
-    );
-    const d = result?.data;
-    if (!d) return null;
-    return mapGameProfileFromApi(d, gameId);
-  }
 }

--- a/src/classes/Game.ts
+++ b/src/classes/Game.ts
@@ -17,31 +17,19 @@ import {
   type ApiGetRawMeta,
 } from "../services/RpgClubApiClient.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
-import { logError, logWarn } from "../utilities/LogUtils.js";
 import {
   mapGameFromApi,
   mapGameRow,
   mapReleaseRow,
   mapReleaseFromApi,
-  mapPlatformDefRow,
-  mapPlatformFromApi,
-  mapRegionDefRow,
-  mapRegionFromApi,
-  buildPlatformCode,
-  IGDB_REGION_MAP,
   type ReleaseApiData,
-  type PlatformApiData,
-  type RegionApiData,
 } from "../functions/GameMappers.js";
 import type {
   IGame,
   IRelease,
   IReleaseWithNames,
-  IPlatformDef,
-  IGameWithPlatforms,
   IGameSearchResult,
   IGameAutocompleteResult,
-  IRegionDef,
   ICompany,
   IGameAssociationSummary,
   INowPlayingMember,
@@ -67,14 +55,7 @@ import {
   type GameProfileApiData,
   mapGameProfileFromApi,
 } from "../functions/GameProfileMapper.js";
-import {
-  importGameFromIgdb as _importGameFromIgdb,
-  importReleaseDatesFromIgdb as _importReleaseDatesFromIgdb,
-  saveFullGameMetadata as _saveFullGameMetadata,
-  addGamePlatformsByIgdbIds as _addGamePlatformsByIgdbIds,
-  updateInitialReleaseDate as _updateInitialReleaseDate,
-  saveReleaseDates,
-} from "../functions/GameIgdbSync.js";
+import GamePlatformRegionService from "./GamePlatformRegionService.js";
 
 export default class Game {
   static async createGame(
@@ -241,80 +222,6 @@ export default class Game {
     return `https://www.youtube.com/watch?v=${videoId}`;
   }
 
-  static async importGameFromIgdb(
-    igdbId: number,
-  ): Promise<{ gameId: number; title: string }> {
-    return _importGameFromIgdb(igdbId);
-  }
-
-  static async importReleaseDatesFromIgdb(
-    gameId: number,
-    igdbId: number,
-  ): Promise<void> {
-    return _importReleaseDatesFromIgdb(gameId, igdbId);
-  }
-
-  static async saveFullGameMetadata(
-    gameId: number,
-    details: IGDBGameDetails,
-  ): Promise<void> {
-    return _saveFullGameMetadata(gameId, details);
-  }
-
-  static async updateInitialReleaseDate(gameId: number): Promise<void> {
-    return _updateInitialReleaseDate(gameId);
-  }
-
-  static async ensurePlatform(igdbPlatform: {
-    id: number;
-    name: string | null;
-  }): Promise<IPlatformDef | null> {
-    const existing = await Game.getPlatformByIgdbId(igdbPlatform.id);
-    if (existing) {
-      return existing;
-    }
-
-    try {
-      await dbMutate(GameSql.insertPlatform, {
-        code: buildPlatformCode(igdbPlatform.name, igdbPlatform.id),
-        name: igdbPlatform.name ?? `IGDB Platform ${igdbPlatform.id}`,
-        igdbId: igdbPlatform.id,
-      });
-      return Game.getPlatformByIgdbId(igdbPlatform.id);
-    } catch (err) {
-      logError("Game.insertPlatform", err);
-      return null;
-    }
-  }
-
-  static async ensureRegion(igdbRegionId: number): Promise<IRegionDef | null> {
-    const existing = await Game.getRegionByIgdbId(igdbRegionId);
-    if (existing) {
-      return existing;
-    }
-
-    const regionConfig = IGDB_REGION_MAP[igdbRegionId];
-    if (!regionConfig) {
-      return null;
-    }
-
-    try {
-      const regionId = await dbInsert(
-        GameSql.insertRegion,
-        {
-          code: regionConfig.code,
-          name: regionConfig.name,
-          igdbId: igdbRegionId,
-        },
-        "id",
-      );
-      return Game.getRegionById(regionId);
-    } catch (err) {
-      logError("Game.insertRegion", err);
-      return null;
-    }
-  }
-
   // --- Getters for View ---
 
   static async getGameDevelopers(gameId: number): Promise<string[]> {
@@ -469,198 +376,6 @@ export default class Game {
     );
     if (!result?.data) return [];
     return result.data.map(mapReleaseFromApi);
-  }
-
-  static async getPlatformsForGame(gameId: number): Promise<IPlatformDef[]> {
-    return dbQuery(GameSql.getPlatformsForGame, { gameId }, mapPlatformDefRow);
-  }
-
-  static async getAllPlatforms(): Promise<IPlatformDef[]> {
-    return dbQuery(GameSql.getAllPlatforms, {}, mapPlatformDefRow);
-  }
-
-  static async getPlatformsByIgdbIds(
-    igdbIds: number[],
-  ): Promise<Map<number, IPlatformDef>> {
-    const uniqueIds = Array.from(new Set(igdbIds.filter(isPositiveInt)));
-    if (!uniqueIds.length) {
-      return new Map();
-    }
-
-    const binds: Record<string, number> = {};
-    const placeholders: string[] = [];
-    uniqueIds.forEach((id, idx) => {
-      const key = `id${idx}`;
-      binds[key] = id;
-      placeholders.push(`:${key}`);
-    });
-
-    const platforms = await dbQuery(
-      GameSql.getPlatformsByIgdbIds(placeholders.join(", ")),
-      binds,
-      mapPlatformDefRow,
-    );
-    const map = new Map<number, IPlatformDef>();
-    platforms.forEach((platform) => {
-      if (platform.igdbPlatformId) map.set(platform.igdbPlatformId, platform);
-    });
-    return map;
-  }
-
-  static async getPlatformsForGameWithStandard(
-    gameId: number,
-    standardPlatformIds: number[],
-  ): Promise<IPlatformDef[]> {
-    const gamePlatforms = await Game.getPlatformsForGame(gameId);
-    const allPlatforms = await Game.getAllPlatforms();
-    const byId = new Map(
-      allPlatforms.map((platform) => [platform.id, platform]),
-    );
-    const seen = new Set<number>();
-    const merged: IPlatformDef[] = [];
-
-    for (const platform of gamePlatforms) {
-      const full = byId.get(platform.id) ?? platform;
-      if (!seen.has(platform.id)) {
-        merged.push(full);
-        seen.add(platform.id);
-      }
-    }
-
-    const extra = standardPlatformIds
-      .filter((id) => !seen.has(id))
-      .map((id) => byId.get(id))
-      .filter((platform): platform is IPlatformDef => Boolean(platform));
-
-    extra.sort((a, b) => a.name.localeCompare(b.name));
-    merged.push(...extra);
-
-    return merged;
-  }
-
-  static async getPlatformByCode(code: string): Promise<IPlatformDef | null> {
-    const rows = await dbQuery(
-      GameSql.getPlatformByCode,
-      { code },
-      mapPlatformDefRow,
-    );
-    return rows[0] ?? null;
-  }
-
-  static async getPlatformById(id: number): Promise<IPlatformDef | null> {
-    const result = await apiGet<{ data: PlatformApiData }>(`/api/v1/platforms/${id}`);
-    if (!result?.data) return null;
-    return mapPlatformFromApi(result.data);
-  }
-
-  static async attachPlatformsToGames(
-    games: IGame[],
-  ): Promise<IGameWithPlatforms[]> {
-    const gameIds = Array.from(
-      new Set(games.map((game) => game.id).filter(isPositiveInt)),
-    );
-    if (!gameIds.length) {
-      return games.map((game) => ({ ...game, platforms: [] }));
-    }
-
-    const binds: Record<string, number> = {};
-    const placeholders: string[] = [];
-    gameIds.forEach((id, idx) => {
-      const key = `id${idx}`;
-      binds[key] = id;
-      placeholders.push(`:${key}`);
-    });
-
-    const gameToPlatforms = new Map<number, IPlatformDef[]>();
-    const missingPlatformIds = new Set<number>();
-
-    const rows = await dbQuery(
-      GameSql.attachPlatformsToGames(placeholders.join(", ")),
-      binds,
-      (row: {
-        GAME_ID: number;
-        PLATFORM_ID: number;
-        PLATFORM_CODE: string | null;
-        PLATFORM_NAME: string | null;
-        PLATFORM_ABBREVIATION: string | null;
-        IGDB_PLATFORM_ID: number | null;
-      }) => row,
-    );
-
-    rows.forEach((row) => {
-      const gameId = Number(row.GAME_ID);
-      const platformId = Number(row.PLATFORM_ID);
-      if (!Number.isInteger(gameId) || !Number.isInteger(platformId)) return;
-      if (!row.PLATFORM_NAME || !row.PLATFORM_CODE) {
-        missingPlatformIds.add(platformId);
-        return;
-      }
-      const platform: IPlatformDef = {
-        id: platformId,
-        code: String(row.PLATFORM_CODE),
-        name: String(row.PLATFORM_NAME),
-        abbreviation: row.PLATFORM_ABBREVIATION
-          ? String(row.PLATFORM_ABBREVIATION)
-          : null,
-        igdbPlatformId: row.IGDB_PLATFORM_ID
-          ? Number(row.IGDB_PLATFORM_ID)
-          : null,
-      };
-      if (!gameToPlatforms.has(gameId)) gameToPlatforms.set(gameId, []);
-      gameToPlatforms.get(gameId)!.push(platform);
-    });
-
-    if (missingPlatformIds.size) {
-      logWarn(
-        "Game.getPlatformsByIgdbIds",
-        `Missing platform IDs in GAMEDB_PLATFORMS: ${Array.from(missingPlatformIds).join(", ")}`,
-      );
-    }
-
-    return games.map((game) => ({
-      ...game,
-      platforms: gameToPlatforms.get(game.id) ?? [],
-    }));
-  }
-
-  static async getPlatformByIgdbId(
-    igdbId: number,
-  ): Promise<IPlatformDef | null> {
-    const rows = await dbQuery(
-      GameSql.getPlatformByIgdbId,
-      { igdbId },
-      mapPlatformDefRow,
-    );
-    return rows[0] ?? null;
-  }
-
-  static async getAllRegions(): Promise<IRegionDef[]> {
-    const rows = await Game.fetchAllPages<RegionApiData>("/api/v1/regions");
-    return rows.map(mapRegionFromApi);
-  }
-
-  static async getRegionByCode(code: string): Promise<IRegionDef | null> {
-    const rows = await dbQuery(
-      GameSql.getRegionByCode,
-      { code },
-      mapRegionDefRow,
-    );
-    return rows[0] ?? null;
-  }
-
-  static async getRegionById(id: number): Promise<IRegionDef | null> {
-    const result = await apiGet<{ data: RegionApiData }>(`/api/v1/regions/${id}`);
-    if (!result?.data) return null;
-    return mapRegionFromApi(result.data);
-  }
-
-  static async getRegionByIgdbId(igdbId: number): Promise<IRegionDef | null> {
-    const rows = await dbQuery(
-      GameSql.getRegionByIgdbId,
-      { igdbId },
-      mapRegionDefRow,
-    );
-    return rows[0] ?? null;
   }
 
   static async searchGamesAutocomplete(
@@ -919,20 +634,13 @@ export default class Game {
       });
       const games: IGame[] = rows;
 
-      const withPlatforms = await Game.attachPlatformsToGames(games);
+      const withPlatforms = await GamePlatformRegionService.attachPlatformsToGames(games);
       return withPlatforms.map((g) => ({
         ...g,
         upcomingReleaseDate: upcomingDates.get(g.id) ?? null,
         upcomingReleasePlatforms: upcomingPlatforms.get(g.id) ?? [],
       }));
     });
-  }
-
-  static async addGamePlatformsByIgdbIds(
-    gameId: number,
-    igdbPlatformIds: number[],
-  ): Promise<void> {
-    return _addGamePlatformsByIgdbIds(gameId, igdbPlatformIds);
   }
 
   static async getGamesForAudit(
@@ -1101,35 +809,6 @@ export default class Game {
     description: string | null,
   ): Promise<void> {
     await dbMutate(GameSql.updateGameDescription, { description, gameId });
-  }
-
-  static async clearReleaseDates(
-    gameId: number,
-  ): Promise<{ releases: number; announcements: number }> {
-    return dbTransaction(async (conn) => {
-      const announceCount = await dbMutateConn(
-        conn,
-        GameSql.clearReleaseAnnouncements,
-        { gameId },
-      );
-      const releaseCount = await dbMutateConn(conn, GameSql.clearReleases, {
-        gameId,
-      });
-      await dbMutateConn(conn, GameSql.clearInitialReleaseDate, { gameId });
-      return {
-        releases: Number(releaseCount),
-        announcements: Number(announceCount),
-      };
-    });
-  }
-
-  static async refreshReleaseDates(
-    gameId: number,
-    releases: NonNullable<IGDBGameDetails["release_dates"]>,
-  ): Promise<void> {
-    await Game.clearReleaseDates(gameId);
-    if (!releases.length) return;
-    await saveReleaseDates(gameId, releases);
   }
 
   static async touchGameUpdatedAt(gameId: number): Promise<void> {

--- a/src/classes/GamePlatformRegionService.ts
+++ b/src/classes/GamePlatformRegionService.ts
@@ -1,0 +1,316 @@
+import {
+  dbQuery,
+  dbMutate,
+  dbInsert,
+  dbTransaction,
+  dbMutateConn,
+} from "../db/SqlManager.js";
+import { GameSql } from "../db/sql/index.js";
+import {
+  mapPlatformDefRow,
+  mapPlatformFromApi,
+  mapRegionDefRow,
+  mapRegionFromApi,
+  buildPlatformCode,
+  IGDB_REGION_MAP,
+  type PlatformApiData,
+  type RegionApiData,
+} from "../functions/GameMappers.js";
+import type { IPlatformDef, IRegionDef, IGame, IGameWithPlatforms } from "../types/GameTypes.js";
+import { apiGet } from "../services/RpgClubApiClient.js";
+import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { logError, logWarn } from "../utilities/LogUtils.js";
+
+export default class GamePlatformRegionService {
+  private static async fetchAllPages<T>(
+    path: string,
+    params: Record<string, unknown> = {},
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+    for (;;) {
+      const result = await apiGet<{ data: T[]; meta: { next: number | null } }>(
+        path,
+        { params: { ...params, page, per: 500 } },
+      );
+      if (!result?.data?.length) break;
+      results.push(...result.data);
+      if (!result.meta?.next) break;
+      page++;
+    }
+    return results;
+  }
+
+  static async ensurePlatform(igdbPlatform: {
+    id: number;
+    name: string | null;
+  }): Promise<IPlatformDef | null> {
+    const existing = await GamePlatformRegionService.getPlatformByIgdbId(igdbPlatform.id);
+    if (existing) {
+      return existing;
+    }
+
+    try {
+      await dbMutate(GameSql.insertPlatform, {
+        code: buildPlatformCode(igdbPlatform.name, igdbPlatform.id),
+        name: igdbPlatform.name ?? `IGDB Platform ${igdbPlatform.id}`,
+        igdbId: igdbPlatform.id,
+      });
+      return GamePlatformRegionService.getPlatformByIgdbId(igdbPlatform.id);
+    } catch (err) {
+      logError("GamePlatformRegionService.insertPlatform", err);
+      return null;
+    }
+  }
+
+  static async ensureRegion(igdbRegionId: number): Promise<IRegionDef | null> {
+    const existing = await GamePlatformRegionService.getRegionByIgdbId(igdbRegionId);
+    if (existing) {
+      return existing;
+    }
+
+    const regionConfig = IGDB_REGION_MAP[igdbRegionId];
+    if (!regionConfig) {
+      return null;
+    }
+
+    try {
+      const regionId = await dbInsert(
+        GameSql.insertRegion,
+        {
+          code: regionConfig.code,
+          name: regionConfig.name,
+          igdbId: igdbRegionId,
+        },
+        "id",
+      );
+      return GamePlatformRegionService.getRegionById(regionId);
+    } catch (err) {
+      logError("GamePlatformRegionService.insertRegion", err);
+      return null;
+    }
+  }
+
+  static async getPlatformsForGame(gameId: number): Promise<IPlatformDef[]> {
+    return dbQuery(GameSql.getPlatformsForGame, { gameId }, mapPlatformDefRow);
+  }
+
+  static async getAllPlatforms(): Promise<IPlatformDef[]> {
+    return dbQuery(GameSql.getAllPlatforms, {}, mapPlatformDefRow);
+  }
+
+  static async getPlatformsByIgdbIds(
+    igdbIds: number[],
+  ): Promise<Map<number, IPlatformDef>> {
+    const uniqueIds = Array.from(new Set(igdbIds.filter(isPositiveInt)));
+    if (!uniqueIds.length) {
+      return new Map();
+    }
+
+    const binds: Record<string, number> = {};
+    const placeholders: string[] = [];
+    uniqueIds.forEach((id, idx) => {
+      const key = `id${idx}`;
+      binds[key] = id;
+      placeholders.push(`:${key}`);
+    });
+
+    const platforms = await dbQuery(
+      GameSql.getPlatformsByIgdbIds(placeholders.join(", ")),
+      binds,
+      mapPlatformDefRow,
+    );
+    const map = new Map<number, IPlatformDef>();
+    platforms.forEach((platform) => {
+      if (platform.igdbPlatformId) map.set(platform.igdbPlatformId, platform);
+    });
+    return map;
+  }
+
+  static async getPlatformsForGameWithStandard(
+    gameId: number,
+    standardPlatformIds: number[],
+  ): Promise<IPlatformDef[]> {
+    const gamePlatforms = await GamePlatformRegionService.getPlatformsForGame(gameId);
+    const allPlatforms = await GamePlatformRegionService.getAllPlatforms();
+    const byId = new Map(
+      allPlatforms.map((platform) => [platform.id, platform]),
+    );
+    const seen = new Set<number>();
+    const merged: IPlatformDef[] = [];
+
+    for (const platform of gamePlatforms) {
+      const full = byId.get(platform.id) ?? platform;
+      if (!seen.has(platform.id)) {
+        merged.push(full);
+        seen.add(platform.id);
+      }
+    }
+
+    const extra = standardPlatformIds
+      .filter((id) => !seen.has(id))
+      .map((id) => byId.get(id))
+      .filter((platform): platform is IPlatformDef => Boolean(platform));
+
+    extra.sort((a, b) => a.name.localeCompare(b.name));
+    merged.push(...extra);
+
+    return merged;
+  }
+
+  static async getPlatformByCode(code: string): Promise<IPlatformDef | null> {
+    const rows = await dbQuery(
+      GameSql.getPlatformByCode,
+      { code },
+      mapPlatformDefRow,
+    );
+    return rows[0] ?? null;
+  }
+
+  static async getPlatformById(id: number): Promise<IPlatformDef | null> {
+    const result = await apiGet<{ data: PlatformApiData }>(`/api/v1/platforms/${id}`);
+    if (!result?.data) return null;
+    return mapPlatformFromApi(result.data);
+  }
+
+  static async attachPlatformsToGames(
+    games: IGame[],
+  ): Promise<IGameWithPlatforms[]> {
+    const gameIds = Array.from(
+      new Set(games.map((game) => game.id).filter(isPositiveInt)),
+    );
+    if (!gameIds.length) {
+      return games.map((game) => ({ ...game, platforms: [] }));
+    }
+
+    const binds: Record<string, number> = {};
+    const placeholders: string[] = [];
+    gameIds.forEach((id, idx) => {
+      const key = `id${idx}`;
+      binds[key] = id;
+      placeholders.push(`:${key}`);
+    });
+
+    const gameToPlatforms = new Map<number, IPlatformDef[]>();
+    const missingPlatformIds = new Set<number>();
+
+    const rows = await dbQuery(
+      GameSql.attachPlatformsToGames(placeholders.join(", ")),
+      binds,
+      (row: {
+        GAME_ID: number;
+        PLATFORM_ID: number;
+        PLATFORM_CODE: string | null;
+        PLATFORM_NAME: string | null;
+        PLATFORM_ABBREVIATION: string | null;
+        IGDB_PLATFORM_ID: number | null;
+      }) => row,
+    );
+
+    rows.forEach((row) => {
+      const gameId = Number(row.GAME_ID);
+      const platformId = Number(row.PLATFORM_ID);
+      if (!Number.isInteger(gameId) || !Number.isInteger(platformId)) return;
+      if (!row.PLATFORM_NAME || !row.PLATFORM_CODE) {
+        missingPlatformIds.add(platformId);
+        return;
+      }
+      const platform: IPlatformDef = {
+        id: platformId,
+        code: String(row.PLATFORM_CODE),
+        name: String(row.PLATFORM_NAME),
+        abbreviation: row.PLATFORM_ABBREVIATION
+          ? String(row.PLATFORM_ABBREVIATION)
+          : null,
+        igdbPlatformId: row.IGDB_PLATFORM_ID
+          ? Number(row.IGDB_PLATFORM_ID)
+          : null,
+      };
+      if (!gameToPlatforms.has(gameId)) gameToPlatforms.set(gameId, []);
+      gameToPlatforms.get(gameId)!.push(platform);
+    });
+
+    if (missingPlatformIds.size) {
+      logWarn(
+        "GamePlatformRegionService.attachPlatformsToGames",
+        `Missing platform IDs in GAMEDB_PLATFORMS: ${Array.from(missingPlatformIds).join(", ")}`,
+      );
+    }
+
+    return games.map((game) => ({
+      ...game,
+      platforms: gameToPlatforms.get(game.id) ?? [],
+    }));
+  }
+
+  static async getPlatformByIgdbId(
+    igdbId: number,
+  ): Promise<IPlatformDef | null> {
+    const rows = await dbQuery(
+      GameSql.getPlatformByIgdbId,
+      { igdbId },
+      mapPlatformDefRow,
+    );
+    return rows[0] ?? null;
+  }
+
+  static async getAllRegions(): Promise<IRegionDef[]> {
+    const rows = await GamePlatformRegionService.fetchAllPages<RegionApiData>("/api/v1/regions");
+    return rows.map(mapRegionFromApi);
+  }
+
+  static async getRegionByCode(code: string): Promise<IRegionDef | null> {
+    const rows = await dbQuery(
+      GameSql.getRegionByCode,
+      { code },
+      mapRegionDefRow,
+    );
+    return rows[0] ?? null;
+  }
+
+  static async getRegionById(id: number): Promise<IRegionDef | null> {
+    const result = await apiGet<{ data: RegionApiData }>(`/api/v1/regions/${id}`);
+    if (!result?.data) return null;
+    return mapRegionFromApi(result.data);
+  }
+
+  static async getRegionByIgdbId(igdbId: number): Promise<IRegionDef | null> {
+    const rows = await dbQuery(
+      GameSql.getRegionByIgdbId,
+      { igdbId },
+      mapRegionDefRow,
+    );
+    return rows[0] ?? null;
+  }
+
+  static async addGamePlatformsByIgdbIds(
+    gameId: number,
+    igdbPlatformIds: number[],
+  ): Promise<void> {
+    if (!isPositiveInt(gameId)) return;
+    const uniqueIds = Array.from(
+      new Set(igdbPlatformIds.filter(isPositiveInt)),
+    );
+    if (!uniqueIds.length) return;
+
+    const platformMap = await GamePlatformRegionService.getPlatformsByIgdbIds(uniqueIds);
+    const missingIds = uniqueIds.filter((id) => !platformMap.has(id));
+    if (missingIds.length) {
+      logWarn(
+        "GamePlatformRegionService.addGamePlatformsByIgdbIds",
+        `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingIds.join(", ")}`,
+      );
+    }
+
+    await dbTransaction(async (conn) => {
+      for (const igdbId of uniqueIds) {
+        const platform = platformMap.get(igdbId);
+        if (!platform) continue;
+        await dbMutateConn(conn, GameSql.addGamePlatformMerge, {
+          gameId,
+          platformId: platform.id,
+        });
+      }
+    });
+  }
+}

--- a/src/classes/GameProfileService.ts
+++ b/src/classes/GameProfileService.ts
@@ -1,0 +1,234 @@
+import { dbQuery } from "../db/SqlManager.js";
+import { GameSql } from "../db/sql/index.js";
+import { apiGet } from "../services/RpgClubApiClient.js";
+import { mapReleaseFromApi } from "../functions/GameMappers.js";
+import type {
+  IReleaseWithNames,
+  ICompany,
+  IGameAssociationSummary,
+  INowPlayingMember,
+  ICompletedMember,
+  ICollectionOwnerMember,
+  IMappedGameProfile,
+} from "../types/GameTypes.js";
+import {
+  type GameRelationsApiData,
+  type NowPlayingApiEntry,
+  type CompletionGameApiEntry,
+  type CompanyApiData,
+  type GameProfileApiData,
+  mapGameProfileFromApi,
+} from "../functions/GameProfileMapper.js";
+
+export default class GameProfileService {
+  private static async fetchAllPages<T>(
+    path: string,
+    params: Record<string, unknown> = {},
+  ): Promise<T[]> {
+    const results: T[] = [];
+    let page = 1;
+    for (;;) {
+      const result = await apiGet<{ data: T[]; meta: { next: number | null } }>(
+        path,
+        { params: { ...params, page, per: 500 } },
+      );
+      if (!result?.data?.length) break;
+      results.push(...result.data);
+      if (!result.meta?.next) break;
+      page++;
+    }
+    return results;
+  }
+
+  private static readonly relationsCache = new Map<
+    number,
+    { promise: Promise<GameRelationsApiData | null>; expires: number }
+  >();
+
+  private static readonly RELATIONS_CACHE_TTL_MS = 2000;
+
+  static async getGameRelations(
+    gameId: number,
+  ): Promise<GameRelationsApiData | null> {
+    const now = Date.now();
+    const cached = GameProfileService.relationsCache.get(gameId);
+    if (cached && cached.expires > now) return cached.promise;
+
+    const promise = (async () => {
+      const result = await apiGet<{ data: GameRelationsApiData }>(
+        `/api/v1/games/${gameId}/relations`,
+      );
+      return result?.data ?? null;
+    })();
+    promise.catch(() => GameProfileService.relationsCache.delete(gameId));
+
+    GameProfileService.relationsCache.set(gameId, {
+      promise,
+      expires: now + GameProfileService.RELATIONS_CACHE_TTL_MS,
+    });
+    return promise;
+  }
+
+  static async getGameReleasesDetailed(
+    gameId: number,
+  ): Promise<IReleaseWithNames[]> {
+    const relations = await GameProfileService.getGameRelations(gameId);
+    if (!relations?.releases?.length) return [];
+    return relations.releases.map((r) => ({
+      ...mapReleaseFromApi(r),
+      platformName: r.platform_name ?? null,
+      regionName: r.region_name ?? null,
+    }));
+  }
+
+  static async getAllCompanies(): Promise<ICompany[]> {
+    const rows =
+      await GameProfileService.fetchAllPages<CompanyApiData>("/api/v1/companies");
+    return rows.map((d) => ({
+      id: Number(d.company_id),
+      name: String(d.name),
+      igdbId: d.igdb_company_id != null ? Number(d.igdb_company_id) : null,
+    }));
+  }
+
+  static async getCompanyById(id: number): Promise<ICompany | null> {
+    const result = await apiGet<{ data: CompanyApiData }>(`/api/v1/companies/${id}`);
+    if (!result?.data) return null;
+    return {
+      id: Number(result.data.company_id),
+      name: String(result.data.name),
+      igdbId:
+        result.data.igdb_company_id != null
+          ? Number(result.data.igdb_company_id)
+          : null,
+    };
+  }
+
+  static async getGameAssociations(
+    gameId: number,
+  ): Promise<IGameAssociationSummary> {
+    type WinRow = {
+      ROUND_NUMBER: number;
+      THREAD_ID: string | null;
+      REDDIT_URL: string | null;
+      MONTH_YEAR: string;
+    };
+    type NomRow = {
+      ROUND_NUMBER: number;
+      USER_ID: string;
+      USERNAME?: string | null;
+      GLOBAL_NAME?: string | null;
+    };
+
+    const [gotmWins, nrGotmWins, gotmNominations, nrGotmNominations] =
+      await Promise.all([
+        dbQuery<
+          WinRow,
+          {
+            round: number;
+            threadId: string | null;
+            redditUrl: string | null;
+            monthYear: string;
+          }
+        >(GameSql.getGotmWins, { gameId }, (row) => ({
+          round: Number(row.ROUND_NUMBER),
+          threadId: row.THREAD_ID ?? null,
+          redditUrl: row.REDDIT_URL ?? null,
+          monthYear: String(row.MONTH_YEAR),
+        })),
+        dbQuery<
+          WinRow,
+          {
+            round: number;
+            threadId: string | null;
+            redditUrl: string | null;
+            monthYear: string;
+          }
+        >(GameSql.getNrGotmWins, { gameId }, (row) => ({
+          round: Number(row.ROUND_NUMBER),
+          threadId: row.THREAD_ID ?? null,
+          redditUrl: row.REDDIT_URL ?? null,
+          monthYear: String(row.MONTH_YEAR),
+        })),
+        dbQuery<NomRow, { round: number; userId: string; username: string }>(
+          GameSql.getGotmNominations,
+          { gameId },
+          (row) => ({
+            round: Number(row.ROUND_NUMBER),
+            userId: String(row.USER_ID),
+            username: String(row.GLOBAL_NAME || row.USERNAME || row.USER_ID),
+          }),
+        ),
+        dbQuery<NomRow, { round: number; userId: string; username: string }>(
+          GameSql.getNrGotmNominations,
+          { gameId },
+          (row) => ({
+            round: Number(row.ROUND_NUMBER),
+            userId: String(row.USER_ID),
+            username: String(row.GLOBAL_NAME || row.USERNAME || row.USER_ID),
+          }),
+        ),
+      ]);
+
+    return { gotmWins, nrGotmWins, gotmNominations, nrGotmNominations };
+  }
+
+  static async getNowPlayingMembers(
+    gameId: number,
+  ): Promise<INowPlayingMember[]> {
+    const rows = await GameProfileService.fetchAllPages<NowPlayingApiEntry>(
+      `/api/v1/games/${gameId}/now_playing`,
+    );
+    return rows.map((d) => ({
+      userId: String(d.user_id),
+      username: d.user?.username ?? null,
+      globalName: d.user?.global_name ?? null,
+      threadId: null,
+      addedAt: null,
+    }));
+  }
+
+  static async getGameCompletions(gameId: number): Promise<ICompletedMember[]> {
+    const rows = await GameProfileService.fetchAllPages<CompletionGameApiEntry>(
+      `/api/v1/games/${gameId}/completions`,
+    );
+    return rows.map((d) => ({
+      userId: String(d.user_id),
+      username: d.user?.username ?? null,
+      globalName: d.user?.global_name ?? null,
+      completionType: String(d.completion_type),
+      completedAt: d.completed_at ? new Date(d.completed_at) : null,
+      finalPlaytimeHours:
+        d.final_playtime_hrs != null ? Number(d.final_playtime_hrs) : null,
+    }));
+  }
+
+  static async getGameCollectionOwners(
+    gameId: number,
+  ): Promise<ICollectionOwnerMember[]> {
+    return dbQuery(
+      GameSql.getGameCollectionOwners,
+      { gameId },
+      (row: {
+        USER_ID: string;
+        USERNAME: string | null;
+        GLOBAL_NAME: string | null;
+      }) => ({
+        userId: String(row.USER_ID),
+        username: row.USERNAME ?? null,
+        globalName: row.GLOBAL_NAME ?? null,
+      }),
+    );
+  }
+
+  static async getGameProfile(
+    gameId: number,
+  ): Promise<IMappedGameProfile | null> {
+    const result = await apiGet<{ data: GameProfileApiData }>(
+      `/api/v1/games/${gameId}/profile`,
+    );
+    const d = result?.data;
+    if (!d) return null;
+    return mapGameProfileFromApi(d, gameId);
+  }
+}

--- a/src/classes/GameSearchService.ts
+++ b/src/classes/GameSearchService.ts
@@ -1,0 +1,266 @@
+import { dbWithConnection, dbQueryConn } from "../db/SqlManager.js";
+import { GameSql } from "../db/sql/index.js";
+import GameSearchSynonym from "./GameSearchSynonym.js";
+import { mapGameRow } from "../functions/GameMappers.js";
+import {
+  autocompleteSearchCache,
+  pendingAutocompleteSearches,
+  foldAccentE,
+  buildAutocompleteCacheKey,
+  pruneAutocompleteCache,
+  AUTOCOMPLETE_CACHE_TTL_MS,
+} from "../functions/GameAutocompleteCache.js";
+import type {
+  IGame,
+  IGameSearchResult,
+  IGameAutocompleteResult,
+} from "../types/GameTypes.js";
+import GamePlatformRegionService from "./GamePlatformRegionService.js";
+
+export default class GameSearchService {
+  static async searchGamesAutocomplete(
+    query: string,
+    limit: number = 24,
+  ): Promise<IGameAutocompleteResult[]> {
+    const baseQuery = query.trim();
+    if (!baseQuery) {
+      return [];
+    }
+
+    const safeLimit = Math.min(24, Math.max(1, Math.trunc(limit) || 24));
+    const now = Date.now();
+    pruneAutocompleteCache(now);
+
+    const cacheKey = buildAutocompleteCacheKey(baseQuery, safeLimit);
+    const cached = autocompleteSearchCache.get(cacheKey);
+    if (cached && cached.expiresAt > now) {
+      return cached.results;
+    }
+    const pending = pendingAutocompleteSearches.get(cacheKey);
+    if (pending) {
+      return pending;
+    }
+
+    const lowerQuery = baseQuery.toLowerCase();
+    const foldedLowerQuery = foldAccentE(lowerQuery).toLowerCase();
+    const normalizedQuery = foldedLowerQuery.replace(/[^a-z0-9]/g, "");
+    if (!normalizedQuery && !/[a-z0-9]/.test(foldedLowerQuery)) {
+      return [];
+    }
+
+    const queryPromise = dbWithConnection(async (conn) => {
+      const titleFoldExpr = `REPLACE(REPLACE(REPLACE(REPLACE(LOWER(title), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')`;
+      const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '', 'g')`;
+
+      const binds = {
+        exactRaw: foldedLowerQuery,
+        rawPrefix: `${foldedLowerQuery}%`,
+        rawContains: `%${foldedLowerQuery}%`,
+        exactNorm: normalizedQuery || null,
+        normPrefix: normalizedQuery ? `${normalizedQuery}%` : null,
+        normContains: normalizedQuery ? `%${normalizedQuery}%` : null,
+        limit: safeLimit,
+      };
+
+      const games = await dbQueryConn(
+        conn,
+        GameSql.searchGamesAutocomplete(titleFoldExpr, titleNormExpr),
+        binds,
+        (row: any): IGameAutocompleteResult => {
+          const ird = row.INITIAL_RELEASE_DATE ?? row.initial_release_date;
+          return {
+            id: Number(row.GAME_ID ?? row.game_id),
+            title: String(row.TITLE ?? row.title),
+            initialReleaseDate:
+              ird instanceof Date ? ird : ird ? new Date(ird) : null,
+          };
+        },
+      );
+
+      autocompleteSearchCache.set(cacheKey, {
+        expiresAt: Date.now() + AUTOCOMPLETE_CACHE_TTL_MS,
+        results: games,
+      });
+      pruneAutocompleteCache(Date.now());
+
+      return games;
+    });
+
+    pendingAutocompleteSearches.set(cacheKey, queryPromise);
+    try {
+      return await queryPromise;
+    } finally {
+      pendingAutocompleteSearches.delete(cacheKey);
+    }
+  }
+
+  static async searchGames(
+    query: string,
+    filters: {
+      upcomingRelease?: boolean;
+      platformId?: number;
+      year?: number;
+      developerId?: number;
+      publisherId?: number;
+    } = {},
+  ): Promise<IGameSearchResult[]> {
+    return dbWithConnection(async (connection) => {
+      const baseQuery = query.trim();
+      const hasFilters =
+        filters.upcomingRelease ||
+        filters.platformId ||
+        filters.year ||
+        filters.developerId ||
+        filters.publisherId;
+      if (!baseQuery && !hasFilters) {
+        return [];
+      }
+
+      const titleFoldExpr = `REPLACE(REPLACE(REPLACE(REPLACE(LOWER(title), 'é', 'e'), 'è', 'e'), 'ê', 'e'), 'ë', 'e')`;
+      const titleNormExpr = `REGEXP_REPLACE(${titleFoldExpr}, '[^a-z0-9]', '', 'g')`;
+
+      const clauses: string[] = [];
+      const binds: Record<string, string | number> = {};
+
+      if (baseQuery) {
+        const queryVariants = new Set<string>();
+        queryVariants.add(baseQuery);
+        const spacedQuery = baseQuery
+          .replace(/([a-zA-Z])(\d)/g, "$1 $2")
+          .replace(/(\d)([a-zA-Z])/g, "$1 $2");
+        queryVariants.add(spacedQuery);
+
+        const tokens = spacedQuery.split(/\s+/).filter(Boolean);
+        const tokenOptions: string[][] = [];
+        for (const token of tokens) {
+          const options = new Set<string>();
+          options.add(token);
+          const tokenSynonyms = await GameSearchSynonym.getTermsForQuery(token);
+          tokenSynonyms.forEach((synonym) => {
+            if (synonym.trim()) {
+              options.add(synonym.trim());
+            }
+          });
+          tokenOptions.push(Array.from(options));
+        }
+
+        if (tokenOptions.length) {
+          let variants: string[] = [""];
+          const MAX_VARIANTS = 50;
+          for (const options of tokenOptions) {
+            const nextVariants: string[] = [];
+            for (const prefix of variants) {
+              for (const option of options) {
+                const next = prefix ? `${prefix} ${option}` : option;
+                nextVariants.push(next);
+                if (nextVariants.length >= MAX_VARIANTS) break;
+              }
+              if (nextVariants.length >= MAX_VARIANTS) break;
+            }
+            variants = nextVariants;
+            if (variants.length >= MAX_VARIANTS) break;
+          }
+          variants.forEach((variant) => queryVariants.add(variant));
+        }
+
+        const termSet = new Map<string, string>();
+        Array.from(queryVariants).forEach((term) => {
+          const folded = foldAccentE(term).toLowerCase();
+          const norm = folded.replace(/[^a-z0-9]/g, "");
+          if (norm) {
+            termSet.set(norm, folded);
+          }
+        });
+
+        if (!termSet.size) {
+          return [];
+        }
+
+        Array.from(termSet.entries()).forEach(([norm, term], index) => {
+          const rawKey = `searchQuery${index}`;
+          const normKey = `normalizedQuery${index}`;
+          binds[rawKey] = `%${term}%`;
+          binds[normKey] = `%${norm}%`;
+          clauses.push(
+            `(${titleFoldExpr} LIKE :${rawKey} OR ${titleNormExpr} LIKE :${normKey})`,
+          );
+        });
+      }
+
+      const filterClauses: string[] = [];
+      if (filters.upcomingRelease) {
+        filterClauses.push("u.upcoming_date IS NOT NULL");
+      }
+      if (filters.platformId) {
+        filterClauses.push(
+          "g.game_id IN (SELECT game_id FROM gamedb_game_platforms WHERE platform_id = :filterPlatformId)",
+        );
+        binds["filterPlatformId"] = filters.platformId;
+      }
+      if (filters.year) {
+        filterClauses.push(
+          "EXTRACT(YEAR FROM g.initial_release_date) = :filterYear",
+        );
+        binds["filterYear"] = filters.year;
+      }
+      if (filters.developerId) {
+        filterClauses.push(
+          `g.game_id IN (SELECT game_id FROM gamedb_game_companies WHERE company_id = :filterDeveloperId AND role = 'Developer')`,
+        );
+        binds["filterDeveloperId"] = filters.developerId;
+      }
+      if (filters.publisherId) {
+        filterClauses.push(
+          `g.game_id IN (SELECT game_id FROM gamedb_game_companies WHERE company_id = :filterPublisherId AND role = 'Publisher')`,
+        );
+        binds["filterPublisherId"] = filters.publisherId;
+      }
+
+      const titlePart = clauses.length ? `(${clauses.join(" OR ")})` : "";
+      const filterPart = filterClauses.length
+        ? `(${filterClauses.join(" AND ")})`
+        : "";
+      const whereClause =
+        titlePart && filterPart
+          ? `${titlePart} AND ${filterPart}`
+          : titlePart || filterPart || "1=0";
+
+      const upcomingCol = "u.upcoming_date";
+      const orderPrefix = filters.upcomingRelease
+        ? `${upcomingCol} ASC NULLS LAST, `
+        : "";
+
+      const entry = GameSql.searchGames(whereClause, orderPrefix);
+
+      const upcomingDates = new Map<number, Date | null>();
+      const upcomingPlatforms = new Map<number, string[]>();
+
+      const rows = await dbQueryConn(connection, entry, binds, (row: any) => {
+        const id = Number(row.game_id);
+        const urd = row.upcoming_release_date;
+        upcomingDates.set(
+          id,
+          urd instanceof Date ? urd : urd ? new Date(urd) : null,
+        );
+        upcomingPlatforms.set(
+          id,
+          row.upcoming_platforms
+            ? String(row.upcoming_platforms)
+                .split(",")
+                .map((s: string) => s.trim())
+                .filter(Boolean)
+            : [],
+        );
+        return mapGameRow(row);
+      });
+      const games: IGame[] = rows;
+
+      const withPlatforms = await GamePlatformRegionService.attachPlatformsToGames(games);
+      return withPlatforms.map((g) => ({
+        ...g,
+        upcomingReleaseDate: upcomingDates.get(g.id) ?? null,
+        upcomingReleasePlatforms: upcomingPlatforms.get(g.id) ?? [],
+      }));
+    });
+  }
+}

--- a/src/classes/UserGameBacklog.ts
+++ b/src/classes/UserGameBacklog.ts
@@ -1,6 +1,7 @@
 import { apiGet, apiPost, apiPatch, apiDelete } from "../services/RpgClubApiClient.js";
 import Game from "./Game.js";
 import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
+import GamePlatformRegionService from "./GamePlatformRegionService.js";
 
 export interface IUserGameBacklogEntry {
   entryId: number;
@@ -48,7 +49,7 @@ async function mapEntries(rawEntries: BacklogApiData[]): Promise<IUserGameBacklo
     ),
   );
   const platformResults = await Promise.all(
-    uniquePlatformIds.map((id) => Game.getPlatformById(id)),
+    uniquePlatformIds.map((id) => GamePlatformRegionService.getPlatformById(id)),
   );
   const platformMap = new Map(
     uniquePlatformIds.map((id, idx) => [id, platformResults[idx]]),

--- a/src/classes/UserGameCollection.ts
+++ b/src/classes/UserGameCollection.ts
@@ -3,6 +3,7 @@ import { UserGameCollectionSql } from "../db/sql/index.js";
 import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
 import { apiGet, apiPost, apiPatch, apiDelete } from "../services/RpgClubApiClient.js";
 import Game from "./Game.js";
+import GamePlatformRegionService from "./GamePlatformRegionService.js";
 
 export const COLLECTION_OWNERSHIP_TYPES = [
   "Digital",
@@ -117,7 +118,9 @@ type CollectionResponse = { data: CollectionApiData };
 async function enrichEntry(raw: CollectionApiData): Promise<IUserGameCollectionEntry> {
   const [game, platform] = await Promise.all([
     Game.getGameById(raw.gamedb_game_id),
-    raw.platform_id != null ? Game.getPlatformById(raw.platform_id) : Promise.resolve(null),
+    raw.platform_id != null
+      ? GamePlatformRegionService.getPlatformById(raw.platform_id)
+      : Promise.resolve(null),
   ]);
   return {
     entryId: Number(raw.entry_id),

--- a/src/commands/admin/gotm-audit-handlers.ts
+++ b/src/commands/admin/gotm-audit-handlers.ts
@@ -16,7 +16,7 @@ import {
   replyIfNotOwner,
 } from "../../functions/InteractionUtils.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
-import type { IGameWithPlatforms } from "../../classes/Game.js";
+import type { IGameWithPlatforms } from "../../types/GameTypes.js";
 import Game from "../../classes/Game.js";
 import {
   getGotmAuditImportById,

--- a/src/commands/admin/gotm-audit-handlers.ts
+++ b/src/commands/admin/gotm-audit-handlers.ts
@@ -40,6 +40,7 @@ import {
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 export async function handleGotmAuditSelect(
   interaction: StringSelectMenuInteraction): Promise<void> {
@@ -167,7 +168,7 @@ export async function handleGotmAuditAction(interaction: ButtonInteraction): Pro
 
     let results: IGameWithPlatforms[] = [];
     try {
-      results = await Game.searchGames(item.gameTitle);
+      results = await GameSearchService.searchGames(item.gameTitle);
     } catch (err: any) {
       await safeReply(interaction, buildTextReply(
         `GameDB search failed: ${err?.message ?? "Unknown error"}`,
@@ -369,7 +370,7 @@ export async function handleGotmAuditQueryModal(
 
   let results: IGameWithPlatforms[] = [];
   try {
-    results = await Game.searchGames(query);
+    results = await GameSearchService.searchGames(query);
   } catch (err: any) {
     await safeReply(interaction, {
       ...buildTextReply(`GameDB search failed: ${err?.message ?? "Unknown error"}`, true),

--- a/src/commands/admin/gotm-audit.service.ts
+++ b/src/commands/admin/gotm-audit.service.ts
@@ -46,6 +46,7 @@ import {
   buildGotmAuditPromptComponents,
 } from "./gotm-audit-ui.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 export async function handleGotmAudit(
   interaction: CommandInteraction,
@@ -191,7 +192,7 @@ export async function processNextGotmAuditItem(
 
   let results: IGameWithPlatforms[] = [];
   try {
-    results = await Game.searchGames(nextItem.gameTitle);
+    results = await GameSearchService.searchGames(nextItem.gameTitle);
   } catch (err: any) {
     await updateGotmAuditItem(nextItem.itemId, {
       status: "ERROR",

--- a/src/commands/admin/gotm-audit.service.ts
+++ b/src/commands/admin/gotm-audit.service.ts
@@ -8,7 +8,7 @@ import {
   buildTextReply,
   buildTitledContainer,
 } from "../../functions/ComponentsV2Utils.js";
-import type { IGameWithPlatforms } from "../../classes/Game.js";
+import type { IGameWithPlatforms } from "../../types/GameTypes.js";
 import Game from "../../classes/Game.js";
 import Gotm, {
   insertGotmRoundInDatabase,

--- a/src/commands/backlog/backlog-autocomplete.utils.ts
+++ b/src/commands/backlog/backlog-autocomplete.utils.ts
@@ -1,10 +1,10 @@
 import { type AutocompleteInteraction } from "discord.js";
-import Game from "../../classes/Game.js";
 import UserGameBacklog from "../../classes/UserGameBacklog.js";
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 export const BACKLOG_ENTRY_VALUE_PREFIX = "backlog";
 
@@ -35,7 +35,7 @@ export async function autocompleteBacklogGameTitle(
     return;
   }
 
-  const results = await Game.searchGamesAutocomplete(query);
+  const results = await GameSearchService.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: truncateLabel(formatGameTitleWithYear(game)),

--- a/src/commands/backlog/backlog-crud.command.ts
+++ b/src/commands/backlog/backlog-crud.command.ts
@@ -22,7 +22,6 @@ import {
 import { resolveCollectionGameForAdd } from "../collection/collection-game-resolve.utils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
-import Game from "../../classes/Game.js";
 import {
   autocompleteBacklogEntry,
   autocompleteBacklogGameTitle,
@@ -30,6 +29,7 @@ import {
 } from "./backlog-autocomplete.utils.js";
 import { buildApiErrorMessage } from "../../utilities/ApiErrorUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
+import { importGameFromIgdb } from "../../functions/GameIgdbSync.js";
 
 @Discord()
 @SlashGroup({ description: "Manage your game backlog", name: "backlog" })
@@ -93,7 +93,7 @@ export class BacklogCrudCommand {
         resolution.options,
         async (selectionInteraction, igdbId) => {
           try {
-            const imported = await Game.importGameFromIgdb(igdbId);
+            const imported = await importGameFromIgdb(igdbId);
             const created = await UserGameBacklog.addEntry({
               userId: interaction.user.id,
               gameId: imported.gameId,

--- a/src/commands/collection/collection-autocomplete.utils.ts
+++ b/src/commands/collection/collection-autocomplete.utils.ts
@@ -1,5 +1,4 @@
 import { type AutocompleteInteraction } from "discord.js";
-import Game from "../../classes/Game.js";
 import UserGameCollection, {
   type CollectionOwnershipType,
 } from "../../classes/UserGameCollection.js";
@@ -7,6 +6,7 @@ import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 export const COLLECTION_ENTRY_VALUE_PREFIX = "collection";
 
@@ -43,7 +43,7 @@ export async function autocompleteCollectionGameTitle(
     return;
   }
 
-  const results = await Game.searchGamesAutocomplete(query);
+  const results = await GameSearchService.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: truncateLabel(formatGameTitleWithYear(game)),

--- a/src/commands/collection/collection-crud.command.ts
+++ b/src/commands/collection/collection-crud.command.ts
@@ -31,7 +31,6 @@ import {
 } from "../profile.command.js";
 import { saveCompletion } from "../../functions/CompletionHelpers.js";
 import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
-import Game from "../../classes/Game.js";
 import {
   autocompleteCollectionEntry,
   autocompleteCollectionGameTitle,
@@ -40,6 +39,7 @@ import {
 import { resolveCollectionGameForAdd } from "./collection-game-resolve.utils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { isValidPlaytimeHours } from "../../utilities/ValidationUtils.js";
+import { importGameFromIgdb } from "../../functions/GameIgdbSync.js";
 
 @Discord()
 @SlashGroup({ description: "Manage your game collection", name: "collection" })
@@ -111,7 +111,7 @@ export class CollectionCrudCommand {
         resolution.options,
         async (selectionInteraction, igdbId) => {
           try {
-            const imported = await Game.importGameFromIgdb(igdbId);
+            const imported = await importGameFromIgdb(igdbId);
             const created = await UserGameCollection.addEntry({
               userId: interaction.user.id,
               gameId: imported.gameId,

--- a/src/commands/collection/collection-csv-import.command.ts
+++ b/src/commands/collection/collection-csv-import.command.ts
@@ -103,6 +103,7 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
+import { importGameFromIgdb } from "../../functions/GameIgdbSync.js";
 
 @Discord()
 @SlashGroup("collection")
@@ -262,7 +263,7 @@ export class CollectionCsvImportCommand {
 
     if (nextItem.rawIgdbId) {
       try {
-        const imported = await Game.importGameFromIgdb(nextItem.rawIgdbId);
+        const imported = await importGameFromIgdb(nextItem.rawIgdbId);
         await this.applyCsvImportSelection({
           ownerId,
           item: nextItem,
@@ -334,7 +335,7 @@ export class CollectionCsvImportCommand {
           }
 
           try {
-            const imported = await Game.importGameFromIgdb(igdbId);
+            const imported = await importGameFromIgdb(igdbId);
             await updateCollectionCsvImportItem(currentItem.itemId, {
               matchCandidateJson: JSON.stringify([{
                 gameId: imported.gameId,
@@ -1026,7 +1027,7 @@ export class CollectionCsvImportCommand {
       source = "gamedb";
     } else {
       try {
-        const imported = await Game.importGameFromIgdb(enteredId);
+        const imported = await importGameFromIgdb(enteredId);
         resolvedGameId = imported.gameId;
         source = "igdb";
       } catch {

--- a/src/commands/collection/collection-game-resolve.utils.ts
+++ b/src/commands/collection/collection-game-resolve.utils.ts
@@ -4,6 +4,8 @@ import type { IgdbSelectOption } from "../../services/IGDB/IgdbSelectService.js"
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { truncateLabel } from "../../config/textLimits.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
+import { importGameFromIgdb } from "../../functions/GameIgdbSync.js";
 
 export type ResolvedCollectionGame =
   | { kind: "resolved"; gameId: number; title: string }
@@ -19,7 +21,7 @@ export async function buildCollectionIgdbSelectOptions(
       .filter(isPositiveInt),
   ));
   const platformMap = platformIds.length
-    ? await Game.getPlatformsByIgdbIds(platformIds)
+    ? await GamePlatformRegionService.getPlatformsByIgdbIds(platformIds)
     : new Map<number, { name: string; abbreviation?: string }>();
 
   return trimmedResults.map((game) => {
@@ -54,7 +56,7 @@ export async function resolveCollectionGameForAdd(
       return { kind: "resolved", gameId: localGame.id, title: localGame.title };
     }
 
-    const importedById = await Game.importGameFromIgdb(numericValue);
+    const importedById = await importGameFromIgdb(numericValue);
     return { kind: "resolved", gameId: importedById.gameId, title: importedById.title };
   }
 

--- a/src/commands/collection/collection-game-resolve.utils.ts
+++ b/src/commands/collection/collection-game-resolve.utils.ts
@@ -6,6 +6,7 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { truncateLabel } from "../../config/textLimits.js";
 import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 import { importGameFromIgdb } from "../../functions/GameIgdbSync.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 export type ResolvedCollectionGame =
   | { kind: "resolved"; gameId: number; title: string }
@@ -65,7 +66,7 @@ export async function resolveCollectionGameForAdd(
     throw new Error("Invalid game selection.");
   }
 
-  const localResults = await Game.searchGames(titleQuery);
+  const localResults = await GameSearchService.searchGames(titleQuery);
   const exactLocal = localResults.find(
     (game) => game.title.toLowerCase() === titleQuery.toLowerCase(),
   );

--- a/src/commands/collection/collection-import-ui.utils.ts
+++ b/src/commands/collection/collection-import-ui.utils.ts
@@ -15,6 +15,7 @@ import {
 } from "../../functions/ComponentsV2Utils.js";
 import type { ImportCandidate } from "../../functions/ImportCandidateUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 export async function buildImportCandidatesContainer(params: {
   ownerId: string;
@@ -46,7 +47,7 @@ export async function buildImportCandidatesContainer(params: {
 
   const gameIds = params.candidates.map((entry) => entry.gameId);
   const games = await Game.getGamesByIds(gameIds);
-  const gamesWithPlatforms = await Game.attachPlatformsToGames(games);
+  const gamesWithPlatforms = await GamePlatformRegionService.attachPlatformsToGames(games);
   const gameMeta = new Map<number, { year: string; platforms: string }>();
   for (const game of gamesWithPlatforms) {
     const year = game.initialReleaseDate

--- a/src/commands/collection/collection-steam-import.command.ts
+++ b/src/commands/collection/collection-steam-import.command.ts
@@ -100,6 +100,7 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
+import { importGameFromIgdb } from "../../functions/GameIgdbSync.js";
 
 @Discord()
 @SlashGroup("collection")
@@ -304,7 +305,7 @@ export class CollectionSteamImportCommand {
           }
 
           try {
-            const imported = await Game.importGameFromIgdb(igdbId);
+            const imported = await importGameFromIgdb(igdbId);
             await updateSteamCollectionImportItem(currentItem.itemId, {
               matchCandidateJson: JSON.stringify([{
                 gameId: imported.gameId,
@@ -973,7 +974,7 @@ export class CollectionSteamImportCommand {
       source = "gamedb";
     } else {
       try {
-        const imported = await Game.importGameFromIgdb(enteredId);
+        const imported = await importGameFromIgdb(enteredId);
         resolvedGameId = imported.gameId;
         source = "igdb";
       } catch {

--- a/src/commands/create-thread.command.ts
+++ b/src/commands/create-thread.command.ts
@@ -20,6 +20,7 @@ import { safeDeferReply, safeReply, sanitizeOptionalInput, sanitizeUserInput } f
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { formatGameTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../config/textLimits.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 const DEFAULT_FIRST_POST_PREFIX = "Thread created by";
 
@@ -38,7 +39,7 @@ async function autocompleteCreateThreadTitle(
     return;
   }
 
-  const results = await Game.searchGamesAutocomplete(query);
+  const results = await GameSearchService.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: truncateLabel(formatGameTitleWithYear(game)),

--- a/src/commands/game-completion.command.ts
+++ b/src/commands/game-completion.command.ts
@@ -90,10 +90,10 @@ import {
   COMPLETIONATOR_STATUS_OPTIONS,
   type CompletionatorAction,
 } from "./game-completion/completion.types.js";
-import Game from "../classes/Game.js";
 import Member from "../classes/Member.js";
 import { isPositiveInt, isValidPlaytimeHours } from "../utilities/ValidationUtils.js";
 import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 // Note: This is a simplified working version that delegates complex Completionator logic
 // to service files. The full implementation would import and delegate all handlers.
@@ -211,7 +211,7 @@ export class GameCompletionCommands {
       return;
     }
 
-    const localResults = await Game.searchGames(searchTerm);
+    const localResults = await GameSearchService.searchGames(searchTerm);
     const exactMatch = localResults.find(
       (game) => game.title.toLowerCase() === searchTerm.toLowerCase(),
     );

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -42,6 +42,7 @@ import {
 } from "../../functions/uiComponents.js";
 import { assertCustomIdSegments, parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
+import { saveFullGameMetadata } from "../../functions/GameIgdbSync.js";
 
 /**
  * Creates a completion session and returns the session ID
@@ -529,6 +530,6 @@ export async function importGameFromIgdb(
     }
     throw err;
   });
-  await Game.saveFullGameMetadata(newGame.id, details);
+  await saveFullGameMetadata(newGame.id, details);
   return { gameId: newGame.id, title: details.name };
 }

--- a/src/commands/game-completion/completion-add.service.ts
+++ b/src/commands/game-completion/completion-add.service.ts
@@ -43,6 +43,7 @@ import {
 import { assertCustomIdSegments, parseCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
 import { saveFullGameMetadata } from "../../functions/GameIgdbSync.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 /**
  * Creates a completion session and returns the session ID
@@ -61,7 +62,7 @@ export async function promptCompletionSelection(
   searchTerm: string,
   ctx: CompletionAddContext,
 ): Promise<void> {
-  const localResults = await Game.searchGames(searchTerm);
+  const localResults = await GameSearchService.searchGames(searchTerm);
   if (localResults.length) {
     const sessionId = createCompletionSession(ctx);
     const gameOptions = localResults.map((game) => ({
@@ -521,7 +522,7 @@ export async function importGameFromIgdb(
       throw err;
     }
 
-    const matches = await Game.searchGames(details.name);
+    const matches = await GameSearchService.searchGames(details.name);
     const exact = matches.find(
       (game) => game.title.toLowerCase() === details.name.toLowerCase(),
     );

--- a/src/commands/game-completion/completion-autocomplete.utils.ts
+++ b/src/commands/game-completion/completion-autocomplete.utils.ts
@@ -3,7 +3,8 @@
 import type { AutocompleteInteraction } from "discord.js";
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
-import Game, { type IPlatformDef } from "../../classes/Game.js";
+import type { IPlatformDef } from "../../types/GameTypes.js";
+import Game from "../../classes/Game.js";
 import Member from "../../classes/Member.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";

--- a/src/commands/game-completion/completion-autocomplete.utils.ts
+++ b/src/commands/game-completion/completion-autocomplete.utils.ts
@@ -4,13 +4,13 @@ import type { AutocompleteInteraction } from "discord.js";
 import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import type { IPlatformDef } from "../../types/GameTypes.js";
-import Game from "../../classes/Game.js";
 import Member from "../../classes/Member.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
 import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 const PLATFORM_CACHE_TTL_MS = 5 * 60 * 1000;
 const COMPLETION_TITLE_VALUE_PREFIX = "completion";
@@ -73,7 +73,7 @@ export async function autocompleteGameCompletionTitle(
     await interaction.respond([]);
     return;
   }
-  const results = await Game.searchGamesAutocomplete(query);
+  const results = await GameSearchService.searchGamesAutocomplete(query);
   const resultOptions = results.slice(0, 24).map((game) => ({
     name: truncateLabel(formatGameTitleWithYear(game)),
     value: game.title,

--- a/src/commands/game-completion/completion-autocomplete.utils.ts
+++ b/src/commands/game-completion/completion-autocomplete.utils.ts
@@ -10,6 +10,7 @@ import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 const PLATFORM_CACHE_TTL_MS = 5 * 60 * 1000;
 const COMPLETION_TITLE_VALUE_PREFIX = "completion";
@@ -22,7 +23,7 @@ async function getCachedPlatforms(): Promise<IPlatformDef[]> {
     return platformCache.platforms;
   }
 
-  const platforms = await Game.getAllPlatforms();
+  const platforms = await GamePlatformRegionService.getAllPlatforms();
   platformCache = {
     expiresAt: now + PLATFORM_CACHE_TTL_MS,
     platforms,

--- a/src/commands/game-completion/completion-common.service.ts
+++ b/src/commands/game-completion/completion-common.service.ts
@@ -9,7 +9,6 @@ import {
 } from "discord.js";
 import { ContainerBuilder } from "@discordjs/builders";
 import Member, { type ICompletionRecord } from "../../classes/Member.js";
-import Game from "../../classes/Game.js";
 import { safeDeferUpdate, safeReply } from "../../functions/InteractionUtils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import {
@@ -27,6 +26,7 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { MAX_CONTAINER_TEXT, MAX_SECTION_TEXT } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 export type CommonCompletionSort =
   | "title_asc"
@@ -383,7 +383,7 @@ export async function renderCommonCompletionPage(
     interaction.client.users.fetch(state.rightId).catch(() => interaction.user),
     Member.getAllCompletions(state.leftId),
     Member.getAllCompletions(state.rightId),
-    Game.getAllPlatforms(),
+    GamePlatformRegionService.getAllPlatforms(),
   ]);
 
   const platformMap = new Map(

--- a/src/commands/game-completion/completion-list.service.ts
+++ b/src/commands/game-completion/completion-list.service.ts
@@ -11,7 +11,6 @@ import {
 } from "discord.js";
 import { ContainerBuilder } from "@discordjs/builders";
 import Member from "../../classes/Member.js";
-import Game from "../../classes/Game.js";
 import { COMPLETION_PAGE_SIZE } from "../profile.command.js";
 import { formatDiscordTimestamp, formatTableDate } from "../../functions/DateFormatUtils.js";
 import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
@@ -29,6 +28,7 @@ import {
   MAX_QUERY_LENGTH,
   truncateLabel,
 } from "../../config/textLimits.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 import {
   buildActionButton,
   buildButtonRow,
@@ -331,7 +331,7 @@ async function buildCompletionComponents(
     year,
     title: query,
   });
-  const platforms = await Game.getAllPlatforms();
+  const platforms = await GamePlatformRegionService.getAllPlatforms();
   const platformMap = new Map(
     platforms.map((platform) => [platform.id, platform.abbreviation ?? platform.name]),
   );

--- a/src/commands/game-completion/completion-platform.service.ts
+++ b/src/commands/game-completion/completion-platform.service.ts
@@ -12,7 +12,6 @@ import {
   saveCompletion,
 } from "../../functions/CompletionHelpers.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
-import Game from "../../classes/Game.js";
 import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 import {
   COMPLETION_PLATFORM_SELECT_PREFIX,
@@ -23,6 +22,7 @@ import { truncateLabel } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { buildSelectRow } from "../../functions/uiComponents.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 export function createCompletionPlatformSession(
   ctx: CompletionPlatformContext,
@@ -37,7 +37,7 @@ export async function promptCompletionPlatformSelection(
   interaction: CommandInteraction | StringSelectMenuInteraction | ButtonInteraction,
   ctx: Omit<CompletionPlatformContext, "platforms">,
 ): Promise<void> {
-  const platforms = await Game.getPlatformsForGameWithStandard(
+  const platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
     ctx.gameId,
     STANDARD_PLATFORM_IDS,
   );
@@ -143,7 +143,7 @@ export async function handleCompletionPlatformSelect(
 }
 
 export async function resolveDefaultCompletionPlatformId(gameId: number): Promise<number | null> {
-  const platforms = await Game.getPlatformsForGameWithStandard(
+  const platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
     gameId,
     STANDARD_PLATFORM_IDS,
   );

--- a/src/commands/game-completion/completionator-handlers.service.ts
+++ b/src/commands/game-completion/completionator-handlers.service.ts
@@ -12,7 +12,6 @@ import {
 } from "../../functions/InteractionUtils.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import Member from "../../classes/Member.js";
-import Game from "../../classes/Game.js";
 import type { CompletionatorModalKind, CompletionatorDateChoice } from "./completion.types.js";
 import { completionatorAddFormStates, completionatorThreadContexts } from "./completion.types.js";
 import {
@@ -35,6 +34,7 @@ import { searchGameDbWithFallback, importGameFromIgdb } from "./completionator-p
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 export class CompletionatorHandlersService {
   private workflowService: CompletionatorWorkflowService;
@@ -553,7 +553,7 @@ export class CompletionatorHandlersService {
         state.platformId = null;
       } else {
         const platformId = Number(value);
-        const platforms = await Game.getPlatformsForGameWithStandard(
+        const platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
           item.gameDbGameId,
           STANDARD_PLATFORM_IDS,
         );

--- a/src/commands/game-completion/completionator-parser.service.ts
+++ b/src/commands/game-completion/completionator-parser.service.ts
@@ -2,11 +2,11 @@
 
 import axios from "axios";
 import type { CompletionType } from "../profile.command.js";
-import Game from "../../classes/Game.js";
 import {
   buildProgressiveTitleVariants,
   normalizeTitleWithSteps,
 } from "../../functions/ImportTitleNormalization.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 export async function fetchCsv(url: string): Promise<string | null> {
   try {
@@ -133,10 +133,10 @@ export function parseCompletionatorDate(value: string | undefined): Date | null 
 
 export async function searchGameDbWithFallback(
   rawTitle: string,
-): Promise<Awaited<ReturnType<typeof Game.searchGames>>> {
+): Promise<Awaited<ReturnType<typeof GameSearchService.searchGames>>> {
   const variants = buildProgressiveTitleVariants(rawTitle);
   for (const variant of variants) {
-    const results = await Game.searchGames(variant);
+    const results = await GameSearchService.searchGames(variant);
     if (results.length) {
       return results;
     }
@@ -145,7 +145,7 @@ export async function searchGameDbWithFallback(
   const normalizedTitle = normalizeTitleWithSteps(rawTitle);
   const titleVariants = buildTitleVariants(rawTitle, normalizedTitle);
   for (const variant of titleVariants) {
-    const variantResults = await Game.searchGames(variant);
+    const variantResults = await GameSearchService.searchGames(variant);
     if (variantResults.length) {
       return variantResults;
     }
@@ -160,9 +160,11 @@ export async function searchGameDbWithFallback(
     return [];
   }
 
-  const resultMap = new Map<number, Awaited<ReturnType<typeof Game.searchGames>>[number]>();
+  type GameSearchResult =
+    Awaited<ReturnType<typeof GameSearchService.searchGames>>[number];
+  const resultMap = new Map<number, GameSearchResult>();
   for (const token of uniqueTokens) {
-    const matches = await Game.searchGames(token);
+    const matches = await GameSearchService.searchGames(token);
     for (const match of matches) {
       if (!resultMap.has(match.id)) {
         resultMap.set(match.id, match);

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -19,7 +19,8 @@ import {
   SectionBuilder,
   TextDisplayBuilder,
 } from "@discordjs/builders";
-import Game, { type IGameWithPlatforms, type IPlatformDef } from "../../classes/Game.js";
+import type { IGameWithPlatforms, IPlatformDef } from "../../types/GameTypes.js";
+import Game from "../../classes/Game.js";
 import Member, { type ICompletionRecord } from "../../classes/Member.js";
 import type {
   CompletionatorAddFormState,

--- a/src/commands/game-completion/completionator-ui.service.ts
+++ b/src/commands/game-completion/completionator-ui.service.ts
@@ -56,6 +56,7 @@ import {
 } from "../../functions/uiComponents.js";
 import { truncateDescription, truncateLabel } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 export class CompletionatorUiService {
   buildCompletionatorBaseLines(
@@ -282,8 +283,8 @@ export class CompletionatorUiService {
   }> {
     const game = await Game.getGameById(gameId);
     const completions = await Member.getCompletionsForGame(userId, gameId);
-    const gamePlatforms = await Game.getPlatformsForGame(gameId);
-    const platforms = await Game.getAllPlatforms();
+    const gamePlatforms = await GamePlatformRegionService.getPlatformsForGame(gameId);
+    const platforms = await GamePlatformRegionService.getAllPlatforms();
     const platformMap = 
       new Map(platforms.map((platform: IPlatformDef) => [platform.id, platform.name]));
     const formattedPlatforms = gamePlatforms

--- a/src/commands/game-completion/completionator-workflow.service.ts
+++ b/src/commands/game-completion/completionator-workflow.service.ts
@@ -5,7 +5,8 @@ import type {
   StringSelectMenuInteraction,
 } from "discord.js";
 import type { ContainerBuilder } from "@discordjs/builders";
-import Game, { type IPlatformDef } from "../../classes/Game.js";
+import type { IPlatformDef } from "../../types/GameTypes.js";
+import Game from "../../classes/Game.js";
 import Member from "../../classes/Member.js";
 import type {
   CompletionatorAddFormState,

--- a/src/commands/game-completion/completionator-workflow.service.ts
+++ b/src/commands/game-completion/completionator-workflow.service.ts
@@ -41,6 +41,7 @@ import { logError } from "../../utilities/LogUtils.js";
 import { truncateDescription } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 export class CompletionatorWorkflowService {
   private uiService: CompletionatorUiService;
@@ -469,7 +470,7 @@ export class CompletionatorWorkflowService {
       | ModalSubmitInteraction,
     session: ICompletionatorImport,
     item: ICompletionatorItem,
-    results: Awaited<ReturnType<typeof Game.searchGames>>,
+    results: Awaited<ReturnType<typeof GameSearchService.searchGames>>,
     ephemeral?: boolean,
     context?: CompletionatorThreadContext,
   ): Promise<void> {

--- a/src/commands/game-completion/completionator-workflow.service.ts
+++ b/src/commands/game-completion/completionator-workflow.service.ts
@@ -40,6 +40,7 @@ import { canSafeReply, safeDeferReply, safeDeferUpdate } from "../../functions/I
 import { logError } from "../../utilities/LogUtils.js";
 import { truncateDescription } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 export class CompletionatorWorkflowService {
   private uiService: CompletionatorUiService;
@@ -212,7 +213,7 @@ export class CompletionatorWorkflowService {
         gameDbGameId: gameId,
       });
       item.gameDbGameId = gameId;
-      let platforms = await Game.getPlatformsForGameWithStandard(
+      let platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
         gameId,
         STANDARD_PLATFORM_IDS,
       );
@@ -414,7 +415,8 @@ export class CompletionatorWorkflowService {
     components: Array<any>;
     files: any[];
   }> {
-    let platforms = await Game.getPlatformsForGameWithStandard(gameId, STANDARD_PLATFORM_IDS);
+    let platforms = await GamePlatformRegionService
+      .getPlatformsForGameWithStandard(gameId, STANDARD_PLATFORM_IDS);
     const state = this.getOrCreateCompletionatorAddFormState(session, item, gameId, ownerId);
     const resolution = 
       await this.resolveCompletionatorPlatformState(state, item, gameId, platforms);
@@ -758,15 +760,13 @@ export class CompletionatorWorkflowService {
         return { platforms };
       }
 
-      const allPlatforms = await Game.getAllPlatforms();
+      const allPlatforms = await GamePlatformRegionService.getAllPlatforms();
       const mappedPlatformId = this.uiService.resolvePlatformId(item.platformName, allPlatforms);
       if (mappedPlatformId) {
         const wasAdded = await this.ensureCompletionatorPlatformRelease(gameId, mappedPlatformId);
         if (wasAdded) {
-          const refreshedPlatforms = await Game.getPlatformsForGameWithStandard(
-            gameId,
-            STANDARD_PLATFORM_IDS,
-          );
+          const refreshedPlatforms = await GamePlatformRegionService
+            .getPlatformsForGameWithStandard(gameId, STANDARD_PLATFORM_IDS);
           state.platformId = mappedPlatformId;
           state.otherPlatform = false;
           return { platforms: refreshedPlatforms };
@@ -791,9 +791,9 @@ export class CompletionatorWorkflowService {
     }
 
     const game = await Game.getGameById(gameId);
-    let region = await Game.getRegionByCode("WW");
+    let region = await GamePlatformRegionService.getRegionByCode("WW");
     if (!region) {
-      region = await Game.ensureRegion(8);
+      region = await GamePlatformRegionService.ensureRegion(8);
     }
     if (!region) {
       return false;

--- a/src/commands/game-journal.command.ts
+++ b/src/commands/game-journal.command.ts
@@ -83,6 +83,7 @@ import {
   JOURNAL_SEARCH_PAGE_SIZE as SEARCH_PAGE_SIZE,
 } from "../config/pagination.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../config/textLimits.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 const gjHmenu = new EphemeralOwnerMenu();
 
@@ -324,7 +325,7 @@ async function autocompleteJournalSearchGame(
     await interaction.respond([]);
     return;
   }
-  const results = await Game.searchGamesAutocomplete(query);
+  const results = await GameSearchService.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: truncateLabel(formatGameTitleWithYear(game)),

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -57,7 +57,8 @@ import {
   type AllAcceptStats,
 } from "../services/GamedbAuditService.js";
 import { isAdmin } from "./admin/admin-auth.utils.js";
-import Game, { IGame } from "../classes/Game.js";
+import type { IGame } from "../types/GameTypes.js";
+import Game from "../classes/Game.js";
 import GameSearchSynonym from "../classes/GameSearchSynonym.js";
 import GameSearchSynonymDraft, {
   type ISynonymDraftPair,

--- a/src/commands/gamedb-admin.command.ts
+++ b/src/commands/gamedb-admin.command.ts
@@ -59,6 +59,7 @@ import {
 import { isAdmin } from "./admin/admin-auth.utils.js";
 import type { IGame } from "../types/GameTypes.js";
 import Game from "../classes/Game.js";
+import GameProfileService from "../classes/GameProfileService.js";
 import GameSearchSynonym from "../classes/GameSearchSynonym.js";
 import GameSearchSynonymDraft, {
   type ISynonymDraftPair,
@@ -1186,8 +1187,8 @@ export class GameDbAdmin {
       fieldLines.push("**Release Data** ❌ Missing");
     }
 
-    const associations = await Game.getGameAssociations(game.id);
-    const nowPlaying = await Game.getNowPlayingMembers(game.id);
+    const associations = await GameProfileService.getGameAssociations(game.id);
+    const nowPlaying = await GameProfileService.getNowPlayingMembers(game.id);
 
     const threadId =
       associations.gotmWins.find((w) => w.threadId)?.threadId ??

--- a/src/commands/gamedb/gamedb-add.command.ts
+++ b/src/commands/gamedb/gamedb-add.command.ts
@@ -39,6 +39,7 @@ import { logError, logWarn } from "../../utilities/LogUtils.js";
 import { apiPost } from "../../services/RpgClubApiClient.js";
 import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 import { importReleaseDatesFromIgdb, saveFullGameMetadata } from "../../functions/GameIgdbSync.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 async function fetchIgdbCoverImage(details: IGDBGameDetails): Promise<Buffer | null> {
   if (!details.cover?.image_id) return null;
@@ -199,7 +200,7 @@ export async function handleNoResults(
   query: string,
 ): Promise<void> {
   try {
-    const existing = await Game.searchGames(query);
+    const existing = await GameSearchService.searchGames(query);
     const existingList = existing
       .slice(0, 10)
       .map((g) => `• **${g.title}** (GameDB #${g.id})`);
@@ -376,7 +377,7 @@ export class GameDbAddCommand {
         game = await Game.getGameById(gameId);
       }
     } else {
-      const matches = await Game.searchGames(searchTerm);
+      const matches = await GameSearchService.searchGames(searchTerm);
       const exactMatches = matches.filter(
         (entry) => entry.title.trim().toLowerCase() === searchTerm.toLowerCase(),
       );

--- a/src/commands/gamedb/gamedb-add.command.ts
+++ b/src/commands/gamedb/gamedb-add.command.ts
@@ -37,6 +37,8 @@ import { showGameProfile, trimTextDisplayContent } from "./gamedb-profile.servic
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { logError, logWarn } from "../../utilities/LogUtils.js";
 import { apiPost } from "../../services/RpgClubApiClient.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
+import { importReleaseDatesFromIgdb, saveFullGameMetadata } from "../../functions/GameIgdbSync.js";
 
 async function fetchIgdbCoverImage(details: IGDBGameDetails): Promise<Buffer | null> {
   if (!details.cover?.image_id) return null;
@@ -69,7 +71,7 @@ export async function processReleaseDates(
     }
   }
   const uniquePlatformIds: number[] = Array.from(new Set(platformIds));
-  const platformMap = await Game.getPlatformsByIgdbIds(uniquePlatformIds);
+  const platformMap = await GamePlatformRegionService.getPlatformsByIgdbIds(uniquePlatformIds);
   const missingPlatformIds = uniquePlatformIds.filter((id) => !platformMap.has(id));
   if (missingPlatformIds.length) {
     logWarn("GamedbAdd.addGame", `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingPlatformIds.join(", ")}`);
@@ -84,7 +86,7 @@ export async function processReleaseDates(
     }
 
     const platform = platformMap.get(platformId);
-    const region = await Game.ensureRegion(release.region);
+    const region = await GamePlatformRegionService.ensureRegion(release.region);
 
     if (!platform || !region) {
       continue;
@@ -168,12 +170,12 @@ export async function addGameToDatabase(
     throw err;
   }
 
-  await Game.saveFullGameMetadata(newGame.id, details);
+  await saveFullGameMetadata(newGame.id, details);
 
   const igdbPlatformIds: number[] = (details.platforms ?? [])
     .map((platform) => platform.id)
     .filter(isPositiveInt);
-  await Game.addGamePlatformsByIgdbIds(newGame.id, igdbPlatformIds);
+  await GamePlatformRegionService.addGamePlatformsByIgdbIds(newGame.id, igdbPlatformIds);
 
   await processReleaseDates(newGame.id, details.release_dates || []);
 
@@ -414,7 +416,7 @@ export class GameDbAddCommand {
 
     try {
       const before = await Game.getGameReleases(game.id);
-      await Game.importReleaseDatesFromIgdb(game.id, game.igdbId);
+      await importReleaseDatesFromIgdb(game.id, game.igdbId);
       const after = await Game.getGameReleases(game.id);
       const added = after.length - before.length;
 

--- a/src/commands/gamedb/gamedb-add.command.ts
+++ b/src/commands/gamedb/gamedb-add.command.ts
@@ -19,7 +19,8 @@ import {
 } from "../../functions/InteractionUtils.js";
 import { igdbService, type IGDBGameDetails } from "../../services/IGDB/IgdbService.js";
 import { createIgdbSession } from "../../services/IGDB/IgdbSelectService.js";
-import Game, { type IGame } from "../../classes/Game.js";
+import type { IGame } from "../../types/GameTypes.js";
+import Game from "../../classes/Game.js";
 import {
   buildTextContainer,
   buildTextReply,

--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -63,6 +63,7 @@ import {
   buildSelectRow,
 } from "../../functions/uiComponents.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 const COMPLETION_WIZARD_SESSIONS = new Map<string, CompletionWizardSession>();
 
@@ -257,7 +258,7 @@ export async function startCompletionWizard(
   gameId: number,
   gameTitle: string,
 ): Promise<void> {
-  const platforms = await Game.getPlatformsForGameWithStandard(
+  const platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
     gameId,
     STANDARD_PLATFORM_IDS,
   );
@@ -334,7 +335,7 @@ export class GameDbCompletionCommand {
       session.removeChoice = value as CompletionWizardSession["removeChoice"];
     }
 
-    const platforms = await Game.getPlatformsForGameWithStandard(
+    const platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
       session.gameId,
       STANDARD_PLATFORM_IDS,
     );
@@ -360,7 +361,7 @@ export class GameDbCompletionCommand {
     if (await replyIfNotOwner(interaction, session.userId, "This action isn't for you.")) return;
 
     const missing = getCompletionWizardMissingSelections(session);
-    const platforms = await Game.getPlatformsForGameWithStandard(
+    const platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
       session.gameId,
       STANDARD_PLATFORM_IDS,
     );
@@ -514,7 +515,7 @@ export class GameDbCompletionCommand {
 
     const note = noteRaw.length ? noteRaw : null;
     try {
-      const platforms = await Game.getPlatformsForGame(gameId);
+      const platforms = await GamePlatformRegionService.getPlatformsForGame(gameId);
       if (!platforms.length) {
         safeIgnore(safeReply(interaction, buildTextReply("This game has no platform data yet. Add to Now Playing from `/now-playing list` " +
             "after platform data is available.", false)));

--- a/src/commands/gamedb/gamedb-csv-import.command.ts
+++ b/src/commands/gamedb/gamedb-csv-import.command.ts
@@ -73,6 +73,8 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { truncateDescription } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
+import { saveFullGameMetadata } from "../../functions/GameIgdbSync.js";
 
 const GAMEDB_CSV_ACTIONS = ["start", "resume", "status", "pause", "cancel"] as const;
 type GameDbCsvAction = (typeof GAMEDB_CSV_ACTIONS)[number];
@@ -151,7 +153,7 @@ async function importGameFromCsv(igdbId: number): Promise<{ gameId: number; titl
     const igdbPlatformIds: number[] = (details.platforms ?? [])
       .map((platform) => platform.id)
       .filter(isPositiveInt);
-    await Game.addGamePlatformsByIgdbIds(existing.id, igdbPlatformIds);
+    await GamePlatformRegionService.addGamePlatformsByIgdbIds(existing.id, igdbPlatformIds);
     await processReleaseDates(existing.id, details.release_dates ?? []);
 
     if (!existing.imageData) {
@@ -181,11 +183,11 @@ async function importGameFromCsv(igdbId: number): Promise<{ gameId: number; titl
     Game.getFeaturedVideoUrl(details),
   );
 
-  await Game.saveFullGameMetadata(newGame.id, details);
+  await saveFullGameMetadata(newGame.id, details);
   const igdbPlatformIds: number[] = (details.platforms ?? [])
     .map((platform) => platform.id)
     .filter(isPositiveInt);
-  await Game.addGamePlatformsByIgdbIds(newGame.id, igdbPlatformIds);
+  await GamePlatformRegionService.addGamePlatformsByIgdbIds(newGame.id, igdbPlatformIds);
   await processReleaseDates(newGame.id, details.release_dates ?? []);
 
   return { gameId: newGame.id, title: newGame.title };

--- a/src/commands/gamedb/gamedb-csv-import.service.ts
+++ b/src/commands/gamedb/gamedb-csv-import.service.ts
@@ -19,7 +19,6 @@ import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { igdbService, type IGDBGame } from "../../services/IGDB/IgdbService.js";
 import { type IgdbSelectOption } from "../../services/IGDB/IgdbSelectService.js";
-import Game from "../../classes/Game.js";
 import { type IGameDbCsvImportItem } from "../../classes/GameDbCsvImport.js";
 import { GAMEDB_CSV_PLATFORM_MAP } from "../../config/gamedbCsvPlatformMap.js";
 import { buildIgdbSearchLink } from "./gamedb-utils.js";
@@ -28,6 +27,7 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { truncateDescription, truncateLabel } from "../../config/textLimits.js";
 import { logWarn } from "../../utilities/LogUtils.js";
 import { GAMEDB_CSV_RESULT_LIMIT } from "../../config/pagination.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 const GAMEDB_CSV_ACTION_PREFIX = "gamedb-csv-action";
 const GAMEDB_CSV_SELECT_PREFIX = "gamedb-csv-select";
@@ -36,7 +36,7 @@ let csvPlatformLookup: Map<string, number> | null = null;
 
 export async function getPlatformLookupMap(): Promise<Map<string, number>> {
   if (csvPlatformLookup) return csvPlatformLookup;
-  const platforms = await Game.getAllPlatforms();
+  const platforms = await GamePlatformRegionService.getAllPlatforms();
   const map = new Map<string, number>();
   for (const platform of platforms) {
     if (!platform.igdbPlatformId) continue;
@@ -249,7 +249,7 @@ export async function buildIgdbSelectOptions(
   }
 
   const uniquePlatformIds: number[] = Array.from(new Set(platformIds));
-  const platformMap = await Game.getPlatformsByIgdbIds(uniquePlatformIds);
+  const platformMap = await GamePlatformRegionService.getPlatformsByIgdbIds(uniquePlatformIds);
   const missingPlatformIds = uniquePlatformIds.filter((id) => !platformMap.has(id));
   if (missingPlatformIds.length) {
     logWarn("GamedbCsvImport", `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingPlatformIds.join(", ")}`);

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -24,7 +24,8 @@ import { formatPlatformDisplayName } from "../../functions/PlatformDisplay.js";
 import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 import { padCommandName } from "../help.command.js";
-import Game, { type IGame, type IRelease } from "../../classes/Game.js";
+import type { IGame, IRelease } from "../../types/GameTypes.js";
+import Game from "../../classes/Game.js";
 import {
   buildComponentsV2Flags,
   getSearchRowsFromComponents,

--- a/src/commands/gamedb/gamedb-profile.service.ts
+++ b/src/commands/gamedb/gamedb-profile.service.ts
@@ -25,7 +25,7 @@ import { formatTableDate } from "../../functions/DateFormatUtils.js";
 import { renderUsernameWithEmoji } from "../../services/UserEmojiService.js";
 import { padCommandName } from "../help.command.js";
 import type { IGame, IRelease } from "../../types/GameTypes.js";
-import Game from "../../classes/Game.js";
+import GameProfileService from "../../classes/GameProfileService.js";
 import {
   buildComponentsV2Flags,
   getSearchRowsFromComponents,
@@ -157,7 +157,7 @@ export async function buildGameProfile(
     | GameProfileRenderContext,
 ): Promise<GameProfileResult | null> {
   try {
-    const profile = await Game.getGameProfile(gameId);
+    const profile = await GameProfileService.getGameProfile(gameId);
     if (!profile) {
       return null;
     }

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -31,7 +31,7 @@ import {
   safeV2TextContent,
 } from "../../functions/ComponentsV2Utils.js";
 import { shouldRenderPrevNextButtons } from "../../functions/PaginationUtils.js";
-import Game from "../../classes/Game.js";
+import GameProfileService from "../../classes/GameProfileService.js";
 import { decodeBase64Url } from "../../functions/CustomIdUtils.js";
 import {
   autocompleteSearchCompany,
@@ -59,6 +59,7 @@ import {
   buildButtonRow,
   buildSelectRow,
 } from "../../functions/uiComponents.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 function formatUpcomingDate(date: Date | null | undefined): string {
   if (!date) return "";
@@ -79,11 +80,11 @@ async function buildFilterSummary(filters: ISearchFilters): Promise<string> {
   }
   if (filters.year) parts.push(`Year: ${filters.year}`);
   if (filters.developerId) {
-    const company = await Game.getCompanyById(filters.developerId);
+    const company = await GameProfileService.getCompanyById(filters.developerId);
     parts.push(`Developer: ${company?.name ?? `ID ${filters.developerId}`}`);
   }
   if (filters.publisherId) {
-    const company = await Game.getCompanyById(filters.publisherId);
+    const company = await GameProfileService.getCompanyById(filters.publisherId);
     parts.push(`Publisher: ${company?.name ?? `ID ${filters.publisherId}`}`);
   }
   return parts.join(" | ");
@@ -96,7 +97,7 @@ export async function runSearchFlow(
   filters?: ISearchFilters,
 ): Promise<void> {
   const activeFilters = filters ?? {};
-  const results = await Game.searchGames(searchTerm, activeFilters);
+  const results = await GameSearchService.searchGames(searchTerm, activeFilters);
 
   if (results.length === 0) {
     if (!searchTerm) {
@@ -367,7 +368,7 @@ export class GameDbSearchCommand {
       return;
     }
 
-    const results = await Game.searchGames(searchTerm, filters);
+    const results = await GameSearchService.searchGames(searchTerm, filters);
 
     const gameId = Number(interaction.values?.[0]);
     if (!Number.isFinite(gameId)) {
@@ -436,7 +437,7 @@ export class GameDbSearchCommand {
       return;
     }
 
-    const results = await Game.searchGames(searchTerm, filters);
+    const results = await GameSearchService.searchGames(searchTerm, filters);
     const totalPages = Math.max(
       1,
       Math.ceil(results.length / GAME_SEARCH_PAGE_SIZE),
@@ -493,7 +494,7 @@ export class GameDbSearchCommand {
       return;
     }
 
-    const results = await Game.searchGames(searchTerm, filters);
+    const results = await GameSearchService.searchGames(searchTerm, filters);
     if (results.length === 0) {
       const msg = searchTerm
         ? `No results found for "${searchTerm}".`

--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -53,6 +53,7 @@ import { handleNoResults } from "./gamedb-add.command.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { MAX_CONTAINER_TEXT } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 import {
   buildActionButton,
   buildButtonRow,
@@ -73,7 +74,7 @@ async function buildFilterSummary(filters: ISearchFilters): Promise<string> {
   const parts: string[] = [];
   if (filters.upcomingRelease) parts.push("Upcoming release");
   if (filters.platformId) {
-    const platform = await Game.getPlatformById(filters.platformId);
+    const platform = await GamePlatformRegionService.getPlatformById(filters.platformId);
     parts.push(`Platform: ${platform?.name ?? `ID ${filters.platformId}`}`);
   }
   if (filters.year) parts.push(`Year: ${filters.year}`);

--- a/src/commands/gamedb/gamedb-thread.command.ts
+++ b/src/commands/gamedb/gamedb-thread.command.ts
@@ -26,6 +26,7 @@ import { getThreadsByGameId, setThreadGameLink, upsertThreadRecord } from "../..
 import { NOW_PLAYING_FORUM_ID } from "../../config/channels.js";
 import { NOW_PLAYING_SIDEGAME_TAG_ID } from "../../config/tags.js";
 import Game from "../../classes/Game.js";
+import GameProfileService from "../../classes/GameProfileService.js";
 import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
 import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
@@ -184,8 +185,8 @@ async function runNowPlayingThreadWizard(
     });
     await setThreadGameLink(thread.id, gameId);
     await sendStatus(`Created and linked ${channelMention(thread.id)}.`);
-    const nowPlayingMembers = await Game.getNowPlayingMembers(gameId);
-    const completions = await Game.getGameCompletions(gameId);
+    const nowPlayingMembers = await GameProfileService.getNowPlayingMembers(gameId);
+    const completions = await GameProfileService.getGameCompletions(gameId);
     const mentionIds = new Set<string>([interaction.user.id]);
     nowPlayingMembers.forEach((member) => mentionIds.add(member.userId));
     completions.forEach((member) => mentionIds.add(member.userId));

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -16,11 +16,12 @@ import {
 import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
 import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import { encodeWithMaxLength } from "../../functions/CustomIdUtils.js";
-import Game from "../../classes/Game.js";
+import GameProfileService from "../../classes/GameProfileService.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
 import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
 import { GAMEDB_SEARCH_PREFIX } from "../../config/customIdPrefixes.js";
 import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
+import GameSearchService from "../../classes/GameSearchService.js";
 
 export interface ISearchFilters {
   upcomingRelease?: boolean;
@@ -244,7 +245,7 @@ export async function autocompleteSearchCompany(
 ): Promise<void> {
   const focused = interaction.options.getFocused(true);
   const rawQuery = focused?.value ? String(focused.value) : "";
-  const companies = await Game.getAllCompanies();
+  const companies = await GameProfileService.getAllCompanies();
   const query = rawQuery.toLowerCase().trim();
   const filtered = query
     ? companies.filter((c) => c.name.toLowerCase().includes(query))
@@ -266,7 +267,7 @@ export async function autocompleteGameDbViewTitle(
     await interaction.respond([]);
     return;
   }
-  const results = await Game.searchGamesAutocomplete(query);
+  const results = await GameSearchService.searchGamesAutocomplete(query);
   const resultOptions = results.slice(0, 24).map((game) => {
     const label = formatGameTitleWithYear(game);
     return {

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -20,6 +20,7 @@ import Game from "../../classes/Game.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
 import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
 import { GAMEDB_SEARCH_PREFIX } from "../../config/customIdPrefixes.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 export interface ISearchFilters {
   upcomingRelease?: boolean;
@@ -222,7 +223,7 @@ export async function autocompleteSearchPlatform(
 ): Promise<void> {
   const focused = interaction.options.getFocused(true);
   const rawQuery = focused?.value ? String(focused.value) : "";
-  const platforms = await Game.getAllPlatforms();
+  const platforms = await GamePlatformRegionService.getAllPlatforms();
   const query = rawQuery.toLowerCase().trim();
   const filtered = query
     ? platforms.filter((p) =>

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -24,7 +24,8 @@ import {
   sanitizeUserInput,
 } from "../../functions/InteractionUtils.js";
 import { getHltbCacheByGameId, upsertHltbCache } from "../../classes/HltbCache.js";
-import Game, { type GameSource } from "../../classes/Game.js";
+import type { GameSource } from "../../types/GameTypes.js";
+import Game from "../../classes/Game.js";
 import { searchHltb } from "../../scripts/SearchHltb.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import {

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -52,6 +52,7 @@ import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import UserGameBacklog from "../../classes/UserGameBacklog.js";
 import { buildApiErrorMessage } from "../../utilities/ApiErrorUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 @Discord()
 @SlashGroup("gamedb")
@@ -213,7 +214,7 @@ export class GameDbViewCommand {
     gameId: number,
   ): Promise<void> {
     try {
-      const platforms = await Game.getPlatformsForGame(gameId);
+      const platforms = await GamePlatformRegionService.getPlatformsForGame(gameId);
       const validPlatforms = platforms.filter(
         (p) => p.name?.trim() && String(p.id)?.trim(),
       );

--- a/src/commands/hltb.command.ts
+++ b/src/commands/hltb.command.ts
@@ -4,7 +4,6 @@ import { Discord, Slash, SlashOption } from "discordx";
 import { MediaGalleryBuilder, MediaGalleryItemBuilder } from "@discordjs/builders";
 import { searchHltb, type HltbSearchResult } from "../scripts/SearchHltb.js";
 import { COLOR_PRIMARY } from "../config/colors.js";
-import Game from "../classes/Game.js";
 import { getHltbCacheByGameId, upsertHltbCache } from "../classes/HltbCache.js";
 import {
   deferWithPrivateFlag,
@@ -23,6 +22,7 @@ import {
   parseTitleWithYear,
 } from "../functions/GameTitleAutocompleteUtils.js";
 import { truncateLabel } from "../config/textLimits.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 function buildKeepTypingOption(query: string): { name: string; value: string } {
   const label = `Keep typing: "${query}"`;
@@ -42,7 +42,7 @@ async function autocompleteHltbTitle(
     await interaction.respond([]);
     return;
   }
-  const results = await Game.searchGamesAutocomplete(query);
+  const results = await GameSearchService.searchGamesAutocomplete(query);
   const resultOptions = results.slice(0, 24).map((game) => {
     const label = formatGameTitleWithYear(game);
     return {
@@ -140,7 +140,7 @@ async function resolveHltbResult(title: string): Promise<HltbSearchResult | null
   const searchTerm = parsedTitle.title.trim();
   if (!searchTerm) return null;
 
-  const matches = await Game.searchGames(searchTerm);
+  const matches = await GameSearchService.searchGames(searchTerm);
   const normalizedTitle = searchTerm.toLowerCase();
   const exactTitleMatches = matches.filter(
     (game) => game.title.toLowerCase() === normalizedTitle,

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -17,7 +17,6 @@ import {
   upsertNomination,
 } from "../classes/Nomination.js";
 import type { IGame } from "../types/GameTypes.js";
-import Game from "../classes/Game.js";
 import { buildNominationListPayload } from "../functions/NominationListComponents.js";
 import {
   buildComponentsV2Flags,
@@ -48,6 +47,7 @@ import { showGameProfileFromNomination } from "./gamedb.command.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../config/textLimits.js";
 import { logError } from "../utilities/LogUtils.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 const NOMINATE_REASON_MAX_LENGTH = 1500;
 
@@ -62,7 +62,7 @@ async function autocompleteNominationTitle(
     return;
   }
 
-  const results = await Game.searchGamesAutocomplete(query);
+  const results = await GameSearchService.searchGamesAutocomplete(query);
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: truncateLabel(formatGameTitleWithYear(game)),
@@ -81,7 +81,7 @@ function parseNominationKind(value: string): NominationKind | null {
 async function resolveNominatedGameByTitle(searchTerm: string): Promise<IGame | null> {
   const parsed = parseTitleWithYear(searchTerm);
   const normalizedSearchTerm = parsed.title;
-  const existing = await Game.searchGames(normalizedSearchTerm);
+  const existing = await GameSearchService.searchGames(normalizedSearchTerm);
   const exact = existing.find((game) => {
     if (game.title.toLowerCase() !== normalizedSearchTerm.toLowerCase()) {
       return false;

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -16,7 +16,8 @@ import {
   listNominationsForRound,
   upsertNomination,
 } from "../classes/Nomination.js";
-import Game, { type IGame } from "../classes/Game.js";
+import type { IGame } from "../types/GameTypes.js";
+import Game from "../classes/Game.js";
 import { buildNominationListPayload } from "../functions/NominationListComponents.js";
 import {
   buildComponentsV2Flags,

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -33,7 +33,8 @@ import {
   type AnyRepliable,
   replyIfNotOwner,
 } from "../functions/InteractionUtils.js";
-import Game, { type IGame } from "../classes/Game.js";
+import type { IGame } from "../types/GameTypes.js";
+import Game from "../classes/Game.js";
 import {
   buildActionButton,
   buildButtonRow,

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -133,6 +133,7 @@ import {
   startNowPlayingIgdbImport,
   startNowPlayingIgdbImportFromInteraction,
 } from "./now-playing/nowPlayingIgdbImport.service.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 @Discord()
 @SlashGroup({ description: "Show now playing data", name: "now-playing" })
@@ -412,7 +413,7 @@ export class NowPlayingCommand {
     }
 
     try {
-      const results = await Game.searchGames(query);
+      const results = await GameSearchService.searchGames(query);
       if (!results.length) {
         await startNowPlayingIgdbImportFromInteraction(
           interaction,
@@ -517,7 +518,7 @@ export class NowPlayingCommand {
       return null;
     }
 
-    const existing = await Game.searchGames(normalizedSearchTerm);
+    const existing = await GameSearchService.searchGames(normalizedSearchTerm);
     const exact = existing.find((game) => {
       if (game.title.toLowerCase() !== normalizedSearchTerm.toLowerCase()) {
         return false;

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -128,6 +128,7 @@ import {
   deleteEligibleNowPlayingMessageInCurrentChannel,
 } from "./now-playing/nowPlayingMessageService.js";
 import { promptNowPlayingAddPlatformSelection } from "./now-playing/nowPlayingAddService.js";
+import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
 import {
   startNowPlayingIgdbImport,
   startNowPlayingIgdbImportFromInteraction,
@@ -207,7 +208,7 @@ export class NowPlayingCommand {
       return;
     }
 
-    const platform = await Game.getPlatformById(platformId);
+    const platform = await GamePlatformRegionService.getPlatformById(platformId);
     if (!platform) {
       const container = buildTextContainer("Selected platform was not found.");
       await safeReply(interaction, {
@@ -928,7 +929,7 @@ export class NowPlayingCommand {
     const limitedEntries = entries.slice(0, 10);
     const optionsPerEntry = await Promise.all(
       limitedEntries.map(async (entry) => {
-        const platforms = await Game.getPlatformsForGameWithStandard(
+        const platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
           entry.gameId,
           STANDARD_PLATFORM_IDS,
         );
@@ -976,7 +977,8 @@ export class NowPlayingCommand {
       return;
     }
 
-    const platforms = await Game.getPlatformsForGameWithStandard(gameId, STANDARD_PLATFORM_IDS);
+    const platforms = await GamePlatformRegionService
+      .getPlatformsForGameWithStandard(gameId, STANDARD_PLATFORM_IDS);
     if (!platforms.length) {
       const container = buildTextContainer("No platform data is available for this game.");
       if (mode === "update" && "update" in interaction) {

--- a/src/commands/now-playing/nowPlayingAddService.ts
+++ b/src/commands/now-playing/nowPlayingAddService.ts
@@ -13,6 +13,7 @@ import {
 } from "../../functions/ComponentsV2Utils.js";
 import { nowPlayingAddPlatformSessions } from "./nowPlayingContexts.js";
 import { NOW_PLAYING_ADD_PLATFORM_SELECT_PREFIX } from "./nowPlayingIds.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 export async function promptNowPlayingAddPlatformSelection(
   interaction: StringSelectMenuInteraction,
@@ -26,7 +27,8 @@ export async function promptNowPlayingAddPlatformSelection(
   if (!game) {
     throw new Error("Selected game not found. Please try again.");
   }
-  const platforms = await Game.getPlatformsForGameWithStandard(game.id, STANDARD_PLATFORM_IDS);
+  const platforms = await GamePlatformRegionService
+    .getPlatformsForGameWithStandard(game.id, STANDARD_PLATFORM_IDS);
   if (!platforms.length) {
     throw new Error("No platform data is available for this game.");
   }

--- a/src/commands/now-playing/nowPlayingCompletion.handler.ts
+++ b/src/commands/now-playing/nowPlayingCompletion.handler.ts
@@ -110,6 +110,7 @@ import {
   withPmNowPlayingList,
 } from "./nowPlayingListRenderer.js";
 import { NOW_PLAYING_HELP_PREFIX } from "../now-playing-help.js";
+import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 async function confirmDuplicateCompletion(
   interaction: CommandInteraction | ModalSubmitInteraction | ButtonInteraction,
@@ -473,7 +474,8 @@ async function promptNowPlayingCompletionPlatformSelection(
   finalPlaytimeHours: number | null,
   note: string | null,
 ): Promise<void> {
-  const platforms = await Game.getPlatformsForGameWithStandard(game.id, STANDARD_PLATFORM_IDS);
+  const platforms = await GamePlatformRegionService
+    .getPlatformsForGameWithStandard(game.id, STANDARD_PLATFORM_IDS);
   if (!platforms.length) {
     const container = buildTextContainer("No platform data is available for this game.");
     await safeReply(interaction, {

--- a/src/commands/now-playing/nowPlayingCompletion.handler.ts
+++ b/src/commands/now-playing/nowPlayingCompletion.handler.ts
@@ -37,7 +37,8 @@ import {
   safeReply,
   safeUpdate,
 } from "../../functions/InteractionUtils.js";
-import Game, { type IGame } from "../../classes/Game.js";
+import type { IGame } from "../../types/GameTypes.js";
+import Game from "../../classes/Game.js";
 import {
   buildActionButton,
   buildButtonRow,

--- a/src/commands/now-playing/nowPlayingIgdbImport.service.ts
+++ b/src/commands/now-playing/nowPlayingIgdbImport.service.ts
@@ -1,5 +1,4 @@
 import { type StringSelectMenuInteraction } from "discord.js";
-import Game from "../../classes/Game.js";
 import {
   safeDeferUpdate,
   safeReply,
@@ -18,12 +17,7 @@ import {
 import { truncateDescription } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import { promptNowPlayingAddPlatformSelection } from "./nowPlayingAddService.js";
-
-export async function importGameFromIgdb(
-  igdbId: number,
-): Promise<{ gameId: number; title: string }> {
-  return Game.importGameFromIgdb(igdbId);
-}
+import { importGameFromIgdb } from "../../functions/GameIgdbSync.js";
 
 export async function startNowPlayingIgdbImportFromInteraction(
   interaction: AnyRepliable,

--- a/src/commands/now-playing/nowPlayingIgdbImport.ts
+++ b/src/commands/now-playing/nowPlayingIgdbImport.ts
@@ -1,5 +1,4 @@
 import { type StringSelectMenuInteraction } from "discord.js";
-import Game from "../../classes/Game.js";
 import {
   safeDeferUpdate,
   safeReply,
@@ -17,6 +16,7 @@ import {
 } from "../../functions/ComponentsV2Utils.js";
 import { truncateDescription } from "../../config/textLimits.js";
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
+import { importGameFromIgdb } from "../../functions/GameIgdbSync.js";
 
 interface INowPlayingIgdbSession {
   userId: string;
@@ -32,12 +32,6 @@ type PromptNowPlayingAddPlatformSelection = (
   note: string | null,
   mode: "reply" | "update",
 ) => Promise<void>;
-
-export async function importGameFromIgdb(
-  igdbId: number,
-): Promise<{ gameId: number; title: string }> {
-  return Game.importGameFromIgdb(igdbId);
-}
 
 export async function startNowPlayingIgdbImport(
   interaction: StringSelectMenuInteraction,

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -68,6 +68,8 @@ import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
 import { buildSelectRow } from "../functions/uiComponents.js";
+import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
+import { saveFullGameMetadata } from "../functions/GameIgdbSync.js";
 
 type CompletionAddContext = {
   targetUserId: string;
@@ -419,7 +421,7 @@ export class SuperAdmin {
     ctx: CompletionAddContext,
     game: IGame,
   ): Promise<void> {
-    const platforms = await Game.getPlatformsForGameWithStandard(
+    const platforms = await GamePlatformRegionService.getPlatformsForGameWithStandard(
       game.id,
       STANDARD_PLATFORM_IDS,
     );
@@ -699,7 +701,7 @@ export class SuperAdmin {
       details.url ?? null,
       Game.getFeaturedVideoUrl(details),
     );
-    await Game.saveFullGameMetadata(newGame.id, details);
+    await saveFullGameMetadata(newGame.id, details);
     return { gameId: newGame.id, title: details.name };
   }
 

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -70,6 +70,7 @@ import { logError, logWarn } from "../utilities/LogUtils.js";
 import { buildSelectRow } from "../functions/uiComponents.js";
 import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
 import { saveFullGameMetadata } from "../functions/GameIgdbSync.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 type CompletionAddContext = {
   targetUserId: string;
@@ -364,7 +365,7 @@ export class SuperAdmin {
     searchTerm: string,
     ctx: CompletionAddContext,
   ): Promise<void> {
-    const localResults = await Game.searchGames(searchTerm);
+    const localResults = await GameSearchService.searchGames(searchTerm);
     if (localResults.length) {
       const sessionId = buildStableSuperAdminSessionId("sacomp", [
         interaction.id,

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -32,7 +32,8 @@ import {
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
 import Member, { type IMemberRecord } from "../classes/Member.js";
-import Game, { type IGame } from "../classes/Game.js";
+import type { IGame } from "../types/GameTypes.js";
+import Game from "../classes/Game.js";
 import { STANDARD_PLATFORM_IDS } from "../config/standardPlatforms.js";
 import { igdbService } from "../services/IGDB/IgdbService.js";
 import {

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -45,6 +45,7 @@ import { logError } from "../utilities/LogUtils.js";
 import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
 import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
 import { saveFullGameMetadata } from "../functions/GameIgdbSync.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 const PUSH_PIN_EMOJI = "📌";
 const PLUS_EMOJI = "➕";
@@ -297,7 +298,7 @@ export class MessageReactionAdd {
     session.completionType = value as CompletionType;
     session.promptMessageId = interaction.message?.id ?? session.promptMessageId;
     session.promptChannelId = interaction.channelId ?? session.promptChannelId;
-    const matches = await Game.searchGames(session.query);
+    const matches = await GameSearchService.searchGames(session.query);
     if (!matches.length) {
       await this.promptIgdbImport(interaction, session);
       return;

--- a/src/events/MessageReactionAdd.command.ts
+++ b/src/events/MessageReactionAdd.command.ts
@@ -43,6 +43,8 @@ import {
 } from "../functions/uiComponents.js";
 import { logError } from "../utilities/LogUtils.js";
 import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
+import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
+import { saveFullGameMetadata } from "../functions/GameIgdbSync.js";
 
 const PUSH_PIN_EMOJI = "📌";
 const PLUS_EMOJI = "➕";
@@ -539,7 +541,7 @@ export class MessageReactionAdd {
       return;
     }
 
-    const platforms = await Game.getPlatformsForGame(game.id);
+    const platforms = await GamePlatformRegionService.getPlatformsForGame(game.id);
     if (!platforms.length) {
       await updateMessage("No platform release data is available for this game.");
       return;
@@ -656,7 +658,7 @@ export class MessageReactionAdd {
       details.url ?? null,
       Game.getFeaturedVideoUrl(details),
     );
-    await Game.saveFullGameMetadata(newGame.id, details);
+    await saveFullGameMetadata(newGame.id, details);
     return { gameId: newGame.id, title: details.name };
   }
 }

--- a/src/events/PresenceUpdate.command.ts
+++ b/src/events/PresenceUpdate.command.ts
@@ -10,7 +10,6 @@ import crypto from "node:crypto";
 import type { Presence } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { ButtonComponent, Discord, On } from "discordx";
-import Game from "../classes/Game.js";
 import Member from "../classes/Member.js";
 import PresencePromptOptOut, { normalizePresenceGameTitle } from "../classes/PresencePromptOptOut.js";
 import PresencePromptHistory from "../classes/PresencePromptHistory.js";
@@ -21,6 +20,7 @@ import { PRESENCE_PROMPT_CHANNEL_ID } from "../config/channels.js";
 import { buildActionButton, buildButtonRow } from "../functions/uiComponents.js";
 import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
 import { importGameFromIgdb } from "../functions/GameIgdbSync.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 const YES_PREFIX = "presence-np-yes";
 const NO_PREFIX = "presence-np-no";
@@ -67,7 +67,7 @@ async function resolvePresenceGame(
   title: string,
 ): Promise<{ gameId: number; title: string } | null> {
   const normalized = normalizePresenceGameTitle(title);
-  const searchResults = await Game.searchGames(title);
+  const searchResults = await GameSearchService.searchGames(title);
   const exact = searchResults.find(
     (game) => normalizePresenceGameTitle(game.title) === normalized,
   );

--- a/src/events/PresenceUpdate.command.ts
+++ b/src/events/PresenceUpdate.command.ts
@@ -19,6 +19,8 @@ import { replyIfNotOwner, safeReply, safeUpdate } from "../functions/Interaction
 import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { PRESENCE_PROMPT_CHANNEL_ID } from "../config/channels.js";
 import { buildActionButton, buildButtonRow } from "../functions/uiComponents.js";
+import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
+import { importGameFromIgdb } from "../functions/GameIgdbSync.js";
 
 const YES_PREFIX = "presence-np-yes";
 const NO_PREFIX = "presence-np-no";
@@ -83,7 +85,7 @@ async function resolvePresenceGame(
     return null;
   }
 
-  return Game.importGameFromIgdb(igdbGame.id);
+  return importGameFromIgdb(igdbGame.id);
 }
 
 function buildPromptButtons(sessionId: string): ActionRowBuilder<ButtonBuilder> {
@@ -205,7 +207,7 @@ export class PresenceUpdate {
         return;
       }
 
-      const platforms = await Game.getPlatformsForGame(resolved.gameId);
+      const platforms = await GamePlatformRegionService.getPlatformsForGame(resolved.gameId);
       if (!platforms.length) {
         await safeUpdate(interaction, {
           content:

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -17,7 +17,8 @@ import {
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
 import { type CompletionType } from "../commands/profile.command.js";
 import { formatPlaytimeHours, formatTableDate } from "./DateFormatUtils.js";
-import Game, { type IGame } from "../classes/Game.js";
+import type { IGame } from "../types/GameTypes.js";
+import Game from "../classes/Game.js";
 import Member from "../classes/Member.js";
 import { ANNOUNCEMENT_CHANNEL_ID, BOT_DEV_CHANNEL_ID } from "../config/channels.js";
 import {

--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -19,6 +19,7 @@ import { type CompletionType } from "../commands/profile.command.js";
 import { formatPlaytimeHours, formatTableDate } from "./DateFormatUtils.js";
 import type { IGame } from "../types/GameTypes.js";
 import Game from "../classes/Game.js";
+import GameProfileService from "../classes/GameProfileService.js";
 import Member from "../classes/Member.js";
 import { ANNOUNCEMENT_CHANNEL_ID, BOT_DEV_CHANNEL_ID } from "../config/channels.js";
 import {
@@ -188,7 +189,7 @@ export async function announceCompletion(
       return;
     }
 
-    const completions = await Game.getGameCompletions(game.id);
+    const completions = await GameProfileService.getGameCompletions(game.id);
     const isFirst = completions.length === 1;
 
     const playtimeText = formatPlaytimeHours(finalPlaytimeHours);

--- a/src/functions/GameAutocompleteCache.ts
+++ b/src/functions/GameAutocompleteCache.ts
@@ -1,4 +1,4 @@
-import type { IGameAutocompleteResult } from "../classes/Game.js";
+import type { IGameAutocompleteResult } from "../types/GameTypes.js";
 
 export const AUTOCOMPLETE_CACHE_TTL_MS = 60_000;
 export const AUTOCOMPLETE_CACHE_MAX_ENTRIES = 300;

--- a/src/functions/GameIgdbSync.ts
+++ b/src/functions/GameIgdbSync.ts
@@ -16,6 +16,7 @@ import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
 import { clearAutocompleteSearchCaches } from "./GameAutocompleteCache.js";
 import Game from "../classes/Game.js";
+import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
 
 type IGDBReleaseDate = NonNullable<IGDBGameDetails["release_dates"]>[number];
 
@@ -101,7 +102,7 @@ export async function saveReleaseDates(
   for (const { release, date } of earliestByPlatform.values()) {
     if (!release.platform?.id) continue;
 
-    const platform = await Game.ensurePlatform({
+    const platform = await GamePlatformRegionService.ensurePlatform({
       id: release.platform.id,
       name: release.platform.name ?? null,
     });
@@ -111,7 +112,7 @@ export async function saveReleaseDates(
       continue;
     }
 
-    const region = await Game.ensureRegion(release.region ?? 8);
+    const region = await GamePlatformRegionService.ensureRegion(release.region ?? 8);
     if (!region) continue;
 
     const format: "Physical" | "Digital" | null = null;
@@ -120,6 +121,35 @@ export async function saveReleaseDates(
   }
 
   await updateInitialReleaseDate(gameId);
+}
+
+export async function clearReleaseDates(
+  gameId: number,
+): Promise<{ releases: number; announcements: number }> {
+  return dbTransaction(async (conn) => {
+    const announceCount = await dbMutateConn(
+      conn,
+      GameSql.clearReleaseAnnouncements,
+      { gameId },
+    );
+    const releaseCount = await dbMutateConn(conn, GameSql.clearReleases, {
+      gameId,
+    });
+    await dbMutateConn(conn, GameSql.clearInitialReleaseDate, { gameId });
+    return {
+      releases: Number(releaseCount),
+      announcements: Number(announceCount),
+    };
+  });
+}
+
+export async function refreshReleaseDates(
+  gameId: number,
+  releases: NonNullable<IGDBGameDetails["release_dates"]>,
+): Promise<void> {
+  await clearReleaseDates(gameId);
+  if (!releases.length) return;
+  await saveReleaseDates(gameId, releases);
 }
 
 export async function saveFullGameMetadata(
@@ -336,7 +366,7 @@ export async function addGamePlatformsByIgdbIds(
   );
   if (!uniqueIds.length) return;
 
-  const platformMap = await Game.getPlatformsByIgdbIds(uniqueIds);
+  const platformMap = await GamePlatformRegionService.getPlatformsByIgdbIds(uniqueIds);
   const missingIds = uniqueIds.filter((id) => !platformMap.has(id));
   if (missingIds.length) {
     logWarn(

--- a/src/functions/GameIgdbSync.ts
+++ b/src/functions/GameIgdbSync.ts
@@ -11,9 +11,8 @@ import {
   type IGDBGameDetails,
   igdbService,
 } from "../services/IGDB/IgdbService.js";
-import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
-import { logError, logWarn } from "../utilities/LogUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 import { clearAutocompleteSearchCaches } from "./GameAutocompleteCache.js";
 import Game from "../classes/Game.js";
 import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
@@ -354,35 +353,4 @@ export async function importReleaseDatesFromIgdb(
     throw new Error("Failed to load game details from IGDB.");
   }
   await saveReleaseDates(gameId, details.release_dates ?? []);
-}
-
-export async function addGamePlatformsByIgdbIds(
-  gameId: number,
-  igdbPlatformIds: number[],
-): Promise<void> {
-  if (!isPositiveInt(gameId)) return;
-  const uniqueIds = Array.from(
-    new Set(igdbPlatformIds.filter(isPositiveInt)),
-  );
-  if (!uniqueIds.length) return;
-
-  const platformMap = await GamePlatformRegionService.getPlatformsByIgdbIds(uniqueIds);
-  const missingIds = uniqueIds.filter((id) => !platformMap.has(id));
-  if (missingIds.length) {
-    logWarn(
-      "Game.syncIgdbPlatforms",
-      `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingIds.join(", ")}`,
-    );
-  }
-
-  await dbTransaction(async (conn) => {
-    for (const igdbId of uniqueIds) {
-      const platform = platformMap.get(igdbId);
-      if (!platform) continue;
-      await dbMutateConn(conn, GameSql.addGamePlatformMerge, {
-        gameId,
-        platformId: platform.id,
-      });
-    }
-  });
 }

--- a/src/functions/GameMappers.ts
+++ b/src/functions/GameMappers.ts
@@ -1,4 +1,4 @@
-import type { IGame, IRelease, IPlatformDef, IRegionDef } from "../classes/Game.js";
+import type { IGame, IRelease, IPlatformDef, IRegionDef } from "../types/GameTypes.js";
 import type { HltbCacheEntry } from "../classes/HltbCache.js";
 
 export const IGDB_REGION_MAP: Record<number, { code: string; name: string }> = {

--- a/src/functions/GameProfileMapper.ts
+++ b/src/functions/GameProfileMapper.ts
@@ -6,7 +6,7 @@ import type {
   ICompletedMember,
   ICollectionOwnerMember,
   IMappedGameProfile,
-} from "../classes/Game.js";
+} from "../types/GameTypes.js";
 import {
   mapGameFromApi,
   mapReleaseFromApi,

--- a/src/functions/ImportCandidateUtils.ts
+++ b/src/functions/ImportCandidateUtils.ts
@@ -6,6 +6,7 @@ import {
   normalizeTitleWithSteps,
 } from "./ImportTitleNormalization.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 export type ImportCandidate = {
   gameId: number;
@@ -84,7 +85,7 @@ export async function buildImportCandidates(title: string): Promise<ImportCandid
   if (!variants.length) return [];
 
   for (const variant of variants) {
-    const results = await Game.searchGames(variant);
+    const results = await GameSearchService.searchGames(variant);
     if (!results.length) continue;
 
     const normalizedSearch = normalizeCandidate(variant);

--- a/src/functions/journalView.ts
+++ b/src/functions/journalView.ts
@@ -12,6 +12,7 @@ import { formatTableDate, formatPlaytimeHours } from "./DateFormatUtils.js";
 import { buildComponentsV2EditFlags, buildContentContainer } from "./ComponentsV2Utils.js";
 import { buildActionButton, buildButtonRow, buildUserHeaderContainer } from "./uiComponents.js";
 import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
+import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
 
 const JOURNAL_PAGE_SIZE = 1;
 
@@ -149,7 +150,7 @@ export async function buildJournalView(options: IJournalViewOptions): Promise<{
     const completionLines: string[] = [];
     for (const completion of completions) {
       const platform = completion.platformId
-        ? await Game.getPlatformById(completion.platformId).catch(() => null)
+        ? await GamePlatformRegionService.getPlatformById(completion.platformId).catch(() => null)
         : null;
       const platformName = platform?.abbreviation ?? platform?.name ?? "Unknown Platform";
       const completedDate = completion.completedAt

--- a/src/services/GamedbAuditService.ts
+++ b/src/services/GamedbAuditService.ts
@@ -11,6 +11,7 @@ import {
   buildComponentsV2EditFlags,
 } from "../functions/ComponentsV2Utils.js";
 import { COMPONENTS_V2_FLAG } from "../config/flags.js";
+import { importReleaseDatesFromIgdb } from "../functions/GameIgdbSync.js";
 
 export type AutoAcceptResult = {
   updated: number;
@@ -215,7 +216,7 @@ async function performAutoAcceptReleaseData(
       }
 
       const beforeCount = (await Game.getGameReleases(game.id)).length;
-      await Game.importReleaseDatesFromIgdb(game.id, game.igdbId);
+      await importReleaseDatesFromIgdb(game.id, game.igdbId);
       const afterCount = (await Game.getGameReleases(game.id)).length;
 
       if (afterCount > beforeCount) {
@@ -456,7 +457,7 @@ async function performAutoAcceptAll(
     // Release dates
     const releasesBefore = (await Game.getGameReleases(game.id)).length;
     try {
-      await Game.importReleaseDatesFromIgdb(game.id, game.igdbId);
+      await importReleaseDatesFromIgdb(game.id, game.igdbId);
       const releasesAfter = (await Game.getGameReleases(game.id)).length;
       if (releasesAfter > releasesBefore) {
         stats.releases.updated++;

--- a/src/services/IGDB/IgdbScanService.ts
+++ b/src/services/IGDB/IgdbScanService.ts
@@ -1,5 +1,6 @@
 import { pgQuery } from "../../db/postgresClient.js";
 import Game from "../../classes/Game.js";
+import { refreshReleaseDates } from "../../functions/GameIgdbSync.js";
 import { igdbService } from "./IgdbService.js";
 import { sleep } from "../../utilities/DelayUtils.js";
 import { logError, logInfo, logWarn } from "../../utilities/LogUtils.js";
@@ -137,7 +138,7 @@ export async function igdbScanTick(): Promise<void> {
 
         const releases = details.release_dates ?? [];
         if (releases.length > 0) {
-          await Game.refreshReleaseDates(candidate.gameId, releases);
+          await refreshReleaseDates(candidate.gameId, releases);
           releaseUpdated++;
         }
 

--- a/src/services/ThreadLinkPromptService.ts
+++ b/src/services/ThreadLinkPromptService.ts
@@ -36,6 +36,7 @@ import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError, logInfo, logWarn } from "../utilities/LogUtils.js";
 import { buildActionButton, buildButtonRow } from "../functions/uiComponents.js";
 import { saveFullGameMetadata } from "../functions/GameIgdbSync.js";
+import GameSearchService from "../classes/GameSearchService.js";
 
 function hasIgdbConfig(): boolean {
   return Boolean(process.env.IGDB_CLIENT_ID && process.env.IGDB_CLIENT_SECRET);
@@ -109,7 +110,7 @@ export class ThreadLinkButtonHandlers {
     safeIgnore(interaction.message.edit({ components: [] }));
 
     try {
-      const localMatches = (await Game.searchGames(title)).filter((g) =>
+      const localMatches = (await GameSearchService.searchGames(title)).filter((g) =>
         g.title.toLowerCase() === title.toLowerCase(),
       );
       let gameId: number | null = localMatches[0]?.id ?? null;

--- a/src/services/ThreadLinkPromptService.ts
+++ b/src/services/ThreadLinkPromptService.ts
@@ -35,6 +35,7 @@ import { assertCustomIdSegments } from "../utilities/CustomIdUtils.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
 import { logError, logInfo, logWarn } from "../utilities/LogUtils.js";
 import { buildActionButton, buildButtonRow } from "../functions/uiComponents.js";
+import { saveFullGameMetadata } from "../functions/GameIgdbSync.js";
 
 function hasIgdbConfig(): boolean {
   return Boolean(process.env.IGDB_CLIENT_ID && process.env.IGDB_CLIENT_SECRET);
@@ -141,7 +142,7 @@ export class ThreadLinkButtonHandlers {
           details.url ?? null,
           Game.getFeaturedVideoUrl(details),
         );
-        await Game.saveFullGameMetadata(newGame.id, details);
+        await saveFullGameMetadata(newGame.id, details);
         chosenName = nameHint ?? details.name;
         return newGame.id;
       };

--- a/src/tests/now-playing-completion-safe-update.test.ts
+++ b/src/tests/now-playing-completion-safe-update.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { NowPlayingCompletionHandlers } from "../commands/now-playing/nowPlayingCompletion.handler.js";
 import Member from "../classes/Member.js";
 import Game from "../classes/Game.js";
+import GamePlatformRegionService from "../classes/GamePlatformRegionService.js";
 
 test("nowplaying edit menu add completion uses safe update fallback", async () => {
   const command = new NowPlayingCompletionHandlers() as any;
@@ -139,7 +140,8 @@ test("nowplaying completion modal reuses existing now-playing platform and skips
   const originalAddCompletion = Member.addCompletion;
   const originalRemoveNowPlaying = Member.removeNowPlaying;
   const originalGetGameById = Game.getGameById;
-  const originalGetPlatformsForGameWithStandard = Game.getPlatformsForGameWithStandard;
+  const originalGetPlatformsForGameWithStandard =
+    GamePlatformRegionService.getPlatformsForGameWithStandard;
 
   const addCompletionCalls: any[] = [];
   const listUpdatePayloads: any[] = [];
@@ -174,7 +176,7 @@ test("nowplaying completion modal reuses existing now-playing platform and skips
       title: "Alpha",
       imageData: null,
     })) as any;
-    Game.getPlatformsForGameWithStandard = (async () => {
+    GamePlatformRegionService.getPlatformsForGameWithStandard = (async () => {
       platformLookupCalls += 1;
       return [];
     }) as any;
@@ -248,6 +250,7 @@ test("nowplaying completion modal reuses existing now-playing platform and skips
     Member.addCompletion = originalAddCompletion;
     Member.removeNowPlaying = originalRemoveNowPlaying;
     Game.getGameById = originalGetGameById;
-    Game.getPlatformsForGameWithStandard = originalGetPlatformsForGameWithStandard;
+    GamePlatformRegionService.getPlatformsForGameWithStandard =
+      originalGetPlatformsForGameWithStandard;
   }
 });

--- a/src/types/GameTypes.ts
+++ b/src/types/GameTypes.ts
@@ -1,0 +1,170 @@
+import type { HltbCacheEntry } from "../classes/HltbCache.js";
+
+export interface IGame {
+  id: number;
+  title: string;
+  description: string | null;
+  imageData: Buffer | null; // BLOB
+  thumbnailBad: boolean;
+  thumbnailApproved: boolean;
+  igdbId: number | null;
+  slug: string | null;
+  totalRating: number | null;
+  igdbUrl: string | null;
+  featuredVideoUrl: string | null;
+  initialReleaseDate: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+  coverUrl: string | null;
+}
+
+export interface IRelease {
+  id: number;
+  gameId: number;
+  platformId: number;
+  regionId: number;
+  format: "Physical" | "Digital" | null;
+  releaseDate: Date | null;
+  notes: string | null;
+}
+
+export interface IReleaseWithNames extends IRelease {
+  platformName: string | null;
+  regionName: string | null;
+}
+
+export interface IPlatformDef {
+  id: number;
+  code: string;
+  name: string;
+  abbreviation: string | null;
+  igdbPlatformId: number | null;
+}
+
+export interface IGameWithPlatforms extends IGame {
+  platforms: IPlatformDef[];
+}
+
+export interface IGameSearchResult extends IGameWithPlatforms {
+  upcomingReleaseDate: Date | null;
+  upcomingReleasePlatforms: string[];
+}
+
+export interface IGameAutocompleteResult {
+  id: number;
+  title: string;
+  initialReleaseDate: Date | null;
+}
+
+export interface IRegionDef {
+  id: number;
+  code: string;
+  name: string;
+  igdbRegionId: number | null;
+}
+
+export interface ICompany {
+  id: number;
+  name: string;
+  igdbId: number | null;
+}
+
+export interface IGenre {
+  id: number;
+  name: string;
+  igdbId: number | null;
+}
+
+export interface ITheme {
+  id: number;
+  name: string;
+  igdbId: number | null;
+}
+
+export interface IGameMode {
+  id: number;
+  name: string;
+  igdbId: number | null;
+}
+
+export interface IPerspective {
+  id: number;
+  name: string;
+  igdbId: number | null;
+}
+
+export interface IEngine {
+  id: number;
+  name: string;
+  igdbId: number | null;
+}
+
+export interface IFranchise {
+  id: number;
+  name: string;
+  igdbId: number | null;
+}
+
+export interface ICollection {
+  id: number;
+  name: string;
+  igdbId: number | null;
+}
+
+export interface IGameAssociationSummary {
+  gotmWins: {
+    round: number;
+    threadId: string | null;
+    redditUrl: string | null;
+    monthYear: string;
+  }[];
+  nrGotmWins: {
+    round: number;
+    threadId: string | null;
+    redditUrl: string | null;
+    monthYear: string;
+  }[];
+  gotmNominations: { round: number; userId: string; username: string }[];
+  nrGotmNominations: { round: number; userId: string; username: string }[];
+}
+
+export interface INowPlayingMember {
+  userId: string;
+  username: string | null;
+  globalName: string | null;
+  threadId: string | null;
+  addedAt: Date | null;
+}
+
+export interface ICompletedMember {
+  userId: string;
+  username: string | null;
+  globalName: string | null;
+  completionType: string;
+  completedAt: Date | null;
+  finalPlaytimeHours: number | null;
+}
+
+export interface ICollectionOwnerMember {
+  userId: string;
+  username: string | null;
+  globalName: string | null;
+}
+
+export interface IMappedGameProfile {
+  game: IGame;
+  releases: IReleaseWithNames[];
+  associations: IGameAssociationSummary;
+  nowPlayingMembers: INowPlayingMember[];
+  collectionOwners: ICollectionOwnerMember[];
+  completions: ICompletedMember[];
+  alternateVersions: IGame[];
+  threadIds: string[];
+  hltbCache: HltbCacheEntry | null;
+  primaryImageUrl: string | null;
+  series: string | null;
+  developers: string[];
+  publishers: string[];
+}
+
+export type GameSource = "API";


### PR DESCRIPTION
## Summary

Completes the `Game.ts` split from issue #912. `Game.ts` shrinks from
~1410 lines to **469 lines**, retaining only core CRUD, index queries,
image ops, field updates, and metadata getters.

## What changed

- **Step 1** -- Extracted all interfaces/types to `src/types/GameTypes.ts`
  and updated every import site.
- **Steps 2-3** -- Broke the `Game.ts` <-> `GameIgdbSync.ts` circular
  dependency and extracted `GamePlatformRegionService.ts` (all
  platform/region methods).
- **Step 4** -- Removed the IGDB-sync facade delegates from `Game.ts`
  and migrated callers to named imports from `GameIgdbSync.ts`.
- **Step 5** -- Extracted `GameSearchService.ts` (`searchGamesAutocomplete`,
  `searchGames`) and migrated all callers.
- **Step 6** -- Extracted `GameProfileService.ts`: `getGameReleasesDetailed`,
  `getGameAssociations`, `getNowPlayingMembers`, `getGameCompletions`,
  `getGameCollectionOwners`, `getGameProfile`, `getAllCompanies`,
  `getCompanyById`, plus the shared `getGameRelations` cache and
  `fetchAllPages` helper. `Game.ts` metadata getters now call
  `GameProfileService.getGameRelations`.

## Notes

- `getGameRelations` is shared infrastructure: it backs both the staying
  metadata getters (genres/themes/modes/etc.) and the moved profile reads,
  so it lives in `GameProfileService` as a public method that `Game.ts`
  calls. No import cycle results (`Game` -> `GameProfileService` is
  one-directional).

## Verification

- `tsc --noEmit` clean
- `npm run lint` clean
- All 59 tests pass

Closes #912

🤖 Generated with [Claude Code](https://claude.com/claude-code)
