### PR TITLE
feat: add title autocomplete to gamedb search

### DIFF
--- a/src/commands/gamedb/gamedb-search.command.ts
+++ b/src/commands/gamedb/gamedb-search.command.ts
@@ -36,6 +36,7 @@ import { decodeBase64Url } from "../../functions/CustomIdUtils.js";
 import {
   autocompleteSearchCompany,
   autocompleteSearchPlatform,
+  autocompleteSearchTitle,
   buildComponentsV2Flags,
   buildSearchCustomId,
   buildSearchRecoveryComponents,
@@ -60,7 +61,10 @@ import {
   buildSelectRow,
 } from "../../functions/uiComponents.js";
 import GameSearchService from "../../classes/GameSearchService.js";
-import { formatGameTitleWithYear } from "../../functions/GameTitleAutocompleteUtils.js";
+import {
+  formatGameTitleWithYear,
+  parseTitleWithYear,
+} from "../../functions/GameTitleAutocompleteUtils.js";
 
 function formatUpcomingDate(date: Date | null | undefined): string {
   if (!date) return "";
@@ -244,6 +248,9 @@ export class GameDbSearchCommand {
       name: "title",
       required: false,
       type: ApplicationCommandOptionType.String,
+      autocomplete: async (interaction: AutocompleteInteraction) => {
+        await autocompleteSearchTitle(interaction);
+      },
     })
     query: string | null,
     @SlashOption({
@@ -295,14 +302,20 @@ export class GameDbSearchCommand {
     await safeDeferReply(interaction, { flags: buildComponentsV2Flags(false) });
 
     try {
-      const searchTerm = query ? sanitizeUserInput(query, { preserveNewlines: false }) : "";
+      const rawSearchTerm = query ? sanitizeUserInput(query, { preserveNewlines: false }) : "";
+      const parsedTitle = rawSearchTerm ? parseTitleWithYear(rawSearchTerm) : null;
+      const searchTerm = parsedTitle ? parsedTitle.title : rawSearchTerm;
       const filters: ISearchFilters = {};
       if (upcomingRelease === true) filters.upcomingRelease = true;
       const platformId = platformValue ? Number(platformValue) : null;
       if (platformId && isPositiveInt(platformId)) {
         filters.platformId = platformId;
       }
-      if (year && isPositiveInt(year)) filters.year = year;
+      if (year && isPositiveInt(year)) {
+        filters.year = year;
+      } else if (parsedTitle?.year) {
+        filters.year = parsedTitle.year;
+      }
       const developerId = developerValue ? Number(developerValue) : null;
       if (developerId && isPositiveInt(developerId)) {
         filters.developerId = developerId;

--- a/src/commands/gamedb/gamedb-utils.ts
+++ b/src/commands/gamedb/gamedb-utils.ts
@@ -252,8 +252,11 @@ export async function autocompleteSearchCompany(
   await interaction.respond(options);
 }
 
-export async function autocompleteGameDbViewTitle(
+async function autocompleteGameTitle(
   interaction: AutocompleteInteraction,
+  selectValue: (game: Awaited<ReturnType<
+    typeof GameSearchService.searchGamesAutocomplete
+  >>[number]) => string,
 ): Promise<void> {
   const focused = interaction.options.getFocused(true);
   const rawQuery = focused?.value ? String(focused.value) : "";
@@ -263,13 +266,25 @@ export async function autocompleteGameDbViewTitle(
     return;
   }
   const results = await GameSearchService.searchGamesAutocomplete(query);
-  const resultOptions = results.slice(0, 24).map((game) => {
-    const label = formatGameTitleWithYear(game);
-    return {
-      name: truncateLabel(label),
-      value: String(game.id),
-    };
-  });
+  const resultOptions = results.slice(0, 24).map((game) => ({
+    name: truncateLabel(formatGameTitleWithYear(game)),
+    value: selectValue(game),
+  }));
   const options = [buildKeepTypingOption(query), ...resultOptions];
   await interaction.respond(options);
+}
+
+export async function autocompleteGameDbViewTitle(
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  await autocompleteGameTitle(interaction, (game) => String(game.id));
+}
+
+export async function autocompleteSearchTitle(
+  interaction: AutocompleteInteraction,
+): Promise<void> {
+  await autocompleteGameTitle(
+    interaction,
+    (game) => truncateLabel(formatGameTitleWithYear(game)),
+  );
 }


### PR DESCRIPTION
## Summary
- `/gamedb search`'s `title` option now has autocomplete, showing
  `Title (YYYY)` suggestions the same way completions, backlog,
  collection, nominate, create-thread, and hltb already do.
- Selecting a suggestion strips the `(YYYY)` suffix before searching and
  folds the year into the `year` filter (only when the user hasn't set one
  explicitly), so picking a specific remake/re-release resolves to that
  exact entry instead of a generic title match.
- Extracted a shared `autocompleteGameTitle` helper in `gamedb-utils.ts` so
  the existing `/gamedb view` autocomplete (value = game id) and the new
  search autocomplete (value = formatted title) don't duplicate the
  fetch/format/keep-typing logic.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual: `/gamedb search title:` in Discord shows `(year)` suggestions
      and selecting one for a duplicated title resolves to that release

🤖 Generated with [Claude Code](https://claude.com/claude-code)