### PR TITLE
feat: add /nominate-delete so members can remove their own nomination

### DIFF
--- a/src/commands/help.command.ts
+++ b/src/commands/help.command.ts
@@ -35,6 +35,7 @@ import { buildActionButton, buildButtonRow , buildSelectRow } from "../functions
 type HelpTopicId =
   | "noms"
   | "nominate"
+  | "nominate-delete"
   | "round"
   | "round-history"
   | "hltb"
@@ -149,6 +150,16 @@ const HELP_TOPICS: HelpTopic[] = [
       "title (required) - GameDB title chosen from autocomplete. type (required) - GOTM or NR-GOTM. reason (required) - why you are nominating it.",
     notes:
       "Title autocomplete includes the release year when available. Running the command again updates your nomination for that category.",
+  },
+  {
+    id: "nominate-delete",
+    label: "/nominate-delete",
+    summary: "Delete your own GOTM or NR-GOTM nomination for the upcoming round.",
+    syntax: "Syntax: /nominate-delete type:<GOTM|NR-GOTM>",
+    parameters: "type (required) - GOTM or NR-GOTM.",
+    notes:
+      "Only removes your own nomination, and only while nominations are still open. " +
+      "The updated nomination list is posted to the nomination channel.",
   },
   {
     id: "round",
@@ -347,7 +358,7 @@ const HELP_CATEGORIES: { id: string; name: string; topicIds: HelpTopicId[] }[] =
   {
     id: "monthly-games",
     name: "Monthly Games",
-    topicIds: ["noms", "nominate", "round", "round-history"],
+    topicIds: ["noms", "nominate", "nominate-delete", "round", "round-history"],
   },
   {
     id: "members",
@@ -877,6 +888,7 @@ export function buildMainHelpResponse(): {
     "**Monthly Games**\n" +
     `${formatCommandLine("noms", "Show the current nomination list.")}\n` +
     `${formatCommandLine("nominate", "Submit a GOTM or NR-GOTM nomination.")}\n` +
+    `${formatCommandLine("nominate-delete", "Delete your own nomination.")}\n` +
     `${formatCommandLine("round", "See the current round and winners.")}\n` +
     `${formatCommandLine("round-history", "Browse historical rounds with filters.")}\n` +
     "\n" +

--- a/src/commands/nominate.command.ts
+++ b/src/commands/nominate.command.ts
@@ -2,7 +2,6 @@ import type {
   AutocompleteInteraction,
   CommandInteraction,
   StringSelectMenuInteraction,
-  TextBasedChannel,
 } from "discord.js";
 import {
   ApplicationCommandOptionType,
@@ -12,16 +11,15 @@ import {
 import { Discord, SelectMenuComponent, Slash, SlashChoice, SlashOption } from "discordx";
 import type { NominationKind } from "../classes/Nomination.js";
 import {
+  deleteNominationForUser,
   getNominationForUser,
   listNominationsForRound,
   upsertNomination,
 } from "../classes/Nomination.js";
 import type { IGame } from "../types/GameTypes.js";
 import { buildNominationListPayload } from "../functions/NominationListComponents.js";
-import {
-  buildComponentsV2Flags,
-  buildTextContainer,
-} from "../functions/ComponentsV2Utils.js";
+import { buildComponentsV2Flags } from "../functions/ComponentsV2Utils.js";
+import { announceNominationChange } from "../functions/NominationAdminHelpers.js";
 import {
   formatGameTitleWithYear,
   resolveExactTitleMatch,
@@ -37,16 +35,12 @@ import {
   safeReply,
   sanitizeUserInput,
 } from "../functions/InteractionUtils.js";
-import { buildTextReply, safeV2TextContent } from "../functions/ComponentsV2Utils.js";
+import { buildTextReply } from "../functions/ComponentsV2Utils.js";
 import { toUnixTimestamp } from "../functions/DateFormatUtils.js";
-import {
-  GOTM_NOMINATION_CHANNEL_ID,
-  NR_GOTM_NOMINATION_CHANNEL_ID,
-} from "../config/nominationChannels.js";
 import { showGameProfileFromNomination } from "./gamedb.command.js";
 import { isPositiveInt } from "../utilities/ValidationUtils.js";
 import { DISCORD_SELECT_OPTIONS_MAX, truncateLabel } from "../config/textLimits.js";
-import { logError } from "../utilities/LogUtils.js";
+import { buildApiErrorMessage } from "../utilities/ApiErrorUtils.js";
 import GameSearchService from "../classes/GameSearchService.js";
 import Game from "../classes/Game.js";
 
@@ -90,47 +84,6 @@ async function resolveNominatedGameByTitle(
 
   const existing = await GameSearchService.searchGames(searchTerm);
   return { game: resolveExactTitleMatch(existing, searchTerm), candidates: existing };
-}
-
-async function announceNominationList(
-  interaction: CommandInteraction,
-  kind: NominationKind,
-  nominatorUserId: string,
-  nominatedTitle: string,
-  payload: Awaited<ReturnType<typeof buildNominationListPayload>>,
-): Promise<void> {
-  const channelId = kind === "gotm" ? GOTM_NOMINATION_CHANNEL_ID : NR_GOTM_NOMINATION_CHANNEL_ID;
-
-  try {
-    const channel = await interaction.client.channels.fetch(channelId);
-    const textChannel: TextBasedChannel | null = channel?.isTextBased()
-      ? (channel as TextBasedChannel)
-      : null;
-    if (!textChannel || !isSendableTextChannel(textChannel)) {
-      return;
-    }
-
-    const nominationNotice = buildTextContainer(
-        safeV2TextContent(`${userMention(nominatorUserId)} Nominated "${nominatedTitle}"!`, 1000),
-      );
-
-    await textChannel.send({
-      components: [nominationNotice, ...payload.components],
-      files: payload.files,
-      flags: buildComponentsV2Flags(false),
-      allowedMentions: { parse: [] },
-    });
-  } catch (error) {
-    logError("NominateCommand.announceNominationList", error);
-  }
-}
-
-type SendableTextChannel = TextBasedChannel & {
-  send: (content: unknown) => Promise<unknown>;
-};
-
-function isSendableTextChannel(channel: TextBasedChannel | null): channel is SendableTextChannel {
-  return Boolean(channel && typeof (channel as SendableTextChannel).send === "function");
 }
 
 @Discord()
@@ -251,17 +204,97 @@ export class NominateCommand {
         nominations,
         false,
       );
-      await announceNominationList(
-        interaction,
-        selectedKind,
-        interaction.user.id,
-        saved.gameTitle,
-        payload,
-      );
+      const notice =
+        `${userMention(interaction.user.id)} Nominated "${saved.gameTitle}"!`;
+      await announceNominationChange(selectedKind, interaction, notice, payload);
     } catch (error: unknown) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
       await safeReply(
-        interaction, buildTextReply(`Could not save your nomination: ${errorMessage}`, true),
+        interaction,
+        buildTextReply(buildApiErrorMessage("Could not save your nomination.", error), true),
+      );
+    }
+  }
+
+  @Slash({
+    description: "Delete your own GOTM or NR-GOTM nomination for the upcoming round",
+    name: "nominate-delete",
+  })
+  async nominateDelete(
+    @SlashChoice(
+      { name: "GOTM", value: "gotm" },
+      { name: "NR-GOTM", value: "nr-gotm" },
+    )
+    @SlashOption({
+      description: "Nomination type",
+      name: "type",
+      required: true,
+      type: ApplicationCommandOptionType.String,
+    })
+    rawKind: string,
+    interaction: CommandInteraction,
+  ): Promise<void> {
+    const selectedKind = parseNominationKind(rawKind);
+    if (!selectedKind) {
+      await safeReply(interaction, buildTextReply("Please choose either GOTM or NR-GOTM.", true));
+      return;
+    }
+
+    await safeDeferReply(interaction, { flags: MessageFlags.Ephemeral });
+
+    const kindLabel = selectedKind === "gotm" ? "GOTM" : "NR-GOTM";
+    try {
+      const window = await getUpcomingNominationWindow();
+      if (areNominationsClosed(window)) {
+        const voteUnix = toUnixTimestamp(window.nextVoteAt);
+        const closedMsg =
+          `Nominations for Round ${window.targetRound} are closed and can no longer be ` +
+          `deleted. Voting is scheduled for <t:${voteUnix}:F>.`;
+        await safeReply(interaction, buildTextReply(closedMsg, true));
+        return;
+      }
+
+      const existing = await getNominationForUser(
+        selectedKind, window.targetRound, interaction.user.id,
+      );
+      if (!existing) {
+        const missingMsg =
+          `You have no ${kindLabel} nomination for Round ${window.targetRound} to delete.`;
+        await safeReply(interaction, buildTextReply(missingMsg, true));
+        return;
+      }
+
+      const deleted = await deleteNominationForUser(
+        selectedKind, window.targetRound, interaction.user.id,
+      );
+      if (!deleted) {
+        const failedMsg =
+          `Could not delete your ${kindLabel} nomination "${existing.gameTitle}". ` +
+          "It may have already been removed.";
+        await safeReply(interaction, buildTextReply(failedMsg, true));
+        return;
+      }
+
+      const successMsg =
+        `Deleted your ${kindLabel} nomination for Round ${window.targetRound}: ` +
+        `"${existing.gameTitle}".`;
+      await safeReply(interaction, buildTextReply(successMsg, true));
+
+      const nominations = await listNominationsForRound(selectedKind, window.targetRound);
+      const payload = await buildNominationListPayload(
+        kindLabel,
+        "/nominate",
+        window,
+        nominations,
+        false,
+      );
+      const notice =
+        `${userMention(interaction.user.id)} withdrew their nomination ` +
+        `"${existing.gameTitle}".`;
+      await announceNominationChange(selectedKind, interaction, notice, payload);
+    } catch (error: unknown) {
+      await safeReply(
+        interaction,
+        buildTextReply(buildApiErrorMessage("Could not delete your nomination.", error), true),
       );
     }
   }

--- a/src/functions/NominationAdminHelpers.ts
+++ b/src/functions/NominationAdminHelpers.ts
@@ -4,7 +4,7 @@ import {
   ModalBuilder,
   StringSelectMenuBuilder,
   TextInputStyle,
-  type RepliableInteraction,
+  type Client,
   type TextBasedChannel,
 } from "discord.js";
 import {
@@ -131,7 +131,7 @@ export function buildDeletionReasonState(
 
 export async function announceNominationChange(
   kind: NominationKind,
-  interaction: RepliableInteraction,
+  interaction: { client: Client },
   content: string,
   payload: NominationListPayload,
 ): Promise<void> {
@@ -139,7 +139,7 @@ export async function announceNominationChange(
     kind === "gotm" ? GOTM_NOMINATION_CHANNEL_ID : NR_GOTM_NOMINATION_CHANNEL_ID;
 
   try {
-    const channel = await (interaction.client as any).channels.fetch(channelId);
+    const channel = await interaction.client.channels.fetch(channelId);
     const textChannel: TextBasedChannel | null = channel?.isTextBased()
       ? (channel as TextBasedChannel)
       : null;


### PR DESCRIPTION
## Summary
- Adds a `/nominate-delete type:<GOTM|NR-GOTM>` slash command so members can delete their own nomination for the upcoming round while nominations are still open. Confirms privately, then posts the updated nomination list to the matching nomination channel with a withdrawal notice.
- Centralizes the nomination-channel announcement: `/nominate` now reuses the shared `announceNominationChange` helper instead of a duplicate local sender, and the helper's parameter type was narrowed to `{ client: Client }` (removing an `as any` cast).
- Error replies in the touched flows now use `buildApiErrorMessage` so failed API calls surface the full request and response. Adds `/nominate-delete` to `/help` under Monthly Games.

## Test plan
- [ ] `/nominate-delete` with an existing nomination deletes it, replies ephemerally, and posts the updated list to the right channel
- [ ] `/nominate-delete` with no nomination for the round replies "You have no ... nomination"
- [ ] `/nominate-delete` after nominations close is rejected with the closed message
- [ ] `/nominate` still announces new nominations to the nomination channel
- [ ] `/help` shows the new command under Monthly Games
- [ ] `tsc --noEmit`, `npm test` (70/70), and `npm run lint` pass

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)