### PR TITLE
fix: deliver giveaway key via follow-up, not cross-paradigm editReply

### DIFF
--- a/src/commands/giveaway.command.ts
+++ b/src/commands/giveaway.command.ts
@@ -892,52 +892,72 @@ export class GiveawayCommand {
     }
 
     await safeDeferUpdate(interaction);
-    const result = await claimKey(interaction, keyId);
-    if (result.status === "unavailable") {
-      await safeReply(interaction, buildTextReply("That key is no longer available.", false));
-      return;
-    }
+    // Feedback is delivered via follow-ups (fresh messages), not editReply. The
+    // "Are you sure?" message is a plain content/button message while these
+    // replies are Components v2; editing across paradigms is rejected by Discord
+    // with a non-ack error that safeReply rethrows without logging, which is the
+    // silent failure this handler must avoid. The whole flow is wrapped so any
+    // failure is logged and surfaced instead of leaving the claimant with
+    // nothing after their key is already marked claimed.
+    try {
+      const result = await claimKey(interaction, keyId);
+      if (result.status === "unavailable") {
+        await safeReply(interaction, {
+          ...buildTextReply("That key is no longer available.", true),
+          __forceFollowUp: true,
+        });
+        return;
+      }
 
-    await safeReply(interaction, buildTextReply("Sending your key by DM now.", false));
+      const dmResult = await interaction.user
+        .send({
+          content:
+            `You claimed **${result.key.keyTitle}** (${result.key.platform}).\n` +
+            `Key: \`${result.key.keyValue}\`\n` +
+            `This key was donated by ${result.key.donorName}, be sure to thank them!`,
+        })
+        .catch((err: unknown) => {
+          logError("giveaway.handleClaimConfirm.dm", err);
+          return null;
+        });
 
-    const dmResult = await interaction.user
-      .send({
-        content:
-          `You claimed **${result.key.keyTitle}** (${result.key.platform}).\n` +
-          `Key: \`${result.key.keyValue}\`\n` +
-          `This key was donated by ${result.key.donorName}, be sure to thank them!`,
-      })
-      .catch((err: unknown) => {
-        logError("giveaway.handleClaimConfirm.dm", err);
-        return null;
-      });
-
-    if (dmResult) {
+      const resultMessage = dmResult
+        ? "Your key was sent by DM. Thanks for claiming responsibly."
+        : "I could not send you a DM. Please enable DMs and contact an admin to resend your key.";
       await safeReply(interaction, {
-        ...buildTextReply("Your key was sent by DM. Thanks for claiming responsibly.", false),
+        ...buildTextReply(resultMessage, true),
         __forceFollowUp: true,
       });
-    } else {
+    } catch (err: unknown) {
+      logError("giveaway.handleClaimConfirm", err);
       await safeReply(interaction, {
         ...buildTextReply(
-          "I could not send you a DM. Please enable DMs and contact an admin to resend your key.",
-          false,
+          "Something went wrong while delivering your key. Please contact an admin.",
+          true,
         ),
         __forceFollowUp: true,
       });
+      return;
     }
 
+    // Cosmetic list refreshes only. These must never affect the claimant's
+    // delivery result, so they are guarded separately: a refresh failure has
+    // already been preceded by a successful key delivery above.
     if (scope === "public") {
-      const sessionId = extraSegs[0];
-      const messageId = extraSegs[1];
-      const ownerId = extraSegs[2];
-      await updatePublicListMessage(
-        interaction as unknown as StringSelectMenuInteraction,
-        sessionId,
-        ownerId,
-        page,
-        messageId,
-      );
+      try {
+        const sessionId = extraSegs[0];
+        const messageId = extraSegs[1];
+        const ownerId = extraSegs[2];
+        await updatePublicListMessage(
+          interaction as unknown as StringSelectMenuInteraction,
+          sessionId,
+          ownerId,
+          page,
+          messageId,
+        );
+      } catch (err: unknown) {
+        logError("giveaway.updatePublicListMessage", err);
+      }
     }
 
     safeIgnore(refreshGiveawayHubMessage(interaction.client));


### PR DESCRIPTION
## Summary
- Addresses the most likely remaining cause of the claim "Yes" silent failure:
  a Components v1 vs v2 mismatch on editReply.
- The confirm ("Are you sure?") message is plain content+buttons (v1), but the
  post-claim feedback (`buildTextReply`) is a Components v2 payload. After
  `safeDeferUpdate`, feedback went out via `safeReply` -> `editReply`, editing the
  v1 message with a v2 body. Discord rejects that with a non-ack "Invalid Form
  Body" error, which `safeReply` rethrows without logging.
- The throw landed right after the audit log and before the DM send, so the key
  was marked claimed and logged, but the claimant got no DM, no feedback, and no
  error surfaced anywhere. This matches every observation: audit log present, no
  DM, no logs, no "Sending your key by DM now".

## Changes
- Send all post-claim feedback via follow-ups (fresh ephemeral messages) instead
  of editing the confirm message, removing the v1/v2 edit mismatch entirely.
- Wrap the delivery path (claim -> DM -> result message) in try/catch that logs
  the full error as `giveaway.handleClaimConfirm` and shows a visible message, so
  any remaining failure is diagnosable instead of silent.
- Move the cosmetic public-list and hub refreshes out of the delivery path into a
  separately guarded block, so a refresh failure (the public list edit hits the
  same v1/v2 issue) can never be reported to the claimant as a delivery failure.

## Honest status after three prior misses
I am not claiming certainty. This fixes the strongest-fitting cause AND makes the
handler self-diagnosing. If a claim still fails after deploy, the logs will now
contain a `giveaway.handleClaimConfirm` line with the full error, and the user
will see a visible message instead of silence. That log line is the thing to send
back; it will pinpoint the exact failing call.

## Operational note (still outstanding)
Keys claimed during the broken window were marked claimed but never delivered.
Those users cannot re-claim (they get "no longer available") and need an admin to
re-send manually.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`), 71/71
- [x] Lint clean (`npm run lint`)
- [ ] After deploy: a real hub claim delivers the key DM and shows an ephemeral
      confirmation; if it fails, capture the `giveaway.handleClaimConfirm` log

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)