### PR TITLE
chore: Refresh api-reference skill docs for test_mode fields

### DIFF
--- a/.claude/skills/api-reference/SKILL.md
+++ b/.claude/skills/api-reference/SKILL.md
@@ -108,7 +108,7 @@ PATCH   /api/v1/collection_csv_imports/{id}  # Update a collection CSV import jo
 GET     /api/v1/collection_csv_imports/{id}/items/next_pending  # Get the next pending import item
 GET     /api/v1/collection_csv_imports/{id}/summary  # Summarize a collection CSV import job
 POST    /api/v1/users/{user_id}/collection_csv_imports  # Start a collection CSV import job
-  data: { source_file_name, source_file_size, template_version, items }
+  data: { source_file_name, source_file_size, template_version, items, test_mode }
 GET     /api/v1/users/{user_id}/collection_csv_imports/active  # Get the user's active or paused import
 ```
 
@@ -146,7 +146,7 @@ PATCH   /api/v1/completionator_imports/{id}  # Update a Completionator import jo
 GET     /api/v1/completionator_imports/{id}/items/next_pending  # Get the next pending import item
 GET     /api/v1/completionator_imports/{id}/summary  # Summarize a Completionator import job
 POST    /api/v1/users/{user_id}/completionator_imports  # Start a Completionator import job
-  data: { source_filename, items }
+  data: { source_filename, items, test_mode }
 GET     /api/v1/users/{user_id}/completionator_imports/active  # Get the user's active or paused import
 ```
 


### PR DESCRIPTION
## Summary
- Regenerated `.claude/skills/api-reference/SKILL.md` from the live OpenAPI spec via
  `.claude/skills/api-reference/refresh.sh`.
- `POST /api/v1/users/{user_id}/completionator_imports` now documents `test_mode`
  (bot has sent it since #1064).
- `POST /api/v1/users/{user_id}/collection_csv_imports` now documents `test_mode`
  (bot has sent it since #1063).

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) - 91/91
- [x] Lint clean (`npm run lint`)
- [x] Both POST bodies above include `test_mode` in the regenerated docs

Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)