### PR TITLE
Replace pokopia list dropdowns with clickable pokemon/habitat buttons

### DIFF
--- a/src/RPGClub_GameDB.ts
+++ b/src/RPGClub_GameDB.ts
@@ -29,6 +29,7 @@ import { startThreadLinkPromptService } from "./services/ThreadLinkPromptService
 import { refreshGiveawayHubMessage } from "./services/GiveawayHubService.js";
 import { startGameReleaseAnnouncementService } from "./services/GameReleaseAnnouncementService.js";
 import { startUserEmojiService } from "./services/UserEmojiService.js";
+import { startPokopiaEmojiService } from "./services/PokopiaEmojiService.js";
 import { restoreJournalMessageContextsFromDb } from "./commands/now-playing/nowPlayingContexts.js";
 import { truncateWithEllipsis } from "./utilities/ValidationUtils.js";
 import { logError } from "./utilities/LogUtils.js";
@@ -197,6 +198,7 @@ bot.once("clientReady", async () => {
   startRssFeedService(bot);
   await refreshGiveawayHubMessage(bot);
   await startUserEmojiService(bot);
+  await startPokopiaEmojiService(bot);
   await restoreJournalMessageContextsFromDb();
   console.log("Startup sequence completed.");
 });

--- a/src/commands/pokopia/pokopia-autocomplete.utils.ts
+++ b/src/commands/pokopia/pokopia-autocomplete.utils.ts
@@ -1,0 +1,46 @@
+import type { AutocompleteInteraction } from "discord.js";
+import { sanitizeUserInput } from "../../functions/InteractionUtils.js";
+import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../../config/textLimits.js";
+import { getSortedHabitats, getSortedPokemon } from "./pokopia-data.service.js";
+
+function getQuery(interaction: AutocompleteInteraction): string {
+  const focused = interaction.options.getFocused(true);
+  const rawQuery = focused?.value ? String(focused.value) : "";
+  return sanitizeUserInput(rawQuery, { preserveNewlines: false }).trim().toLowerCase();
+}
+
+export async function autocompletePokopiaPokemon(
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  const query = getQuery(interaction);
+  const pokemon = getSortedPokemon("number", "asc");
+
+  const filtered = query
+    ? pokemon.filter((p) => `${p.number} ${p.name}`.toLowerCase().includes(query))
+    : pokemon;
+
+  await interaction.respond(
+    filtered.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((p) => ({
+      name: truncateLabel(`${p.number} ${p.name}`),
+      value: p.number,
+    })),
+  );
+}
+
+export async function autocompletePokopiaHabitat(
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  const query = getQuery(interaction);
+  const habitats = getSortedHabitats("asc");
+
+  const filtered = query
+    ? habitats.filter((h) => h.habitat.toLowerCase().includes(query))
+    : habitats;
+
+  await interaction.respond(
+    filtered.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((h) => ({
+      name: truncateLabel(h.habitat),
+      value: h.slug,
+    })),
+  );
+}

--- a/src/commands/pokopia/pokopia-components.command.ts
+++ b/src/commands/pokopia/pokopia-components.command.ts
@@ -1,5 +1,5 @@
-import type { ButtonInteraction, StringSelectMenuInteraction } from "discord.js";
-import { ButtonComponent, Discord, SelectMenuComponent } from "discordx";
+import type { ButtonInteraction } from "discord.js";
+import { ButtonComponent, Discord } from "discordx";
 import {
   replyIfNotOwner,
   safeReply,
@@ -9,13 +9,13 @@ import { buildComponentsV2Flags, buildTextReply } from "../../functions/Componen
 import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import {
   POKOPIA_BACK_PREFIX,
+  POKOPIA_DETAIL_PREFIX,
   POKOPIA_LIST_NAV_PREFIX,
-  POKOPIA_SELECT_PREFIX,
 } from "../../config/customIdPrefixes.js";
 import {
   parsePokopiaBackId,
+  parsePokopiaDetailId,
   parsePokopiaListNavId,
-  parsePokopiaSelectId,
 } from "./pokopia-customid.utils.js";
 import {
   buildHabitatDetailPayload,
@@ -52,23 +52,22 @@ export class PokopiaComponentsCommand {
     });
   }
 
