### PR TITLE
refactor: Disable IgdbScanService

### DIFF
--- a/src/RPGClub_GameDB.ts
+++ b/src/RPGClub_GameDB.ts
@@ -28,7 +28,6 @@ import { startThreadSyncService } from "./services/ThreadSyncService.js";
 import { startThreadLinkPromptService } from "./services/ThreadLinkPromptService.js";
 import { refreshGiveawayHubMessage } from "./services/GiveawayHubService.js";
 import { startGameReleaseAnnouncementService } from "./services/GameReleaseAnnouncementService.js";
-import { startIgdbScanService } from "./services/IGDB/IgdbScanService.js";
 import { startUserEmojiService } from "./services/UserEmojiService.js";
 import { restoreJournalMessageContextsFromDb } from "./commands/now-playing/nowPlayingContexts.js";
 import { truncateWithEllipsis } from "./utilities/ValidationUtils.js";
@@ -194,7 +193,6 @@ bot.once("clientReady", async () => {
   startThreadSyncService(bot);
   startThreadLinkPromptService(bot);
   startGameReleaseAnnouncementService(bot);
-  startIgdbScanService();
   await joinAllTargetForumThreads(bot);
   startRssFeedService(bot);
   await refreshGiveawayHubMessage(bot);


### PR DESCRIPTION
## Summary
- Removed `startIgdbScanService()` invocation from the bot startup sequence
- Removed the corresponding import from `RPGClub_GameDB.ts`
- The API is now responsible for IGDB scanning; keeping the service active risked duplication or conflicts

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Confirm bot starts up without IGDB scan service running

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)