### PR TITLE
chore: update GitHub Actions off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Log in to GHCR
         uses: docker/login-action@v3


### PR DESCRIPTION
## Summary
- Bump `actions/checkout@v4` -> `@v5` in `.github/workflows/docker-publish.yml`. v5 runs on the Node 24 runtime (`runs.using: node24`), which clears the Node 20 deprecation warning GitHub emits during workflow runs.
- The `docker/login-action`, `docker/metadata-action`, and `docker/build-push-action` steps are container-based actions and are unaffected by the Node runtime change, so they are intentionally left as-is.
- `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` was NOT set; the fix is a version bump per the acceptance criteria.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] `actions/checkout@v5` confirmed to declare `runs.using: node24` (verification proxy for the warning clearing)
- [ ] No Node 20 deprecation warning appears in workflow run logs (only observable after this merges to `main`, since the workflow triggers on push to `main`/tags)

Closes #960

🤖 Generated with [Claude Code](https://claude.com/claude-code)