### PR TITLE
fix: resolve game id via mapGameFromApi in syncReleaseAnnouncements

### DIFF
--- a/src/classes/GameReleaseAnnouncement.ts
+++ b/src/classes/GameReleaseAnnouncement.ts
@@ -1,5 +1,6 @@
 import { apiGet, apiPatch } from "../services/RpgClubApiClient.js";
 import { logWarn } from "../utilities/LogUtils.js";
+import { mapGameFromApi } from "../functions/GameMappers.js";
 
 export interface IReleaseAnnouncementCandidate {
   announcementId: number;
@@ -28,7 +29,7 @@ type ReleaseAnnouncementDueData = {
 type ReleaseAnnouncementDueResponse = { data: ReleaseAnnouncementDueData[] };
 
 type GamesListResponse = {
-  data: { id: number }[];
+  data: unknown[];
   meta: { pages: number; page: number };
 };
 
@@ -68,19 +69,20 @@ export default class GameReleaseAnnouncement {
       });
       if (!response) break;
       totalPages = response.meta.pages;
+      const gameIds = response.data
+        .map((item) => mapGameFromApi(item).id)
+        .filter((id) => {
+          if (!Number.isFinite(id) || id <= 0) {
+            logWarn(
+              "GameReleaseAnnouncement.syncReleaseAnnouncements",
+              `Skipping game with invalid id: ${JSON.stringify(id)}`,
+            );
+            return false;
+          }
+          return true;
+        });
       await Promise.all(
-        response.data
-          .filter((game) => {
-            if (!Number.isFinite(game.id) || game.id <= 0) {
-              logWarn(
-                "GameReleaseAnnouncement.syncReleaseAnnouncements",
-                `Skipping game with invalid id: ${JSON.stringify(game.id)}`,
-              );
-              return false;
-            }
-            return true;
-          })
-          .map((game) => apiPatch(`/api/v1/games/${game.id}/release_announcements`)),
+        gameIds.map((id) => apiPatch(`/api/v1/games/${id}/release_announcements`)),
       );
       page++;
     } while (page <= totalPages);


### PR DESCRIPTION
## Summary
- `syncReleaseAnnouncements` typed the `/api/v1/games` list response as
  `{ id: number }[]`, but the API can return items with `game_id` instead of
  `id`. This caused `game.id` to be `undefined` for those records, producing
  repeated "Skipping game with invalid id: undefined" log noise and silently
  dropping games from release-announcement syncing.
- The fix passes each raw list item through `mapGameFromApi` (which resolves
  the id as `game_id ?? id`), consistent with the pattern already used in
  `Game.getAllGameIds()`.
- The existing invalid-id guard is retained but will no longer fire for
  normal records.

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] "Skipping game with invalid id: undefined" log entries no longer appear
  in `syncReleaseAnnouncements` on the production bot

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)