### PR TITLE
chore: Add GitHub Actions CI for lint, compile, and tests (required to merge PRs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type-check
+        run: npx tsc --noEmit
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Tests
+        run: >-
+          node --no-warnings=ExperimentalWarning --loader ts-node/esm
+          --test src/tests/*.test.ts


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` triggered on pull requests targeting `main`.
- Three independent jobs (`lint`, `compile`, `test`) so each can be set as a required status check: `npm run lint`, `npx tsc --noEmit`, and the test suite.
- Each job checks out the repo, sets up Node 20 (matching the Dockerfile) with npm dependency caching, and runs `npm ci` before its check.

## Notes
- The `test` job runs the test command directly (`node --loader ts-node/esm --test src/tests/*.test.ts`) rather than `npm test`. The `npm test` script pipes through `tee`, which masks node's exit code, so failing tests would not fail the job. Running directly propagates the exit code so failing tests block the merge.
- Branch protection (marking lint/compile/test as required status checks on `main`) must be enabled in repo settings after this workflow runs once on a PR; that step needs admin access and the checks must exist before they can be marked required.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Opening a PR triggers the workflow automatically
- [ ] A PR with lint/type/test errors is blocked from merging (after branch protection is enabled)
- [ ] A clean PR shows all three checks passing

Closes #956

🤖 Generated with [Claude Code](https://claude.com/claude-code)