### PR TITLE
fix: single-column button rows for pokopia lists

### DIFF
--- a/src/commands/pokopia/pokopia-render.service.ts
+++ b/src/commands/pokopia/pokopia-render.service.ts
@@ -40,9 +40,9 @@ import {
 } from "./pokopia-customid.utils.js";
 import { getHabitatEmoji, getPokemonEmoji } from "../../services/PokopiaEmojiService.js";
 
-type PokopiaComponent = ContainerBuilder | ActionRowBuilder<ButtonBuilder>;
+type PokopiaComponent = ContainerBuilder | ActionRowBuilder<ButtonBuilder> | TextDisplayBuilder;
 
-const BUTTONS_PER_ROW = 2;
+const BUTTONS_PER_ROW = 1;
 
 function chunkButtons(buttons: ButtonBuilder[]): ActionRowBuilder<ButtonBuilder>[] {
   const rows: ActionRowBuilder<ButtonBuilder>[] = [];
@@ -119,10 +119,9 @@ export function buildPokemonListPayload(
     .addTextDisplayComponents(
       new TextDisplayBuilder().setContent(safeV2TextContent("## Pokopia Pokedex", 250)),
     )
-    .addActionRowComponents(...chunkButtons(itemButtons))
-    .addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(safeV2TextContent(footer, 250)),
-    );
+    .addActionRowComponents(...chunkButtons(itemButtons));
+
+  const footerText = new TextDisplayBuilder().setContent(safeV2TextContent(footer, 250));
 
   const navRow = buildOptionalPrevNextRowWithIds(
     buildPokopiaListNavId({
@@ -136,7 +135,7 @@ export function buildPokemonListPayload(
   );
 
   return {
-    components: paginateComponents(container, navRow),
+    components: paginateComponents(container, footerText, navRow),
     files,
   };
 }
@@ -170,10 +169,9 @@ export function buildHabitatListPayload(
     .addTextDisplayComponents(
       new TextDisplayBuilder().setContent(safeV2TextContent("## Pokopia Habitats", 250)),
     )
-    .addActionRowComponents(...chunkButtons(itemButtons))
-    .addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(safeV2TextContent(footer, 250)),
-    );
+    .addActionRowComponents(...chunkButtons(itemButtons));
+
+  const footerText = new TextDisplayBuilder().setContent(safeV2TextContent(footer, 250));
 
   const navRow = buildOptionalPrevNextRowWithIds(
     buildPokopiaListNavId({
@@ -187,7 +185,7 @@ export function buildHabitatListPayload(
   );
 
   return {
-    components: paginateComponents(container, navRow),
+    components: paginateComponents(container, footerText, navRow),
     files,
   };
 }

--- a/src/config/pagination.ts
+++ b/src/config/pagination.ts
@@ -17,4 +17,4 @@ export const COLLECTION_LIST_PAGE_SIZE     = 20;
 export const BACKLOG_LIST_PAGE_SIZE        = 20;
 export const GAMEDB_CSV_RESULT_LIMIT       = 15;
 export const GOTM_AUDIT_RESULT_LIMIT       = 25;
-export const POKOPIA_LIST_PAGE_SIZE        = 10;
+export const POKOPIA_LIST_PAGE_SIZE        = 8;


### PR DESCRIPTION
## Summary
- Pokopia pokedex/habitat list buttons now render one per row for consistent visual width
- Discord containers cap at 10 child components, so with 1 button per row the page size drops from 10 to 8, and the page/total footer moves outside the container as a sibling text component to leave room for 8 button rows + title

## Test plan
- [x] tsc --noEmit
- [x] npm run lint