### PR TITLE
fix: Download and attach link preview images instead of hotlinking

### DIFF
--- a/src/events/MessageCreated.command.ts
+++ b/src/events/MessageCreated.command.ts
@@ -64,9 +64,9 @@ export class MessageCreated {
       const ogData = await fetchOpenGraphData(url);
       if (!ogData) return;
 
-      const container = buildLinkPreviewContainer(ogData);
+      const { container, files } = await buildLinkPreviewContainer(ogData);
       const { components, flags } = buildContainerSend(container);
-      await refreshedMessage.reply({ components, flags });
+      await refreshedMessage.reply({ components, flags, files });
     } catch (error) {
       logError("MessageCreated", error);
     }

--- a/src/functions/LinkPreviewEmbeds.ts
+++ b/src/functions/LinkPreviewEmbeds.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import * as cheerio from "cheerio";
+import { AttachmentBuilder } from "discord.js";
 import {
   ContainerBuilder,
   MediaGalleryBuilder,
@@ -14,6 +15,7 @@ const URL_PATTERN = /https?:\/\/[^\s<>"]+/;
 const FETCH_TIMEOUT_MS = 8000;
 const TITLE_MAX_LENGTH = 200;
 const DESCRIPTION_MAX_LENGTH = 500;
+const PREVIEW_IMAGE_NAME = "link-preview.png";
 
 export interface IOpenGraphData {
   title: string | undefined;
@@ -22,8 +24,27 @@ export interface IOpenGraphData {
   url: string;
 }
 
+export interface ILinkPreview {
+  container: ContainerBuilder;
+  files: AttachmentBuilder[];
+}
+
 export function extractFirstUrl(content: string): string | undefined {
   return content.match(URL_PATTERN)?.[0];
+}
+
+async function downloadPreviewImage(imageUrl: string): Promise<AttachmentBuilder | undefined> {
+  try {
+    const response = await axios.get<ArrayBuffer>(imageUrl, {
+      timeout: FETCH_TIMEOUT_MS,
+      responseType: "arraybuffer",
+      headers: { "User-Agent": "Mozilla/5.0 (compatible; TheRPGClubBot/1.0)" },
+    });
+    return new AttachmentBuilder(Buffer.from(response.data), { name: PREVIEW_IMAGE_NAME });
+  } catch (error) {
+    logWarn("LinkPreviewEmbeds", `Failed to download preview image ${imageUrl}: ${error}`);
+    return undefined;
+  }
 }
 
 export async function fetchOpenGraphData(url: string): Promise<IOpenGraphData | undefined> {
@@ -48,7 +69,7 @@ export async function fetchOpenGraphData(url: string): Promise<IOpenGraphData | 
   }
 }
 
-export function buildLinkPreviewContainer(data: IOpenGraphData): ContainerBuilder {
+export async function buildLinkPreviewContainer(data: IOpenGraphData): Promise<ILinkPreview> {
   const title = data.title ? truncateWithEllipsis(data.title, TITLE_MAX_LENGTH) : data.url;
   const bodyParts: string[] = [];
   if (data.description) {
@@ -57,10 +78,18 @@ export function buildLinkPreviewContainer(data: IOpenGraphData): ContainerBuilde
   bodyParts.push(data.url);
 
   const container = buildTitledContainer(title, bodyParts.join("\n\n"), { color: COLOR_PRIMARY });
+
+  const files: AttachmentBuilder[] = [];
   if (data.imageUrl) {
-    container.addMediaGalleryComponents(
-      new MediaGalleryBuilder().addItems(new MediaGalleryItemBuilder().setURL(data.imageUrl)),
-    );
+    const attachment = await downloadPreviewImage(data.imageUrl);
+    if (attachment) {
+      files.push(attachment);
+      container.addMediaGalleryComponents(
+        new MediaGalleryBuilder().addItems(
+          new MediaGalleryItemBuilder().setURL(`attachment://${PREVIEW_IMAGE_NAME}`),
+        ),
+      );
+    }
   }
-  return container;
+  return { container, files };
 }


### PR DESCRIPTION
## Summary
- The link-fallback embeds from #1040 hotlinked the scraped og:image URL directly,
  which rendered as a broken image for some sites in Discord.
- Now downloads the image into memory, attaches it as a Discord attachment, and
  references it via `attachment://` so it renders correctly. The in-memory buffer
  is discarded after the message is sent (never written to disk).

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)