### PR TITLE
feat: Rebuild link preview to match website RSS embed format

### DIFF
--- a/src/functions/LinkPreviewEmbeds.ts
+++ b/src/functions/LinkPreviewEmbeds.ts
@@ -3,20 +3,19 @@ import * as cheerio from "cheerio";
 import { AttachmentBuilder } from "discord.js";
 import {
   ContainerBuilder,
-  SectionBuilder,
+  MediaGalleryBuilder,
+  MediaGalleryItemBuilder,
   TextDisplayBuilder,
-  ThumbnailBuilder,
 } from "@discordjs/builders";
 import { COLOR_PRIMARY } from "../config/colors.js";
 import { logWarn } from "../utilities/LogUtils.js";
-import { truncateWithEllipsis } from "../utilities/ValidationUtils.js";
 import { safeV2TextContent } from "./ComponentsV2Utils.js";
 
 const URL_PATTERN = /https?:\/\/[^\s<>"]+/;
 const FETCH_TIMEOUT_MS = 8000;
-const TITLE_MAX_LENGTH = 200;
 const DESCRIPTION_MAX_WORDS = 150;
-const PREVIEW_IMAGE_NAME = "link-preview.png";
+const MAX_GALLERY_IMAGES = 10;
+const REQUEST_HEADERS = { "User-Agent": "Mozilla/5.0 (compatible; TheRPGClubBot/1.0)" };
 
 function truncateWords(text: string, maxWords: number): string {
   const words = text.split(/\s+/).filter(Boolean);
@@ -25,9 +24,11 @@ function truncateWords(text: string, maxWords: number): string {
 }
 
 export interface IOpenGraphData {
+  siteName: string;
+  homepageUrl: string;
   title: string | undefined;
   description: string | undefined;
-  imageUrl: string | undefined;
+  imageUrls: string[];
   url: string;
 }
 
@@ -40,16 +41,44 @@ export function extractFirstUrl(content: string): string | undefined {
   return content.match(URL_PATTERN)?.[0];
 }
 
-async function downloadPreviewImage(imageUrl: string): Promise<AttachmentBuilder | undefined> {
+function resolveImageUrls($: cheerio.CheerioAPI, pageUrl: string): string[] {
+  const ogImages = $('meta[property="og:image"]')
+    .map((_, el) => $(el).attr("content"))
+    .get()
+    .filter((src): src is string => Boolean(src));
+
+  const sources = ogImages.length > 0
+    ? ogImages
+    : $("img")
+      .map((_, el) => $(el).attr("src"))
+      .get()
+      .filter((src): src is string => Boolean(src));
+
+  const resolved: string[] = [];
+  for (const src of sources) {
+    try {
+      resolved.push(new URL(src, pageUrl).toString());
+    } catch {
+      // skip unresolvable image sources
+    }
+    if (resolved.length >= MAX_GALLERY_IMAGES) break;
+  }
+  return [...new Set(resolved)];
+}
+
+async function downloadImage(
+  imageUrl: string,
+  name: string,
+): Promise<AttachmentBuilder | undefined> {
   try {
     const response = await axios.get<ArrayBuffer>(imageUrl, {
       timeout: FETCH_TIMEOUT_MS,
       responseType: "arraybuffer",
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; TheRPGClubBot/1.0)" },
+      headers: REQUEST_HEADERS,
     });
-    return new AttachmentBuilder(Buffer.from(response.data), { name: PREVIEW_IMAGE_NAME });
+    return new AttachmentBuilder(Buffer.from(response.data), { name });
   } catch (error) {
-    logWarn("LinkPreviewEmbeds", `Failed to download preview image ${imageUrl}: ${error}`);
+    logWarn("LinkPreviewEmbeds", `Failed to download image ${imageUrl}: ${error}`);
     return undefined;
   }
 }
@@ -58,7 +87,7 @@ export async function fetchOpenGraphData(url: string): Promise<IOpenGraphData | 
   try {
     const response = await axios.get<string>(url, {
       timeout: FETCH_TIMEOUT_MS,
-      headers: { "User-Agent": "Mozilla/5.0 (compatible; TheRPGClubBot/1.0)" },
+      headers: REQUEST_HEADERS,
     });
     const $ = cheerio.load(response.data);
     const ogTag = (property: string): string | undefined =>
@@ -66,10 +95,12 @@ export async function fetchOpenGraphData(url: string): Promise<IOpenGraphData | 
 
     const title = ogTag("og:title") ?? ($("title").text().trim() || undefined);
     const description = ogTag("og:description");
-    const imageUrl = ogTag("og:image");
+    const imageUrls = resolveImageUrls($, url);
+    const homepageUrl = new URL(url).origin;
+    const siteName = ogTag("og:site_name") ?? new URL(url).hostname.replace(/^www\./, "");
 
-    if (!title && !description && !imageUrl) return undefined;
-    return { title, description, imageUrl, url };
+    if (!title && !description && imageUrls.length === 0) return undefined;
+    return { siteName, homepageUrl, title, description, imageUrls, url };
   } catch (error) {
     logWarn("LinkPreviewEmbeds", `Failed to fetch Open Graph data for ${url}: ${error}`);
     return undefined;
@@ -77,37 +108,42 @@ export async function fetchOpenGraphData(url: string): Promise<IOpenGraphData | 
 }
 
 export async function buildLinkPreviewContainer(data: IOpenGraphData): Promise<ILinkPreview> {
-  const title = data.title ? truncateWithEllipsis(data.title, TITLE_MAX_LENGTH) : undefined;
-  const bodyParts: string[] = [];
-  if (title) bodyParts.push(`**${title}**`);
-  if (data.description) bodyParts.push(truncateWords(data.description, DESCRIPTION_MAX_WORDS));
+  const container = new ContainerBuilder().setAccentColor(COLOR_PRIMARY);
 
-  const container = new ContainerBuilder()
-    .setAccentColor(COLOR_PRIMARY)
-    .addTextDisplayComponents(
-      new TextDisplayBuilder().setContent(safeV2TextContent(data.url, 500)),
-    );
-
-  const files: AttachmentBuilder[] = [];
-  const bodyText = new TextDisplayBuilder().setContent(
-    safeV2TextContent(bodyParts.join("\n"), 3500),
+  const siteLine = `[${data.siteName}](${data.homepageUrl})`;
+  container.addTextDisplayComponents(
+    new TextDisplayBuilder().setContent(safeV2TextContent(siteLine, 500)),
   );
 
-  let thumbnailUrl: string | undefined;
-  if (data.imageUrl) {
-    const attachment = await downloadPreviewImage(data.imageUrl);
-    if (attachment) {
-      files.push(attachment);
-      thumbnailUrl = `attachment://${PREVIEW_IMAGE_NAME}`;
-    }
+  if (data.title) {
+    const titleLine = `**[${data.title}](${data.url})**`;
+    container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(safeV2TextContent(titleLine, 500)),
+    );
   }
 
-  if (thumbnailUrl) {
-    const section = new SectionBuilder().addTextDisplayComponents(bodyText);
-    section.setThumbnailAccessory(new ThumbnailBuilder().setURL(thumbnailUrl));
-    container.addSectionComponents(section);
-  } else {
-    container.addTextDisplayComponents(bodyText);
+  if (data.description) {
+    const description = truncateWords(data.description, DESCRIPTION_MAX_WORDS);
+    container.addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(safeV2TextContent(description, 3500)),
+    );
+  }
+
+  const files: AttachmentBuilder[] = [];
+  const galleryItems: MediaGalleryItemBuilder[] = [];
+  const downloads = await Promise.all(
+    data.imageUrls.map((imageUrl, index) => downloadImage(imageUrl, `link-preview-${index}.png`)),
+  );
+  for (const attachment of downloads) {
+    if (!attachment) continue;
+    files.push(attachment);
+    galleryItems.push(new MediaGalleryItemBuilder().setURL(`attachment://${attachment.name}`));
+  }
+
+  if (galleryItems.length > 0) {
+    container.addMediaGalleryComponents(
+      new MediaGalleryBuilder().addItems(...galleryItems),
+    );
   }
 
   return { container, files };


### PR DESCRIPTION
## Summary
- Rebuilds the link fallback preview layout to match a website's RSS embed format:
  - Site name, linked to the site's homepage
  - Full article title (not truncated), linked to the article
  - The existing ~150-word article excerpt
  - A media gallery of up to 10 images gathered from the page (og:image tags,
    falling back to `<img>` sources), each downloaded and attached rather than
    hotlinked so they render reliably

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)