### PR TITLE
fix: deliver giveaway key DM even when donor-notify side effects fail

### DIFF
--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -58,6 +58,7 @@ import {
 import { GIVEAWAY_HUB_CHANNEL_ID, GIVEAWAY_LOG_CHANNEL_ID } from "../config/channels.js";
 import { MEMBER_ROLE_ID } from "../config/roles.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 import { COLOR_SUCCESS } from "../config/colors.js";
 import { CLAIM_MENU_CHUNK_SIZE } from "../config/pagination.js";
 import {
@@ -317,31 +318,10 @@ async function claimKey(
     return { status: "unavailable" };
   }
 
-  const logChannel = await interaction.client.channels
-    .fetch(GIVEAWAY_LOG_CHANNEL_ID)
-    .catch(() => null);
-  const textChannel = logChannel?.isTextBased() ? logChannel : null;
-  await logGiveawayClaim(
-    textChannel,
-    interaction.user.id,
-    key.gameTitle,
-    key.platform,
-    key.keyId,
-  );
-
-  const donorUser = await interaction.client.users
-    .fetch(key.donorUserId)
-    .catch(() => null);
-  const donorName = donorUser?.username ?? userMention(key.donorUserId);
-  const notifyDonor = await Member.getGiveawayDonorNotifySetting(key.donorUserId);
-  if (notifyDonor && donorUser && key.donorUserId !== interaction.user.id) {
-    const claimantMention = userMention(interaction.user.id);
-    safeIgnore(donorUser.send({
-      content:
-        `Your donated key for **${key.gameTitle}** (${key.platform}) was claimed by ` +
-        `${claimantMention}. Thanks for contributing!`,
-    }));
-  }
+  // The key is now claimed in the DB. The claimant's key delivery (DM) is the
+  // critical path; logging and donor notification are best-effort and must never
+  // throw, or the claimant loses a key that is already marked claimed.
+  const donorName = await runClaimSideEffects(interaction, key);
 
   return {
     status: "claimed",
@@ -353,6 +333,48 @@ async function claimKey(
       donorName,
     },
   };
+}
+
+/**
+ * Writes the claim log and notifies the donor. Never throws: any failure is
+ * logged and swallowed so the claimant's key DM still proceeds. Returns the
+ * donor display name (falls back to a mention).
+ */
+export async function runClaimSideEffects(
+  interaction: AnyRepliable,
+  key: { donorUserId: string; gameTitle: string; platform: string; keyId: number },
+): Promise<string> {
+  let donorName: string = userMention(key.donorUserId);
+  try {
+    const logChannel = await interaction.client.channels
+      .fetch(GIVEAWAY_LOG_CHANNEL_ID)
+      .catch(() => null);
+    const textChannel = logChannel?.isTextBased() ? logChannel : null;
+    await logGiveawayClaim(
+      textChannel,
+      interaction.user.id,
+      key.gameTitle,
+      key.platform,
+      key.keyId,
+    );
+
+    const donorUser = await interaction.client.users
+      .fetch(key.donorUserId)
+      .catch(() => null);
+    donorName = donorUser?.username ?? userMention(key.donorUserId);
+    const notifyDonor = await Member.getGiveawayDonorNotifySetting(key.donorUserId);
+    if (notifyDonor && donorUser && key.donorUserId !== interaction.user.id) {
+      const claimantMention = userMention(interaction.user.id);
+      safeIgnore(donorUser.send({
+        content:
+          `Your donated key for **${key.gameTitle}** (${key.platform}) was claimed by ` +
+          `${claimantMention}. Thanks for contributing!`,
+      }));
+    }
+  } catch (err: unknown) {
+    logError("giveaway.runClaimSideEffects", err);
+  }
+  return donorName;
 }
 
 function buildDonateModal(): ModalBuilder {
@@ -885,7 +907,10 @@ export class GiveawayCommand {
           `Key: \`${result.key.keyValue}\`\n` +
           `This key was donated by ${result.key.donorName}, be sure to thank them!`,
       })
-      .catch(() => null);
+      .catch((err: unknown) => {
+        logError("giveaway.handleClaimConfirm.dm", err);
+        return null;
+      });
 
     if (dmResult) {
       await safeReply(interaction, {

--- a/src/tests/giveaway-claim-side-effects.test.ts
+++ b/src/tests/giveaway-claim-side-effects.test.ts
@@ -1,0 +1,58 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { runClaimSideEffects } from "../commands/giveaway.command.js";
+import Member from "../classes/Member.js";
+
+function buildInteraction(donorSends: unknown[]): any {
+  return {
+    user: { id: "claimant-1" },
+    client: {
+      channels: {
+        fetch: async () => ({ isTextBased: () => true, send: async () => {} }),
+      },
+      users: {
+        fetch: async () => ({
+          username: "DonorName",
+          send: async (payload: unknown) => {
+            donorSends.push(payload);
+          },
+        }),
+      },
+    },
+  };
+}
+
+const key = {
+  donorUserId: "donor-1",
+  gameTitle: "Some Game",
+  platform: "Steam",
+  keyId: 42,
+};
+
+test("runClaimSideEffects swallows donor-notify failures and still returns a name", async () => {
+  const original = Member.getGiveawayDonorNotifySetting;
+  try {
+    // A non-404 API error here previously aborted the whole claim before the
+    // claimant's key DM was sent.
+    Member.getGiveawayDonorNotifySetting = (async () => {
+      throw new Error("API 500");
+    }) as any;
+
+    const donorName = await runClaimSideEffects(buildInteraction([]), key);
+    assert.equal(donorName, "DonorName", "donor name resolves despite notify failure");
+  } finally {
+    Member.getGiveawayDonorNotifySetting = original;
+  }
+});
+
+test("runClaimSideEffects notifies the donor when the setting is enabled", async () => {
+  const original = Member.getGiveawayDonorNotifySetting;
+  const donorSends: unknown[] = [];
+  try {
+    Member.getGiveawayDonorNotifySetting = (async () => true) as any;
+    await runClaimSideEffects(buildInteraction(donorSends), key);
+    assert.equal(donorSends.length, 1, "donor receives a notification DM");
+  } finally {
+    Member.getGiveawayDonorNotifySetting = original;
+  }
+});


### PR DESCRIPTION
## Summary
- Confirmed symptom: clicking "Yes" on the claim confirm marks the key claimed
  and writes the audit log, but the claimant never receives the key DM and no
  error appears.
- Root cause: after the claim and log, `claimKey` called the unguarded
  `Member.getGiveawayDonorNotifySetting`. `apiGet` returns null only on 404 and
  throws on every other error (5xx, auth, network), so a hiccup on the donor's
  `giveaway_settings` endpoint threw out of `claimKey` before the claimant's key
  data was returned. The interaction was already deferred, so there was no
  "interaction failed", just a silent stop after the log.

## The fix
- Extract post-claim work (audit log, donor fetch, donor notification) into
  `runClaimSideEffects`, which logs and swallows any failure and always returns a
  donor name. The claimant's key delivery no longer depends on best-effort side
  effects.
- Log the real error when the claimant DM fails, instead of swallowing it with
  `.catch(() => null)`.
- Add unit tests: side effects never throw when donor-notify fails, and the
  donor is notified when the setting is enabled.

## Operational note (needs maintainer action)
While this bug was live, affected claims marked keys as claimed in the DB but
never delivered them. Those users cannot re-claim (they get "no longer
available"). An admin may need to look up and re-send those keys manually.

## Follow-ups (not in this PR)
- The donor `giveaway_settings` endpoint is returning a non-404 error for at
  least one donor; worth checking server-side why, since the notification is now
  silently skipped when it fails.
- Recommended (per repo convention): a lint rule flagging decorator regex
  segment count vs the handler's `assertCustomIdSegments` argument (would have
  caught the earlier #987 regression).

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`), 71/71
- [x] Lint clean (`npm run lint`)
- [ ] After deploy (rebuild on desktop, not just restart): a real claim delivers
      the key DM, and no `giveaway.runClaimSideEffects` error blocks it

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)