### PR TITLE
fix: /create-thread fails for games without a cover blob -- should use cover_url from API

### DIFF
--- a/src/commands/create-thread.command.ts
+++ b/src/commands/create-thread.command.ts
@@ -131,7 +131,7 @@ export class CreateThreadCommand {
       return;
     }
 
-    if (!game.imageData) {
+    if (!game.coverUrl) {
       await safeReply(interaction, buildTextReply(
         `Cannot create a thread for "${game.title}" because it has no cover image.`,
         true,
@@ -168,7 +168,7 @@ export class CreateThreadCommand {
     const fileName = `gamedb_${game.id}.png`;
     const messagePayload: MessageCreateOptions = {
       content: postText,
-      files: [new AttachmentBuilder(game.imageData, { name: fileName })],
+      files: [new AttachmentBuilder(game.coverUrl, { name: fileName })],
     };
 
     const thread = await forum.threads.create({


### PR DESCRIPTION
## Summary
- Replaced the `game.imageData` null-guard with `game.coverUrl` so `/create-thread` no longer blocks on a buffer that is always null for API-sourced games
- Updated `AttachmentBuilder` to pass `game.coverUrl` (a URL string) instead of the null buffer

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/create-thread` succeeds for a game that has `cover_url` set in the API
- [ ] `/create-thread` still replies with "has no cover image" for a game where `coverUrl` is null

Closes #947

🤖 Generated with [Claude Code](https://claude.com/claude-code)