### PR TITLE
fix: nextround-setup wizard message spam, dead buttons, and month label prompt

### DIFF
--- a/src/commands/admin/round-setup-wizard.service.ts
+++ b/src/commands/admin/round-setup-wizard.service.ts
@@ -350,10 +350,21 @@ export async function handleNextRoundSetup(
       logHistory || "Processing...",
       { color: COLOR_PRIMARY, footer: wizardFooter },
     );
-    await safeReply(interaction, {
+    const payload = {
       components: [updatedContainer],
       flags: buildComponentsV2EditFlags(),
-    });
+    };
+    // Discord.js flips interaction.replied = true on the first editReply, so
+    // routing repeat updates through safeReply(interaction, ...) would send a
+    // brand-new followUp message every time instead of editing. Editing the
+    // captured message directly keeps every update on the same message.
+    if (message) {
+      await message.edit(payload).catch((err) => {
+        logError("round-setup-wizard.service.updateEmbed", err);
+      });
+    } else {
+      await safeReply(interaction, payload);
+    }
   };
 
   const wizardLog = async (msg: string) => {
@@ -543,9 +554,25 @@ export async function handleNextRoundSetup(
 
   const nextMonthDate = new Date();
   nextMonthDate.setMonth(nextMonthDate.getMonth() + 1);
-  const monthYear = formatMonthYear(nextMonthDate);
+  const computedMonthYear = formatMonthYear(nextMonthDate);
+  const monthYearChoice = await wizardChoice(
+    `Use auto-assigned month label **${computedMonthYear}**, or enter a custom label?`,
+    addCancelOption([
+      { label: `Use ${computedMonthYear}`, value: "default", style: ButtonStyle.Primary },
+      { label: "Enter custom label", value: "custom" },
+    ]),
+  );
+  if (!monthYearChoice) return;
+  let monthYear = computedMonthYear;
+  if (monthYearChoice === "custom") {
+    const monthYearInput = await wizardPrompt(
+      'Enter the month label to use (e.g. "August 2026").',
+    );
+    if (!monthYearInput) return;
+    monthYear = monthYearInput.trim();
+  }
   await persistWizardState({ monthYear });
-  await wizardLog(`Auto-assigned label: **${monthYear}**`);
+  await wizardLog(`Month label set to: **${monthYear}**`);
 
   const gotmNominations = await listNominationsForRound("gotm", nextRound);
   const nrNominations = await listNominationsForRound("nr-gotm", nextRound);
@@ -1036,7 +1063,13 @@ export async function handleNextRoundSetup(
        
       buildActionButton({ customId: "wiz-cancel", label: "Cancel", style: ButtonStyle.Danger }),
     );
-    await safeReply(interaction, { components: [row] });
+    if (message) {
+      await message.edit({ components: [row] }).catch((err) => {
+        logError("round-setup-wizard.service.confirmDbActions", err);
+      });
+    } else {
+      await safeReply(interaction, { components: [row] });
+    }
 
     let decision = "cancel";
     if (!message || typeof message.awaitMessageComponent !== "function") {
@@ -1053,7 +1086,13 @@ export async function handleNextRoundSetup(
           time: 300_000,
         });
         await safeDeferUpdate(collected);
-        await safeReply(interaction, { components: [] });
+        if (message) {
+          await message.edit({ components: [] }).catch((err) => {
+            logError("round-setup-wizard.service.confirmDbActions", err);
+          });
+        } else {
+          await safeReply(interaction, { components: [] });
+        }
         if (collected.customId === "wiz-commit") decision = "commit";
         else if (collected.customId === "wiz-edit") decision = "edit";
       } catch (err: any) {


### PR DESCRIPTION
## Summary
- `interaction.editReply()` sets `interaction.replied = true` after its
  first call. Every subsequent `wizardLog`/`updateEmbed` update was routed
  through `safeReply(interaction, ...)`, which after that point falls
  through to `interaction.followUp(...)` -- posting a brand-new message
  for every wizard step instead of editing the same one, and leaving the
  Commit/Edit/Cancel button collector attached to a stale message. That's
  why every button click showed "Interaction failed" and the wizard
  eventually timed out to "Cancelled."
- Fixed by editing the captured `Message` object directly
  (`message.edit(...)`) for all updates after the initial reply, instead
  of going back through the interaction's reply/followUp state machine.
- Also: the wizard silently auto-assigned next month's label, which was
  sometimes wrong. It now asks the user to confirm the computed label or
  type a custom one before continuing.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual: run `/admin nextround-setup`, confirm the wizard message is
      edited in place (no message spam), and Commit/Edit/Cancel buttons
      work at the confirmation step

Related to #1016 (already closed by #1017/#1018)

🤖 Generated with [Claude Code](https://claude.com/claude-code)