### PR TITLE
fix: restore game cover thumbnail in completion announcements

### DIFF
--- a/src/functions/CompletionHelpers.ts
+++ b/src/functions/CompletionHelpers.ts
@@ -1,5 +1,4 @@
 import {
-  AttachmentBuilder,
   ButtonStyle,
   ComponentType,
   type ButtonInteraction,
@@ -34,7 +33,6 @@ import { logError } from "../utilities/LogUtils.js";
 import { buildActionButton, buildButtonRow } from "./uiComponents.js";
 
 const MAX_PLAYTIME_HOURS = 999999.99;
-const COMPLETION_COVER_ATTACHMENT_PREFIX = "completion-cover";
 
 export function validateCompletionPlaytimeInput(
   input: string,
@@ -229,18 +227,15 @@ export async function announceCompletion(
     const section = new SectionBuilder().addTextDisplayComponents(
       new TextDisplayBuilder().setContent(safeV2TextContent(summaryText, 3500)),
     );
-    const files: AttachmentBuilder[] = [];
-    if (game.imageData) {
-      const coverName = `${COMPLETION_COVER_ATTACHMENT_PREFIX}-${game.id}.png`;
-      files.push(new AttachmentBuilder(game.imageData, { name: coverName }));
+    const thumbnailUrl = game.coverUrl ?? null;
+    if (thumbnailUrl) {
       section.setThumbnailAccessory(
-        new ThumbnailBuilder().setURL(`attachment://${coverName}`).setDescription(game.title),
+        new ThumbnailBuilder().setURL(thumbnailUrl).setDescription(game.title),
       );
     }
     container.addSectionComponents(section);
 
     await (channel as any).send({
-      files,
       components: [container],
       flags: buildComponentsV2EditFlags(),
     });


### PR DESCRIPTION
## Summary
- `announceCompletion` in `CompletionHelpers.ts` was checking `game.imageData` for the cover
  thumbnail, but `mapGameFromApi` (used by `Game.getGameById`) always sets `imageData: null` --
  only the SQL row mapper populated it from the database blob.
- The same fix was applied to gamedb-profile, gamedb-thread, and GOTM components in a prior
  commit (#768) but was missed in the completion announcement path.
- Replaces the `imageData`/file-attachment approach with `game.coverUrl`, which is already
  populated from the `/api/v1/games/:id` response, restoring the game cover in announcements.

## Test plan
- [ ] Type-check passes (`npx tsc --noEmit`)
- [ ] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [ ] Log a completion with `announce:true` (via `/game-completion add` or the Now Playing
      completion flow) and confirm the game cover thumbnail appears in the announcement channel.
- [ ] Log a completion for a game with no cover URL and confirm the announcement still posts
      without a thumbnail.

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)