### PR TITLE
chore: normalize Errors in structured logs and drop pg client blob

### DIFF
--- a/src/tests/log-utils.test.ts
+++ b/src/tests/log-utils.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { formatStructuredLog } from "../utilities/LogUtils.js";
+
+test("formatStructuredLog preserves Error message and stack", () => {
+  const error = new Error("Connection terminated unexpectedly");
+  const parsed = JSON.parse(formatStructuredLog({ context: "ctx", error }));
+  assert.equal(parsed.context, "ctx");
+  assert.equal(parsed.error.message, "Connection terminated unexpectedly");
+  assert.equal(typeof parsed.error.stack, "string");
+});
+
+test("formatStructuredLog drops the pg-pool client blob on errors", () => {
+  const error = new Error("idle client error") as Error & { client?: unknown };
+  error.client = { connectionParameters: { user: "neondb_owner" } };
+  const parsed = JSON.parse(formatStructuredLog({ context: "ctx", error }));
+  assert.equal(parsed.error.client, undefined);
+  assert.equal(parsed.error.message, "idle client error");
+});
+
+test("formatStructuredLog keeps known pg error fields", () => {
+  const error = new Error("db error") as Error & Record<string, unknown>;
+  error.code = "57P01";
+  error.severity = "FATAL";
+  const parsed = JSON.parse(formatStructuredLog({ context: "ctx", error }));
+  assert.equal(parsed.error.code, "57P01");
+  assert.equal(parsed.error.severity, "FATAL");
+});
+
+test("formatStructuredLog handles circular references", () => {
+  const node: Record<string, unknown> = { name: "root" };
+  node.self = node;
+  const output = formatStructuredLog({ context: "ctx", node });
+  const parsed = JSON.parse(output);
+  assert.equal(parsed.node.name, "root");
+  assert.equal(parsed.node.self, "[Circular]");
+});

--- a/src/utilities/LogUtils.ts
+++ b/src/utilities/LogUtils.ts
@@ -1,5 +1,44 @@
+// Extra string-ish fields pg attaches to query/connection errors. Worth keeping
+// in logs; the noisy `client` property pg-pool attaches is intentionally dropped.
+const ERROR_EXTRA_FIELDS = [
+  "code",
+  "severity",
+  "detail",
+  "hint",
+  "position",
+  "schema",
+  "table",
+  "column",
+  "constraint",
+  "routine",
+] as const;
+
+function normalizeError(error: Error): Record<string, unknown> {
+  const normalized: Record<string, unknown> = {
+    name: error.name,
+    message: error.message,
+    stack: error.stack,
+  };
+  const source = error as unknown as Record<string, unknown>;
+  for (const field of ERROR_EXTRA_FIELDS) {
+    if (source[field] !== undefined) normalized[field] = source[field];
+  }
+  return normalized;
+}
+
 export function formatStructuredLog(fields: Record<string, unknown>): string {
-  return JSON.stringify(fields);
+  // Error message/stack are non-enumerable, so a raw stringify drops them while
+  // serializing any attached object (e.g. pg-pool sets err.client). Normalize
+  // Errors and guard against circular references so logs stay small and useful.
+  const seen = new WeakSet<object>();
+  return JSON.stringify(fields, (_key, value) => {
+    if (value instanceof Error) return normalizeError(value);
+    if (typeof value === "object" && value !== null) {
+      if (seen.has(value)) return "[Circular]";
+      seen.add(value);
+    }
+    return value;
+  });
 }
 
 export function logError(context: string, error: unknown): void {


### PR DESCRIPTION
## Summary
- `formatStructuredLog` now normalizes `Error` values: it preserves
  `name`/`message`/`stack` (non-enumerable, so a raw `JSON.stringify` was
  dropping them) plus known pg fields (`code`, `severity`, etc.).
- It strips the `client` object pg-pool attaches to idle-connection errors,
  which was dumping the full pg client internals and leaking connection
  params (host, user, database) into logs under `postgresClient.clientError`.
- Adds circular-reference guarding so any object graph logs safely.
- Fix is centralized in `formatStructuredLog`, so `logError`, `logWarn`,
  and `logInfo` all benefit.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Lint clean (`npx eslint`)
- [x] Full test suite passes (63 tests)
- [x] New `src/tests/log-utils.test.ts` covers: message/stack preserved,
      `client` blob dropped, pg fields kept, circular refs handled

Closes #921

🤖 Generated with [Claude Code](https://claude.com/claude-code)