### PR TITLE
fix: resolve GameDB title autocomplete by id instead of text round-trip

### DIFF
--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -48,6 +48,7 @@ import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../config/textLimits.js";
 import { logError } from "../utilities/LogUtils.js";
 import GameSearchService from "../classes/GameSearchService.js";
+import Game from "../classes/Game.js";
 
 const NOMINATE_REASON_MAX_LENGTH = 1500;
 
@@ -66,7 +67,7 @@ async function autocompleteNominationTitle(
   await interaction.respond(
     results.slice(0, DISCORD_SELECT_OPTIONS_MAX).map((game) => ({
       name: truncateLabel(formatGameTitleWithYear(game)),
-      value: truncateLabel(formatGameTitleWithYear(game)),
+      value: String(game.id),
     })),
   );
 }
@@ -78,9 +79,17 @@ function parseNominationKind(value: string): NominationKind | null {
   return null;
 }
 
-async function resolveNominatedGameByTitle(searchTerm: string): Promise<IGame | null> {
+async function resolveNominatedGameByTitle(
+  searchTerm: string,
+): Promise<{ game: IGame | null; candidates: IGame[] }> {
+  const numericId = Number(searchTerm);
+  if (isPositiveInt(numericId)) {
+    const byId = await Game.getGameById(numericId);
+    return { game: byId, candidates: byId ? [byId] : [] };
+  }
+
   const existing = await GameSearchService.searchGames(searchTerm);
-  return resolveExactTitleMatch(existing, searchTerm);
+  return { game: resolveExactTitleMatch(existing, searchTerm), candidates: existing };
 }
 
 async function announceNominationList(
@@ -197,10 +206,14 @@ export class NominateCommand {
         return;
       }
 
-      const game = await resolveNominatedGameByTitle(cleanedTitle);
+      const { game, candidates } = await resolveNominatedGameByTitle(cleanedTitle);
       if (!game) {
+        const candidateList = candidates.length
+          ? candidates.slice(0, 5).map((g) => `"${g.title}"`).join(", ")
+          : "no results";
         const notFoundMsg =
-          `I could not find a unique GameDB match for "${cleanedTitle}". ` +
+          `I could not find a unique GameDB match for "${cleanedTitle}" ` +
+          `(GameDB search returned: ${candidateList}). ` +
           "Please use the title autocomplete or add the game to GameDB first.";
         await safeReply(interaction, buildTextReply(notFoundMsg, true));
         return;

--- a/src/commands/now-playing.command.ts
+++ b/src/commands/now-playing.command.ts
@@ -31,10 +31,12 @@ import {
 } from "../functions/ComponentsV2Utils.js";
 import {
   autocompleteGameCompletionPlatform,
-  autocompleteGameCompletionTitle,
   resolveGameCompletionPlatformId,
 } from "./game-completion/completion-autocomplete.utils.js";
+import { autocompleteCollectionGameTitle } from "./collection/collection-autocomplete.utils.js";
 import { resolveExactTitleMatch } from "../functions/GameTitleAutocompleteUtils.js";
+import { isPositiveInt } from "../utilities/ValidationUtils.js";
+import Game from "../classes/Game.js";
 
 import { renderUsernameWithEmoji } from "../services/UserEmojiService.js";
 import { safeIgnore } from "../utilities/AsyncUtils.js";
@@ -77,7 +79,7 @@ export class NowPlayingCommand {
   @Slash({ description: "Add a game to your now playing list", name: "add" })
   async addNowPlayingSlash(
     @SlashOption({
-      autocomplete: autocompleteGameCompletionTitle,
+      autocomplete: autocompleteCollectionGameTitle,
       description: "Game title (autocomplete from GameDB)",
       name: "title",
       required: true,
@@ -106,9 +108,15 @@ export class NowPlayingCommand {
       return;
     }
 
-    const game = await this.resolveNowPlayingGameByTitle(title);
+    const { game, candidates } = await this.resolveNowPlayingGameByTitle(title);
     if (!game) {
-      const container = buildTextContainer(`I could not find a unique GameDB match for "${title}". Please choose from autocomplete.`);
+      const candidateList = candidates.length
+        ? candidates.slice(0, 5).map((g) => `"${g.title}"`).join(", ")
+        : "no results";
+      const container = buildTextContainer(
+        `I could not find a unique GameDB match for "${title}" ` +
+        `(GameDB search returned: ${candidateList}). Please choose from autocomplete.`,
+      );
       await safeReply(interaction, {
         components: [container],
         flags: buildComponentsV2Flags(false),
@@ -300,9 +308,17 @@ export class NowPlayingCommand {
     });
   }
 
-  private async resolveNowPlayingGameByTitle(searchTerm: string): Promise<IGame | null> {
+  private async resolveNowPlayingGameByTitle(
+    searchTerm: string,
+  ): Promise<{ game: IGame | null; candidates: IGame[] }> {
+    const numericId = Number(searchTerm);
+    if (isPositiveInt(numericId)) {
+      const byId = await Game.getGameById(numericId);
+      return { game: byId, candidates: byId ? [byId] : [] };
+    }
+
     const existing = await GameSearchService.searchGames(searchTerm);
-    return resolveExactTitleMatch(existing, searchTerm);
+    return { game: resolveExactTitleMatch(existing, searchTerm), candidates: existing };
   }
 
   private async promptEditNowPlayingNote(


### PR DESCRIPTION
## Summary
- The first attempt at #1049 normalized punctuation in the exact-title
  comparison, but that didn't fix it -- the merged PR still surfaced "I
  could not find a unique GameDB match" for a title selected via
  autocomplete.
- Root cause: `/now-playing add` and `/nominate` searched GameDB again by
  the *text* an autocomplete option displayed, rather than resolving the
  option the user actually picked. Any mismatch between the search-time
  and select-time text (including truncation baked into long option
  values) turns a valid autocomplete selection into an unresolved match.
  Platform selection and `/collection add` already avoid this class of bug
  by having autocomplete return the numeric id and resolving directly by
  id.
- Switches `/now-playing add`'s title autocomplete to the existing
  id-returning `autocompleteCollectionGameTitle`, and `/nominate`'s title
  autocomplete to return the game id as its value. Both resolvers try a
  direct id lookup first, falling back to the fuzzy title search only for
  manually typed text.
- The fallback's "not found" message now also lists what GameDB search
  actually returned, so any future mismatch is self-diagnosing without
  needing live API access to debug.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] `npm run lint` passes with no violations
- [ ] Manually verify `/now-playing add title: Xenoblade Chronicles X:
      Definitive Edition` resolves when selected from autocomplete

Closes #1049

🤖 Generated with [Claude Code](https://claude.com/claude-code)