### PR TITLE
fix: send lowercase status to Wizard Sessions PATCH endpoint

### DIFF
--- a/src/classes/AdminWizardSession.ts
+++ b/src/classes/AdminWizardSession.ts
@@ -67,10 +67,6 @@ function toDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
 }
 
-function toDbStatus(status: AdminWizardSessionStatus): string {
-  return status.toUpperCase();
-}
-
 function fromDbStatus(status: string): AdminWizardSessionStatus {
   const normalized = status.trim().toLowerCase();
   if (ADMIN_WIZARD_SESSION_STATUSES.includes(normalized as AdminWizardSessionStatus)) {
@@ -247,7 +243,7 @@ export async function closeActiveAdminWizardSession(params: {
 
   const result = await apiPatch<{ data: WizardSessionApiData }>(
     `/api/v1/wizard_sessions/${active.sessionId}`,
-    { data: { status: toDbStatus(params.status) } },
+    { data: { status: params.status } },
   );
   return Boolean(result?.data);
 }


### PR DESCRIPTION
## Summary
- TheRPGClub-api#171 tracks a 422 bug where every Wizard Sessions write fails
  validation because the controller assigns/passes through uppercase status
  strings (`ACTIVE`) while the model validates against lowercase
  (`STATUSES = %w[active completed cancelled]`).
- The chosen fix direction (per issue update) is to standardize the API on
  lowercase, matching the model. This updates the bot side to match: drop the
  `toDbStatus` uppercase conversion in `AdminWizardSession.ts` and send
  `params.status` (already lowercase internally) as-is to
  `PATCH /api/v1/wizard_sessions/{id}`.
- Note: this bot-side change alone does not unblock the wizard — the
  `POST upsert` action in the API still hardcodes `status: "ACTIVE"`
  server-side regardless of what the bot sends, so TheRPGClub-api#171 must
  ship first.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] `npm run lint` passes
- [ ] Manual verification: once TheRPGClub-api#171 ships, run `/nextround-setup`
  end-to-end (start, resume after restart, complete, cancel) and confirm no
  422s

🤖 Generated with [Claude Code](https://claude.com/claude-code)