### PR TITLE
fix: replace GameDB Add to Now Playing note field with platform select

### DIFF
--- a/src/commands/gamedb/gamedb-completion.command.ts
+++ b/src/commands/gamedb/gamedb-completion.command.ts
@@ -50,7 +50,6 @@ import {
   buildComponentsV2Flags,
   isUniqueConstraintError,
   MAX_COMPLETION_NOTE_LEN,
-  MAX_NOW_PLAYING_NOTE_LEN,
 } from "./gamedb-utils.js";
 import { trimTextDisplayContent } from "./gamedb-profile.service.js";
 import { updateGameProfileMessageById } from "./gamedb-profile.service.js";
@@ -489,49 +488,42 @@ export class GameDbCompletionCommand {
     }
   }
    
-  @ModalComponent({ id: /^gamedb-nowplaying-modal:\d+$/ })
-  async handleGameDbNowPlayingModal(interaction: ModalSubmitInteraction): Promise<void> {
+  @SelectMenuComponent({ id: /^gamedb-nowplaying-platform-select:\d+$/ })
+  async handleGameDbNowPlayingPlatformSelect(
+    interaction: StringSelectMenuInteraction,
+  ): Promise<void> {
     const segs = assertCustomIdSegments(interaction, 1);
     if (!segs) return;
     const [gameIdRaw] = segs;
     const gameId = Number(gameIdRaw);
-    await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
     if (!isPositiveInt(gameId)) {
-      safeIgnore(safeReply(interaction, buildTextReply("Invalid GameDB id.", false)));
+      safeIgnore(safeReply(interaction, buildTextReply("Invalid GameDB id.", true)));
       return;
     }
 
     const game = await Game.getGameById(gameId);
     if (!game) {
-      safeIgnore(safeReply(interaction, buildTextReply("That game was not found in GameDB.", false)));
+      safeIgnore(safeReply(interaction, buildTextReply("That game was not found in GameDB.", true)));
       return;
     }
 
-    const noteRaw = getModalField(interaction, "gamedb-nowplaying-note");
-    if (noteRaw.length > MAX_NOW_PLAYING_NOTE_LEN) {
-      safeIgnore(safeReply(interaction, buildTextReply(`Note must be ${MAX_NOW_PLAYING_NOTE_LEN} characters or fewer.`, false)));
+    const platformId = Number(interaction.values?.[0]);
+    if (!isPositiveInt(platformId)) {
+      safeIgnore(safeReply(interaction, buildTextReply("Invalid platform selection.", true)));
       return;
     }
 
-    const note = noteRaw.length ? noteRaw : null;
     try {
-      const platforms = await GamePlatformRegionService.getPlatformsForGame(gameId);
-      if (!platforms.length) {
-        safeIgnore(safeReply(interaction, buildTextReply("This game has no platform data yet. Add to Now Playing from `/now-playing list` " +
-            "after platform data is available.", false)));
-        return;
-      }
-      const defaultPlatform = platforms[0];
-      await Member.addNowPlaying(interaction.user.id, gameId, defaultPlatform.id, note);
+      await Member.addNowPlaying(interaction.user.id, gameId, platformId, null);
       const nowPlaying = new NowPlayingCommand();
       await nowPlaying.showSingle(interaction, interaction.user, true);
     } catch (err: any) {
       if (isUniqueConstraintError(err)) {
-        safeIgnore(safeReply(interaction, buildTextReply(`**${game.title}** is already in your Now Playing list.`, false)));
+        safeIgnore(safeReply(interaction, buildTextReply(`**${game.title}** is already in your Now Playing list.`, true)));
         return;
       }
       const msg = err?.message ?? "Failed to add to Now Playing.";
-      safeIgnore(safeReply(interaction, buildTextReply(`Failed to add: ${msg}`, false)));
+      safeIgnore(safeReply(interaction, buildTextReply(`Failed to add: ${msg}`, true)));
     }
   }
 }

--- a/src/commands/gamedb/gamedb-view.command.ts
+++ b/src/commands/gamedb/gamedb-view.command.ts
@@ -3,10 +3,8 @@ import {
   ButtonInteraction,
   CommandInteraction,
   MessageFlags,
-  ModalBuilder,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
-  TextInputStyle,
 } from "discord.js";
 import {
   ButtonComponent,
@@ -27,7 +25,7 @@ import { getHltbCacheByGameId, upsertHltbCache } from "../../classes/HltbCache.j
 import Game from "../../classes/Game.js";
 import { apiPost } from "../../services/RpgClubApiClient.js";
 import { searchHltb } from "../../scripts/SearchHltb.js";
-import { buildTextReply } from "../../functions/ComponentsV2Utils.js";
+import { buildTextContainer, buildTextReply } from "../../functions/ComponentsV2Utils.js";
 import {
   autocompleteGameDbViewTitle,
   buildComponentsV2Flags,
@@ -46,13 +44,12 @@ import { assertCustomIdSegments } from "../../utilities/CustomIdUtils.js";
 import {
   buildSelectOptions,
   buildSelectRow,
-  buildTextInputRow,
 } from "../../functions/uiComponents.js";
-import { safeIgnore } from "../../utilities/AsyncUtils.js";
 import UserGameBacklog from "../../classes/UserGameBacklog.js";
 import { buildApiErrorMessage } from "../../utilities/ApiErrorUtils.js";
 import { logError } from "../../utilities/LogUtils.js";
 import GamePlatformRegionService from "../../classes/GamePlatformRegionService.js";
+import { STANDARD_PLATFORM_IDS } from "../../config/standardPlatforms.js";
 
 @Discord()
 @SlashGroup("gamedb")
@@ -174,20 +171,31 @@ export class GameDbViewCommand {
     }
 
     if (action === "nowplaying") {
-      const modal = new ModalBuilder()
+      const platforms = await GamePlatformRegionService
+        .getPlatformsForGameWithStandard(gameId, STANDARD_PLATFORM_IDS);
+      if (!platforms.length) {
+        await safeReply(interaction, buildTextReply(
+          "This game has no platform data yet. Add to Now Playing from " +
+            "`/now-playing list` after platform data is available.", true,
+        ));
+        return;
+      }
+      const options = buildSelectOptions(platforms.map((platform) => ({
+        label: platform.name,
+        value: String(platform.id),
+      })));
+      const select = new StringSelectMenuBuilder()
         // eslint-disable-next-line local/custom-id-has-matching-handler
-        .setCustomId(`gamedb-nowplaying-modal:${gameId}`)
-        .setTitle("Add to Now Playing")
-        .addComponents(
-          buildTextInputRow({
-            customId: "gamedb-nowplaying-note",
-            label: "Note (optional)",
-            style: TextInputStyle.Paragraph,
-            required: false,
-            maxLength: 500,
-          }),
-        );
-      safeIgnore(interaction.showModal(modal));
+        .setCustomId(`gamedb-nowplaying-platform-select:${gameId}`)
+        .setPlaceholder("Select the platform")
+        .addOptions(options);
+      await safeReply(interaction, {
+        components: [
+          buildTextContainer(`Select the platform for **${game.title}**.`),
+          buildSelectRow(select),
+        ],
+        flags: buildComponentsV2Flags(true),
+      });
       return;
     }
 


### PR DESCRIPTION
## Summary
- The "Add to Now Playing" button on the gamedb view message opened a modal
  with an unused "Note" textarea and had no way to pick a platform, so the
  handler silently defaulted to whatever platform happened to be first.
- Replaced the modal with a platform select menu (reusing
  `GamePlatformRegionService.getPlatformsForGameWithStandard`, the same
  helper the existing now-playing add flow uses), so the user explicitly
  chooses the platform when adding a game from GameDB.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] Lint passes (`npm run lint`)

Closes #1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)