### PR TITLE
refactor: replace stray console.* calls with the project logger

### DIFF
--- a/src/commands/generate-vote-image.command.ts
+++ b/src/commands/generate-vote-image.command.ts
@@ -12,7 +12,7 @@ import { getUpcomingNominationWindow } from "../functions/NominationWindow.js";
 import { isAdmin } from "./admin/admin-auth.utils.js";
 import { composeVoteImage, type VoteImageType } from "../services/collageGenerator.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
-import { formatStructuredLog, logError } from "../utilities/LogUtils.js";
+import { logError, logInfo } from "../utilities/LogUtils.js";
 
 const GENERATION_LOCK_TTL_MS = 2 * 60 * 1000;
 
@@ -114,20 +114,18 @@ export class GenerateVoteImageCommand {
     }
 
     const startedAt = Date.now();
-    console.info(formatStructuredLog({
-      event: "vote_image_lock_acquired",
+    logInfo("vote_image_lock_acquired", {
       guildId: interaction.guildId,
       round: roundNumber,
       voteType: voteKind.label,
-    }));
+    });
 
     try {
-      console.info(formatStructuredLog({
-        event: "vote_image_generation_started",
+      logInfo("vote_image_generation_started", {
         guildId: interaction.guildId,
         round: roundNumber,
         voteType: voteKind.label,
-      }));
+      });
 
       const nominations = await listNominationsForRound(voteKind.nominationKind, roundNumber);
       if (!nominations.length) {
@@ -191,15 +189,14 @@ export class GenerateVoteImageCommand {
         return;
       }
 
-      console.info(formatStructuredLog({
-        event: "vote_image_generation_succeeded",
+      logInfo("vote_image_generation_succeeded", {
         guildId: interaction.guildId,
         round: roundNumber,
         voteType: voteKind.label,
         count: orderedNominations.length,
         durationMs: Date.now() - startedAt,
         errorCode: null,
-      }));
+      });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
       const lower = errorMessage.toLowerCase();
@@ -234,12 +231,11 @@ export class GenerateVoteImageCommand {
       });
     } finally {
       releaseLock(interaction.guildId, roundNumber, voteKind.label);
-      console.info(formatStructuredLog({
-        event: "vote_image_lock_released",
+      logInfo("vote_image_lock_released", {
         guildId: interaction.guildId,
         round: roundNumber,
         voteType: voteKind.label,
-      }));
+      });
     }
   }
 }

--- a/src/services/DockerVolumeBackupService.ts
+++ b/src/services/DockerVolumeBackupService.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { promisify } from "node:util";
+import { logInfo } from "../utilities/LogUtils.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -88,12 +89,12 @@ async function backupVolume(
     "/volume",
     ".",
   ]);
-  console.info(`Docker volume backup created: ${archivePath}`);
+  logInfo("DockerVolumeBackupService", `Docker volume backup created: ${archivePath}`);
 }
 
 async function runBackup(options: DockerBackupOptions): Promise<void> {
   if (!DEFAULT_BACKUP_ENABLED) {
-    console.info("Docker volume backups are disabled by DOCKER_BACKUP_ENABLED.");
+    logInfo("DockerVolumeBackupService", "Docker volume backups are disabled by DOCKER_BACKUP_ENABLED.");
     return;
   }
 
@@ -116,14 +117,15 @@ async function runBackup(options: DockerBackupOptions): Promise<void> {
     .sort((a, b) => a.localeCompare(b));
 
   if (!filtered.length) {
-    console.info("No Docker volumes found to back up.");
+    logInfo("DockerVolumeBackupService", "No Docker volumes found to back up.");
     return;
   }
 
   const backupDirDocker = toDockerPath(backupDir);
   const timestamp = formatTimestamp(new Date());
 
-  console.info(
+  logInfo(
+    "DockerVolumeBackupService",
     `Starting Docker volume backup for ${filtered.length} volume(s). Reason: ${reason}.`,
   );
 
@@ -136,7 +138,7 @@ export async function runDockerVolumeBackup(
   options: DockerBackupOptions = {},
 ): Promise<void> {
   if (activeBackup) {
-    console.info("Docker volume backup already running. Skipping duplicate request.");
+    logInfo("DockerVolumeBackupService", "Docker volume backup already running. Skipping duplicate request.");
     return activeBackup;
   }
 


### PR DESCRIPTION
## Summary
- Replaced 5 `console.info` calls in `DockerVolumeBackupService.ts` with `logInfo("DockerVolumeBackupService", ...)`
- Replaced 4 `console.info(formatStructuredLog({...}))` calls in `generate-vote-image.command.ts` with `logInfo(event, { ... })`, and removed the now-unused `formatStructuredLog` import

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] No remaining `console.*` calls in either file

Closes #927

🤖 Generated with [Claude Code](https://claude.com/claude-code)