### PR TITLE
fix: set DOCKER_API_VERSION=1.45 for Watchtower

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,4 +20,5 @@ services:
     environment:
       WATCHTOWER_POLL_INTERVAL: "300"
       WATCHTOWER_CLEANUP: "true"
+      DOCKER_API_VERSION: "1.45"
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Adds `DOCKER_API_VERSION: "1.45"` to the Watchtower service environment
- Watchtower defaults to negotiating Docker API version 1.25, which is below the 1.40 minimum the daemon requires, causing an immediate startup failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)