### PR TITLE
fix: correct giveaway select handler segment counts (real claim fix)

### DIFF
--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -704,7 +704,8 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-claim:[^:]+:\d+:\d+:\d+$/ })
   async handleClaim(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = assertCustomIdSegments(interaction, 3);
+    // buildKeySelectMenus appends a trailing row index segment; it is unused here.
+    const segs = assertCustomIdSegments(interaction, 4);
     if (!segs) return;
     const [sessionId, ownerId, pageRaw] = segs;
     if (await replyIfNotOwner(interaction, ownerId)) return;
@@ -744,7 +745,8 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-hub-claim-select:\d+:\d+$/ })
   async handleHubClaimSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = assertCustomIdSegments(interaction, 1);
+    // buildKeySelectMenus appends a trailing row index segment; it is unused here.
+    const segs = assertCustomIdSegments(interaction, 2);
     if (!segs) return;
     const [userId] = segs;
     if (await replyIfNotOwner(interaction, userId, "This giveaway claim isn't for you.")) return;
@@ -783,7 +785,8 @@ export class GiveawayCommand {
    
   @SelectMenuComponent({ id: /^giveaway-claim-public:[^:]+:\d+:\d+:\d+:\d+$/ })
   async handlePublicClaim(interaction: StringSelectMenuInteraction): Promise<void> {
-    const segs = assertCustomIdSegments(interaction, 4);
+    // buildKeySelectMenus appends a trailing row index segment; it is unused here.
+    const segs = assertCustomIdSegments(interaction, 5);
     if (!segs) return;
     const [sessionId, pageRaw, messageId, userId] = segs;
     if (await replyIfNotOwner(interaction, userId, "This giveaway claim isn't for you.")) return;


### PR DESCRIPTION
## Summary
- This is the actual fix for the giveaway "interaction failed" on key claim.
  PR #986 (custom ID length) targeted an unreachable code path and did not
  resolve it.
- All three key-select handlers asserted the wrong custom ID segment count.
  `buildKeySelectMenus` appends a trailing row-index segment to every select
  custom ID, and the decorator regexes were updated to expect it, but the
  handlers' `assertCustomIdSegments` counts were not (regressed in `7da5015`).
- The regex matched so the handler fired, then the segment assertion returned
  null and the handler returned without acknowledging the interaction, which
  Discord surfaces as "interaction failed" the moment a key is selected.

## The fix
- `handleClaim`: assert 3 -> 4
- `handleHubClaimSelect`: assert 1 -> 2
- `handlePublicClaim`: assert 4 -> 5

Destructuring is unchanged; the trailing row index is intentionally ignored.

## Why #986 did not fix it
The select fails on key selection, which is upstream of the confirm button. The
length bug could only fire after a select succeeded, which never happened, so it
was unreachable. The length fix is still correct and necessary for the public
path (once the public select works it builds the 103-char confirm button), but
it is not sufficient on its own. This segment-count bug gates all three flows.

## Verification note for the maintainer
- `assertCustomIdSegments` logs `UnexpectedCustomId` on the failed click, so the
  failure should appear in the server logs (Discord side shows only "interaction
  failed"). Worth confirming that log was present before this fix.
- The bot runs from compiled output (`build/`). Rebuild on the desktop after
  pulling, not just restart, or it will run stale code.

## Follow-up (not in this PR)
A static lint rule "decorator regex segment count must equal the handler's
assertCustomIdSegments argument" would have caught all three. Recommended as a
fast follow.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`), 69/69
- [x] Lint clean (`npm run lint`)
- [x] Verified all three select custom IDs now parse (hub/private/public)

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)