### PR TITLE
perf: coarsen RSS + presence polls so Neon can scale to zero

### DIFF
--- a/src/RPGClub_GameDB.ts
+++ b/src/RPGClub_GameDB.ts
@@ -35,7 +35,11 @@ import { truncateWithEllipsis } from "./utilities/ValidationUtils.js";
 import { logError } from "./utilities/LogUtils.js";
 installConsoleLogging();
 
-const PRESENCE_CHECK_INTERVAL_MS: number = 30 * 60 * 1000;
+// Re-asserts the bot's stored presence to Discord. Each tick reads it from the
+// GameDB (now on Neon) directly via BotPresenceHistory.getLatestPresenceActivity();
+// at 30 min this woke Neon's serverless compute twice an hour. Presence only
+// changes on an explicit command, so hourly re-assertion is plenty.
+const PRESENCE_CHECK_INTERVAL_MS: number = 60 * 60 * 1000; // 1 hour
 let presenceInterval: NodeJS.Timeout | null = null;
 
 function clearPresenceInterval(): void {

--- a/src/services/NominationReminderService.ts
+++ b/src/services/NominationReminderService.ts
@@ -5,12 +5,12 @@ import BotVotingInfo, { type IBotVotingInfoEntry } from "../classes/BotVotingInf
 import { NOMINATION_DISCUSSION_CHANNEL_IDS } from "../config/nominationChannels.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
 
-// Coarse safety-net sweep. Each cycle queries the GameDB (now on Neon); at 60s
-// this kept Neon's serverless compute permanently active (never scaling to
-// zero), driving most of our Neon compute-hour cost. Reminders fire on 5-day
-// and 1-day boundaries, so hourly granularity is ample. Immediate, on-demand
-// triggering will move to an API endpoint in therpgclub-api so admins can run
-// it manually instead of relying on a tight poll.
+// Coarse safety-net sweep. Each cycle calls therpgclub-api (which is backed by
+// Neon), not the DB directly; at 60s this drove avoidable load on the API and
+// its Neon-backed compute. Reminders fire on 5-day and 1-day boundaries, so
+// hourly granularity is ample. Immediate, on-demand triggering will move to an
+// API endpoint in therpgclub-api so admins can run it manually instead of
+// relying on a tight poll.
 const CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const REMINDER_ZONE = "America/New_York";
 

--- a/src/services/PublicReminderService.ts
+++ b/src/services/PublicReminderService.ts
@@ -7,13 +7,13 @@ import {
 } from "../classes/PublicReminder.js";
 import { logError } from "../utilities/LogUtils.js";
 
-// Coarse safety-net sweep. Each cycle queries the GameDB (now on Neon); at 60s
-// this kept Neon's serverless compute permanently active (never scaling to
-// zero), driving most of our Neon compute-hour cost. These are user-scheduled
-// reminders with specific times, so we keep this tighter than the hourly
-// services. 30 min bounds how late a reminder can fire. Immediate, on-demand
-// triggering will move to an API endpoint in therpgclub-api so users can run it
-// manually instead of relying on a tight poll.
+// Coarse safety-net sweep. Each cycle calls therpgclub-api (which is backed by
+// Neon), not the DB directly; at 60s this drove avoidable load on the API and
+// its Neon-backed compute. These are user-scheduled reminders with specific
+// times, so we keep this tighter than the hourly services. 30 min bounds how
+// late a reminder can fire. Immediate, on-demand triggering will move to an API
+// endpoint in therpgclub-api so users can run it manually instead of relying on
+// a tight poll.
 const PUBLIC_REMINDER_INTERVAL_MS: number = 30 * 60 * 1000; // 30 minutes
 const MAX_PER_CYCLE = 50;
 

--- a/src/services/RssFeedService.ts
+++ b/src/services/RssFeedService.ts
@@ -10,7 +10,11 @@ import {
 } from "../classes/RssFeed.js";
 import { logError, logWarn } from "../utilities/LogUtils.js";
 
-const POLL_INTERVAL_MS: number = 5 * 60 * 1000;
+// Coarse safety-net sweep. Each tick queries the GameDB (now on Neon) directly
+// to dedupe RSS items (getSeenItemHashes / markItemsSeen); at 5 min it sat right
+// at Neon's 5-minute scale-to-zero threshold, keeping the serverless compute
+// permanently awake. RSS posts are not time-critical, so hourly is fine.
+const POLL_INTERVAL_MS: number = 60 * 60 * 1000; // 1 hour
 const ERROR_LOG_COOLDOWN = 60 * 60 * 1000; // 1 hour
 const lastErrorLog = new Map<string, number>();
 

--- a/src/services/ThreadSyncService.ts
+++ b/src/services/ThreadSyncService.ts
@@ -8,10 +8,10 @@ import { upsertThreadRecord } from "../classes/Thread.js";
 import { NOW_PLAYING_FORUM_ID } from "../config/channels.js";
 import { logError, logInfo, logWarn } from "../utilities/LogUtils.js";
 
-// Coarse safety-net sweep. Each cycle reads forum threads and upserts them into
-// the GameDB (now on Neon); at 10 min it helped keep Neon's serverless compute
-// from scaling to zero, adding to our compute-hour cost. Thread state is not
-// time-critical, so hourly is fine. On-demand syncing will move to an API
+// Coarse safety-net sweep. Each cycle reads forum threads and upserts them via
+// therpgclub-api (which is backed by Neon), not the DB directly; at 10 min it
+// drove avoidable load on the API and its Neon-backed compute. Thread state is
+// not time-critical, so hourly is fine. On-demand syncing will move to an API
 // endpoint in therpgclub-api so admins can trigger it manually instead of
 // relying on a tight poll.
 const DEFAULT_SYNC_INTERVAL_MS = 60 * 60 * 1000; // 1 hour


### PR DESCRIPTION
## Why

Follow-up to #914. Two **direct-to-Neon** pollers were missed in that pass, and after #914 merged they became the visible thing keeping the serverless compute awake:

- **`RssFeedService`** — every **5 min**, queries Neon directly to dedupe RSS items (`getSeenItemHashes` / `markItemsSeen`). 5 min sits exactly at Neon's 5-minute scale-to-zero threshold, so it was the "compute woke a few seconds ago every ~5 min" pattern observed right after #914.
- **Bot presence refresh** (`RPGClub_GameDB.ts`) — every **30 min**, reads the last-set presence from Neon via `BotPresenceHistory.getLatestPresenceActivity()`.

## What

| Poller | Before | After |
|---|---|---|
| `RssFeedService` | 5m | **1h** |
| Bot presence refresh | 30m | **1h** |

Also corrects the comments added in #914: the **nomination**, **public-reminder**, and **thread-sync** sweeps call `therpgclub-api` (which is Neon-backed), **not the database directly**. Coarsening them still helps by reducing load on the API and its Neon compute, but the original wording ("queries the GameDB") was inaccurate.

## Result

After this, the bot's only remaining direct-to-Neon pollers (release announcements, IGDB scan, RSS, presence) all run **hourly**, so the compute can actually idle between them. (`GamedbAuditService` is exported but never started, so it's a no-op.)

## Testing

- `npm run compile` (tsc --noEmit) — passes
- `npx eslint` on the changed files — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
