### PR TITLE
feat: add Dockerfile, .dockerignore, and docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+build
+.git
+.env
+.env.local
+.claude
+.vscode
+.agents
+snapshots
+test-results.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+# ---- builder stage ----
+FROM node:20-bookworm-slim AS builder
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src/ ./src/
+
+RUN npm run build
+
+# ---- runtime stage ----
+FROM node:20-bookworm-slim AS runtime
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=builder /app/build ./build
+
+RUN useradd --uid 1001 --create-home botuser
+USER botuser
+
+CMD ["node", "build/RPGClub_GameDB.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  bot:
+    image: ghcr.io/therpgclub/therpgclub-bot:latest
+    env_file: .env
+    environment:
+      DOCKER_BACKUP_ENABLED: "false"
+    restart: unless-stopped
+    init: true
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"


### PR DESCRIPTION
## Summary
- Adds a multi-stage `Dockerfile` on `node:20-bookworm-slim`: builder stage runs `npm ci` + `npm run build` (tsc); runtime stage runs `npm ci --omit=dev`, copies `build/`, runs as a non-root user
- Adds `.dockerignore` excluding `node_modules`, `build`, `.git`, `.env*`, `.claude`, `.vscode`, `.agents`, `snapshots`, and `test-results.txt`
- Adds `docker-compose.yml` targeting `ghcr.io/therpgclub/therpgclub-bot:latest` with `restart: unless-stopped`, `init: true` (SIGTERM forwarding), `DOCKER_BACKUP_ENABLED=false`, and json-file log rotation (10MB / 3 files)

## Test plan
- [ ] `docker build .` succeeds locally
- [ ] `sharp` resolves without error in the runtime stage
- [ ] `tsc --noEmit` stays clean (no changes to src/)
- [ ] `docker run --env-file .env -e DOCKER_BACKUP_ENABLED=false <image>` logs "Startup sequence completed." and `/help` responds
- [ ] `docker stop` exits promptly (no SIGKILL timeout)

Closes #931

🤖 Generated with [Claude Code](https://claude.com/claude-code)