### PR TITLE
refactor: migrate getAllMembersAvatarHistoryCounts to API

### DIFF
--- a/src/classes/Member.ts
+++ b/src/classes/Member.ts
@@ -353,6 +353,18 @@ type AvatarHistoryApiListResponse = {
   meta: { count: number; pages: number };
 };
 
+type AvatarHistoryCountApiRecord = {
+  user_id: string;
+  username: string | null;
+  global_name: string | null;
+  avatar_change_count: number;
+};
+
+type AvatarHistoryCountListResponse = {
+  data: AvatarHistoryCountApiRecord[];
+  meta: { pages: number };
+};
+
 function mapUserApiRecord(raw: UserApiRecord): IMemberRecord {
   return {
     userId: raw.user_id,
@@ -1287,21 +1299,27 @@ export default class Member {
   }
 
   static async getAllMembersAvatarHistoryCounts(): Promise<IMemberAvatarHistoryCount[]> {
-    return dbQuery<{
-      USER_ID: string;
-      USERNAME: string | null;
-      GLOBAL_NAME: string | null;
-      TOTAL: number;
-    }, IMemberAvatarHistoryCount>(
-      MemberSql.getAllMembersAvatarHistoryCounts,
-      {},
-      (row) => ({
-        userId: String(row.USER_ID),
-        username: row.USERNAME ?? null,
-        globalName: row.GLOBAL_NAME ?? null,
-        count: Number(row.TOTAL),
-      }),
-    );
+    const results: IMemberAvatarHistoryCount[] = [];
+    let page = 1;
+    let pages = 1;
+    do {
+      const response = await apiGet<AvatarHistoryCountListResponse>(
+        "/api/v1/users/avatar_history_counts",
+        { params: { page, per: 500 } },
+      );
+      if (!response) break;
+      for (const row of response.data) {
+        results.push({
+          userId: row.user_id,
+          username: row.username ?? null,
+          globalName: row.global_name ?? null,
+          count: row.avatar_change_count,
+        });
+      }
+      pages = Number(response.meta?.pages ?? 1);
+      page += 1;
+    } while (page <= pages);
+    return results;
   }
 
   static async upsert(record: IMemberRecord): Promise<void> {

--- a/src/db/sql/member.sql.ts
+++ b/src/db/sql/member.sql.ts
@@ -47,18 +47,4 @@ export const MemberSql = {
     postgres: `DELETE FROM journal_message_contexts WHERE created_at_ms < :cutoffMs`,
   } satisfies ISqlEntry,
 
-  // No API aggregate endpoint available yet -- see issue #849
-  getAllMembersAvatarHistoryCounts: {
-    postgres: `SELECT h.user_id,
-              u.username,
-              u.global_name,
-              COUNT(*) AS total
-         FROM rpg_club_user_avatar_history h
-         JOIN rpg_club_users u ON u.user_id = h.user_id
-        WHERE COALESCE(u.is_bot, false) = false
-          AND u.server_left_at IS NULL
-        GROUP BY h.user_id, u.username, u.global_name
-        ORDER BY COALESCE(u.global_name, u.username, h.user_id)`,
-  } satisfies ISqlEntry,
-
 };


### PR DESCRIPTION
## Summary
- Replaces the SQL aggregate query for the avatar-history leaderboard with a paginated call to the new `GET /api/v1/users/avatar_history_counts` endpoint
- Removes the `getAllMembersAvatarHistoryCounts` entry from `src/db/sql/member.sql.ts` now that the API endpoint is available (TheRPGClub/TheRPGClub-api#145)
- Updates the api-reference skill with the new endpoint

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] `/avatar-history all` leaderboard renders correctly in Discord

Closes #970

🤖 Generated with [Claude Code](https://claude.com/claude-code)