### PR TITLE
refactor: migrate GamePlatformRegionService.ts to API

### DIFF
--- a/src/classes/GamePlatformRegionService.ts
+++ b/src/classes/GamePlatformRegionService.ts
@@ -1,13 +1,5 @@
 import {
-  dbQuery,
-  dbTransaction,
-  dbMutateConn,
-} from "../db/SqlManager.js";
-import { GameSql } from "../db/sql/index.js";
-import {
-  mapPlatformDefRow,
   mapPlatformFromApi,
-  mapRegionDefRow,
   mapRegionFromApi,
   buildPlatformCode,
   IGDB_REGION_MAP,
@@ -16,8 +8,8 @@ import {
 } from "../functions/GameMappers.js";
 import type { IPlatformDef, IRegionDef, IGame, IGameWithPlatforms } from "../types/GameTypes.js";
 import { apiGet, apiPost } from "../services/RpgClubApiClient.js";
+import GameProfileService from "./GameProfileService.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
-import { logWarn } from "../utilities/LogUtils.js";
 
 export default class GamePlatformRegionService {
   private static async fetchAllPages<T>(
@@ -76,11 +68,15 @@ export default class GamePlatformRegionService {
   }
 
   static async getPlatformsForGame(gameId: number): Promise<IPlatformDef[]> {
-    return dbQuery(GameSql.getPlatformsForGame, { gameId }, mapPlatformDefRow);
+    const relations = await GameProfileService.getGameRelations(gameId);
+    const platforms = (relations?.platforms ?? []).map(mapPlatformFromApi);
+    return platforms.sort((a, b) => a.name.localeCompare(b.name));
   }
 
   static async getAllPlatforms(): Promise<IPlatformDef[]> {
-    return dbQuery(GameSql.getAllPlatforms, {}, mapPlatformDefRow);
+    const rows =
+      await GamePlatformRegionService.fetchAllPages<PlatformApiData>("/api/v1/platforms");
+    return rows.map(mapPlatformFromApi).sort((a, b) => a.name.localeCompare(b.name));
   }
 
   static async getPlatformsByIgdbIds(
@@ -91,21 +87,13 @@ export default class GamePlatformRegionService {
       return new Map();
     }
 
-    const binds: Record<string, number> = {};
-    const placeholders: string[] = [];
-    uniqueIds.forEach((id, idx) => {
-      const key = `id${idx}`;
-      binds[key] = id;
-      placeholders.push(`:${key}`);
-    });
-
-    const platforms = await dbQuery(
-      GameSql.getPlatformsByIgdbIds(placeholders.join(", ")),
-      binds,
-      mapPlatformDefRow,
+    const rows = await GamePlatformRegionService.fetchAllPages<PlatformApiData>(
+      "/api/v1/platforms",
+      { igdb_ids: uniqueIds },
     );
     const map = new Map<number, IPlatformDef>();
-    platforms.forEach((platform) => {
+    rows.forEach((row) => {
+      const platform = mapPlatformFromApi(row);
       if (platform.igdbPlatformId) map.set(platform.igdbPlatformId, platform);
     });
     return map;
@@ -143,12 +131,12 @@ export default class GamePlatformRegionService {
   }
 
   static async getPlatformByCode(code: string): Promise<IPlatformDef | null> {
-    const rows = await dbQuery(
-      GameSql.getPlatformByCode,
-      { code },
-      mapPlatformDefRow,
+    const result = await apiGet<{ data: PlatformApiData[] }>(
+      "/api/v1/platforms",
+      { params: { code } },
     );
-    return rows[0] ?? null;
+    const first = result?.data?.[0];
+    return first ? mapPlatformFromApi(first) : null;
   }
 
   static async getPlatformById(id: number): Promise<IPlatformDef | null> {
@@ -163,63 +151,17 @@ export default class GamePlatformRegionService {
     const gameIds = Array.from(
       new Set(games.map((game) => game.id).filter(isPositiveInt)),
     );
-    if (!gameIds.length) {
-      return games.map((game) => ({ ...game, platforms: [] }));
-    }
-
-    const binds: Record<string, number> = {};
-    const placeholders: string[] = [];
-    gameIds.forEach((id, idx) => {
-      const key = `id${idx}`;
-      binds[key] = id;
-      placeholders.push(`:${key}`);
-    });
 
     const gameToPlatforms = new Map<number, IPlatformDef[]>();
-    const missingPlatformIds = new Set<number>();
-
-    const rows = await dbQuery(
-      GameSql.attachPlatformsToGames(placeholders.join(", ")),
-      binds,
-      (row: {
-        GAME_ID: number;
-        PLATFORM_ID: number;
-        PLATFORM_CODE: string | null;
-        PLATFORM_NAME: string | null;
-        PLATFORM_ABBREVIATION: string | null;
-        IGDB_PLATFORM_ID: number | null;
-      }) => row,
+    await Promise.all(
+      gameIds.map(async (gameId) => {
+        const relations = await GameProfileService.getGameRelations(gameId);
+        gameToPlatforms.set(
+          gameId,
+          (relations?.platforms ?? []).map(mapPlatformFromApi),
+        );
+      }),
     );
-
-    rows.forEach((row) => {
-      const gameId = Number(row.GAME_ID);
-      const platformId = Number(row.PLATFORM_ID);
-      if (!Number.isInteger(gameId) || !Number.isInteger(platformId)) return;
-      if (!row.PLATFORM_NAME || !row.PLATFORM_CODE) {
-        missingPlatformIds.add(platformId);
-        return;
-      }
-      const platform: IPlatformDef = {
-        id: platformId,
-        code: String(row.PLATFORM_CODE),
-        name: String(row.PLATFORM_NAME),
-        abbreviation: row.PLATFORM_ABBREVIATION
-          ? String(row.PLATFORM_ABBREVIATION)
-          : null,
-        igdbPlatformId: row.IGDB_PLATFORM_ID
-          ? Number(row.IGDB_PLATFORM_ID)
-          : null,
-      };
-      if (!gameToPlatforms.has(gameId)) gameToPlatforms.set(gameId, []);
-      gameToPlatforms.get(gameId)!.push(platform);
-    });
-
-    if (missingPlatformIds.size) {
-      logWarn(
-        "GamePlatformRegionService.attachPlatformsToGames",
-        `Missing platform IDs in GAMEDB_PLATFORMS: ${Array.from(missingPlatformIds).join(", ")}`,
-      );
-    }
 
     return games.map((game) => ({
       ...game,
@@ -242,12 +184,12 @@ export default class GamePlatformRegionService {
   }
 
   static async getRegionByCode(code: string): Promise<IRegionDef | null> {
-    const rows = await dbQuery(
-      GameSql.getRegionByCode,
-      { code },
-      mapRegionDefRow,
+    const result = await apiGet<{ data: RegionApiData[] }>(
+      "/api/v1/regions",
+      { params: { code } },
     );
-    return rows[0] ?? null;
+    const first = result?.data?.[0];
+    return first ? mapRegionFromApi(first) : null;
   }
 
   static async getRegionById(id: number): Promise<IRegionDef | null> {
@@ -265,34 +207,4 @@ export default class GamePlatformRegionService {
     return first ? mapRegionFromApi(first) : null;
   }
 
-  static async addGamePlatformsByIgdbIds(
-    gameId: number,
-    igdbPlatformIds: number[],
-  ): Promise<void> {
-    if (!isPositiveInt(gameId)) return;
-    const uniqueIds = Array.from(
-      new Set(igdbPlatformIds.filter(isPositiveInt)),
-    );
-    if (!uniqueIds.length) return;
-
-    const platformMap = await GamePlatformRegionService.getPlatformsByIgdbIds(uniqueIds);
-    const missingIds = uniqueIds.filter((id) => !platformMap.has(id));
-    if (missingIds.length) {
-      logWarn(
-        "GamePlatformRegionService.addGamePlatformsByIgdbIds",
-        `Missing IGDB platform IDs in GAMEDB_PLATFORMS: ${missingIds.join(", ")}`,
-      );
-    }
-
-    await dbTransaction(async (conn) => {
-      for (const igdbId of uniqueIds) {
-        const platform = platformMap.get(igdbId);
-        if (!platform) continue;
-        await dbMutateConn(conn, GameSql.addGamePlatformMerge, {
-          gameId,
-          platformId: platform.id,
-        });
-      }
-    });
-  }
 }

--- a/src/commands/gamedb/gamedb-csv-import.command.ts
+++ b/src/commands/gamedb/gamedb-csv-import.command.ts
@@ -73,7 +73,6 @@ import { isPositiveInt } from "../../utilities/ValidationUtils.js";
 import { truncateDescription } from "../../config/textLimits.js";
 import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import { buildTextInputRow } from "../../functions/uiComponents.js";
-import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
 
 const GAMEDB_CSV_ACTIONS = ["start", "resume", "status", "pause", "cancel"] as const;
 type GameDbCsvAction = (typeof GAMEDB_CSV_ACTIONS)[number];
@@ -145,10 +144,6 @@ async function importGameFromCsv(igdbId: number): Promise<{ gameId: number; titl
   const game = await Game.createGame(igdbId);
   const details = await igdbService.getGameDetails(igdbId);
   if (details) {
-    const igdbPlatformIds: number[] = (details.platforms ?? [])
-      .map((platform) => platform.id)
-      .filter(isPositiveInt);
-    await GamePlatformRegionService.addGamePlatformsByIgdbIds(game.id, igdbPlatformIds);
     await processReleaseDates(game.id, details.release_dates ?? []);
   }
   if (!game.imageData) {

--- a/src/db/sql/game.sql.ts
+++ b/src/db/sql/game.sql.ts
@@ -1,68 +1,6 @@
 import type { ISqlEntry } from "./types.js";
 
-const PLATFORM_COLS_PG = `platform_id,
-              platform_code,
-              platform_name,
-              platform_abbreviation,
-              igdb_platform_id`;
-
 export const GameSql = {
-  getPlatformsForGame: {
-    postgres: `SELECT DISTINCT p.platform_id,
-              p.platform_code,
-              p.platform_name,
-              p.platform_abbreviation,
-              p.igdb_platform_id
-         FROM gamedb_releases r
-         JOIN gamedb_platforms p ON p.platform_id = r.platform_id
-        WHERE r.game_id = :gameId
-        ORDER BY p.platform_name ASC`,
-  } satisfies ISqlEntry,
-
-  getAllPlatforms: {
-    postgres: `SELECT ${PLATFORM_COLS_PG}
-         FROM gamedb_platforms
-        ORDER BY platform_name ASC`,
-  } satisfies ISqlEntry,
-
-  getPlatformsByIgdbIds: (placeholders: string) =>
-    ({
-      postgres: `SELECT ${PLATFORM_COLS_PG}
-         FROM gamedb_platforms
-        WHERE igdb_platform_id IN (${placeholders})`,
-    }) satisfies ISqlEntry,
-
-  attachPlatformsToGames: (placeholders: string) =>
-    ({
-      postgres: `SELECT gp.game_id,
-              gp.platform_id,
-              p.platform_code,
-              p.platform_name,
-              p.platform_abbreviation,
-              p.igdb_platform_id
-         FROM gamedb_game_platforms gp
-         LEFT JOIN gamedb_platforms p ON p.platform_id = gp.platform_id
-        WHERE gp.game_id IN (${placeholders})`,
-    }) satisfies ISqlEntry,
-
-  getPlatformByCode: {
-    postgres: `SELECT ${PLATFORM_COLS_PG}
-         FROM gamedb_platforms
-        WHERE platform_code = :code`,
-  } satisfies ISqlEntry,
-
-  getRegionByCode: {
-    postgres: `SELECT region_id, region_code, region_name, igdb_region_id
-         FROM gamedb_regions
-        WHERE region_code = :code`,
-  } satisfies ISqlEntry,
-
-  addGamePlatformMerge: {
-    postgres: `INSERT INTO gamedb_game_platforms (game_id, platform_id)
-           VALUES (:gameId, :platformId)
-           ON CONFLICT (game_id, platform_id) DO NOTHING`,
-  } satisfies ISqlEntry,
-
   getGotmWins: {
     postgres: `SELECT ge.round_number,
                 COALESCE(

--- a/src/functions/GameMappers.ts
+++ b/src/functions/GameMappers.ts
@@ -34,6 +34,8 @@ export type PlatformApiData = {
   platform_id: number;
   platform_code: string;
   platform_name: string;
+  platform_abbreviation?: string | null;
+  igdb_platform_id?: number | null;
 };
 
 export type RegionApiData = {
@@ -122,27 +124,6 @@ export function mapReleaseRow(row: any): IRelease {
   };
 }
 
-export function mapPlatformDefRow(row: any): IPlatformDef {
-  return {
-    id: Number(row.PLATFORM_ID),
-    code: String(row.PLATFORM_CODE),
-    name: String(row.PLATFORM_NAME),
-    abbreviation: row.PLATFORM_ABBREVIATION
-      ? String(row.PLATFORM_ABBREVIATION)
-      : null,
-    igdbPlatformId: row.IGDB_PLATFORM_ID ? Number(row.IGDB_PLATFORM_ID) : null,
-  };
-}
-
-export function mapRegionDefRow(row: any): IRegionDef {
-  return {
-    id: Number(row.REGION_ID),
-    code: String(row.REGION_CODE),
-    name: String(row.REGION_NAME),
-    igdbRegionId: row.IGDB_REGION_ID ? Number(row.IGDB_REGION_ID) : null,
-  };
-}
-
 export function mapReleaseFromApi(data: ReleaseApiData): IRelease {
   return {
     id: Number(data.release_id),
@@ -160,8 +141,9 @@ export function mapPlatformFromApi(data: PlatformApiData): IPlatformDef {
     id: Number(data.platform_id),
     code: String(data.platform_code),
     name: String(data.platform_name),
-    abbreviation: null,
-    igdbPlatformId: null,
+    abbreviation: data.platform_abbreviation ?? null,
+    igdbPlatformId:
+      data.igdb_platform_id != null ? Number(data.igdb_platform_id) : null,
   };
 }
 

--- a/src/functions/GameProfileMapper.ts
+++ b/src/functions/GameProfileMapper.ts
@@ -49,7 +49,13 @@ export type RelationReleaseApiData = {
 
 export type GameRelationsApiData = {
   releases: RelationReleaseApiData[];
-  platforms: { platform_id: number; platform_code: string; platform_name: string }[];
+  platforms: Array<{
+    platform_id: number;
+    platform_code: string;
+    platform_name: string;
+    platform_abbreviation?: string | null;
+    igdb_platform_id?: number | null;
+  }>;
   collection: { name: string } | null;
   companies: Array<CompanyApiData & { role: string | null }>;
   franchises: Array<{ name: string }>;


### PR DESCRIPTION
## Summary
- Migrated all remaining postgres-backed reads in `GamePlatformRegionService.ts` (`getPlatformsForGame`, `getAllPlatforms`, `getPlatformsByIgdbIds`, `getPlatformByCode`, `attachPlatformsToGames`, `getRegionByCode`) to the Rails API, using `/api/v1/platforms` and `/api/v1/regions` filters (`code`, `igdb_ids[]`, `igdb_id`) and `GameProfileService.getGameRelations` for per-game platform lookups.
- Removed `addGamePlatformsByIgdbIds` (and its `addGamePlatformMerge` SQL) entirely rather than migrating it — it only had one caller, immediately after `Game.createGame(igdbId)`, and `POST /api/v1/games` already syncs `gamedb_game_platforms` server-side as part of the IGDB import, so the direct SQL insert was redundant.
- Removed the now-unreferenced `getPlatformsForGame`/`getAllPlatforms`/`getPlatformsByIgdbIds`/`attachPlatformsToGames`/`getPlatformByCode`/`getRegionByCode`/`addGamePlatformMerge` entries from `game.sql.ts`, and the now-unused `mapPlatformDefRow`/`mapRegionDefRow` row mappers.
- Extended `PlatformApiData`/`mapPlatformFromApi` to map `platform_abbreviation` and `igdb_platform_id` (now present on the API's `Platform` schema), replacing hardcoded `null`s.

## Test plan
- [x] `grep -n "SqlManager\|dbQuery\|dbMutate\|dbTransaction\|dbMutateConn" src/classes/GamePlatformRegionService.ts` returns no results
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` passes
- [x] `bash .claude/skills/run-rpgclubbot/smoke.sh` passes (71/71 tests)

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)