### PR TITLE
feat: add test_mode option to /collection import-csv

### DIFF
--- a/src/classes/CollectionCsvImport.ts
+++ b/src/classes/CollectionCsvImport.ts
@@ -30,6 +30,7 @@ export interface ICollectionCsvImport {
   sourceFileName: string | null;
   sourceFileSize: number | null;
   templateVersion: string | null;
+  testMode: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
@@ -62,6 +63,7 @@ type CollectionCsvImportApiData = {
   source_file_name: string | null;
   source_file_size: number | null;
   template_version: string | null;
+  test_mode: boolean;
   created_at: string;
   updated_at: string;
 };
@@ -105,6 +107,7 @@ function mapImport(row: CollectionCsvImportApiData): ICollectionCsvImport {
     sourceFileName: row.source_file_name ?? null,
     sourceFileSize: row.source_file_size == null ? null : Number(row.source_file_size),
     templateVersion: row.template_version ?? null,
+    testMode: Boolean(row.test_mode),
     createdAt: toDate(row.created_at),
     updatedAt: toDate(row.updated_at),
   };
@@ -136,6 +139,7 @@ export async function createCollectionCsvImportSession(params: {
   sourceFileName: string | null;
   sourceFileSize: number | null;
   templateVersion: string | null;
+  testMode?: boolean;
   items: Array<{
     rowIndex: number;
     rawTitle: string;
@@ -153,6 +157,7 @@ export async function createCollectionCsvImportSession(params: {
         source_file_name: params.sourceFileName,
         source_file_size: params.sourceFileSize,
         template_version: params.templateVersion,
+        test_mode: params.testMode ?? false,
         items: params.items.map((item) => ({
           row_index: item.rowIndex,
           raw_title: item.rawTitle,

--- a/src/commands/collection/collection-csv-import.command.ts
+++ b/src/commands/collection/collection-csv-import.command.ts
@@ -214,6 +214,7 @@ export class CollectionCsvImportCommand {
       });
       const reasonLines = buildImportReasonSummary(reasonCounts, CSV_IMPORT_REASON_LABELS);
       const done = [
+        ...(session.testMode ? ["**TEST MODE** - nothing was persisted"] : []),
         `## CSV Import #${session.importId}`,
         "Import completed.",
         `Added: ${stats.added}`,
@@ -420,6 +421,7 @@ export class CollectionCsvImportCommand {
       note: nextItem.rawNote,
       sourceGameDbId: nextItem.rawGameDbId,
       sourceIgdbId: nextItem.rawIgdbId,
+      testMode: session.testMode,
     });
     const guidance = candidates.length > 1
       ? "Ambiguous match. Use Choose to select the right GameDB title."
@@ -531,6 +533,13 @@ export class CollectionCsvImportCommand {
       required: false,
     })
     file: Attachment | undefined,
+    @SlashOption({
+      name: "test_mode",
+      description: "Run in test mode (no data is persisted)",
+      type: ApplicationCommandOptionType.Boolean,
+      required: false,
+    })
+    testMode: boolean | undefined,
     interaction: CommandInteraction,
   ): Promise<void> {
     const guild = interaction.guild;
@@ -629,6 +638,7 @@ export class CollectionCsvImportCommand {
           sourceFileName: file.name ?? null,
           sourceFileSize: typeof file.size === "number" ? file.size : null,
           templateVersion: COLLECTION_CSV_TEMPLATE_VERSION,
+          testMode: testMode ?? false,
           items: parsed.rows.map((row) => ({
             rowIndex: row.rowIndex,
             rawTitle: row.title,
@@ -659,7 +669,8 @@ export class CollectionCsvImportCommand {
         const stats = await countCollectionCsvImportItems(session.importId);
         const reasonCounts = await countCollectionCsvImportResultReasons(session.importId);
         const reasonLines = buildImportReasonSummary(reasonCounts, CSV_IMPORT_REASON_LABELS);
-        const statusLine = `Status: ${session.status}`;
+        const statusLine = `Status: ${session.status}` +
+          (session.testMode ? " (TEST MODE)" : "");
         const countsLine = `**Pending** ${stats.pending} | **Added** ${stats.added}` +
           ` | **Updated** ${stats.updated} | **Skipped** ${stats.skipped}` +
           ` | **Failed** ${stats.failed}`;

--- a/src/commands/collection/collection-csv-import.service.ts
+++ b/src/commands/collection/collection-csv-import.service.ts
@@ -191,6 +191,7 @@ export function buildCsvImportItemMessage(params: {
   note: string | null;
   sourceGameDbId: number | null;
   sourceIgdbId: number | null;
+  testMode: boolean;
 }): string {
   const details = [
     `Platform: ${params.platformLabel}`,
@@ -204,8 +205,11 @@ export function buildCsvImportItemMessage(params: {
   }
 
   const noteText = params.note ? `\nNote: ${params.note}` : "";
+  const testModeBanner = params.testMode
+    ? "**TEST MODE** - nothing will be persisted\n"
+    : "";
   return (
-    `## CSV Import #${params.importId}\n` +
+    `${testModeBanner}## CSV Import #${params.importId}\n` +
     `Row ${params.rowIndex}/${params.totalCount}\n` +
     `Title: **${params.title}**\n` +
     `${details.join(" | ")}${noteText}`


### PR DESCRIPTION
## Summary
- Adds a `test_mode` boolean `@SlashOption` to `/collection import-csv action:start`
- Passes `test_mode` through to `createCollectionCsvImportSession`, which POSTs it to `/api/v1/users/{user_id}/collection_csv_imports`
- Surfaces test-mode state in the review UI banner, status view, and completion summary so testers can see nothing was persisted

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`)
- [x] Lint passes (`npm run lint`)

Closes #1055

🤖 Generated with [Claude Code](https://claude.com/claude-code)