### PR TITLE
fix: Guard against undefined game.id in syncReleaseAnnouncements

### DIFF
--- a/src/classes/GameReleaseAnnouncement.ts
+++ b/src/classes/GameReleaseAnnouncement.ts
@@ -1,4 +1,5 @@
 import { apiGet, apiPatch } from "../services/RpgClubApiClient.js";
+import { logWarn } from "../utilities/LogUtils.js";
 
 export interface IReleaseAnnouncementCandidate {
   announcementId: number;
@@ -68,9 +69,18 @@ export default class GameReleaseAnnouncement {
       if (!response) break;
       totalPages = response.meta.pages;
       await Promise.all(
-        response.data.map((game) =>
-          apiPatch(`/api/v1/games/${game.id}/release_announcements`),
-        ),
+        response.data
+          .filter((game) => {
+            if (!Number.isFinite(game.id) || game.id <= 0) {
+              logWarn(
+                "GameReleaseAnnouncement.syncReleaseAnnouncements",
+                `Skipping game with invalid id: ${JSON.stringify(game.id)}`,
+              );
+              return false;
+            }
+            return true;
+          })
+          .map((game) => apiPatch(`/api/v1/games/${game.id}/release_announcements`)),
       );
       page++;
     } while (page <= totalPages);


### PR DESCRIPTION
## Summary
- Added a runtime guard in `GameReleaseAnnouncement.syncReleaseAnnouncements()` that filters
  out any game record where `id` is not a finite positive integer before building the PATCH URL.
- Skipped records are logged with `logWarn` so they are visible in production logs without
  halting the rest of the sync batch.
- Prevents the `PATCH /api/v1/games/undefined/release_announcements` error observed 2026-06-22.

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] A game record with a missing or non-numeric `id` is skipped and a warning is logged
- [ ] A game record with a valid `id` continues to be synced normally

Closes #990

🤖 Generated with [Claude Code](https://claude.com/claude-code)