### PR TITLE
refactor: API Migration Step 11b: Update BotVotingInfo.getCurrentRound to use /api/v1/voting_info/current

### DIFF
--- a/src/classes/BotVotingInfo.ts
+++ b/src/classes/BotVotingInfo.ts
@@ -64,9 +64,8 @@ export default class BotVotingInfo {
   }
 
   static async getCurrentRound(): Promise<IBotVotingInfoEntry | null> {
-    // List is sorted desc by round_number; first record is current.
-    const all = await BotVotingInfo.getAll();
-    return all[0] ?? null;
+    const response = await apiGet<VotingInfoResponse>("/api/v1/voting_info/current");
+    return response ? mapApiData(response.data) : null;
   }
 
   static async setRoundInfo(


### PR DESCRIPTION
## Summary
- Replaces the `getCurrentRound()` workaround (fetching all records and taking `data[0]`) with a direct call to `GET /api/v1/voting_info/current`, now that TheRPGClub#96 is live
- Removes the dependency on `getAll()` for this method, eliminating unnecessary data transfer

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Nomination reminder fires and `getCurrentRound()` returns the correct record
- [ ] `/admin set-nextvote` still works correctly

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)