### PR TITLE
refactor: extract shared memberHasPermission() helper for permission checks

### DIFF
--- a/src/commands/admin/admin-auth.utils.ts
+++ b/src/commands/admin/admin-auth.utils.ts
@@ -3,17 +3,16 @@ import {
   ACCESS_DENIED_ADMIN,
   ACCESS_DENIED_MOD,
   AnyRepliable,
+  memberHasPermission,
   safeReply,
 } from "../../functions/InteractionUtils.js";
 import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
 
 export async function isAdmin(interaction: AnyRepliable): Promise<boolean> {
-  const member: any = (interaction as any).member;
-  const canCheck =
-    member && typeof member.permissionsIn === "function" && interaction.channel;
-  const isAdmin = canCheck
-    ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.Administrator)
-    : false;
+  const isAdmin = memberHasPermission(
+    interaction,
+    PermissionsBitField.Flags.Administrator,
+  );
 
   if (!isAdmin) {
     try {
@@ -27,17 +26,16 @@ export async function isAdmin(interaction: AnyRepliable): Promise<boolean> {
 }
 
 export async function isModerator(interaction: AnyRepliable): Promise<boolean> {
-  const member: any = (interaction as any).member;
-  const canCheck =
-    member && typeof member.permissionsIn === "function" && interaction.channel;
-  let isMod = canCheck
-    ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.ManageMessages)
-    : false;
+  let isMod = memberHasPermission(
+    interaction,
+    PermissionsBitField.Flags.ManageMessages,
+  );
 
   if (!isMod) {
-    const isAdminCheck = canCheck
-      ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.Administrator)
-      : false;
+    const isAdminCheck = memberHasPermission(
+      interaction,
+      PermissionsBitField.Flags.Administrator,
+    );
 
     if (!isAdminCheck) {
       const denial = {

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -10,6 +10,7 @@ import {
 import {
   ACCESS_DENIED_MOD_ADMIN,
   AnyRepliable,
+  memberHasPermission,
   safeReply,
   sanitizeUserInput,
 } from "../../functions/InteractionUtils.js";
@@ -85,15 +86,15 @@ export function getModeratorPermissionFlags(interaction: AnyRepliable): {
   const guild = interaction.guild;
   if (!guild) return null;
 
-  const member: any = interaction.member;
-  const canCheck = member && typeof member.permissionsIn === "function" && interaction.channel;
   const isOwner = guild.ownerId === interaction.user.id;
-  const isAdmin = canCheck
-    ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.Administrator)
-    : false;
-  const isModerator = canCheck
-    ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.ManageMessages)
-    : false;
+  const isAdmin = memberHasPermission(
+    interaction,
+    PermissionsBitField.Flags.Administrator,
+  );
+  const isModerator = memberHasPermission(
+    interaction,
+    PermissionsBitField.Flags.ManageMessages,
+  );
 
   return { isOwner, isAdmin, isModerator };
 }

--- a/src/commands/todo/todoPermissions.ts
+++ b/src/commands/todo/todoPermissions.ts
@@ -3,6 +3,7 @@ import {
   ACCESS_DENIED_MOD_ADMIN,
   ACCESS_DENIED_SERVER_OWNER,
   AnyRepliable,
+  memberHasPermission,
   safeReply,
 } from "../../functions/InteractionUtils.js";
 import { buildTodoTextReply } from "./todoComponents.js";
@@ -15,15 +16,15 @@ export function getTodoPermissionFlags(interaction: AnyRepliable): {
   const guild = interaction.guild;
   if (!guild) return null;
 
-  const member: any = interaction.member;
-  const canCheck = member && typeof member.permissionsIn === "function" && interaction.channel;
   const isOwner = guild.ownerId === interaction.user.id;
-  const isAdmin = canCheck
-    ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.Administrator)
-    : false;
-  const isModerator = canCheck
-    ? member.permissionsIn(interaction.channel).has(PermissionsBitField.Flags.ManageMessages)
-    : false;
+  const isAdmin = memberHasPermission(
+    interaction,
+    PermissionsBitField.Flags.Administrator,
+  );
+  const isModerator = memberHasPermission(
+    interaction,
+    PermissionsBitField.Flags.ManageMessages,
+  );
 
   return { isOwner, isAdmin, isModerator };
 }

--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -7,6 +7,7 @@ import type {
   GuildMember,
   InteractionDeferReplyOptions,
   ModalSubmitInteraction,
+  PermissionResolvable,
   RepliableInteraction,
   User,
 } from "discord.js";
@@ -21,6 +22,16 @@ import {
 } from "./ComponentsV2Utils.js";
 
 export type AnyRepliable = RepliableInteraction | CommandInteraction;
+
+export function memberHasPermission(
+  interaction: AnyRepliable,
+  flag: PermissionResolvable,
+): boolean {
+  const member: any = (interaction as any).member;
+  const canCheck =
+    member && typeof member.permissionsIn === "function" && interaction.channel;
+  return canCheck ? member.permissionsIn(interaction.channel).has(flag) : false;
+}
 
 export function buildIdTimestampFooter(id: string, timestamp: string): string {
   return `ID: ${id} • ${timestamp}`;


### PR DESCRIPTION
## Summary
- Added `memberHasPermission(interaction, flag): boolean` to `src/functions/InteractionUtils.ts`, encapsulating the guarded `canCheck ? member.permissionsIn(channel).has(flag) : false` primitive (with the `member: any` guard).
- Routed the three duplicated call sites through it: `isAdmin`/`isModerator` in `admin-auth.utils.ts`, `getTodoPermissionFlags` in `todoPermissions.ts`, and `getModeratorPermissionFlags` in `gamedb-utils.ts`.
- Per the issue scope, only the boolean primitive is shared; each site's deny/reply messaging is left untouched so behavior is preserved.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [x] Smoke test steps run directly (smoke.sh not present in fresh worktree): tsc + eslint clean, 59/59 tests pass
- [x] Behavior preservation verified by diff inspection (the helper is an exact extraction; `as any` is compile-time only, so routing the typed `interaction.member` sites through it changes nothing at runtime)

Closes #918

🤖 Generated with [Claude Code](https://claude.com/claude-code)