### PR TITLE
Pokopia pokedex: thumbnail accessory for single pokemon, hide back button on direct query

### DIFF
--- a/src/commands/pokopia/pokopia-pokemon.command.ts
+++ b/src/commands/pokopia/pokopia-pokemon.command.ts
@@ -48,7 +48,7 @@ export class PokopiaPokemonCommand {
 
     if (query) {
       const detailPayload = buildPokemonDetailPayload(
-        interaction.user.id, resolvedSort, resolvedOrder, 0, query,
+        interaction.user.id, resolvedSort, resolvedOrder, 0, query, false,
       );
       if (detailPayload) {
         await safeReply(interaction, {

--- a/src/commands/pokopia/pokopia-render.service.ts
+++ b/src/commands/pokopia/pokopia-render.service.ts
@@ -206,22 +206,13 @@ export function buildPokemonDetailPayload(
   order: PokopiaSortOrder,
   page: number,
   number: string,
+  showBackButton = true,
 ): IPokopiaPayload | null {
   const pokemon = getPokemonByNumber(number);
   if (!pokemon) return null;
 
   const files: AttachmentBuilder[] = [attach(pokedexImagePath(pokemon.sprite), pokemon.sprite)];
   const container = new ContainerBuilder();
-  container.addMediaGalleryComponents(
-    new MediaGalleryBuilder().addItems(
-      new MediaGalleryItemBuilder()
-        .setURL(`attachment://${pokemon.sprite}`)
-        .setDescription(pokemon.name),
-    ),
-  );
-  container.addSeparatorComponents(
-    new SeparatorBuilder().setSpacing(SeparatorSpacingSize.Small).setDivider(false),
-  );
 
   const abilities = [pokemon.ability1, pokemon.ability2].filter(Boolean).join(", ");
   const favorites = pokemon.favorites.join(", ");
@@ -237,12 +228,22 @@ export function buildPokemonDetailPayload(
       .filter(([, value]) => value)
       .map(([label, value]) => `**${label}:** ${value}`),
   ].join("\n");
-  container.addTextDisplayComponents(
+  const headerSection = new SectionBuilder().addTextDisplayComponents(
     new TextDisplayBuilder().setContent(safeV2TextContent(detailText, 1800)),
   );
+  headerSection.setThumbnailAccessory(
+    new ThumbnailBuilder()
+      .setURL(`attachment://${pokemon.sprite}`)
+      .setDescription(pokemon.name),
+  );
+  container.addSectionComponents(headerSection);
 
   addHabitatSection(container, files, "Habitat 1", pokemon.habitat1Details, pokemon.habitat1Image);
   addHabitatSection(container, files, "Habitat 2", pokemon.habitat2Details, pokemon.habitat2Image);
+
+  if (!showBackButton) {
+    return { components: paginateComponents(container), files };
+  }
 
   const backRow = buildBackRow(ownerId, "pokemon", sort, order, page);
 


### PR DESCRIPTION
## Summary
- Single pokemon view in /pokopia pokedex now renders the pokemon sprite as a thumbnail accessory on the header/non-habitat section instead of a separate media gallery image.
- The "Back to list" button is no longer shown when the single pokemon view is reached directly via the query option (as opposed to navigating from the list).

## Test plan
- [ ] Run /pokopia pokedex query:<pokemon> and confirm the sprite renders as a thumbnail next to the header text and no "Back to list" button appears.
- [ ] Navigate to a pokemon from the list view and confirm the thumbnail renders correctly and the "Back to list" button still appears and works.