### PR TITLE
refactor: API Migration Step 24b: Migrate PresencePromptHistory to API

### DIFF
--- a/src/classes/PresencePromptHistory.ts
+++ b/src/classes/PresencePromptHistory.ts
@@ -1,5 +1,4 @@
-import { dbQuery, dbMutate } from "../db/SqlManager.js";
-import { PresencePromptHistorySql } from "../db/sql/index.js";
+import { apiPost, apiPatch, apiGet } from "../services/RpgClubApiClient.js";
 import { normalizePresenceGameTitle } from "./PresencePromptOptOut.js";
 
 export type PresencePromptStatus =
@@ -9,6 +8,21 @@ export type PresencePromptStatus =
   | "OPT_OUT_GAME"
   | "OPT_OUT_ALL";
 
+type PresencePromptRecord = {
+  id: number;
+  prompt_id: string;
+  game_title: string;
+  game_title_norm: string;
+  status: PresencePromptStatus;
+  created_at: string;
+  resolved_at: string | null;
+};
+
+type PresencePromptListResponse = {
+  data: PresencePromptRecord[];
+  meta: { count: number; page: number; pages: number; per: number };
+};
+
 export default class PresencePromptHistory {
   static async createPrompt(
     promptId: string,
@@ -16,17 +30,15 @@ export default class PresencePromptHistory {
     gameTitle: string,
   ): Promise<void> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    await dbMutate(
-      PresencePromptHistorySql.createPrompt,
-      { promptId, userId, gameTitle, gameTitleNorm: normalized },
-    );
+    await apiPost(`/api/v1/users/${userId}/presence_prompts`, {
+      data: { prompt_id: promptId, game_title: gameTitle, game_title_norm: normalized },
+    });
   }
 
   static async markResolved(promptId: string, status: PresencePromptStatus): Promise<void> {
-    await dbMutate(
-      PresencePromptHistorySql.markResolved,
-      { status, promptId },
-    );
+    await apiPatch(`/api/v1/presence_prompts/${promptId}`, {
+      data: { status, resolved_at: new Date().toISOString() },
+    });
   }
 
   static async getLastPromptDateForGame(
@@ -34,31 +46,28 @@ export default class PresencePromptHistory {
     gameTitle: string,
   ): Promise<Date | null> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    const rows = await dbQuery(
-      PresencePromptHistorySql.getLastPromptDate,
-      { userId, gameTitleNorm: normalized },
-      (row: { CREATED_AT: Date | string }) =>
-        row.CREATED_AT instanceof Date ? row.CREATED_AT : new Date(row.CREATED_AT as string),
+    const response = await apiGet<PresencePromptListResponse>(
+      `/api/v1/users/${userId}/presence_prompts`,
+      { params: { game_title_norm: normalized, per: 1 } },
     );
-    return rows[0] ?? null;
+    const first = response?.data?.[0];
+    return first ? new Date(first.created_at) : null;
   }
 
   static async countPendingForGame(userId: string, gameTitle: string): Promise<number> {
     const normalized = normalizePresenceGameTitle(gameTitle);
-    const rows = await dbQuery(
-      PresencePromptHistorySql.countPendingForGame,
-      { userId, gameTitleNorm: normalized },
-      (row: { CNT: number }) => Number(row.CNT ?? 0),
+    const response = await apiGet<PresencePromptListResponse>(
+      `/api/v1/users/${userId}/presence_prompts`,
+      { params: { game_title_norm: normalized, status: "PENDING", per: 1 } },
     );
-    return rows[0] ?? 0;
+    return response?.meta?.count ?? 0;
   }
 
   static async countPendingForUser(userId: string): Promise<number> {
-    const rows = await dbQuery(
-      PresencePromptHistorySql.countPendingForUser,
-      { userId },
-      (row: { CNT: number }) => Number(row.CNT ?? 0),
+    const response = await apiGet<PresencePromptListResponse>(
+      `/api/v1/users/${userId}/presence_prompts`,
+      { params: { status: "PENDING", per: 1 } },
     );
-    return rows[0] ?? 0;
+    return response?.meta?.count ?? 0;
   }
 }

--- a/src/db/sql/index.ts
+++ b/src/db/sql/index.ts
@@ -10,6 +10,5 @@ export { GameReleaseAnnouncementSql } from "./gameReleaseAnnouncement.sql.js";
 export { GotmAuditImportSql } from "./gotmAuditImport.sql.js";
 export { HltbCacheSql } from "./hltbCache.sql.js";
 export { MemberSql } from "./member.sql.js";
-export { PresencePromptHistorySql } from "./presencePrompt.sql.js";
 export { SteamCollectionImportSql } from "./steamCollectionImport.sql.js";
 

--- a/src/db/sql/presencePrompt.sql.ts
+++ b/src/db/sql/presencePrompt.sql.ts
@@ -1,44 +1,5 @@
 import type { ISqlEntry } from "./types.js";
 
-export const PresencePromptHistorySql = {
-  createPrompt: {
-    postgres: `INSERT INTO rpg_club_presence_prompt_history
-        (prompt_id, user_id, game_title, game_title_norm, status)
-       VALUES (:promptId, :userId, :gameTitle, :gameTitleNorm, 'PENDING')`,
-  } satisfies ISqlEntry,
-
-  markResolved: {
-    postgres: `UPDATE rpg_club_presence_prompt_history
-          SET status = :status,
-              resolved_at = NOW()
-        WHERE prompt_id = :promptId`,
-  } satisfies ISqlEntry,
-
-  getLastPromptDate: {
-    postgres: `SELECT created_at
-         FROM rpg_club_presence_prompt_history
-        WHERE user_id = :userId
-          AND game_title_norm = :gameTitleNorm
-        ORDER BY created_at DESC
-        LIMIT 1`,
-  } satisfies ISqlEntry,
-
-  countPendingForGame: {
-    postgres: `SELECT COUNT(*) AS cnt
-         FROM rpg_club_presence_prompt_history
-        WHERE user_id = :userId
-          AND game_title_norm = :gameTitleNorm
-          AND status = 'PENDING'`,
-  } satisfies ISqlEntry,
-
-  countPendingForUser: {
-    postgres: `SELECT COUNT(*) AS cnt
-         FROM rpg_club_presence_prompt_history
-        WHERE user_id = :userId
-          AND status = 'PENDING'`,
-  } satisfies ISqlEntry,
-};
-
 export const PresencePromptOptOutSql = {
   isOptedOutAll: {
     postgres: `SELECT COUNT(*) AS cnt


### PR DESCRIPTION
## Summary
- Replace all SQL calls in \`PresencePromptHistory\` with API calls to \`/api/v1/users/:user_id/presence_prompts\` and \`/api/v1/presence_prompts/:id\`
- Delete \`PresencePromptHistorySql\` from \`src/db/sql/presencePrompt.sql.ts\` and its export from \`src/db/sql/index.ts\`
- Count methods now use \`meta.count\` from list responses with \`per: 1\` to avoid fetching all records

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Presence prompts fire correctly and mark resolved after a member responds

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)