### PR TITLE
fix: normalize punctuation when matching typed GameDB titles

### DIFF
--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -24,7 +24,7 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import {
   formatGameTitleWithYear,
-  parseTitleWithYear,
+  resolveExactTitleMatch,
 } from "../functions/GameTitleAutocompleteUtils.js";
 import {
   areNominationsClosed,
@@ -79,33 +79,8 @@ function parseNominationKind(value: string): NominationKind | null {
 }
 
 async function resolveNominatedGameByTitle(searchTerm: string): Promise<IGame | null> {
-  const parsed = parseTitleWithYear(searchTerm);
-  const normalizedSearchTerm = parsed.title;
-  const existing = await GameSearchService.searchGames(normalizedSearchTerm);
-  const exact = existing.find((game) => {
-    if (game.title.toLowerCase() !== normalizedSearchTerm.toLowerCase()) {
-      return false;
-    }
-    if (parsed.year == null) {
-      return true;
-    }
-
-    const releaseDate = game.initialReleaseDate instanceof Date
-      ? game.initialReleaseDate
-      : game.initialReleaseDate
-        ? new Date(game.initialReleaseDate)
-        : null;
-    return releaseDate instanceof Date && !Number.isNaN(releaseDate.getTime())
-      ? releaseDate.getFullYear() === parsed.year
-      : false;
-  });
-  if (exact) {
-    return exact;
-  }
-  if (existing.length === 1) {
-    return existing[0] ?? null;
-  }
-  return null;
+  const existing = await GameSearchService.searchGames(searchTerm);
+  return resolveExactTitleMatch(existing, searchTerm);
 }
 
 async function announceNominationList(

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -34,7 +34,7 @@ import {
   autocompleteGameCompletionTitle,
   resolveGameCompletionPlatformId,
 } from "./game-completion/completion-autocomplete.utils.js";
-import { parseTitleWithYear } from "../functions/GameTitleAutocompleteUtils.js";
+import { resolveExactTitleMatch } from "../functions/GameTitleAutocompleteUtils.js";
 
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
@@ -301,37 +301,8 @@ export class NowPlayingCommand {
   }
 
   private async resolveNowPlayingGameByTitle(searchTerm: string): Promise<IGame | null> {
-    const parsed = parseTitleWithYear(searchTerm);
-    const normalizedSearchTerm = parsed.title.trim();
-    if (!normalizedSearchTerm) {
-      return null;
-    }
-
-    const existing = await GameSearchService.searchGames(normalizedSearchTerm);
-    const exact = existing.find((game) => {
-      if (game.title.toLowerCase() !== normalizedSearchTerm.toLowerCase()) {
-        return false;
-      }
-      if (parsed.year == null) {
-        return true;
-      }
-
-      const releaseDate = game.initialReleaseDate instanceof Date
-        ? game.initialReleaseDate
-        : game.initialReleaseDate
-          ? new Date(game.initialReleaseDate)
-          : null;
-      return releaseDate instanceof Date && !Number.isNaN(releaseDate.getTime())
-        ? releaseDate.getFullYear() === parsed.year
-        : false;
-    });
-    if (exact) {
-      return exact;
-    }
-    if (existing.length === 1) {
-      return existing[0] ?? null;
-    }
-    return null;
+    const existing = await GameSearchService.searchGames(searchTerm);
+    return resolveExactTitleMatch(existing, searchTerm);
   }
 
   private async promptEditNowPlayingNote(

--- a/src/functions/GameTitleAutocompleteUtils.ts
+++ b/src/functions/GameTitleAutocompleteUtils.ts
@@ -1,3 +1,5 @@
+import { foldAccentE } from "./GameAutocompleteCache.js";
+
 type IGameTitleAutocompleteEntry = {
   title: string;
   initialReleaseDate?: Date | string | null;
@@ -51,4 +53,59 @@ export function parseTitleWithYear(
   }
 
   return { title: input, year: null, hasYearSuffix: false };
+}
+
+/**
+ * Collapses a title to a punctuation/accent-insensitive key so titles that
+ * differ only by colon vs. hyphen, curly quotes, or spacing still compare
+ * equal (e.g. "X: Definitive Edition" vs "X - Definitive Edition").
+ */
+export function normalizeTitleKey(title: string): string {
+  return foldAccentE(title)
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+/**
+ * Resolves a single unambiguous GameDB match for a user-supplied title.
+ * Tries a literal (case-insensitive) title match first, falls back to a
+ * punctuation-normalized match, then finally to the sole search result if
+ * the search itself was already unambiguous.
+ */
+export function resolveExactTitleMatch<T extends IGameTitleAutocompleteEntry>(
+  candidates: T[],
+  searchTerm: string,
+): T | null {
+  const parsed = parseTitleWithYear(searchTerm);
+  const normalizedSearchTerm = parsed.title.trim();
+  if (!normalizedSearchTerm) {
+    return null;
+  }
+
+  const matchesYear = (game: T): boolean => {
+    if (parsed.year == null) return true;
+    return getReleaseYear(game) === parsed.year;
+  };
+
+  const literalMatch = candidates.find(
+    (game) => game.title.toLowerCase() === normalizedSearchTerm.toLowerCase() && matchesYear(game),
+  );
+  if (literalMatch) {
+    return literalMatch;
+  }
+
+  const searchKey = normalizeTitleKey(normalizedSearchTerm);
+  const normalizedMatches = candidates.filter(
+    (game) => normalizeTitleKey(game.title) === searchKey && matchesYear(game),
+  );
+  if (normalizedMatches.length === 1) {
+    return normalizedMatches[0] ?? null;
+  }
+
+  if (candidates.length === 1) {
+    return candidates[0] ?? null;
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary
- `/now-playing add` and `/nominate` matched a typed title against GameDB
  with a strict case-insensitive literal comparison, so titles that differ
  only by colon vs. hyphen, curly quotes, or spacing (e.g. text entered via
  the "keep typing" autocomplete option) failed to resolve even when the
  game existed, surfacing "I could not find a unique GameDB match."
- Centralizes the previously duplicated exact-match logic from
  `now-playing.command.ts` and `nominate.command.ts` into a shared
  `resolveExactTitleMatch` helper in `GameTitleAutocompleteUtils.ts`, which
  now falls back to a punctuation/accent-normalized comparison before
  giving up.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] `npm run lint` passes with no violations

Closes #1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)