### PR TITLE
refactor: migrate Member SQL methods to API (#848)

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -1,8 +1,6 @@
 import {
   dbQuery,
   dbMutate,
-  dbWithConnection,
-  dbQueryConn,
 } from "../db/SqlManager.js";
 import { MemberSql } from "../db/sql/index.js";
 import { isPositiveInt, requirePositiveInt } from "../utilities/ValidationUtils.js";
@@ -31,16 +29,6 @@ export interface IMemberRecord {
   steamUrl: string | null;
   profileImage: Buffer | null;
   profileImageAt: Date | null;
-}
-
-export interface IMemberPlatformRecord {
-  userId: string;
-  username: string | null;
-  globalName: string | null;
-  steamUrl: string | null;
-  psnUsername: string | null;
-  xblUsername: string | null;
-  nswFriendCode: string | null;
 }
 
 export interface IMemberSearchFilters {
@@ -326,78 +314,79 @@ export interface ICompletionRecord {
 
 const MAX_NOW_PLAYING = 10;
 
-function buildParams(record: IMemberRecord) {
+type UserApiRecord = {
+  user_id: string;
+  username: string | null;
+  global_name: string | null;
+  is_bot: boolean;
+  server_joined_at: string | null;
+  last_seen_at: string | null;
+  server_left_at: string | null;
+  emoji_name: string | null;
+};
+
+type UserApiResponse = { data: UserApiRecord };
+
+type UserServiceApiRecord = {
+  user_id: string;
+  username: string | null;
+  global_name: string | null;
+  emoji_name: string | null;
+  server_left_at: string | null;
+};
+
+type UserServiceListResponse = {
+  data: UserServiceApiRecord[];
+  meta: { pages: number; count: number };
+};
+
+type AvatarHistoryApiRecord = {
+  event_id: number;
+  user_id: string;
+  avatar_hash: string | null;
+  avatar_url: string | null;
+  changed_at: string;
+};
+
+type AvatarHistoryApiListResponse = {
+  data: AvatarHistoryApiRecord[];
+  meta: { count: number; pages: number };
+};
+
+function mapUserApiRecord(raw: UserApiRecord): IMemberRecord {
   return {
-    userId: record.userId,
-    isBot: record.isBot ? 1 : 0,
-    username: record.username,
-    globalName: record.globalName,
-    avatarBlob: record.avatarBlob,
-    joinedAt: record.serverJoinedAt,
-    leftAt: record.serverLeftAt,
-    lastSeenAt: record.lastSeenAt,
-    roleAdmin: record.roleAdmin ? 1 : 0,
-    roleModerator: record.roleModerator ? 1 : 0,
-    roleRegular: record.roleRegular ? 1 : 0,
-    roleMember: record.roleMember ? 1 : 0,
-    roleNewcomer: record.roleNewcomer ? 1 : 0,
-    completionatorUrl: record.completionatorUrl,
-    psnUsername: record.psnUsername,
-    xblUsername: record.xblUsername,
-    nswFriendCode: record.nswFriendCode,
-    steamUrl: record.steamUrl,
+    userId: raw.user_id,
+    isBot: raw.is_bot ? 1 : 0,
+    username: raw.username,
+    globalName: raw.global_name,
+    avatarBlob: null,
+    serverJoinedAt: raw.server_joined_at ? new Date(raw.server_joined_at) : null,
+    serverLeftAt: raw.server_left_at ? new Date(raw.server_left_at) : null,
+    lastSeenAt: raw.last_seen_at ? new Date(raw.last_seen_at) : null,
+    roleAdmin: 0,
+    roleModerator: 0,
+    roleRegular: 0,
+    roleMember: 0,
+    roleNewcomer: 0,
+    messageCount: null,
+    completionatorUrl: null,
+    psnUsername: null,
+    xblUsername: null,
+    nswFriendCode: null,
+    steamUrl: null,
+    profileImage: null,
+    profileImageAt: null,
   };
 }
 
-type MemberRow = {
-  USER_ID: string; IS_BOT: number; USERNAME: string | null; GLOBAL_NAME: string | null;
-  AVATAR_BLOB: Buffer | null; SERVER_JOINED_AT: Date | null; SERVER_LEFT_AT: Date | null;
-  LAST_SEEN_AT: Date | null; ROLE_ADMIN: number; ROLE_MODERATOR: number;
-  ROLE_REGULAR: number; ROLE_MEMBER: number; ROLE_NEWCOMER: number;
-  MESSAGE_COUNT: number | null; COMPLETIONATOR_URL: string | null;
-  PSN_USERNAME: string | null; XBL_USERNAME: string | null; NSW_FRIEND_CODE: string | null;
-  STEAM_URL: string | null; PROFILE_IMAGE: Buffer | null; PROFILE_IMAGE_AT: Date | null;
-};
-
-function mapMemberRow(row: MemberRow): IMemberRecord {
+function mapAvatarHistoryApiRecord(raw: AvatarHistoryApiRecord): IAvatarHistoryRecord {
   return {
-    userId: row.USER_ID,
-    isBot: row.IS_BOT,
-    username: row.USERNAME ?? null,
-    globalName: row.GLOBAL_NAME ?? null,
-    avatarBlob: row.AVATAR_BLOB ?? null,
-    serverJoinedAt: row.SERVER_JOINED_AT ?? null,
-    serverLeftAt: row.SERVER_LEFT_AT ?? null,
-    lastSeenAt: row.LAST_SEEN_AT ?? null,
-    roleAdmin: row.ROLE_ADMIN,
-    roleModerator: row.ROLE_MODERATOR,
-    roleRegular: row.ROLE_REGULAR,
-    roleMember: row.ROLE_MEMBER,
-    roleNewcomer: row.ROLE_NEWCOMER,
-    messageCount: row.MESSAGE_COUNT ?? null,
-    completionatorUrl: row.COMPLETIONATOR_URL ?? null,
-    psnUsername: row.PSN_USERNAME ?? null,
-    xblUsername: row.XBL_USERNAME ?? null,
-    nswFriendCode: row.NSW_FRIEND_CODE ?? null,
-    steamUrl: row.STEAM_URL ?? null,
-    profileImage: row.PROFILE_IMAGE ?? null,
-    profileImageAt: row.PROFILE_IMAGE_AT ?? null,
-  };
-}
-
-type AvatarHistoryRow = {
-  EVENT_ID: number; USER_ID: string; AVATAR_HASH: string | null;
-  AVATAR_URL: string | null; AVATAR_BLOB: Buffer | null; CHANGED_AT: Date | string;
-};
-
-function mapAvatarHistoryRow(row: AvatarHistoryRow): IAvatarHistoryRecord {
-  return {
-    eventId: Number(row.EVENT_ID),
-    userId: String(row.USER_ID),
-    avatarHash: row.AVATAR_HASH ?? null,
-    avatarUrl: row.AVATAR_URL ?? null,
-    avatarBlob: row.AVATAR_BLOB ?? null,
-    changedAt: row.CHANGED_AT instanceof Date ? row.CHANGED_AT : new Date(row.CHANGED_AT as string),
+    eventId: Number(raw.event_id),
+    userId: String(raw.user_id),
+    avatarHash: raw.avatar_hash ?? null,
+    avatarUrl: raw.avatar_url ?? null,
+    avatarBlob: null,
+    changedAt: new Date(raw.changed_at),
   };
 }
 
@@ -452,13 +441,9 @@ function mapCompletionApiData(d: CompletionApiData): ICompletionRecord {
 export default class Member {
   static async touchLastSeen(userId: string, when: Date = new Date()): Promise<void> {
     try {
-      await dbMutate(
-        MemberSql.touchLastSeen,
-        { userId, lastSeen: when },
-      );
+      await apiPatch(`/api/v1/users/${userId}`, { data: { last_seen: when.toISOString() } });
     } catch (err: any) {
-      const msg = err?.message ?? String(err);
-      logError("Member.updateLastSeen", msg);
+      logError("Member.touchLastSeen", err?.message ?? String(err));
     }
   }
 
@@ -1196,12 +1181,9 @@ export default class Member {
   }
 
   static async getByUserId(userId: string): Promise<IMemberRecord | null> {
-    return dbWithConnection(async (conn) => {
-      const rows = await dbQueryConn<MemberRow, IMemberRecord>(
-        conn, MemberSql.getByUserId, { userId }, mapMemberRow,
-      );
-      return rows[0] ?? null;
-    });
+    const response = await apiGet<UserApiResponse>(`/api/v1/users/${userId}`);
+    if (!response) return null;
+    return mapUserApiRecord(response.data);
   }
 
   static async updateNowPlayingPlatform(
@@ -1228,14 +1210,12 @@ export default class Member {
   ): Promise<IAvatarHistoryRecord[]> {
     const safeLimit = Math.min(Math.max(limit, 1), 50);
     const safeOffset = Math.max(offset, 0);
-    return dbWithConnection(async (conn) => {
-      return dbQueryConn<AvatarHistoryRow, IAvatarHistoryRecord>(
-        conn,
-        MemberSql.getAvatarHistory,
-        { userId, limit: safeLimit, offset: safeOffset },
-        mapAvatarHistoryRow,
-      );
-    });
+    const page = Math.floor(safeOffset / safeLimit) + 1;
+    const response = await apiGet<AvatarHistoryApiListResponse>(
+      `/api/v1/users/${userId}/avatar_history`,
+      { params: { page, per: safeLimit } },
+    );
+    return response?.data?.map(mapAvatarHistoryApiRecord) ?? [];
   }
 
   static async getCompletionsForGame(
@@ -1289,24 +1269,21 @@ export default class Member {
   }
 
   static async countAvatarHistory(userId: string): Promise<number> {
-    const rows = await dbQuery<{ TOTAL: number | null }, number>(
-      MemberSql.countAvatarHistory,
-      { userId },
-      (row) => Number(row.TOTAL ?? 0),
+    const response = await apiGet<AvatarHistoryApiListResponse>(
+      `/api/v1/users/${userId}/avatar_history`,
+      { params: { per: 1, page: 1 } },
     );
-    return rows[0] ?? 0;
+    return response?.meta?.count ?? 0;
   }
 
   static async insertAvatarHistoryRecord(
     userId: string,
     avatarHash: string,
     avatarUrl: string,
-    avatarBlob: Buffer | null,
   ): Promise<void> {
-    await dbMutate(
-      MemberSql.insertAvatarHistoryRecord,
-      { userId, avatarHash, avatarUrl, avatarBlob },
-    );
+    await apiPost(`/api/v1/users/${userId}/avatar_history`, {
+      data: { avatar_hash: avatarHash, avatar_url: avatarUrl },
+    });
   }
 
   static async getAllMembersAvatarHistoryCounts(): Promise<IMemberAvatarHistoryCount[]> {
@@ -1327,75 +1304,27 @@ export default class Member {
     );
   }
 
-  static async getMembersWithPlatforms(): Promise<IMemberPlatformRecord[]> {
-    const members = await dbQuery<{
-      USER_ID: string;
-      USERNAME: string | null;
-      GLOBAL_NAME: string | null;
-      STEAM_URL: string | null;
-      PSN_USERNAME: string | null;
-      XBL_USERNAME: string | null;
-      NSW_FRIEND_CODE: string | null;
-      SERVER_LEFT_AT: Date | null;
-    }, IMemberPlatformRecord>(
-      MemberSql.getMembersWithPlatforms,
-      {},
-      (row) => ({
-        userId: row.USER_ID,
-        username: row.USERNAME ?? null,
-        globalName: row.GLOBAL_NAME ?? null,
-        steamUrl: row.STEAM_URL ?? null,
-        psnUsername: row.PSN_USERNAME ?? null,
-        xblUsername: row.XBL_USERNAME ?? null,
-        nswFriendCode: row.NSW_FRIEND_CODE ?? null,
-      }),
-    );
-
-    return members.sort((a, b) => {
-      const aName = (a.globalName ?? a.username ?? a.userId).toLowerCase();
-      const bName = (b.globalName ?? b.username ?? b.userId).toLowerCase();
-      return aName.localeCompare(bName);
-    });
-  }
-
   static async upsert(record: IMemberRecord): Promise<void> {
-    const params = buildParams(record);
-
-    const rowsUpdated = await dbMutate(MemberSql.updateMember, params);
-    if (rowsUpdated > 0) return;
-
-    try {
-      await dbMutate(MemberSql.insertMember, params);
-    } catch (insErr: any) {
-      const code = insErr?.code ?? insErr?.errorNum;
-      if (code === "ORA-00001") {
-        await dbMutate(MemberSql.updateMember, params);
-      } else {
-        throw insErr;
-      }
+    const body: Record<string, unknown> = {
+      discord_id: record.userId,
+      username: record.username,
+      global_name: record.globalName,
+      is_bot: Boolean(record.isBot),
+      server_left_at: record.serverLeftAt?.toISOString() ?? null,
+    };
+    if (record.serverJoinedAt != null) {
+      body.server_joined_at = record.serverJoinedAt.toISOString();
     }
+    await apiPost("/api/v1/users/upsert", { data: body });
   }
 
   static async markDepartedNotIn(userIds: string[]): Promise<number> {
     if (!userIds.length) return 0;
-
-    const chunkSize = 999; 
-    let totalUpdated = 0;
-
-    for (let i = 0; i < userIds.length; i += chunkSize) {
-      const chunk = userIds.slice(i, i + chunkSize);
-      const binds: Record<string, string> = {};
-      const placeholders = chunk.map((id, idx) => {
-        const key = `id${idx}`;
-        binds[key] = id;
-        return `:${key}`;
-      });
-
-      const affected = await dbMutate(MemberSql.markDepartedNotIn(placeholders.join(", ")), binds);
-      totalUpdated += affected;
-    }
-
-    return totalUpdated;
+    const response = await apiPost<{ count: number }>(
+      "/api/v1/users/mark_departed",
+      { active_ids: userIds },
+    );
+    return response?.count ?? 0;
   }
 
   static async getGameJournalList(userId: string): Promise<IGameJournalListEntry[]> {
@@ -1485,22 +1414,29 @@ export default class Member {
   }
 
   static async updateEmojiName(userId: string, emojiName: string | null): Promise<void> {
-    await dbMutate(
-      MemberSql.updateEmojiName,
-      { userId, emojiName },
-    );
+    await apiPatch(`/api/v1/users/${userId}`, { data: { emoji_name: emojiName } });
   }
 
   static async getAllWithEmojiName(): Promise<Array<{ userId: string; emojiName: string }>> {
-    return dbQuery<{ USER_ID: string; EMOJI_NAME: string },
-      { userId: string; emojiName: string }>(
-      MemberSql.getAllWithEmojiName,
-      {},
-      (row) => ({
-        userId: row.USER_ID,
-        emojiName: row.EMOJI_NAME,
-      }),
-    );
+    const results: Array<{ userId: string; emojiName: string }> = [];
+    let page = 1;
+    const per = 500;
+    let pages = 1;
+    do {
+      const response = await apiGet<UserServiceListResponse>(
+        "/api/v1/users",
+        { params: { has_emoji_name: true, page, per } },
+      );
+      if (!response) break;
+      for (const user of response.data) {
+        if (user.emoji_name) {
+          results.push({ userId: user.user_id, emojiName: user.emoji_name });
+        }
+      }
+      pages = Number(response.meta?.pages ?? 1);
+      page += 1;
+    } while (page <= pages);
+    return results;
   }
 
   static async upsertJournalMessageContext(

--- a/src/commands/superadmin.command.ts
+++ b/src/commands/superadmin.command.ts
@@ -152,19 +152,11 @@ function buildSuperAdminHelpButtons(
   return [buildSelectRow(select)];
 }
 
-type ImageBufferResult = { buffer: Buffer; mimeType: string | null };
-
 function buildStableSuperAdminSessionId(prefix: string, parts: string[]): string {
   const hash = crypto.createHash("sha256");
   // eslint-disable-next-line local/no-direct-interaction-response-methods
   hash.update(parts.join(":"));
   return `${prefix}-${hash.digest("hex").slice(0, 16)}`;
-}
-
-async function downloadImageBuffer(url: string): Promise<ImageBufferResult> {
-  const resp = await axios.get<ArrayBuffer>(url, { responseType: "arraybuffer" });
-  const mime = resp.headers?.["content-type"] ?? null;
-  return { buffer: Buffer.from(resp.data), mimeType: mime ? String(mime) : null };
 }
 
 export function buildSuperAdminHelpContainer(topic: SuperAdminHelpTopic): ContainerBuilder {
@@ -749,14 +741,6 @@ export class SuperAdmin {
       return;
     }
 
-    const roleMap = {
-      admin: process.env.ADMIN_ROLE_ID?.replace(/[<@&>]/g, "").trim() || null,
-      mod: process.env.MODERATOR_ROLE_ID?.replace(/[<@&>]/g, "").trim() || null,
-      regular: process.env.REGULAR_ROLE_ID?.replace(/[<@&>]/g, "").trim() || null,
-      member: process.env.MEMBER_ROLE_ID?.replace(/[<@&>]/g, "").trim() || null,
-      newcomer: process.env.NEWCOMER_ROLE_ID?.replace(/[<@&>]/g, "").trim() || null,
-    };
-
     await safeReply(interaction, buildTextReply("Fetching all guild members... this may take a moment.", true));
 
     const members = await guild.members.fetch();
@@ -765,97 +749,40 @@ export class SuperAdmin {
     let successCount = 0;
     let failCount = 0;
 
-    const avatarBuffersDifferent = (a: Buffer | null, b: Buffer | null): boolean => {
-      if (!a && !b) return false;
-      if (!!a !== !!b) return true;
-      if (!a || !b) return true;
-      if (a.length !== b.length) return true;
-      return !a.equals(b);
-    };
-
     for (const member of members.values()) {
       const user = member.user;
-      const existing = await Member.getByUserId(user.id);
 
-      let avatarBlob: Buffer | null = null;
-      const avatarUrl = user.displayAvatarURL({ extension: "png", size: 512, forceStatic: true });
-      if (avatarUrl) {
-        try {
-          const { buffer } = await downloadImageBuffer(avatarUrl);
-          avatarBlob = buffer;
-        } catch {
-          // ignore avatar fetch failures
-        }
-      }
-
-      const hasRole = (id?: string | null): number => {
-        if (!id) return 0;
-        return member.roles.cache.has(id) ? 1 : 0;
-      };
-      const adminFlag =
-        hasRole(roleMap.admin) || member.permissions.has("Administrator") ? 1 : 0;
-      const moderatorFlag =
-        hasRole(roleMap.mod) || member.permissions.has("ManageMessages") ? 1 : 0;
-      const regularFlag = hasRole(roleMap.regular);
-      const memberFlag = hasRole(roleMap.member);
-      const newcomerFlag = hasRole(roleMap.newcomer);
-
-      const baseRecord: IMemberRecord = {
+      const record: IMemberRecord = {
         userId: user.id,
         isBot: user.bot ? 1 : 0,
         username: user.username,
         globalName: (user as any).globalName ?? null,
         avatarBlob: null,
-        serverJoinedAt: member.joinedAt ?? existing?.serverJoinedAt ?? null,
+        serverJoinedAt: member.joinedAt ?? null,
         serverLeftAt: null,
-        lastSeenAt: existing?.lastSeenAt ?? null,
-        roleAdmin: adminFlag,
-        roleModerator: moderatorFlag,
-        roleRegular: regularFlag,
-        roleMember: memberFlag,
-        roleNewcomer: newcomerFlag,
-        messageCount: existing?.messageCount ?? null,
-        completionatorUrl: existing?.completionatorUrl ?? null,
-        psnUsername: existing?.psnUsername ?? null,
-        xblUsername: existing?.xblUsername ?? null,
-        nswFriendCode: existing?.nswFriendCode ?? null,
-        steamUrl: existing?.steamUrl ?? null,
-        profileImage: existing?.profileImage ?? null,
-        profileImageAt: existing?.profileImageAt ?? null,
+        lastSeenAt: null,
+        roleAdmin: 0,
+        roleModerator: 0,
+        roleRegular: 0,
+        roleMember: 0,
+        roleNewcomer: 0,
+        messageCount: null,
+        completionatorUrl: null,
+        psnUsername: null,
+        xblUsername: null,
+        nswFriendCode: null,
+        steamUrl: null,
+        profileImage: null,
+        profileImageAt: null,
       };
 
-      let avatarToUse: Buffer | null = avatarBlob;
-      if (!avatarToUse && existing?.avatarBlob) {
-        avatarToUse = existing.avatarBlob;
-      } else if (avatarToUse && existing?.avatarBlob) {
-        if (!avatarBuffersDifferent(avatarToUse, existing.avatarBlob)) {
-          avatarToUse = existing.avatarBlob;
-        }
-      }
-
       try {
-        await Member.upsert({ ...baseRecord, avatarBlob: avatarToUse });
+        await Member.upsert(record);
         successCount++;
       } catch (err) {
-        const code = (err as any)?.code ?? (err as any)?.errorNum;
-        if (code === "ORA-03146") {
-          try {
-            await Member.upsert({ ...baseRecord, avatarBlob: null });
-            successCount++;
-            await sleep(1000);
-            continue;
-          } catch (retryErr) {
-            failCount++;
-            logError("SuperadminCommand.upsertUserAfterStrippingAvatar", retryErr);
-            await sleep(1000);
-            continue;
-          }
-        }
         failCount++;
         logError("SuperadminCommand.upsertUser", err);
       }
-
-      await sleep(1000);
     }
 
     await safeReply(interaction, buildTextReply(`Member scan complete. Upserts succeeded: ${successCount}. Failed: ${failCount}. ` +

--- a/src/db/sql/member.sql.ts
+++ b/src/db/sql/member.sql.ts
@@ -1,13 +1,6 @@
 import type { ISqlEntry } from "./types.js";
 
 export const MemberSql = {
-  touchLastSeen: {
-    postgres: `UPDATE rpg_club_users
-            SET last_seen_at = :lastSeen,
-                updated_at = NOW()
-          WHERE user_id = :userId`,
-  } satisfies ISqlEntry,
-
   // Caller must pass dialect-appropriate where clause
   searchMembers: (where: string) =>
     ({
@@ -28,95 +21,6 @@ export const MemberSql = {
         ORDER BY COALESCE(UPPER(global_name), UPPER(username), user_id)
         LIMIT :limit`,
     }) satisfies ISqlEntry,
-
-  getByUserId: {
-    postgres: `SELECT user_id,
-                is_bot,
-                username,
-                global_name,
-               avatar_blob,
-               server_joined_at,
-                server_left_at,
-                last_seen_at,
-                role_admin,
-                role_moderator,
-                role_regular,
-                role_member,
-                role_newcomer,
-                message_count,
-                profile_image,
-                profile_image_at
-           FROM rpg_club_users
-          WHERE user_id = :userId`,
-  } satisfies ISqlEntry,
-
-  getAvatarHistory: {
-    postgres: `SELECT event_id,
-                user_id,
-                avatar_hash,
-                avatar_url,
-                avatar_blob,
-                changed_at
-           FROM rpg_club_user_avatar_history
-          WHERE user_id = :userId
-          ORDER BY changed_at DESC, event_id DESC
-          LIMIT :limit OFFSET :offset`,
-  } satisfies ISqlEntry,
-
-  updateMember: {
-    postgres: `UPDATE rpg_club_users
-            SET is_bot = :isBot,
-                username = :username,
-                global_name = :globalName,
-                avatar_blob = :avatarBlob,
-                server_joined_at = :joinedAt,
-                server_left_at = :leftAt,
-                last_seen_at = :lastSeenAt,
-                last_fetched_at = NOW(),
-                role_admin = :roleAdmin,
-                role_moderator = :roleModerator,
-                role_regular = :roleRegular,
-                role_member = :roleMember,
-                role_newcomer = :roleNewcomer,
-                updated_at = NOW()
-          WHERE user_id = :userId`,
-  } satisfies ISqlEntry,
-
-  insertMember: {
-    postgres: `INSERT INTO rpg_club_users (
-             user_id, is_bot, username, global_name, avatar_blob,
-             server_joined_at, server_left_at, last_seen_at, last_fetched_at,
-             role_admin, role_moderator, role_regular, role_member, role_newcomer,
-             created_at, updated_at
-           ) VALUES (
-             :userId, :isBot, :username, :globalName, :avatarBlob,
-             :joinedAt, :leftAt, :lastSeenAt, NOW(),
-             :roleAdmin, :roleModerator, :roleRegular, :roleMember, :roleNewcomer,
-             NOW(), NOW()
-           )`,
-  } satisfies ISqlEntry,
-
-  markDepartedNotIn: (placeholders: string) =>
-    ({
-      postgres: `UPDATE rpg_club_users
-             SET server_left_at = NOW(),
-                 updated_at = NOW()
-           WHERE server_left_at IS NULL
-             AND user_id NOT IN (${placeholders})`,
-    }) satisfies ISqlEntry,
-
-  updateEmojiName: {
-    postgres: `UPDATE rpg_club_users
-          SET emoji_name = :emojiName,
-              updated_at = NOW()
-        WHERE user_id = :userId`,
-  } satisfies ISqlEntry,
-
-  getAllWithEmojiName: {
-    postgres: `SELECT user_id, emoji_name
-         FROM rpg_club_users
-        WHERE emoji_name IS NOT NULL`,
-  } satisfies ISqlEntry,
 
   upsertJournalMessageContext: {
     postgres: `INSERT INTO journal_message_contexts (channel_id, message_id, created_at_ms, owner_user_id, game_id)
@@ -143,18 +47,7 @@ export const MemberSql = {
     postgres: `DELETE FROM journal_message_contexts WHERE created_at_ms < :cutoffMs`,
   } satisfies ISqlEntry,
 
-  countAvatarHistory: {
-    postgres: `SELECT COUNT(*) AS total
-         FROM rpg_club_user_avatar_history
-        WHERE user_id = :userId`,
-  } satisfies ISqlEntry,
-
-  insertAvatarHistoryRecord: {
-    postgres: `INSERT INTO rpg_club_user_avatar_history
-       (user_id, avatar_hash, avatar_url, avatar_blob)
-       VALUES (:userId, :avatarHash, :avatarUrl, :avatarBlob)`,
-  } satisfies ISqlEntry,
-
+  // No API aggregate endpoint available yet -- see issue #849
   getAllMembersAvatarHistoryCounts: {
     postgres: `SELECT h.user_id,
               u.username,
@@ -166,34 +59,6 @@ export const MemberSql = {
           AND u.server_left_at IS NULL
         GROUP BY h.user_id, u.username, u.global_name
         ORDER BY COALESCE(u.global_name, u.username, h.user_id)`,
-  } satisfies ISqlEntry,
-
-  getMembersWithPlatforms: {
-    postgres: `SELECT u.user_id AS "USER_ID",
-              u.username AS "USERNAME",
-              u.global_name AS "GLOBAL_NAME",
-              MAX(CASE WHEN LOWER(sp.label) LIKE '%steam%'
-                       THEN us.display_text END) AS "STEAM_URL",
-              MAX(CASE WHEN LOWER(sp.label) LIKE '%psn%'
-                        OR LOWER(sp.label) LIKE '%playstation%'
-                       THEN us.display_text END) AS "PSN_USERNAME",
-              MAX(CASE WHEN LOWER(sp.label) LIKE '%xbox%'
-                       THEN us.display_text END) AS "XBL_USERNAME",
-              MAX(CASE WHEN LOWER(sp.label) LIKE '%nintendo%'
-                        OR LOWER(sp.label) LIKE '%switch%'
-                       THEN us.display_text END) AS "NSW_FRIEND_CODE"
-         FROM rpg_club_users u
-         JOIN user_socials us ON us.user_id = u.user_id
-         JOIN social_platforms sp ON sp.id = us.platform_id
-        WHERE COALESCE(u.is_bot, false) = false
-          AND u.server_left_at IS NULL
-          AND (LOWER(sp.label) LIKE '%steam%'
-            OR LOWER(sp.label) LIKE '%psn%'
-            OR LOWER(sp.label) LIKE '%playstation%'
-            OR LOWER(sp.label) LIKE '%xbox%'
-            OR LOWER(sp.label) LIKE '%nintendo%'
-            OR LOWER(sp.label) LIKE '%switch%')
-        GROUP BY u.user_id, u.username, u.global_name`,
   } satisfies ISqlEntry,
 
 };

--- a/src/events/GuildMemberUpdate.command.ts
+++ b/src/events/GuildMemberUpdate.command.ts
@@ -148,29 +148,28 @@ export class GuildMemberUpdate {
     await syncUserEmojiFromDisplayNameChange(_client, newMember);
 
     try {
-      const existing = await Member.getByUserId(user.id);
       const record: IMemberRecord = {
         userId: user.id,
         isBot: user.bot ? 1 : 0,
-        username: user.username ?? existing?.username ?? null,
-        globalName: newNick ?? existing?.globalName ?? null,
-        avatarBlob: existing?.avatarBlob ?? null,
-        serverJoinedAt: newMember.joinedAt ?? existing?.serverJoinedAt ?? null,
-        serverLeftAt: existing?.serverLeftAt ?? null,
-        lastSeenAt: existing?.lastSeenAt ?? null,
-        roleAdmin: existing?.roleAdmin ?? 0,
-        roleModerator: existing?.roleModerator ?? 0,
-        roleRegular: existing?.roleRegular ?? 0,
-        roleMember: existing?.roleMember ?? 0,
-        roleNewcomer: existing?.roleNewcomer ?? 0,
-        messageCount: existing?.messageCount ?? null,
-        completionatorUrl: existing?.completionatorUrl ?? null,
-        psnUsername: existing?.psnUsername ?? null,
-        xblUsername: existing?.xblUsername ?? null,
-        nswFriendCode: existing?.nswFriendCode ?? null,
-        steamUrl: existing?.steamUrl ?? null,
-        profileImage: existing?.profileImage ?? null,
-        profileImageAt: existing?.profileImageAt ?? null,
+        username: user.username ?? null,
+        globalName: newNick ?? null,
+        avatarBlob: null,
+        serverJoinedAt: newMember.joinedAt ?? null,
+        serverLeftAt: null,
+        lastSeenAt: null,
+        roleAdmin: 0,
+        roleModerator: 0,
+        roleRegular: 0,
+        roleMember: 0,
+        roleNewcomer: 0,
+        messageCount: null,
+        completionatorUrl: null,
+        psnUsername: null,
+        xblUsername: null,
+        nswFriendCode: null,
+        steamUrl: null,
+        profileImage: null,
+        profileImageAt: null,
       };
 
       await Member.upsert(record);

--- a/src/utilities/AvatarLogUtils.ts
+++ b/src/utilities/AvatarLogUtils.ts
@@ -68,14 +68,12 @@ async function storeAvatarRecord(
   if (hasBackblazeB2Config()) {
     const storedUrl = await uploadAvatarToBackblaze(userId, avatarHash, discordUrl);
     if (storedUrl) {
-      await Member.insertAvatarHistoryRecord(userId, avatarHash, storedUrl, null);
+      await Member.insertAvatarHistoryRecord(userId, avatarHash, storedUrl);
       return true;
     }
   }
 
-  const blob = await downloadAvatarBuffer(discordUrl);
-  if (!blob) return false;
-  await Member.insertAvatarHistoryRecord(userId, avatarHash, discordUrl, blob);
+  await Member.insertAvatarHistoryRecord(userId, avatarHash, discordUrl);
   return true;
 }
 


### PR DESCRIPTION
## Summary
- Replaces all direct SQL calls in `Member.ts` and dependents with TheRPGClub API calls, completing the migration for issue #848
- `getAllMembersAvatarHistoryCounts` remains as SQL pending a server-side aggregate endpoint (see issue #849 for the API story and #850 for the bot follow-up)
- `getMembersWithPlatforms` deleted as dead code (no callers)
- `insertAvatarHistoryRecord` drops blob parameter; `AvatarLogUtils` simplified to not download blobs as fallback
- `memberscan` in superadmin simplified: no more per-member `getByUserId`, avatar buffer download, or `roleMap`

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `touchLastSeen` fires API PATCH instead of SQL UPDATE
- [ ] `upsert` calls `POST /api/v1/users/upsert` with only the 6 supported fields
- [ ] `markDepartedNotIn` calls `POST /api/v1/users/mark_departed` with `{ active_ids: [...] }` (no data wrapper)
- [ ] `getAllWithEmojiName` pages through `GET /api/v1/users?has_emoji_name=true` and returns emoji_name per user
- [ ] Avatar history insert/fetch work via avatar_history endpoints
- [ ] `getAllMembersAvatarHistoryCounts` still works via SQL until API aggregate endpoint is available

Closes #848

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01GL7nbSFss7XpGrkwGGqhp2