### PR TITLE
feat: add Watchtower for automatic image pulls and restarts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,3 +11,13 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+
+  watchtower:
+    image: containrrr/watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ${DOCKER_CONFIG:-~/.docker}/config.json:/config.json:ro
+    environment:
+      WATCHTOWER_POLL_INTERVAL: "300"
+      WATCHTOWER_CLEANUP: "true"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Adds a `watchtower` service to `docker-compose.yml` that polls GHCR every 5 minutes for a new image digest
- When a new image is detected it pulls and restarts the `bot` container automatically
- Mounts `~/.docker/config.json` read-only so Watchtower can authenticate with GHCR
- Sets `WATCHTOWER_CLEANUP=true` to remove old images after each update

## Desktop setup note
After merging and pulling the updated `docker-compose.yml` on the desktop, run:
```bash
docker compose up -d
```
Watchtower will start alongside the bot and handle all future deploys automatically -- no manual `docker compose pull` needed after a push to main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)