### PR TITLE
feat: Render Reddit Discussion Thread link from /games/:id/profile once API exposes reddit_url

### DIFF
--- a/src/functions/GameProfileMapper.ts
+++ b/src/functions/GameProfileMapper.ts
@@ -68,6 +68,7 @@ type ProfileCollectionOwnerApiData = {
 
 type ProfileGotmWinApiData = {
   round: number;
+  reddit_url: string | null;
 };
 
 type ProfileGotmNominationApiData = {
@@ -115,13 +116,13 @@ export function mapGameProfileFromApi(
     gotmWins: (d.associations.gotm_wins ?? []).map((w) => ({
       round: Number(w.round),
       threadId: null,
-      redditUrl: null,
+      redditUrl: w.reddit_url ?? null,
       monthYear: "",
     })),
     nrGotmWins: (d.associations.nr_gotm_wins ?? []).map((w) => ({
       round: Number(w.round),
       threadId: null,
-      redditUrl: null,
+      redditUrl: w.reddit_url ?? null,
       monthYear: "",
     })),
     gotmNominations: (d.associations.gotm_nominations ?? []).map((n) => ({


### PR DESCRIPTION
## Summary
- Added `reddit_url: string | null` to `ProfileGotmWinApiData` type in `GameProfileMapper.ts`
- Mapped `w.reddit_url ?? null` onto GOTM and NR-GOTM wins instead of hard-coded `null`
- The existing rendering logic in `gamedb-profile.service.ts` already handles non-null `redditUrl` -- no further changes needed

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/gamedb view` for a GOTM-winner game with a `reddit_url` set shows the **Reddit Discussion Thread** line in the embed

Closes #902

🤖 Generated with [Claude Code](https://claude.com/claude-code)