### PR TITLE
fix: read xcancel preview metadata from x.com, keep links on xcancel

### DIFF
--- a/src/functions/LinkPreviewEmbeds.ts
+++ b/src/functions/LinkPreviewEmbeds.ts
@@ -15,7 +15,60 @@ const URL_PATTERN = /https?:\/\/[^\s<>"]+/;
 const FETCH_TIMEOUT_MS = 8000;
 const DESCRIPTION_MAX_WORDS = 150;
 const MAX_GALLERY_IMAGES = 10;
-const REQUEST_HEADERS = { "User-Agent": "Mozilla/5.0 (compatible; TheRPGClubBot/1.0)" };
+const DEFAULT_USER_AGENT = "Mozilla/5.0 (compatible; TheRPGClubBot/1.0)";
+/** Some hosts only serve card metadata to a browser user agent. */
+const BROWSER_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+  + "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36";
+
+interface IPreviewSourceHost {
+  /** Host to scrape instead of the one in the posted link. */
+  fetchHost: string;
+  userAgent: string;
+}
+
+/**
+ * Mirrors whose own pages are unscrapable. Metadata is read from the upstream
+ * host while every rendered link keeps pointing at the mirror that was posted.
+ */
+const PREVIEW_SOURCE_HOSTS: Readonly<Record<string, IPreviewSourceHost>> = {
+  "xcancel.com": { fetchHost: "x.com", userAgent: BROWSER_USER_AGENT },
+};
+
+export interface IPreviewSource {
+  /** URL to actually request. */
+  fetchUrl: string;
+  headers: Record<string, string>;
+  /** True when the scraped host differs from the posted link's host. */
+  rewritten: boolean;
+}
+
+function normalizeHostname(hostname: string): string {
+  return hostname.replace(/^www\./, "").toLowerCase();
+}
+
+/** Map a posted link to the host that will actually answer with usable metadata. */
+export function resolvePreviewSource(displayUrl: string): IPreviewSource {
+  const fallback: IPreviewSource = {
+    fetchUrl: displayUrl,
+    headers: { "User-Agent": DEFAULT_USER_AGENT },
+    rewritten: false,
+  };
+
+  try {
+    const parsed = new URL(displayUrl);
+    const source = PREVIEW_SOURCE_HOSTS[normalizeHostname(parsed.hostname)];
+    if (!source) return fallback;
+
+    parsed.hostname = source.fetchHost;
+    return {
+      fetchUrl: parsed.toString(),
+      headers: { "User-Agent": source.userAgent },
+      rewritten: true,
+    };
+  } catch {
+    return fallback;
+  }
+}
 
 /**
  * Titles served by anti-bot interstitials instead of the real page. Compared
@@ -125,12 +178,13 @@ function resolveImageUrls($: cheerio.CheerioAPI, pageUrl: string): string[] {
 async function downloadImage(
   imageUrl: string,
   name: string,
+  headers: Record<string, string>,
 ): Promise<AttachmentBuilder | undefined> {
   try {
     const response = await axios.get<ArrayBuffer>(imageUrl, {
       timeout: FETCH_TIMEOUT_MS,
       responseType: "arraybuffer",
-      headers: REQUEST_HEADERS,
+      headers,
     });
     return new AttachmentBuilder(Buffer.from(response.data), { name });
   } catch (error) {
@@ -140,10 +194,11 @@ async function downloadImage(
 }
 
 export async function fetchOpenGraphData(url: string): Promise<IOpenGraphData | undefined> {
+  const source = resolvePreviewSource(url);
   try {
-    const response = await axios.get<string>(url, {
+    const response = await axios.get<string>(source.fetchUrl, {
       timeout: FETCH_TIMEOUT_MS,
-      headers: REQUEST_HEADERS,
+      headers: source.headers,
     });
     const $ = cheerio.load(response.data);
     const ogTag = (property: string): string | undefined =>
@@ -151,14 +206,16 @@ export async function fetchOpenGraphData(url: string): Promise<IOpenGraphData | 
 
     const title = ogTag("og:title") ?? ($("title").text().trim() || undefined);
     const description = ogTag("og:description");
-    const imageUrls = resolveImageUrls($, url);
+    const imageUrls = resolveImageUrls($, source.fetchUrl);
     const homepageUrl = new URL(url).origin;
-    const siteName = ogTag("og:site_name") ?? new URL(url).hostname.replace(/^www\./, "");
+    const displayHost = normalizeHostname(new URL(url).hostname);
+    // A rewritten host would otherwise label the preview with the upstream site.
+    const siteName = source.rewritten ? displayHost : ogTag("og:site_name") ?? displayHost;
 
     if (!title && !description && imageUrls.length === 0) return undefined;
     return { siteName, homepageUrl, title, description, imageUrls, url };
   } catch (error) {
-    logWarn("LinkPreviewEmbeds", `Failed to fetch Open Graph data for ${url}: ${error}`);
+    logWarn("LinkPreviewEmbeds", `Failed to fetch Open Graph data for ${source.fetchUrl}: ${error}`);
     return undefined;
   }
 }
@@ -187,8 +244,10 @@ export async function buildLinkPreviewContainer(data: IOpenGraphData): Promise<I
 
   const files: AttachmentBuilder[] = [];
   const galleryItems: MediaGalleryItemBuilder[] = [];
+  const { headers } = resolvePreviewSource(data.url);
   const downloads = await Promise.all(
-    data.imageUrls.map((imageUrl, index) => downloadImage(imageUrl, `link-preview-${index}.png`)),
+    data.imageUrls.map((imageUrl, index) =>
+      downloadImage(imageUrl, `link-preview-${index}.png`, headers)),
   );
   for (const attachment of downloads) {
     if (!attachment) continue;

--- a/src/tests/link-preview-interstitial.test.ts
+++ b/src/tests/link-preview-interstitial.test.ts
@@ -6,6 +6,7 @@ import {
   extractPreviewTitle,
   isInterstitialPreview,
   isInterstitialTitle,
+  resolvePreviewSource,
   INTERSTITIAL_TITLES,
   type IOpenGraphData,
 } from "../functions/LinkPreviewEmbeds.js";
@@ -51,6 +52,32 @@ const STUCK_LINES = [
   "[xcancel.com](https://xcancel.com)",
   `**[Verifying your browser…](${POST_URL})**`,
 ];
+
+test("resolvePreviewSource scrapes x.com for an xcancel link and keeps the path", () => {
+  const source = resolvePreviewSource(POST_URL);
+  assert.equal(source.fetchUrl, "https://x.com/ReticentY2K/status/2082451207650488402");
+  assert.equal(source.rewritten, true);
+  assert.match(source.headers["User-Agent"], /Chrome/);
+});
+
+test("resolvePreviewSource rewrites the www form of a mirrored host", () => {
+  const source = resolvePreviewSource("https://www.xcancel.com/user/status/1?lang=en");
+  assert.equal(source.fetchUrl, "https://x.com/user/status/1?lang=en");
+  assert.equal(source.rewritten, true);
+});
+
+test("resolvePreviewSource leaves unmapped hosts on the bot user agent", () => {
+  const source = resolvePreviewSource("https://store.steampowered.com/app/1086940");
+  assert.equal(source.fetchUrl, "https://store.steampowered.com/app/1086940");
+  assert.equal(source.rewritten, false);
+  assert.match(source.headers["User-Agent"], /TheRPGClubBot/);
+});
+
+test("resolvePreviewSource falls back cleanly on an unparseable url", () => {
+  const source = resolvePreviewSource("not a url");
+  assert.equal(source.fetchUrl, "not a url");
+  assert.equal(source.rewritten, false);
+});
 
 test("isInterstitialTitle matches every seeded title, ellipsis and case insensitive", () => {
   for (const known of INTERSTITIAL_TITLES) {


### PR DESCRIPTION
## Summary

The self-heal watcher from #1075 could not fix these, because the premise it retried on was wrong. Probing the reported URL directly:

- `xcancel.com` returns `<title>Verifying your browser…</title>` to **every** user agent tried, including a full Chrome UA. No retry schedule will ever clear it.
- `x.com` returns complete Open Graph tags for the same post, but **only** to a browser user agent. The existing `Mozilla/5.0 (compatible; TheRPGClubBot/1.0)` UA gets a 4KB shell with zero meta tags.

So the fix is to scrape upstream and render downstream.

- New `PREVIEW_SOURCE_HOSTS` map in [LinkPreviewEmbeds.ts](src/functions/LinkPreviewEmbeds.ts) pairs an unscrapable mirror with the host that actually answers, plus the request headers that host requires. Currently one entry: `xcancel.com` reads from `x.com` with a browser UA.
- `resolvePreviewSource(displayUrl)` returns the URL to request, the headers to send, and whether a rewrite happened. Path, query and protocol are preserved; `www.` forms are matched; an unparseable URL falls back to the original with the bot UA.
- `fetchOpenGraphData` scrapes `source.fetchUrl` and resolves relative images against it, but builds `url`, `homepageUrl` and `siteName` from the **posted** URL. Every link in the rendered container stays on xcancel.
- `siteName` is forced to the display host on a rewrite, so the preview does not label itself "X (formerly Twitter)" while linking to xcancel.
- `downloadImage` takes headers rather than a module constant, so `pbs.twimg.com` media is fetched with the same UA that got the page.

The interstitial detection and retry machinery from #1075 stays in place as a general safety net for other hosts.

## Verification

Ran the real pipeline against the URL from the original report. Result:

```
[xcancel.com](https://xcancel.com)
**[Reticent (@ReticentY2K) on X](https://xcancel.com/ReticentY2K/status/2082451207650488402)**
The Japan-exclusive GBA game 'Summon Night Swordcraft Story 3: The Stone of Beginnings' is getting a completed English patch released on November 5th, 2026!
[media gallery: link-preview-0.png, 106689 bytes]
```

Title, description and image all resolve. Both links point at xcancel.com.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) - 86 tests, lint clean
- [x] `resolvePreviewSource` rewrites xcancel to x.com preserving path and query, matches the `www.` form, leaves unmapped hosts on the bot UA, and falls back on an unparseable URL
- [x] Live fetch through `fetchOpenGraphData` + `buildLinkPreviewContainer` returns real metadata and a downloaded image
- [ ] Manual: post an xcancel link in `#game-news` and confirm the rendered preview shows the post text and image

## Known limitation

This depends on x.com continuing to serve Open Graph tags to browser user agents. If that changes, previews fall back to the existing behavior of posting nothing rather than a broken container. Adding a second mirror to `PREVIEW_SOURCE_HOSTS` is a one-line change if another source is needed later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
