### PR TITLE
fix: survive API outages instead of crash-looping

### DIFF
--- a/src/RPGClub_GameDB.ts
+++ b/src/RPGClub_GameDB.ts
@@ -32,7 +32,23 @@ import { startPokopiaEmojiService } from "./services/PokopiaEmojiService.js";
 import { restoreJournalMessageContextsFromDb } from "./commands/now-playing/nowPlayingContexts.js";
 import { truncateWithEllipsis } from "./utilities/ValidationUtils.js";
 import { logError } from "./utilities/LogUtils.js";
+import { withRetry } from "./utilities/RetryUtils.js";
+import { isTransientApiError } from "./services/RpgClubApiClient.js";
 installConsoleLogging();
+
+// Since Node 15 an unhandled rejection kills the process, so one uncaught
+// throw from an async event or command handler used to restart the whole bot
+// (docker brings it back up). Log and keep running instead; genuinely broken
+// state still surfaces as uncaughtException below, which keeps the
+// crash-and-restart behavior but with a structured log of the reason.
+process.on("unhandledRejection", (reason: unknown) => {
+  logError("process.unhandledRejection", reason);
+});
+
+process.on("uncaughtException", (err: Error) => {
+  logError("process.uncaughtException", err);
+  process.exit(1);
+});
 
 // Re-asserts the bot's stored presence to Discord. Each tick reads it from the
 // GameDB (now on Neon) directly via BotPresenceHistory.getLatestPresenceActivity();
@@ -263,8 +279,25 @@ async function run(): Promise<void> {
     throw Error("Could not find BOT_TOKEN in your environment");
   }
 