-  @SelectMenuComponent({
-    id: new RegExp(`^${POKOPIA_SELECT_PREFIX}:[ph]:[^:]+:[an]:[du]:\\d+$`),
+  @ButtonComponent({
+    id: new RegExp(`^${POKOPIA_DETAIL_PREFIX}:[ph]:[^:]+:[an]:[du]:\\d+:[^:]+$`),
   })
-  async onPokopiaSelect(interaction: StringSelectMenuInteraction): Promise<void> {
-    const parsed = parsePokopiaSelectId(interaction.customId);
+  async onPokopiaDetail(interaction: ButtonInteraction): Promise<void> {
+    const parsed = parsePokopiaDetailId(interaction.customId);
     if (!parsed) {
       safeIgnore(safeReply(interaction, buildTextReply(INVALID_CONTROL_MESSAGE, true)));
       return;
     }
     if (await replyIfNotOwner(interaction, parsed.ownerId, NOT_YOUR_VIEW_MESSAGE)) return;
 
-    const selectedValue = interaction.values[0];
     const payload = parsed.kind === "pokemon"
       ? buildPokemonDetailPayload(
-        parsed.ownerId, parsed.sort, parsed.order, parsed.page, selectedValue,
+        parsed.ownerId, parsed.sort, parsed.order, parsed.page, parsed.itemKey,
       )
-      : buildHabitatDetailPayload(parsed.ownerId, parsed.order, parsed.page, selectedValue);
+      : buildHabitatDetailPayload(parsed.ownerId, parsed.order, parsed.page, parsed.itemKey);
 
     if (!payload) {
       safeIgnore(safeReply(interaction, buildTextReply(INVALID_CONTROL_MESSAGE, true)));

--- a/src/commands/pokopia/pokopia-customid.utils.ts
+++ b/src/commands/pokopia/pokopia-customid.utils.ts
@@ -4,8 +4,8 @@ import {
 } from "../../utilities/CustomIdUtils.js";
 import {
   POKOPIA_BACK_PREFIX,
+  POKOPIA_DETAIL_PREFIX,
   POKOPIA_LIST_NAV_PREFIX,
-  POKOPIA_SELECT_PREFIX,
 } from "../../config/customIdPrefixes.js";
 import type { PokopiaSortField, PokopiaSortOrder } from "./pokopia-data.service.js";
 
@@ -79,28 +79,33 @@ export function parsePokopiaListNavId(customId: string): (IPokopiaListState & {
   return { kind, ownerId, sort, order, page, direction };
 }
 
-export function buildPokopiaSelectId(state: IPokopiaListState): string {
+export function buildPokopiaDetailId(
+  state: IPokopiaListState & { itemKey: string },
+): string {
   return validateCustomId([
-    POKOPIA_SELECT_PREFIX,
+    POKOPIA_DETAIL_PREFIX,
     encodeKind(state.kind),
     state.ownerId,
     encodeSort(state.sort),
     encodeOrder(state.order),
     String(state.page),
+    encodeURIComponent(state.itemKey),
   ].join(":"));
 }
 
-export function parsePokopiaSelectId(customId: string): IPokopiaListState | null {
-  if (!customId.startsWith(`${POKOPIA_SELECT_PREFIX}:`)) return null;
-  const segs = parseCustomIdSegments(customId, 5);
+export function parsePokopiaDetailId(
+  customId: string,
+): (IPokopiaListState & { itemKey: string }) | null {
+  if (!customId.startsWith(`${POKOPIA_DETAIL_PREFIX}:`)) return null;
+  const segs = parseCustomIdSegments(customId, 6);
   if (!segs) return null;
-  const [kindCode, ownerId, sortCode, orderCode, pageRaw] = segs;
+  const [kindCode, ownerId, sortCode, orderCode, pageRaw, itemKeyRaw] = segs;
   const kind = decodeKind(kindCode);
   const sort = decodeSort(sortCode);
   const order = decodeOrder(orderCode);
   const page = Number(pageRaw);
   if (!kind || !sort || !order || Number.isNaN(page)) return null;
-  return { kind, ownerId, sort, order, page };
+  return { kind, ownerId, sort, order, page, itemKey: decodeURIComponent(itemKeyRaw) };
 }
 
 export function buildPokopiaBackId(state: IPokopiaListState): string {

--- a/src/commands/pokopia/pokopia-habitat.command.ts
+++ b/src/commands/pokopia/pokopia-habitat.command.ts
@@ -1,9 +1,10 @@
 import { ApplicationCommandOptionType, CommandInteraction } from "discord.js";
 import { Discord, Slash, SlashChoice, SlashGroup, SlashOption } from "discordx";
 import { safeDeferReply, safeReply } from "../../functions/InteractionUtils.js";
-import { buildComponentsV2Flags } from "../../functions/ComponentsV2Utils.js";
-import { buildHabitatListPayload } from "./pokopia-render.service.js";
+import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
+import { buildHabitatDetailPayload, buildHabitatListPayload } from "./pokopia-render.service.js";
 import type { PokopiaSortOrder } from "./pokopia-data.service.js";
+import { autocompletePokopiaHabitat } from "./pokopia-autocomplete.utils.js";
 
 @Discord()
 @SlashGroup("pokopia")
@@ -18,11 +19,36 @@ export class PokopiaHabitatCommand {
       type: ApplicationCommandOptionType.String,
     })
     order: PokopiaSortOrder | undefined,
+    @SlashOption({
+      description: "Jump directly to a habitat by name",
+      name: "query",
+      required: false,
+      type: ApplicationCommandOptionType.String,
+      autocomplete: autocompletePokopiaHabitat,
+    })
+    query: string | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(true) });
 
     const resolvedOrder = order ?? "asc";
+
+    if (query) {
+      const detailPayload = buildHabitatDetailPayload(
+        interaction.user.id, resolvedOrder, 0, query,
+      );
+      if (detailPayload) {
+        await safeReply(interaction, {
+          components: detailPayload.components,
+          files: detailPayload.files,
+          flags: buildComponentsV2Flags(true),
+        });
+        return;
+      }
+      await safeReply(interaction, buildTextReply("No matching habitat found.", true));
+      return;
+    }
+
     const payload = buildHabitatListPayload(interaction.user.id, resolvedOrder, 0);
 
     await safeReply(interaction, {

--- a/src/commands/pokopia/pokopia-pokemon.command.ts
+++ b/src/commands/pokopia/pokopia-pokemon.command.ts
@@ -4,9 +4,10 @@ import {
   safeDeferReply,
   safeReply,
 } from "../../functions/InteractionUtils.js";
-import { buildComponentsV2Flags } from "../../functions/ComponentsV2Utils.js";
-import { buildPokemonListPayload } from "./pokopia-render.service.js";
+import { buildComponentsV2Flags, buildTextReply } from "../../functions/ComponentsV2Utils.js";
+import { buildPokemonDetailPayload, buildPokemonListPayload } from "./pokopia-render.service.js";
 import type { PokopiaSortField, PokopiaSortOrder } from "./pokopia-data.service.js";
+import { autocompletePokopiaPokemon } from "./pokopia-autocomplete.utils.js";
 
 @Discord()
 @SlashGroup({ description: "Browse the Pokopia pokedex and habitats", name: "pokopia" })
@@ -30,12 +31,37 @@ export class PokopiaPokemonCommand {
       type: ApplicationCommandOptionType.String,
     })
     order: PokopiaSortOrder | undefined,
+    @SlashOption({
+      description: "Jump directly to a Pokemon by number or name",
+      name: "query",
+      required: false,
+      type: ApplicationCommandOptionType.String,
+      autocomplete: autocompletePokopiaPokemon,
+    })
+    query: string | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(true) });
 
     const resolvedSort = sort ?? "number";
     const resolvedOrder = order ?? "asc";
+
+    if (query) {
+      const detailPayload = buildPokemonDetailPayload(
+        interaction.user.id, resolvedSort, resolvedOrder, 0, query,
+      );
+      if (detailPayload) {
+        await safeReply(interaction, {
+          components: detailPayload.components,
+          files: detailPayload.files,
+          flags: buildComponentsV2Flags(true),
+        });
+        return;
+      }
+      await safeReply(interaction, buildTextReply("No matching Pokemon found.", true));
+      return;
+    }
+
     const payload = buildPokemonListPayload(interaction.user.id, resolvedSort, resolvedOrder, 0);
 
     await safeReply(interaction, {

--- a/src/commands/pokopia/pokopia-render.service.ts
+++ b/src/commands/pokopia/pokopia-render.service.ts
@@ -3,7 +3,6 @@ import {
   AttachmentBuilder,
   ButtonBuilder,
   ButtonStyle,
-  StringSelectMenuBuilder,
 } from "discord.js";
 import {
   ContainerBuilder,
@@ -17,35 +16,41 @@ import {
 import { SeparatorSpacingSize } from "discord-api-types/v10";
 import { resolveAssetPath } from "../../functions/AssetPath.js";
 import { safeV2TextContent } from "../../functions/ComponentsV2Utils.js";
-import {
-  buildActionButton,
-  buildButtonRow,
-  buildSelectRow,
-} from "../../functions/uiComponents.js";
+import { buildActionButton, buildButtonRow } from "../../functions/uiComponents.js";
 import {
   buildOptionalPrevNextRowWithIds,
   buildPageFooterText,
 } from "../../functions/PaginationUtils.js";
 import { POKOPIA_LIST_PAGE_SIZE } from "../../config/pagination.js";
+import { DISCORD_BUTTON_LABEL_MAX } from "../../config/textLimits.js";
+import { truncateWithEllipsis } from "../../utilities/ValidationUtils.js";
 import {
   getHabitatBySlug,
   getPokemonByNumber,
   getSortedHabitats,
   getSortedPokemon,
-  pokedexNumberKey,
   type IPokopiaHabitat,
   type PokopiaSortField,
   type PokopiaSortOrder,
 } from "./pokopia-data.service.js";
 import {
   buildPokopiaBackId,
+  buildPokopiaDetailId,
   buildPokopiaListNavId,
-  buildPokopiaSelectId,
 } from "./pokopia-customid.utils.js";
+import { getHabitatEmoji, getPokemonEmoji } from "../../services/PokopiaEmojiService.js";
 
-type PokopiaComponent =
-  | ContainerBuilder
-  | ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>;
+type PokopiaComponent = ContainerBuilder | ActionRowBuilder<ButtonBuilder>;
+
+const BUTTONS_PER_ROW = 5;
+
+function chunkButtons(buttons: ButtonBuilder[]): ActionRowBuilder<ButtonBuilder>[] {
+  const rows: ActionRowBuilder<ButtonBuilder>[] = [];
+  for (let i = 0; i < buttons.length; i += BUTTONS_PER_ROW) {
+    rows.push(buildButtonRow(...buttons.slice(i, i + BUTTONS_PER_ROW)));
+  }
+  return rows;
+}
 
 export interface IPokopiaPayload {
   components: PokopiaComponent[];
@@ -98,29 +103,22 @@ export function buildPokemonListPayload(
     ),
   );
 
-  pageItems.forEach((pokemon) => {
-    files.push(attach(pokedexImagePath(pokemon.sprite), pokemon.sprite));
-    const section = new SectionBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(
-        safeV2TextContent(`**${pokemon.number} ${pokemon.name}**\n${pokemon.ability1 || "-"}`, 500),
-      ),
+  const itemButtons = pageItems.map((pokemon) => {
+    const label = truncateWithEllipsis(
+      `${pokemon.number} ${pokemon.name}`,
+      DISCORD_BUTTON_LABEL_MAX,
     );
-    section.setThumbnailAccessory(
-      new ThumbnailBuilder().setURL(`attachment://${pokemon.sprite}`),
-    );
-    container.addSectionComponents(section);
+    const button = buildActionButton({
+      customId: buildPokopiaDetailId({
+        kind: "pokemon", ownerId, sort, order, page: safePage, itemKey: pokemon.number,
+      }),
+      label,
+      style: ButtonStyle.Secondary,
+    });
+    const emoji = getPokemonEmoji(pokemon.number);
+    if (emoji) button.setEmoji({ id: emoji.id, name: emoji.name });
+    return button;
   });
-
-  const selectOptions = pageItems.map((pokemon) => ({
-    label: `${pokemon.number} ${pokemon.name}`.substring(0, 100),
-    value: pokedexNumberKey(pokemon.number),
-  }));
-  const selectRow = buildSelectRow(
-    new StringSelectMenuBuilder()
-      .setCustomId(buildPokopiaSelectId({ kind: "pokemon", ownerId, sort, order, page: safePage }))
-      .setPlaceholder("View a Pokemon's details...")
-      .addOptions(selectOptions),
-  );
 
   const navRow = buildOptionalPrevNextRowWithIds(
     buildPokopiaListNavId({
@@ -133,7 +131,10 @@ export function buildPokemonListPayload(
     totalPages,
   );
 
-  return { components: paginateComponents(container, selectRow, navRow), files };
+  return {
+    components: paginateComponents(container, ...chunkButtons(itemButtons), navRow),
+    files,
+  };
 }
 
 export function buildHabitatListPayload(
@@ -152,34 +153,19 @@ export function buildHabitatListPayload(
     ),
   );
 
-  pageItems.forEach((habitat) => {
-    const section = new SectionBuilder().addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(
-        safeV2TextContent(`**${habitat.habitat}**\n${habitat.pokemon.length} Pokemon`, 500),
-      ),
-    );
-    if (habitat.image) {
-      files.push(attach(habitatImagePath(habitat.image), habitat.image));
-      section.setThumbnailAccessory(
-        new ThumbnailBuilder().setURL(`attachment://${habitat.image}`),
-      );
-    }
-    container.addSectionComponents(section);
+  const itemButtons = pageItems.map((habitat) => {
+    const label = truncateWithEllipsis(habitat.habitat, DISCORD_BUTTON_LABEL_MAX);
+    const button = buildActionButton({
+      customId: buildPokopiaDetailId({
+        kind: "habitat", ownerId, sort: "name", order, page: safePage, itemKey: habitat.slug,
+      }),
+      label,
+      style: ButtonStyle.Secondary,
+    });
+    const emoji = getHabitatEmoji(habitat.slug);
+    if (emoji) button.setEmoji({ id: emoji.id, name: emoji.name });
+    return button;
   });
-
-  const selectOptions = pageItems.map((habitat) => ({
-    label: habitat.habitat.substring(0, 100),
-    value: habitat.slug,
-  }));
-  const selectId = buildPokopiaSelectId({
-    kind: "habitat", ownerId, sort: "name", order, page: safePage,
-  });
-  const selectRow = buildSelectRow(
-    new StringSelectMenuBuilder()
-      .setCustomId(selectId)
-      .setPlaceholder("View a habitat's details...")
-      .addOptions(selectOptions),
-  );
 
   const navRow = buildOptionalPrevNextRowWithIds(
     buildPokopiaListNavId({
@@ -192,7 +178,10 @@ export function buildHabitatListPayload(
     totalPages,
   );
 
-  return { components: paginateComponents(container, selectRow, navRow), files };
+  return {
+    components: paginateComponents(container, ...chunkButtons(itemButtons), navRow),
+    files,
+  };
 }
 
 function buildBackRow(
@@ -260,6 +249,14 @@ export function buildPokemonDetailPayload(
   return { components: paginateComponents(container, backRow), files };
 }
 
+function formatHabitatDetails(details: string): string {
+  return details
+    .split("\n")
+    .map((line) => line.trim().replace(/,$/, ""))
+    .filter(Boolean)
+    .join(", ");
+}
+
 function addHabitatSection(
   container: ContainerBuilder,
   files: AttachmentBuilder[],
@@ -270,7 +267,7 @@ function addHabitatSection(
   if (!details) return;
   const section = new SectionBuilder().addTextDisplayComponents(
     new TextDisplayBuilder().setContent(
-      safeV2TextContent(`**${label}**\n${details.replace(/\n/g, ", ")}`, 500),
+      safeV2TextContent(`**${label}**\n${formatHabitatDetails(details)}`, 500),
     ),
   );
   if (image) {

--- a/src/config/customIdPrefixes.ts
+++ b/src/config/customIdPrefixes.ts
@@ -17,5 +17,5 @@ export const GAMEDB_SEARCH_PREFIX = "gamedb-search-";
 
 // Pokopia list/detail navigation interaction IDs (shared by pokemon and habitat views)
 export const POKOPIA_LIST_NAV_PREFIX = "pokopia-list-nav-v1";
-export const POKOPIA_SELECT_PREFIX = "pokopia-select-v1";
+export const POKOPIA_DETAIL_PREFIX = "pokopia-detail-v1";
 export const POKOPIA_BACK_PREFIX = "pokopia-back-v1";

--- a/src/services/PokopiaEmojiService.ts
+++ b/src/services/PokopiaEmojiService.ts
@@ -1,0 +1,139 @@
+import type { Client } from "discord.js";
+import { sleep } from "../utilities/DelayUtils.js";
+import { logError, logInfo } from "../utilities/LogUtils.js";
+import { resolveAssetPath } from "../functions/AssetPath.js";
+import {
+  getSortedHabitats,
+  getSortedPokemon,
+  pokedexNumberKey,
+} from "../commands/pokopia/pokopia-data.service.js";
+
+const POKEMON_EMOJI_PREFIX = "pkp_";
+const HABITAT_EMOJI_PREFIX = "pkh_";
+const CREATION_THROTTLE_MS = 600;
+const EMOJI_NAME_MAX = 32;
+
+export interface IPokopiaEmoji {
+  id: string;
+  name: string;
+}
+
+const pokemonEmojiCache = new Map<string, IPokopiaEmoji>();
+const habitatEmojiCache = new Map<string, IPokopiaEmoji>();
+let initialized = false;
+
+function sanitizeKey(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "_")
+    .replace(/_+/g, "_")
+    .replace(/^_+|_+$/g, "");
+}
+
+function buildEmojiName(prefix: string, key: string, seen: Map<string, string>): string {
+  const budget = EMOJI_NAME_MAX - prefix.length;
+  const base = sanitizeKey(key).slice(0, budget) || "x";
+  let candidate = `${prefix}${base}`;
+  let suffixIndex = 1;
+  while (seen.has(candidate) && seen.get(candidate) !== key) {
+    const suffix = `_${suffixIndex}`;
+    candidate = `${prefix}${base.slice(0, Math.max(0, budget - suffix.length))}${suffix}`;
+    suffixIndex += 1;
+  }
+  seen.set(candidate, key);
+  return candidate;
+}
+
+export function getPokemonEmoji(number: string): IPokopiaEmoji | null {
+  return pokemonEmojiCache.get(pokedexNumberKey(number)) ?? null;
+}
+
+export function getHabitatEmoji(slug: string): IPokopiaEmoji | null {
+  return habitatEmojiCache.get(slug) ?? null;
+}
+
+export async function startPokopiaEmojiService(client: Client): Promise<void> {
+  if (initialized) return;
+  initialized = true;
+  syncPokopiaEmoji(client).catch((err) => {
+    logError("PokopiaEmojiService.initialSync", err);
+  });
+}
+
+async function syncPokopiaEmoji(client: Client): Promise<void> {
+  const app = client.application;
+  if (!app) {
+    logError("PokopiaEmojiService", "client.application not available");
+    return;
+  }
+
+  const existing = await app.emojis.fetch();
+  const existingByName = new Map<string, string>();
+  for (const [, emoji] of existing) {
+    if (!emoji.name || !emoji.id) continue;
+    existingByName.set(emoji.name, emoji.id);
+  }
+
+  const seenNames = new Map<string, string>();
+  let created = 0;
+
+  const uniquePokemon = new Map<string, string>();
+  for (const pokemon of getSortedPokemon("number", "asc")) {
+    uniquePokemon.set(pokedexNumberKey(pokemon.number), pokemon.sprite);
+  }
+
+  for (const [key, sprite] of uniquePokemon) {
+    const name = buildEmojiName(POKEMON_EMOJI_PREFIX, key, seenNames);
+    const existingId = existingByName.get(name);
+    if (existingId) {
+      pokemonEmojiCache.set(key, { id: existingId, name });
+      continue;
+    }
+    try {
+      const emoji = await app.emojis.create({
+        attachment: resolveAssetPath("images", "pokopia", "pokedex", sprite),
+        name,
+      });
+      if (emoji.id) {
+        pokemonEmojiCache.set(key, { id: emoji.id, name });
+        created += 1;
+        await sleep(CREATION_THROTTLE_MS);
+      }
+    } catch (err) {
+      logError("PokopiaEmojiService.createPokemonEmoji", err);
+    }
+  }
+
+  const uniqueHabitats = new Map<string, string>();
+  for (const habitat of getSortedHabitats("asc")) {
+    uniqueHabitats.set(habitat.slug, habitat.image);
+  }
+
+  for (const [slug, image] of uniqueHabitats) {
+    const name = buildEmojiName(HABITAT_EMOJI_PREFIX, slug, seenNames);
+    const existingId = existingByName.get(name);
+    if (existingId) {
+      habitatEmojiCache.set(slug, { id: existingId, name });
+      continue;
+    }
+    try {
+      const emoji = await app.emojis.create({
+        attachment: resolveAssetPath("images", "pokopia", "habitat_dex", image),
+        name,
+      });
+      if (emoji.id) {
+        habitatEmojiCache.set(slug, { id: emoji.id, name });
+        created += 1;
+        await sleep(CREATION_THROTTLE_MS);
+      }
+    } catch (err) {
+      logError("PokopiaEmojiService.createHabitatEmoji", err);
+    }
+  }
+
+  logInfo(
+    "PokopiaEmojiService",
+    `Sync complete. Created ${created} emoji. `
+      + `Pokemon cache: ${pokemonEmojiCache.size}, Habitat cache: ${habitatEmojiCache.size}`,
+  );
+}


### PR DESCRIPTION
## Summary
- Pokedex and habitat `/pokopia` lists now render a button per entry instead of a text section + select-menu dropdown. Each button's icon is an application emoji (uploaded once from the pokemon sprite / habitat image via a new `PokopiaEmojiService`), and its label is `{number} {name}` for pokemon or `{name}` for habitats.
- Clicking a button jumps straight into that entry's detail view (replaces the old dropdown-driven navigation).
- Added an optional `query` option with autocomplete (matching number+name for pokemon, name for habitats) on both `/pokopia pokedex` and `/pokopia habitat` to jump directly to a detail page.
- Fixed doubled commas in the pokemon detail habitat text (e.g. "Clink-clang Iron Construction:  , Iron beam or column x3, , Wheelbarrow x1, ...") caused by joining lines that already ended in a trailing comma.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes
- [ ] Manually verify pokedex/habitat button lists, detail navigation, and query autocomplete against a running bot (requires live Discord app emoji upload, which happens on bot startup)