### PR TITLE
chore: Add unit test for Completionator mapImport test_mode round-trip

### DIFF
--- a/src/classes/CompletionatorImport.ts
+++ b/src/classes/CompletionatorImport.ts
@@ -38,7 +38,7 @@ export interface ICompletionatorItem {
   errorText: string | null;
 }
 
-type CompletionatorImportApiData = {
+export type CompletionatorImportApiData = {
   import_id: number;
   user_id: string;
   status: string;
@@ -77,7 +77,7 @@ function toDate(value: Date | string): Date {
   return value instanceof Date ? value : new Date(value);
 }
 
-function mapImport(row: CompletionatorImportApiData): ICompletionatorImport {
+export function mapImport(row: CompletionatorImportApiData): ICompletionatorImport {
   return {
     importId: Number(row.import_id),
     userId: row.user_id,

--- a/src/tests/completionator-import-map.test.ts
+++ b/src/tests/completionator-import-map.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  mapImport,
+  type CompletionatorImportApiData,
+} from "../classes/CompletionatorImport.js";
+
+function buildRow(
+  overrides: Partial<CompletionatorImportApiData> = {},
+): CompletionatorImportApiData {
+  return {
+    import_id: 42,
+    user_id: "123456789012345678",
+    status: "active",
+    current_index: 3,
+    total_count: 10,
+    source_filename: "completionator.csv",
+    test_mode: false,
+    created_at: "2026-05-01T12:00:00Z",
+    updated_at: "2026-05-01T12:30:00Z",
+    ...overrides,
+  };
+}
+
+test("mapImport round-trips test_mode true", () => {
+  const mapped = mapImport(buildRow({ test_mode: true }));
+  assert.equal(mapped.testMode, true);
+});
+
+test("mapImport round-trips test_mode false", () => {
+  const mapped = mapImport(buildRow({ test_mode: false }));
+  assert.equal(mapped.testMode, false);
+});
+
+test("mapImport falls back to false when test_mode is missing", () => {
+  const row = buildRow();
+  delete (row as Partial<CompletionatorImportApiData>).test_mode;
+
+  const mapped = mapImport(row);
+  assert.equal(mapped.testMode, false);
+});
+
+test("mapImport maps the remaining import fields", () => {
+  const mapped = mapImport(buildRow({ test_mode: true }));
+
+  assert.equal(mapped.importId, 42);
+  assert.equal(mapped.userId, "123456789012345678");
+  assert.equal(mapped.status, "ACTIVE");
+  assert.equal(mapped.currentIndex, 3);
+  assert.equal(mapped.totalCount, 10);
+  assert.equal(mapped.sourceFilename, "completionator.csv");
+  assert.equal(mapped.createdAt.toISOString(), "2026-05-01T12:00:00.000Z");
+  assert.equal(mapped.updatedAt.toISOString(), "2026-05-01T12:30:00.000Z");
+});


### PR DESCRIPTION
## Summary
- New `src/tests/completionator-import-map.test.ts` covers `mapImport` round-tripping
  `test_mode: true`, `test_mode: false`, and a missing `test_mode` (older API responses
  must fall back to `false`).
- `mapImport` and `CompletionatorImportApiData` are now exported so the mapper can be
  tested directly. `src/tests/` has no module-mocking setup, so testing through
  `getImportById` would have meant introducing one.
- A fourth case asserts the remaining mapped fields, so a regression in the row mapping
  fails loudly rather than only where `test_mode` is read.

## Test plan
- [x] Type-check passes (`npx tsc --noEmit`)
- [x] Smoke test passes (`bash .claude/skills/run-rpgclubbot/smoke.sh`) - 95/95
- [x] Lint clean (`npm run lint`)
- [x] Mutation-checked: hardcoding `testMode: false` in `mapImport` fails the new
      `test_mode: true` case, confirming the test is not vacuous

Closes #1084

🤖 Generated with [Claude Code](https://claude.com/claude-code)