### PR TITLE
refactor: switch PublicReminderService to GET /api/v1/public_reminders/due

### DIFF
--- a/src/classes/PublicReminder.ts
+++ b/src/classes/PublicReminder.ts
@@ -72,6 +72,15 @@ export async function listUpcomingReminders(limit: number = 20): Promise<IPublic
   return response.data.map(mapReminder);
 }
 
+export async function listDueReminders(limit: number = 20): Promise<IPublicReminder[]> {
+  const safeLimit = Math.min(Math.max(limit, 1), 100);
+  const response = await apiGet<PublicReminderListResponse>("/api/v1/public_reminders/due", {
+    params: { per: safeLimit },
+  });
+  if (!response) return [];
+  return response.data.map(mapReminder);
+}
+
 export async function deleteReminder(reminderId: number): Promise<boolean> {
   const response = await apiDelete<{ deleted: boolean }>(
     `/api/v1/public_reminders/${reminderId}`,

--- a/src/services/PublicReminderService.ts
+++ b/src/services/PublicReminderService.ts
@@ -1,6 +1,6 @@
 import type { Client } from "discordx";
 import {
-  listUpcomingReminders,
+  listDueReminders,
   updateReminderDueDate,
   disableReminder,
   type IPublicReminder,
@@ -42,13 +42,8 @@ export function startPublicReminderService(client: Client): void {
 }
 
 async function checkPublicReminders(client: Client): Promise<void> {
-  const now = Date.now();
-  const reminders = await listUpcomingReminders(MAX_PER_CYCLE);
+  const reminders = await listDueReminders(MAX_PER_CYCLE);
   for (const reminder of reminders) {
-    if (!reminder.enabled) continue;
-    const due = reminder.dueAt.getTime();
-    if (due > now) continue;
-
     try {
       const channel = await client.channels.fetch(reminder.channelId).catch(() => null);
       if (!channel || !(channel as any).isTextBased?.()) continue;


### PR DESCRIPTION
## Summary
- Add `listDueReminders` to `PublicReminder.ts` that calls the new `/api/v1/public_reminders/due` endpoint instead of fetching all enabled reminders
- Update `checkPublicReminders` in `PublicReminderService.ts` to use `listDueReminders`, removing the client-side `enabled` and `due > now` filters
- Retain `listUpcomingReminders` (calls `GET /api/v1/public_reminders?enabled=true`) for the `/publicreminder list` slash command which shows all scheduled reminders

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Scheduled public reminders fire at the correct time
- [ ] Recurring reminders advance their due date; one-shot reminders disable after firing

Closes #819

🤖 Generated with [Claude Code](https://claude.com/claude-code)