-  await loadGotmFromDb();
-  await loadNrGotmFromDb();
+  // The API is the bot's only data source, and commands assume GOTM data is
+  // loaded before login. If the API is down at boot (e.g. recovering from a
+  // Neon blip), keep retrying with capped backoff instead of crash-looping
+  // the container; the bot logs in once its startup data has loaded.
+  // Non-transient failures (bad data, auth, code bugs) still exit nonzero via
+  // the catch below so they surface instead of retrying forever.
+  await withRetry(
+    async () => {
+      await loadGotmFromDb();
+      await loadNrGotmFromDb();
+    },
+    {
+      attempts: Infinity,
+      baseDelayMs: 5_000,
+      maxDelayMs: 60_000,
+      isRetryable: isTransientApiError,
+      context: "RPGClub_GameDB.startupDataLoad",
+    },
+  );
 
   await importx(
     `${dirname(import.meta.url)}/{events,commands}/**/*.{command,handler}.{ts,js}`,
@@ -273,4 +306,7 @@ async function run(): Promise<void> {
   await bot.login(process.env.BOT_TOKEN);
 }
 
-void run();
+run().catch((err: unknown) => {
+  logError("RPGClub_GameDB.run", err);
+  process.exit(1);
+});

--- a/src/services/RpgClubApiClient.ts
+++ b/src/services/RpgClubApiClient.ts
@@ -1,5 +1,7 @@
 import axios, { type AxiosInstance, type AxiosRequestConfig } from "axios";
 
+import { withRetry } from "../utilities/RetryUtils.js";
+
 /**
  * Singleton axios instance pre-configured for the RPG Club API.
  *
@@ -7,7 +9,31 @@ import axios, { type AxiosInstance, type AxiosRequestConfig } from "axios";
  * - Auth:     Authorization: Bearer <RPGCLUB_BOT_API_TOKEN>
  * - 404 responses are NOT thrown -- callers receive `null` via the
  *   `apiGet` / `apiPost` helpers below. All other error statuses throw.
+ * - Requests time out after REQUEST_TIMEOUT_MS. GETs additionally retry
+ *   transient failures (see `isTransientApiError`); writes never retry
+ *   automatically since they are not guaranteed idempotent.
  */
+
+// Axios defaults to no timeout, so a wedged API (e.g. the 2026-07-22 Neon
+// outage) left every bot call hanging until the Fly proxy gave up (~37s).
+const REQUEST_TIMEOUT_MS = 10_000;
+
+const GET_RETRY_ATTEMPTS = 3;
+const GET_RETRY_BASE_DELAY_MS = 1_000;
+
+/**
+ * Failures worth retrying: no response at all (network error or timeout) or a
+ * gateway-flavored status the API returns while restarting behind Fly's proxy.
+ */
+export function isTransientApiError(err: unknown): boolean {
+  if (!axios.isAxiosError(err)) {
+    return false;
+  }
+  if (!err.response) {
+    return true;
+  }
+  return [502, 503, 504].includes(err.response.status);
+}
 
 function createClient(): AxiosInstance {
   const baseURL = process.env.RPGCLUB_API_BASE_URL;
@@ -22,6 +48,7 @@ function createClient(): AxiosInstance {
 
   return axios.create({
     baseURL,
+    timeout: REQUEST_TIMEOUT_MS,
     headers: {
       Authorization: `Bearer ${token}`,
       "Content-Type": "application/json",
@@ -49,7 +76,12 @@ export async function apiGet<T>(
   config?: AxiosRequestConfig,
 ): Promise<T | null> {
   try {
-    const response = await getClient().get<T>(path, config);
+    const response = await withRetry(() => getClient().get<T>(path, config), {
+      attempts: GET_RETRY_ATTEMPTS,
+      baseDelayMs: GET_RETRY_BASE_DELAY_MS,
+      isRetryable: isTransientApiError,
+      context: `RpgClubApiClient.apiGet ${path}`,
+    });
     return response.data;
   } catch (err: unknown) {
     if (axios.isAxiosError(err) && err.response?.status === 404) {

--- a/src/tests/retry-utils.test.ts
+++ b/src/tests/retry-utils.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { withRetry } from "../utilities/RetryUtils.js";
+
+test("withRetry returns the first successful result without retrying", async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => {
+      calls += 1;
+      return "ok";
+    },
+    { attempts: 3, baseDelayMs: 1, context: "test" },
+  );
+  assert.equal(result, "ok");
+  assert.equal(calls, 1);
+});
+
+test("withRetry retries failures until success", async () => {
+  let calls = 0;
+  const result = await withRetry(
+    async () => {
+      calls += 1;
+      if (calls < 3) {
+        throw new Error("transient");
+      }
+      return "recovered";
+    },
+    { attempts: 5, baseDelayMs: 1, context: "test" },
+  );
+  assert.equal(result, "recovered");
+  assert.equal(calls, 3);
+});
+
+test("withRetry rethrows once attempts are exhausted", async () => {
+  let calls = 0;
+  await assert.rejects(
+    withRetry(
+      async () => {
+        calls += 1;
+        throw new Error("still down");
+      },
+      { attempts: 3, baseDelayMs: 1, context: "test" },
+    ),
+    /still down/,
+  );
+  assert.equal(calls, 3);
+});
+
+test("withRetry rethrows non-retryable errors immediately", async () => {
+  let calls = 0;
+  await assert.rejects(
+    withRetry(
+      async () => {
+        calls += 1;
+        throw new Error("fatal");
+      },
+      {
+        attempts: 5,
+        baseDelayMs: 1,
+        isRetryable: () => false,
+        context: "test",
+      },
+    ),
+    /fatal/,
+  );
+  assert.equal(calls, 1);
+});
+
+test("withRetry doubles the delay and caps it at maxDelayMs", async () => {
+  const warns: string[] = [];
+  const originalWarn = console.warn;
+  console.warn = (message: string) => {
+    warns.push(message);
+  };
+  try {
+    let calls = 0;
+    await withRetry(
+      async () => {
+        calls += 1;
+        if (calls < 5) {
+          throw new Error("transient");
+        }
+      },
+      { attempts: 6, baseDelayMs: 10, maxDelayMs: 25, context: "test" },
+    );
+  } finally {
+    console.warn = originalWarn;
+  }
+  const delays = warns.map(
+    (raw) => (JSON.parse(raw).message as { nextDelayMs: number }).nextDelayMs,
+  );
+  assert.deepEqual(delays, [10, 20, 25, 25]);
+});

--- a/src/utilities/RetryUtils.ts
+++ b/src/utilities/RetryUtils.ts
@@ -1,0 +1,55 @@
+import { logWarn } from "./LogUtils.js";
+
+export type WithRetryOptions = {
+  /** Total attempts including the first try. Use Infinity to retry until success. */
+  attempts: number;
+  /** Delay before the first retry. Doubles on each subsequent retry. */
+  baseDelayMs: number;
+  /** Upper bound for the backoff delay. Defaults to 60s. */
+  maxDelayMs?: number;
+  /**
+   * Return false to rethrow immediately instead of retrying.
+   * When omitted, every failure is retried.
+   */
+  isRetryable?: (err: unknown) => boolean;
+  /** Log context for the per-retry warning, e.g. "RpgClubApiClient.apiGet /api/v1/foo". */
+  context: string;
+};
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Run `fn`, retrying failures with capped exponential backoff. Each retry is
+ * logged through `logWarn`; the final failure (attempts exhausted or a
+ * non-retryable error) is rethrown to the caller.
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  options: WithRetryOptions,
+): Promise<T> {
+  const { attempts, baseDelayMs, maxDelayMs = 60_000, isRetryable, context } = options;
+  let attempt = 0;
+  for (;;) {
+    attempt += 1;
+    try {
+      return await fn();
+    } catch (err) {
+      if (attempt >= attempts || (isRetryable && !isRetryable(err))) {
+        throw err;
+      }
+      const nextDelayMs = Math.min(baseDelayMs * 2 ** (attempt - 1), maxDelayMs);
+      logWarn(context, {
+        attempt,
+        nextDelayMs,
+        error: errorMessage(err),
+      });
+      await delay(nextDelayMs);
+    }
+  }
+}


### PR DESCRIPTION
Closes #1069

## Why

During the 2026-07-22 therpgclub-api outage (Neon dropped connections, the API answered
with empty-body 503s for ~25 minutes), the bot crash-looped for the whole window and was
offline in Discord. Three bot-side weaknesses caused that; this PR fixes all three. The
API-side half is TheRPGClub/TheRPGClub-api#218 (TCP keepalives so the API self-recovers
from a Neon blip in seconds).

## What

**New shared helper `src/utilities/RetryUtils.ts`**: `withRetry(fn, options)` with capped
exponential backoff, a per-retry structured `logWarn`, an optional `isRetryable` filter,
and `attempts: Infinity` support. Centralizes the retry pattern for both call sites below.

**`src/services/RpgClubApiClient.ts`**:

- The axios instance now has a 10s `timeout`. Axios defaults to no timeout, so during the
  outage every bot call hung ~37s until the Fly proxy gave up.
- `apiGet` retries up to 2 times (1s then 2s backoff) on transient failures only:
  no response at all (network error/timeout) or 502/503/504, via the exported
  `isTransientApiError`. 404 still returns `null` and is never retried.
- Writes (`apiPost`/`apiPatch`/`apiPostForm`/`apiDelete`) intentionally do NOT retry
  automatically: they are not guaranteed idempotent (e.g. POST /games creates records).
  `apiGetRaw` is also left un-retried since it exists to report the exact wire response
  for diagnostics.

**`src/RPGClub_GameDB.ts`**:

- Startup: the GOTM/NR-GOTM loads now retry with capped backoff (5s doubling to a 60s
  cap, indefinitely) while the API is transiently down, so an outage at boot delays
  login instead of crash-looping the container. Non-transient failures (bad data, auth,
  code bugs) are NOT retried; they fall through to the new `run().catch`, which logs via
  `logError` and exits nonzero so docker restarts with a logged reason. This preserves
  the existing invariant that GOTM data is loaded before `bot.login()`.
- `process.on("unhandledRejection")` now logs and keeps running (since Node 15 the
  default is process death, so one uncaught throw from an async event handler restarted
  the whole bot). `uncaughtException` logs and exits nonzero, matching the previous
  restart behavior but with a structured log.

## Verification

- `tsc --noEmit`: clean.
- New `src/tests/retry-utils.test.ts` (5 tests): first-try success, retry-until-success,
  attempts exhaustion, non-retryable passthrough, and delay doubling/capping asserted via
  the structured warn output.
- Full suite: 70/70 pass.
- `npx eslint` on all four touched files: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
