### PR TITLE
chore: Run all bot repo tests and correct any failures

### DIFF
--- a/src/tests/igdb-select-session.test.ts
+++ b/src/tests/igdb-select-session.test.ts
@@ -77,6 +77,7 @@ test("Import First Match on a missing/expired session replies with the expired n
       interaction.replied = true;
     },
     deferUpdate: async () => {},
+    isMessageComponent: () => true,
   };
 
   const handled = await handleIgdbFirstMatchInteraction(interaction);
@@ -105,6 +106,7 @@ test("Import First Match on a live session imports the first sorted option", asy
     deferred: false,
     reply: async () => {},
     deferUpdate: async () => {},
+    isMessageComponent: () => true,
   };
 
   const handled = await handleIgdbFirstMatchInteraction(interaction);

--- a/src/tests/now-playing-completion-safe-update.test.ts
+++ b/src/tests/now-playing-completion-safe-update.test.ts
@@ -39,6 +39,7 @@ test("nowplaying edit menu add completion uses safe update fallback", async () =
 
     const interaction: any = {
       customId: "nowplaying-edit-menu-complete:123",
+      isMessageComponent: () => true,
       user: { id: "123" },
       guildId: null,
       deferred: true,
@@ -101,6 +102,7 @@ test("nowplaying completion config renders with no image accessory", async () =>
 
     const interaction: any = {
       customId: "nowplaying-edit-menu-complete:123",
+      isMessageComponent: () => true,
       user: { id: "123" },
       guildId: null,
       deferred: true,
@@ -183,6 +185,7 @@ test("nowplaying completion modal reuses existing now-playing platform and skips
 
     const listInteraction: any = {
       customId: "nowplaying-list-complete:123",
+      isMessageComponent: () => true,
       user: { id: "123" },
       guildId: "guild-1",
       message: {

--- a/src/tests/now-playing-journal-components.test.ts
+++ b/src/tests/now-playing-journal-components.test.ts
@@ -403,6 +403,7 @@ test("journal delete confirm removes entry on yes and skips removal on no", asyn
 
     const makeInteraction = (action: "yes" | "no") => ({
       customId: `nowplaying-journal-delete-confirm:${action}:123:1:1:10`,
+      isMessageComponent: () => true,
       user: { id: "123" },
       guildId: "987654321",
       message: { flags: { has: () => false } },

--- a/src/tests/now-playing-remove-select.test.ts
+++ b/src/tests/now-playing-remove-select.test.ts
@@ -39,6 +39,7 @@ test("nowplaying remove select acknowledges interaction and refreshes same messa
 
     const interaction: any = {
       customId: "nowplaying-remove-select:123",
+      isMessageComponent: () => true,
       user: { id: "123" },
       values: ["11"],
       guildId: null,
@@ -87,6 +88,7 @@ test("nowplaying remove select acknowledges interaction and shows error on faile
 
     const interaction: any = {
       customId: "nowplaying-remove-select:123",
+      isMessageComponent: () => true,
       user: { id: "123" },
       values: ["11"],
       guildId: null,


### PR DESCRIPTION
## Summary
- Fixed 7 failing tests caused by mock interactions missing `isMessageComponent`.
- The dev-channel guard in `safeDeferUpdate`/`safeUpdate` (InteractionUtils.ts) calls `interaction.isMessageComponent()`, but several test mocks predate it and did not provide the method.
- Added `isMessageComponent: () => true` to the affected mocks, matching the existing passing mock pattern in `interaction-utils-safe-update.test.ts`. No source changes needed; this was a test-layer gap.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] All tests pass (69/69, was 62/69)
- [x] Lint reports no violations (`npm run lint`)

Closes #955

🤖 Generated with [Claude Code](https://claude.com/claude-code)