### PR TITLE
fix: keep nextround-setup wizard collector on the same message as its buttons

### DIFF
--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -321,11 +321,13 @@ export async function handleNextRoundSetup(
   };
   let message: Message | null = null;
   if (isInteractionSettled(interaction)) {
-    const replyResult = await safeReply(
-      interaction,
-      { ...initialPayload, __forceFollowUp: true } as any,
-    );
-    message = replyResult as Message;
+    // Deferred-but-not-replied interactions route through editReply, which
+    // resolves directly to the Message (no `.resource` wrapper). Every later
+    // wizardLog/updateEmbed call edits this same underlying message, so
+    // capturing editReply's return here keeps `message` in sync with what
+    // the user actually sees (and clicks buttons on) at the commit step.
+    const replyResult = await safeReply(interaction, initialPayload as any);
+    message = (replyResult as Message) ?? null;
   } else {
     const replyResult = await safeReply(
       interaction,


### PR DESCRIPTION
## Summary
- Follow-up to #1017, which already merged before this fix was ready.
- #1017 fixed message resolution but used `__forceFollowUp`, which posts a
  separate follow-up message and returns *that* as the collector target.
  Every later `wizardLog`/`updateEmbed` call -- including the one that adds
  the Commit/Edit/Cancel button row -- continues to edit the *original*
  deferred reply via `editReply`, a different message. Clicking Commit
  landed on a message with no live collector, producing "Interaction
  failed" client-side and then a 300s server-side timeout to "Cancelled."
- `editReply` resolves directly to the `Message` (no `.resource` wrapper)
  when deferred-but-not-replied, so this captures that return value as
  `message` instead of forcing a follow-up, keeping the collector on the
  same message that gets edited (and clicked on) throughout the wizard.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual: click Commit on `/admin nextround-setup` and confirm it
      executes instead of showing "Interaction failed"

Related to #1016 (already closed by #1017)

🤖 Generated with [Claude Code](https://claude.com/claude-code)