### PR TITLE
perf: coarsen DB poll intervals so Neon can scale to zero

### DIFF
--- a/src/services/GameReleaseAnnouncementService.ts
+++ b/src/services/GameReleaseAnnouncementService.ts
@@ -9,7 +9,13 @@ import { buildGameProfileMessagePayload } from "../commands/gamedb.command.js";
 import { buildComponentsV2EditFlags } from "../functions/ComponentsV2Utils.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
 
-const CHECK_INTERVAL_MS = 60_000;
+// Coarse safety-net sweep. Each cycle runs several queries against the GameDB
+// (now on Neon). At 60s this kept Neon's serverless compute permanently active
+// (never scaling to zero), which accounts for most of our Neon compute-hour
+// cost. Releases are date-scheduled, so hourly is more than enough. Immediate,
+// on-demand announcing will move to an API endpoint in therpgclub-api so admins
+// can trigger it manually instead of relying on a tight poll.
+const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const BATCH_SIZE = 25;
 const RELEASE_SCHEDULING_ZONE = "UTC";
 

--- a/src/services/IGDB/IgdbScanService.ts
+++ b/src/services/IGDB/IgdbScanService.ts
@@ -20,7 +20,13 @@ type IgdbScanCandidate = {
   updatedAt: Date | null;
 };
 
-const DEFAULT_SCAN_INTERVAL_MINUTES = 15;
+// Coarse safety-net sweep (default; override via IGDB_SCAN_INTERVAL_MINUTES).
+// Each scan queries the GameDB (now on Neon) for stale entries; at 15 min it
+// helped keep Neon's serverless compute from scaling to zero, adding to our
+// compute-hour cost. IGDB metadata is slow-moving, so hourly is plenty.
+// On-demand scanning will move to an API endpoint in therpgclub-api so admins
+// can trigger it manually instead of relying on a tight poll.
+const DEFAULT_SCAN_INTERVAL_MINUTES = 60; // 1 hour
 const DEFAULT_SCAN_BATCH_SIZE = 25;
 const DEFAULT_SCAN_MIN_AGE_DAYS = 30;
 const DEFAULT_SCAN_THROTTLE_MS = 300;

--- a/src/services/NominationReminderService.ts
+++ b/src/services/NominationReminderService.ts
@@ -5,7 +5,13 @@ import BotVotingInfo, { type IBotVotingInfoEntry } from "../classes/BotVotingInf
 import { NOMINATION_DISCUSSION_CHANNEL_IDS } from "../config/nominationChannels.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
 
-const CHECK_INTERVAL_MS = 60_000;
+// Coarse safety-net sweep. Each cycle queries the GameDB (now on Neon); at 60s
+// this kept Neon's serverless compute permanently active (never scaling to
+// zero), driving most of our Neon compute-hour cost. Reminders fire on 5-day
+// and 1-day boundaries, so hourly granularity is ample. Immediate, on-demand
+// triggering will move to an API endpoint in therpgclub-api so admins can run
+// it manually instead of relying on a tight poll.
+const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const REMINDER_ZONE = "America/New_York";
 
 type ReminderDefinition = {

--- a/src/services/PublicReminderService.ts
+++ b/src/services/PublicReminderService.ts
@@ -7,7 +7,14 @@ import {
 } from "../classes/PublicReminder.js";
 import { logError } from "../utilities/LogUtils.js";
 
-const PUBLIC_REMINDER_INTERVAL_MS: number = 60_000;
+// Coarse safety-net sweep. Each cycle queries the GameDB (now on Neon); at 60s
+// this kept Neon's serverless compute permanently active (never scaling to
+// zero), driving most of our Neon compute-hour cost. These are user-scheduled
+// reminders with specific times, so we keep this tighter than the hourly
+// services. 30 min bounds how late a reminder can fire. Immediate, on-demand
+// triggering will move to an API endpoint in therpgclub-api so users can run it
+// manually instead of relying on a tight poll.
+const PUBLIC_REMINDER_INTERVAL_MS: number = 30 * 60 * 1000; // 30 minutes
 const MAX_PER_CYCLE = 50;
 
 let publicReminderTimer: NodeJS.Timeout | null = null;

--- a/src/services/ThreadSyncService.ts
+++ b/src/services/ThreadSyncService.ts
@@ -7,7 +7,14 @@ import type {
 import { upsertThreadRecord } from "../classes/Thread.js";
 import { NOW_PLAYING_FORUM_ID } from "../config/channels.js";
 import { logError, logInfo, logWarn } from "../utilities/LogUtils.js";
-const DEFAULT_SYNC_INTERVAL_MS = 10 * 60 * 1000;
+
+// Coarse safety-net sweep. Each cycle reads forum threads and upserts them into
+// the GameDB (now on Neon); at 10 min it helped keep Neon's serverless compute
+// from scaling to zero, adding to our compute-hour cost. Thread state is not
+// time-critical, so hourly is fine. On-demand syncing will move to an API
+// endpoint in therpgclub-api so admins can trigger it manually instead of
+// relying on a tight poll.
+const DEFAULT_SYNC_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 
 function isTargetForum(thread: AnyThreadChannel | ThreadChannel | null): boolean {
   const parentId = (thread as any)?.parentId ?? null;


### PR DESCRIPTION
## Why

Our Neon compute was running ~24/7 (flat ~0.25–0.5 CU, never showing `ENDPOINT INACTIVE`), driving the bulk of the project's Neon compute-hour bill. Root cause: several bot background services poll the GameDB — now on Neon — on tight intervals (three of them **every 60 seconds**). Neon only scales a serverless compute to zero after **5 minutes** of query inactivity, so frequent sweeps guarantee the compute never suspends.

This only started after migrating the GameDB off Oracle onto Neon; the same pollers used to hit self-hosted Oracle for free.

## What

Coarsen the DB-polling sweeps to a safety-net cadence:

| Service | Before | After | Rationale |
|---|---|---|---|
| `GameReleaseAnnouncementService` | 60s | **1h** | releases are date-scheduled |
| `NominationReminderService` | 60s | **1h** | reminders fire on 5-day / 1-day boundaries |
| `PublicReminderService` | 60s | **30m** | user-scheduled times, kept a bit tighter |
| `ThreadSyncService` | 10m | **1h** | thread state is not time-critical |
| `IgdbScanService` | 15m | **1h** | IGDB metadata is slow-moving (still overridable via `IGDB_SCAN_INTERVAL_MINUTES`) |

No behavioural change beyond timing; each tick still runs the same logic, just less often.

## Follow-up

This cuts query volume by ~10–60×, but a 30–60 min poll still won't let Neon fully scale to zero on its own. Immediate / on-demand triggering will move to **API endpoints in `therpgclub-api`** so admins and users can run announcements / reminders / syncs manually, rather than depending on a tight background poll. (A separate change pins the Neon compute to a fixed 0.25 CU to cap the per-hour cost.)

## Testing

- `npm run compile` (tsc --noEmit) — passes
- `npx eslint` on the changed files — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
