### PR TITLE
test: cover the link preview repair gate in MessageCreated

### DIFF
--- a/src/events/MessageCreated.command.ts
+++ b/src/events/MessageCreated.command.ts
@@ -9,6 +9,29 @@ import { logError, logInfo } from "../utilities/LogUtils.js";
 
 const EMBED_RENDER_WAIT_MS = 3000;
 
+export interface ILinkPreviewTrigger {
+  authorId: string;
+  content: string;
+}
+
+export interface ILinkPreviewDecision {
+  schedule: boolean;
+  sweepStuckReplies: boolean;
+}
+
+/**
+ * Repair runs in every readable channel, so the decision comes from the message
+ * itself. Link relay bot messages always schedule, even without a URL in their
+ * content, so their stuck interstitial replies still get swept.
+ */
+export function decideLinkPreviewRepair(message: ILinkPreviewTrigger): ILinkPreviewDecision {
+  const sweepStuckReplies: boolean = message.authorId === LINK_RELAY_BOT_USER_ID;
+  return {
+    schedule: sweepStuckReplies || extractFirstUrl(message.content) !== undefined,
+    sweepStuckReplies,
+  };
+}
+
 @Discord()
 export class MessageCreated {
   @On()
@@ -35,8 +58,11 @@ export class MessageCreated {
       }
     }
 
-    const sweepStuckReplies: boolean = message.author.id === LINK_RELAY_BOT_USER_ID;
-    if (sweepStuckReplies || extractFirstUrl(message.content)) {
+    const { schedule, sweepStuckReplies } = decideLinkPreviewRepair({
+      authorId: message.author.id,
+      content: message.content,
+    });
+    if (schedule) {
       void this.postFallbackLinkPreview(message.id, message.channel, sweepStuckReplies);
     }
   }

--- a/src/tests/message-created-link-preview-gate.test.ts
+++ b/src/tests/message-created-link-preview-gate.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { decideLinkPreviewRepair } from "../events/MessageCreated.command.js";
+import { BOT_DEV_PING_USER_ID, LINK_RELAY_BOT_USER_ID } from "../config/users.js";
+
+/** Any author that is not the link relay bot exercises the human path. */
+const HUMAN_USER_ID = BOT_DEV_PING_USER_ID;
+const POST_URL = "https://xcancel.com/ReticentY2K/status/2082451207650488402";
+
+test("schedules repair for a human message containing a URL", () => {
+  const decision = decideLinkPreviewRepair({
+    authorId: HUMAN_USER_ID,
+    content: `check this out ${POST_URL}`,
+  });
+
+  assert.equal(decision.schedule, true);
+  assert.equal(decision.sweepStuckReplies, false);
+});
+
+test("skips repair for a human message with no URL", () => {
+  const decision = decideLinkPreviewRepair({
+    authorId: HUMAN_USER_ID,
+    content: "no links here, just talking about xcancel.com stuff",
+  });
+
+  assert.equal(decision.schedule, false);
+  assert.equal(decision.sweepStuckReplies, false);
+});
+
+test("skips repair for an empty message body", () => {
+  const decision = decideLinkPreviewRepair({ authorId: HUMAN_USER_ID, content: "" });
+
+  assert.equal(decision.schedule, false);
+  assert.equal(decision.sweepStuckReplies, false);
+});
+
+test("schedules a sweep for a link relay bot message with a URL", () => {
+  const decision = decideLinkPreviewRepair({
+    authorId: LINK_RELAY_BOT_USER_ID,
+    content: POST_URL,
+  });
+
+  assert.equal(decision.schedule, true);
+  assert.equal(decision.sweepStuckReplies, true);
+});
+
+test("schedules a sweep for a link relay bot message with no URL in its content", () => {
+  const decision = decideLinkPreviewRepair({ authorId: LINK_RELAY_BOT_USER_ID, content: "" });
+
+  assert.equal(decision.schedule, true);
+  assert.equal(decision.sweepStuckReplies, true);
+});


### PR DESCRIPTION
## Summary
- Follow-up to #1079, which replaced the channel allowlist with a content-based gate. That branch had no test coverage.
- Extracted the scheduling decision from `messageCreate` into a pure `decideLinkPreviewRepair` helper, so the gate can be tested without constructing a Discord client or message.
- Added `src/tests/message-created-link-preview-gate.test.ts` covering the five meaningful cases: human message with a URL (schedule, no sweep), human message without a URL (skip), empty body (skip), link relay bot with a URL (schedule + sweep), and link relay bot with no URL in its content (still schedule + sweep, so the stuck interstitial reply gets swept).

No behavior change: the helper returns exactly what the inline expression did.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) -- 91/91, up from 86
- [x] Lint clean (`npm run lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)