### PR TITLE
perf: hardcode IGDB scan interval to 1h, drop env override

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ These are required or commonly used by the bot. Values depend on your deployment
 - `IGDB_CLIENT_ID`
 - `IGDB_CLIENT_SECRET`
 - `IGDB_SCAN_ENABLED`
-- `IGDB_SCAN_INTERVAL_MINUTES`
 - `IGDB_SCAN_BATCH_SIZE`
 - `IGDB_SCAN_MIN_AGE_DAYS`
 - `IGDB_SCAN_THROTTLE_MS`

--- a/src/services/IGDB/IgdbScanService.ts
+++ b/src/services/IGDB/IgdbScanService.ts
@@ -20,13 +20,14 @@ type IgdbScanCandidate = {
   updatedAt: Date | null;
 };
 
-// Coarse safety-net sweep (default; override via IGDB_SCAN_INTERVAL_MINUTES).
-// Each scan queries the GameDB (now on Neon) for stale entries; at 15 min it
-// helped keep Neon's serverless compute from scaling to zero, adding to our
-// compute-hour cost. IGDB metadata is slow-moving, so hourly is plenty.
-// On-demand scanning will move to an API endpoint in therpgclub-api so admins
-// can trigger it manually instead of relying on a tight poll.
-const DEFAULT_SCAN_INTERVAL_MINUTES = 60; // 1 hour
+// Coarse safety-net sweep. Each scan queries the GameDB (now on Neon) directly
+// for stale entries; a tight interval kept Neon's serverless compute from
+// scaling to zero, adding to our compute-hour cost. IGDB metadata is slow-moving,
+// so hourly is plenty. Hardcoded with no env override (matching the other
+// sweeps) so a stray production value can't silently change it. On-demand
+// scanning will move to an API endpoint in therpgclub-api so admins can trigger
+// it manually instead of relying on a poll.
+const SCAN_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 const DEFAULT_SCAN_BATCH_SIZE = 25;
 const DEFAULT_SCAN_MIN_AGE_DAYS = 30;
 const DEFAULT_SCAN_THROTTLE_MS = 300;
@@ -43,9 +44,7 @@ function parseNumberEnv(name: string, fallback: number, min?: number): number {
 function getScanConfig(): IgdbScanConfig {
   return {
     enabled: process.env.IGDB_SCAN_ENABLED !== "false",
-    intervalMs: parseNumberEnv("IGDB_SCAN_INTERVAL_MINUTES", DEFAULT_SCAN_INTERVAL_MINUTES, 1)
-      * 60
-      * 1000,
+    intervalMs: SCAN_INTERVAL_MS,
     batchSize: parseNumberEnv("IGDB_SCAN_BATCH_SIZE", DEFAULT_SCAN_BATCH_SIZE, 1),
     minAgeDays: parseNumberEnv("IGDB_SCAN_MIN_AGE_DAYS", DEFAULT_SCAN_MIN_AGE_DAYS, 0),
     throttleMs: parseNumberEnv("IGDB_SCAN_THROTTLE_MS", DEFAULT_SCAN_THROTTLE_MS, 0),


### PR DESCRIPTION
## Why

Follow-up to #914 / #915. The IGDB scan was the **only** bot poller whose interval was env-configurable (`IGDB_SCAN_INTERVAL_MINUTES`). #914 changed the code *default* 15m→60m, but a stray production override (e.g. `=15`) would silently win and keep waking Neon — defeating the coarsening.

## What

- **Hardcode** the scan interval to 1h (`SCAN_INTERVAL_MS`), matching the other sweeps; remove the `IGDB_SCAN_INTERVAL_MINUTES` override so it can't be changed out from under us.
- Keep the other IGDB knobs env-configurable: `IGDB_SCAN_ENABLED`, `IGDB_SCAN_BATCH_SIZE`, `IGDB_SCAN_MIN_AGE_DAYS`, `IGDB_SCAN_THROTTLE_MS`.
- Drop `IGDB_SCAN_INTERVAL_MINUTES` from the README env list.

## Note

The 5-minute Neon waker we actually observed was `RssFeedService` (fixed in #915), not the IGDB scan. This change is hardening: it removes a real footgun so a host env value can't reintroduce a tight scan interval.

## Testing

- `npm run compile` (tsc --noEmit) — passes
- `npx eslint` on the changed file — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
