### PR TITLE
refactor: Consolidate duplicate ICompletionatorImport interfaces

### DIFF
--- a/src/commands/game-completion/completion.types.ts
+++ b/src/commands/game-completion/completion.types.ts
@@ -58,34 +58,12 @@ export type CompletionatorModalKind =
   | "gamedb-manual"
   | "igdb-manual";
 
-export interface ICompletionatorImport {
-  importId: number;
-  userId: string;
-  status: string;
-  totalCount: number;
-  sourceFilename: string | null;
-  testMode: boolean;
-  createdAt: Date;
-  updatedAt: Date;
-}
-
-export interface ICompletionatorItem {
-  itemId: number;
-  importId: number;
-  rowIndex: number;
-  gameTitle: string;
-  platformName: string | null;
-  regionName: string | null;
-  sourceType: string | null;
-  timeText: string | null;
-  completedAt: Date | null;
-  completionType: string | null;
-  playtimeHours: number | null;
-  gameDbGameId: number | null;
-  completionId: number | null;
-  status: string;
-  errorText: string | null;
-}
+export type {
+  ICompletionatorImport,
+  ICompletionatorItem,
+  ImportStatus,
+  ImportItemStatus,
+} from "../../classes/CompletionatorImport.js";
 
 export type IgdbSelectOption = {
   id: number;


### PR DESCRIPTION
## Summary
- `src/classes/CompletionatorImport.ts` is now the single source of truth for
  `ICompletionatorImport` and `ICompletionatorItem`.
- `completion.types.ts` re-exports those interfaces (plus `ImportStatus` and
  `ImportItemStatus`) instead of redeclaring drifted copies with `status: string`
  and a missing `currentIndex`.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) - 91/91
- [x] Lint clean (`npm run lint`)
- [x] No call site relied on the looser `status: string` typing (zero type errors
      after tightening to the `ImportStatus` / `ImportItemStatus` unions)

Closes #1083

🤖 Generated with [Claude Code](https://claude.com/claude-code)