### PR TITLE
fix: Postgres client emits "Connection terminated unexpectedly" error

### DIFF
--- a/src/db/postgresClient.ts
+++ b/src/db/postgresClient.ts
@@ -62,6 +62,25 @@ export function getPostgresPool(): pg.Pool {
 }
 
 /**
+ * Returns true for transient TCP/connection errors that are safe to retry on
+ * read-only queries. Write operations must NOT use this -- the server may have
+ * already committed before the socket died, so retrying would double-apply the
+ * mutation.
+ *
+ * Covered cases:
+ *   57P01 -- admin_shutdown (Postgres sent a termination notice)
+ *   57P02 -- crash_shutdown
+ *   ECONNRESET -- TCP reset mid-query
+ *   "Connection terminated unexpectedly" -- pg client idle timeout / NAT drop
+ */
+export function isTransientConnectionError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const code = (err as Error & { code?: string }).code;
+  if (code === "57P01" || code === "57P02" || code === "ECONNRESET") return true;
+  return err.message.includes("Connection terminated unexpectedly");
+}
+
+/**
  * Converts a SQL string using Oracle-style `:name` placeholders and a named
  * bind object into a positional `$N` SQL string and ordered values array.
  * Repeated uses of the same name get the same `$N`. Array params are returned
@@ -89,6 +108,9 @@ export function namedToPositional(
 /**
  * Convenience helper -- runs a parameterised query and returns all rows.
  * Accepts either positional `unknown[]` or named `:param` bind objects.
+ * Retries once on transient connection errors (reset/terminated) since SELECT
+ * queries are idempotent. Write operations use pgMutate/pgInsert instead and
+ * do not retry -- the server may have committed before the socket dropped.
  *
  * @example
  * const rows = await pgQuery<{ id: number }>("SELECT id FROM users WHERE name = :name", { name: "alice" });
@@ -98,8 +120,15 @@ export async function pgQuery<T extends pg.QueryResultRow = pg.QueryResultRow>(
   params?: Record<string, unknown> | unknown[],
 ): Promise<T[]> {
   const { text, values } = namedToPositional(sql, params ?? []);
-  const result = await getPostgresPool().query<T>(text, values);
-  return result.rows;
+  try {
+    const result = await getPostgresPool().query<T>(text, values);
+    return result.rows;
+  } catch (err) {
+    if (!isTransientConnectionError(err)) throw err;
+    logError("postgresClient.queryRetry", err);
+    const result = await getPostgresPool().query<T>(text, values);
+    return result.rows;
+  }
 }
 
 /**

--- a/src/tests/postgres-client-retry.test.ts
+++ b/src/tests/postgres-client-retry.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isTransientConnectionError } from "../db/postgresClient.js";
+
+test("isTransientConnectionError: true for 57P01 admin_shutdown", () => {
+  const err = Object.assign(new Error("terminating connection due to administrator command"), {
+    code: "57P01",
+  });
+  assert.equal(isTransientConnectionError(err), true);
+});
+
+test("isTransientConnectionError: true for 57P02 crash_shutdown", () => {
+  const err = Object.assign(new Error("terminating connection due to crash"), { code: "57P02" });
+  assert.equal(isTransientConnectionError(err), true);
+});
+
+test("isTransientConnectionError: true for ECONNRESET", () => {
+  const err = Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" });
+  assert.equal(isTransientConnectionError(err), true);
+});
+
+test("isTransientConnectionError: true for Connection terminated unexpectedly message", () => {
+  const err = new Error("Connection terminated unexpectedly");
+  assert.equal(isTransientConnectionError(err), true);
+});
+
+test("isTransientConnectionError: false for non-connection errors", () => {
+  assert.equal(isTransientConnectionError(new Error("syntax error at or near")), false);
+  assert.equal(isTransientConnectionError(new Error("relation does not exist")), false);
+  assert.equal(isTransientConnectionError("not an error"), false);
+  assert.equal(isTransientConnectionError(null), false);
+});
+
+test("isTransientConnectionError: false for unknown pg error code", () => {
+  const err = Object.assign(new Error("permission denied"), { code: "42501" });
+  assert.equal(isTransientConnectionError(err), false);
+});


### PR DESCRIPTION
## Summary
- Added `isTransientConnectionError()` to detect transient TCP/connection faults (57P01, 57P02, ECONNRESET, and "Connection terminated unexpectedly")
- `pgQuery` now retries once on these transient errors since SELECT queries are idempotent
- Write helpers (`pgMutate`, `pgInsert`, `pgTransaction`) intentionally do not retry -- the server may have already committed before the socket dropped, avoiding double-mutation

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] New unit tests in `postgres-client-retry.test.ts` verify all transient error classifications (57P01, 57P02, ECONNRESET, message-based) and confirm non-connection errors are not retried

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)