### PR TITLE
fix: surface full API request/response detail in extractErrorMessage

### DIFF
--- a/src/functions/InteractionUtils.ts
+++ b/src/functions/InteractionUtils.ts
@@ -1,5 +1,7 @@
+import axios from "axios";
 import { MessageFlags, MessageFlagsBitField } from "discord.js";
 import { logError, logInfo } from "../utilities/LogUtils.js";
+import { formatApiError, tryParseJson } from "../utilities/ApiErrorUtils.js";
 import type {
   Client,
   CommandInteraction,
@@ -544,6 +546,15 @@ export async function deferWithPrivateFlag(
 }
 
 export function extractErrorMessage(err: unknown): string {
+  if (axios.isAxiosError(err)) {
+    return formatApiError(
+      err.config?.method ?? "?",
+      err.config?.url ?? "?",
+      tryParseJson(err.config?.data as string | null | undefined),
+      err.response?.status,
+      err.response?.data ?? null,
+    );
+  }
   return err instanceof Error ? err.message : String(err);
 }
 

--- a/src/utilities/ApiErrorUtils.ts
+++ b/src/utilities/ApiErrorUtils.ts
@@ -15,7 +15,7 @@ export function formatApiError(
   return `Request:\n\`\`\`json\n${req}\n\`\`\`\nResponse:\n\`\`\`json\n${res}\n\`\`\``;
 }
 
-function tryParseJson(raw: string | null | undefined): unknown {
+export function tryParseJson(raw: string | null | undefined): unknown {
   if (!raw) return null;
   try {
     return JSON.parse(raw);


### PR DESCRIPTION
## Summary
- `extractErrorMessage` (used directly and via `withErrorReply`) returned only the raw
  axios message (e.g. "Request failed with status code 422") for API errors, hiding
  the actual response body and validation reason.
- This was reported via the admin `/nextround-setup` wizard (test mode) failing with
  "Round setup wizard failed: Request failed with status code 422" and no way to tell
  which field/validation caused it.
- The bot already has a `formatApiError`/`buildApiErrorMessage` helper in
  `src/utilities/ApiErrorUtils.ts` (added in #868) used by a few commands directly.
  This wires that same formatting into `extractErrorMessage` itself, so every caller
  (there are ~10 across the command layer, plus `withErrorReply`) gets full
  request/response JSON detail on axios errors without each site needing its own
  try/catch.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] `npm run lint` passes
- [ ] Manual verification: re-run `/nextround-setup` in test mode and confirm the
  error reply now includes the full request/response JSON, so the actual 422 cause
  can be diagnosed

🤖 Generated with [Claude Code](https://claude.com/claude-code)