### PR TITLE
fix: log and surface errors from /admin nextround-setup

### DIFF
--- a/src/commands/admin.command.ts
+++ b/src/commands/admin.command.ts
@@ -24,6 +24,7 @@ import {
   safeUpdate,
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
+import { logError } from "../utilities/LogUtils.js";
 import {
   buildTextReply,
   buildComponentsV2Flags,
@@ -237,7 +238,14 @@ export class Admin {
     const okToUseCommand: boolean = await isAdmin(interaction);
     if (!okToUseCommand) return;
 
-    await handleNextRoundSetup(interaction, testModeInput);
+    await withErrorReply(interaction, async () => {
+      try {
+        await handleNextRoundSetup(interaction, testModeInput);
+      } catch (err: unknown) {
+        logError("admin.command.nextRoundSetup", err);
+        throw err;
+      }
+    }, "Round setup wizard failed");
   }
 
   @Slash({ description: "Add a new GOTM round", name: "add-gotm" })


### PR DESCRIPTION
## Summary
- `nextRoundSetup` called `handleNextRoundSetup` with no top-level try/catch, so any exception thrown before the wizard sent its first reply (a very plausible outcome after the recent postgres/API migration, since API calls in `Gotm.ts`/`NrGotm.ts`/`Nomination.ts` now throw on non-404 errors) became an unhandled rejection: no error shown in Discord, nothing useful in the console.
- Wrapped the call in `withErrorReply` and added `logError("admin.command.nextRoundSetup", err)` so the console now gets a structured error (name/message/stack) and the user gets a visible failure reply instead of the wizard silently going nowhere.
- This doesn't fix a specific migration bug (none reproduced yet without a real failure to observe) -- it's the instrumentation needed to see the actual root cause the next time the command fails.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run lint` passes
- [ ] Run `/admin nextround-setup` against a real environment and confirm the console now logs a structured error if/when it fails

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>