### PR TITLE
chore: remove channel scope from xcancel link preview repair

### DIFF
--- a/src/events/MessageCreated.command.ts
+++ b/src/events/MessageCreated.command.ts
@@ -1,16 +1,12 @@
 import { Role } from "discord.js";
 import type { ArgsOf, Client } from "discordx";
 import { Discord, On } from "discordx";
-import { GAME_DEALS_CHANNEL_ID, GAME_NEWS_CHANNEL_ID } from "../config/channels.js";
 import { MEMBER_ROLE_ID, NEWCOMERS_ROLE_ID } from "../config/roles.js";
 import { LINK_RELAY_BOT_USER_ID } from "../config/users.js";
+import { extractFirstUrl } from "../functions/LinkPreviewEmbeds.js";
 import { renderLinkPreviewForMessage } from "../services/LinkPreviewRecoveryService.js";
 import { logError, logInfo } from "../utilities/LogUtils.js";
 
-const LINK_PREVIEW_CHANNEL_IDS: readonly string[] = [
-  GAME_NEWS_CHANNEL_ID,
-  GAME_DEALS_CHANNEL_ID,
-];
 const EMBED_RENDER_WAIT_MS = 3000;
 
 @Discord()
@@ -39,12 +35,9 @@ export class MessageCreated {
       }
     }
 
-    if (LINK_PREVIEW_CHANNEL_IDS.includes(message.channelId)) {
-      void this.postFallbackLinkPreview(
-        message.id,
-        message.channel,
-        message.author.id === LINK_RELAY_BOT_USER_ID,
-      );
+    const sweepStuckReplies: boolean = message.author.id === LINK_RELAY_BOT_USER_ID;
+    if (sweepStuckReplies || extractFirstUrl(message.content)) {
+      void this.postFallbackLinkPreview(message.id, message.channel, sweepStuckReplies);
     }
   }
 


### PR DESCRIPTION
## Summary
- Removed `LINK_PREVIEW_CHANNEL_IDS` (and the now-unused `GAME_NEWS_CHANNEL_ID` / `GAME_DEALS_CHANNEL_ID` imports) so link preview repair runs in any guild channel the bot can read.
- Replaced the channel allowlist with a cheap content check: repair is only scheduled when the message contains a URL, or when the author is the link relay bot (so `sweepStuckReplies` still runs for its stuck interstitial replies).
- Existing guards unchanged: `skipWhenEmbedded`, the 3s embed render wait, and the manual `/mod` repair path in `src/commands/mod.command.ts`.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) -- 86/86
- [x] Lint clean (`npm run lint`)
- [ ] Post an x.com/xcancel link in a channel outside game-news/game-deals and confirm the fallback preview renders
- [ ] Post a plain non-link message and confirm no preview work is scheduled
- [ ] Confirm a link relay bot message stuck on browser verification still gets its reply swept and re-rendered

Closes #1078

🤖 Generated with [Claude Code](https://claude.com/claude-code)