### PR TITLE
refactor: remove dead duplicate buildChoiceRows from gamedb-utils.ts

### DIFF
--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -62,12 +62,6 @@ export const MAX_NOW_PLAYING_NOTE_LEN = 500;
 
 export const GAMEDB_CSV_AUTO_ACCEPTED = new Map<number, string[]>();
 
-export type PromptChoiceOption = {
-  label: string;
-  value: string;
-  style?: ButtonStyle;
-};
-
 export function decodeISearchFilters(filterStr: string): ISearchFilters {
   return filterStr ? parseCompactFilters(filterStr) : {};
 }
@@ -277,21 +271,4 @@ export async function autocompleteGameDbViewTitle(
   });
   const options = [buildKeepTypingOption(query), ...resultOptions];
   await interaction.respond(options);
-}
-
-export function buildChoiceRows(
-  customIdPrefix: string,
-  options: PromptChoiceOption[],
-): ActionRowBuilder<ButtonBuilder>[] {
-  const rows: ActionRowBuilder<ButtonBuilder>[] = [];
-  for (let i = 0; i < options.length; i += 5) {
-    const slice = options.slice(i, i + 5);
-    const row = buildButtonRow(
-      ...slice.map((opt) =>
-        buildActionButton({ customId: `${customIdPrefix}:${opt.value}`, label: opt.label, style: opt.style ?? ButtonStyle.Secondary }),
-      ),
-    );
-    rows.push(row);
-  }
-  return rows;
 }


### PR DESCRIPTION
## Summary
- Removed the unused `buildChoiceRows` function and `PromptChoiceOption` type from `src/commands/gamedb/gamedb-utils.ts`. Both were exported but never imported anywhere; they duplicated the live copies in `src/commands/admin/admin-prompt.utils.ts` / `admin.types.ts` used by the round-setup wizard.
- The remaining `discord.js` and `uiComponents` imports stay in use by other functions in the file, so no import cleanup was needed.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (lint clean, 59/59 tests pass)
- [x] Confirmed no remaining references to the removed symbols in `gamedb-utils.ts`

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)